### PR TITLE
feat: use keychain instead of userdefaults for api key

### DIFF
--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -300,11 +300,11 @@ class APIKeyManager {
     
     private var apiKey: String?
     private let apiKeyEndpoint = "\(Constants.API.baseURL)/api/keys/chat"
-    private let userDefaultsKey = "tinfoil_premium_api_key"
+    private let keychainKey = "tinfoil_premium_api_key"
     
     private init() {
-        // Load cached API key from UserDefaults on init
-        self.apiKey = UserDefaults.standard.string(forKey: userDefaultsKey)
+        // Load cached API key from Keychain on init
+        self.apiKey = KeychainHelper.shared.loadString(for: keychainKey)
     }
     
     /// Retrieves the API key for premium models
@@ -345,9 +345,9 @@ class APIKeyManager {
                     // Parse response
                     if let responseDict = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                        let key = responseDict["key"] as? String {
-                        // Cache key in memory and UserDefaults
+                        // Cache key in memory and Keychain
                         self.apiKey = key
-                        UserDefaults.standard.set(key, forKey: userDefaultsKey)
+                        KeychainHelper.shared.save(key, for: keychainKey)
                         return key
                     }
                     
@@ -371,7 +371,7 @@ class APIKeyManager {
     /// Clears the cached API key
     func clearApiKey() {
         apiKey = nil
-        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+        KeychainHelper.shared.delete(for: keychainKey)
     }
 }
 

--- a/TinfoilChat/Utilities/KeychainHelper.swift
+++ b/TinfoilChat/Utilities/KeychainHelper.swift
@@ -1,0 +1,125 @@
+//
+//  KeychainHelper.swift
+//  TinfoilChat
+//
+//  Created on 20/07/25.
+//  Copyright © 2025 Tinfoil. All rights reserved.
+//
+
+import Foundation
+import Security
+
+/// A helper class for secure storage in the iOS Keychain
+class KeychainHelper {
+    
+    static let shared = KeychainHelper()
+    
+    private init() {}
+    
+    /// Save data to the keychain
+    /// - Parameters:
+    ///   - data: The data to save
+    ///   - key: The key to identify this item
+    ///   - service: Optional service name, defaults to bundle identifier
+    /// - Returns: True if saved successfully, false otherwise
+    @discardableResult
+    func save(_ data: Data, for key: String, service: String? = nil) -> Bool {
+        let service = service ?? Bundle.main.bundleIdentifier ?? "com.tinfoil.chat"
+        
+        // Create query
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        
+        // Delete any existing item
+        SecItemDelete(query as CFDictionary)
+        
+        // Add new item
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+    
+    /// Save a string to the keychain
+    /// - Parameters:
+    ///   - string: The string to save
+    ///   - key: The key to identify this item
+    ///   - service: Optional service name, defaults to bundle identifier
+    /// - Returns: True if saved successfully, false otherwise
+    @discardableResult
+    func save(_ string: String, for key: String, service: String? = nil) -> Bool {
+        guard let data = string.data(using: .utf8) else { return false }
+        return save(data, for: key, service: service)
+    }
+    
+    /// Retrieve data from the keychain
+    /// - Parameters:
+    ///   - key: The key to identify the item
+    ///   - service: Optional service name, defaults to bundle identifier
+    /// - Returns: The stored data, or nil if not found
+    func load(for key: String, service: String? = nil) -> Data? {
+        let service = service ?? Bundle.main.bundleIdentifier ?? "com.tinfoil.chat"
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+    
+    /// Retrieve a string from the keychain
+    /// - Parameters:
+    ///   - key: The key to identify the item
+    ///   - service: Optional service name, defaults to bundle identifier
+    /// - Returns: The stored string, or nil if not found
+    func loadString(for key: String, service: String? = nil) -> String? {
+        guard let data = load(for: key, service: service) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+    
+    /// Delete an item from the keychain
+    /// - Parameters:
+    ///   - key: The key to identify the item
+    ///   - service: Optional service name, defaults to bundle identifier
+    /// - Returns: True if deleted successfully, false otherwise
+    @discardableResult
+    func delete(for key: String, service: String? = nil) -> Bool {
+        let service = service ?? Bundle.main.bundleIdentifier ?? "com.tinfoil.chat"
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+    
+    /// Clear all items for a specific service
+    /// - Parameter service: The service name, defaults to bundle identifier
+    /// - Returns: True if cleared successfully, false otherwise
+    @discardableResult
+    func clearAll(for service: String? = nil) -> Bool {
+        let service = service ?? Bundle.main.bundleIdentifier ?? "com.tinfoil.chat"
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/TinfoilChat/Utilities/KeychainHelper.swift
+++ b/TinfoilChat/Utilities/KeychainHelper.swift
@@ -26,8 +26,18 @@ class KeychainHelper {
     func save(_ data: Data, for key: String, service: String? = nil) -> Bool {
         let service = service ?? Bundle.main.bundleIdentifier ?? "com.tinfoil.chat"
         
-        // Create query
-        let query: [String: Any] = [
+        // Create deletion query
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        
+        // Delete any existing item
+        SecItemDelete(deleteQuery as CFDictionary)
+        
+        // Create add query
+        let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
@@ -35,11 +45,8 @@ class KeychainHelper {
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
         
-        // Delete any existing item
-        SecItemDelete(query as CFDictionary)
-        
         // Add new item
-        let status = SecItemAdd(query as CFDictionary, nil)
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
         return status == errSecSuccess
     }
     


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced UserDefaults with secure Keychain storage for the API key to improve security.

- **Refactors**
  - Updated APIKeyManager to use KeychainHelper for saving, loading, and deleting the API key.
  - Added a KeychainHelper utility for simple keychain access.

<!-- End of auto-generated description by cubic. -->

