### PR TITLE
feat: add reset password flow

### DIFF
--- a/TinfoilChat/Views/Authentication/ForgotPasswordView.swift
+++ b/TinfoilChat/Views/Authentication/ForgotPasswordView.swift
@@ -1,0 +1,308 @@
+//
+//  ForgotPasswordView.swift
+//  TinfoilChat
+//
+//  Created on 20/07/25.
+//  Copyright © 2025 Tinfoil. All rights reserved.
+//
+
+import SwiftUI
+import Clerk
+
+struct ForgotPasswordView: View {
+    @Environment(Clerk.self) private var clerk
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var email = ""
+    @State private var code = ""
+    @State private var newPassword = ""
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var successMessage: String?
+    @State private var forceResetView = false
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        ZStack {
+            // Background
+            (colorScheme == .dark ? Color.backgroundPrimary : Color(UIColor.systemGroupedBackground))
+                .edgesIgnoringSafeArea(.all)
+            
+            VStack(spacing: 20) {
+                // Header
+                HStack {
+                    Spacer()
+                    Button(action: { 
+                        resetSignInState()
+                        isPresented = false 
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundColor(Color(.systemGray))
+                    }
+                }
+                .padding(.horizontal)
+                
+                VStack(spacing: 8) {
+                    Text("Reset Password")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                    
+                    Text(subtitleText)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal)
+                
+                // Content based on sign in status
+                Group {
+                    if forceResetView {
+                        emailInputView
+                    } else {
+                        switch clerk.client?.signIn?.status {
+                        case .needsFirstFactor:
+                            verificationCodeView
+                            
+                        case .needsNewPassword:
+                            newPasswordView
+                            
+                        default:
+                            emailInputView
+                        }
+                    }
+                }
+                .padding(.horizontal)
+                
+                Spacer()
+            }
+            .padding(.top, 20)
+        }
+        .onDisappear {
+            // Clean up when view is dismissed
+            resetSignInState()
+        }
+    }
+    
+    private var subtitleText: String {
+        switch clerk.client?.signIn?.status {
+        case .needsFirstFactor:
+            return "Enter the verification code sent to your email"
+        case .needsNewPassword:
+            return "Enter your new password"
+        default:
+            return "Enter your email to receive a password reset code"
+        }
+    }
+    
+    private var emailInputView: some View {
+        VStack(spacing: 16) {
+            UIKitTextField(text: $email, placeholder: "Email", keyboardType: .emailAddress)
+                .frame(height: 50)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(UIColor.systemGray4), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 1)
+                .disabled(isLoading)
+            
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+            
+            Button(action: { Task { await sendResetCode() } }) {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: colorScheme == .dark ? .white : .black))
+                        .scaleEffect(0.8)
+                } else {
+                    Text("Send Reset Code")
+                        .font(.headline)
+                        .foregroundColor(colorScheme == .dark ? .black : .white)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(email.isEmpty ? Color.gray.opacity(0.3) : (colorScheme == .dark ? Color.white : Color.black))
+            .cornerRadius(8)
+            .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+            .disabled(email.isEmpty || isLoading)
+        }
+    }
+    
+    private var verificationCodeView: some View {
+        VStack(spacing: 16) {
+            UIKitTextField(text: $code, placeholder: "Verification Code", keyboardType: .numberPad)
+                .frame(height: 50)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(UIColor.systemGray4), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 1)
+                .disabled(isLoading)
+            
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+            
+            Button(action: { Task { await verifyCode() } }) {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: colorScheme == .dark ? .white : .black))
+                        .scaleEffect(0.8)
+                } else {
+                    Text("Verify Code")
+                        .font(.headline)
+                        .foregroundColor(colorScheme == .dark ? .black : .white)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(code.isEmpty ? Color.gray.opacity(0.3) : (colorScheme == .dark ? Color.white : Color.black))
+            .cornerRadius(8)
+            .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+            .disabled(code.isEmpty || isLoading)
+            
+            Button(action: { 
+                resetSignInState()
+                // Force view to show email input again
+                forceResetView = true
+            }) {
+                HStack {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 14, weight: .medium))
+                    Text("Request New Code")
+                        .font(.system(size: 15, weight: .medium))
+                }
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.secondary.opacity(0.5), lineWidth: 1.5)
+                )
+            }
+            .padding(.top, 12)
+        }
+    }
+    
+    private var newPasswordView: some View {
+        VStack(spacing: 16) {
+            UIKitTextField(text: $newPassword, placeholder: "New Password", isSecure: true)
+                .frame(height: 50)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(UIColor.systemGray4), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 1)
+                .disabled(isLoading)
+            
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+            
+            if let success = successMessage {
+                Text(success)
+                    .font(.caption)
+                    .foregroundColor(.green)
+            }
+            
+            Button(action: { Task { await resetPassword() } }) {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: colorScheme == .dark ? .white : .black))
+                        .scaleEffect(0.8)
+                } else {
+                    Text("Reset Password")
+                        .font(.headline)
+                        .foregroundColor(colorScheme == .dark ? .black : .white)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(newPassword.isEmpty ? Color.gray.opacity(0.3) : (colorScheme == .dark ? Color.white : Color.black))
+            .cornerRadius(8)
+            .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+            .disabled(newPassword.isEmpty || isLoading)
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func sendResetCode() async {
+        errorMessage = nil
+        isLoading = true
+        forceResetView = false
+        
+        do {
+            try await SignIn.create(strategy: .identifier(email, strategy: .resetPasswordEmailCode()))
+        } catch {
+            errorMessage = "Failed to send reset code. Please check your email and try again."
+            print("Error sending reset code: \(error)")
+        }
+        
+        isLoading = false
+    }
+    
+    private func verifyCode() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            guard let inProgressSignIn = clerk.client?.signIn else {
+                errorMessage = "No sign in session found"
+                isLoading = false
+                return
+            }
+            
+            try await inProgressSignIn.attemptFirstFactor(strategy: .resetPasswordEmailCode(code: code))
+        } catch {
+            errorMessage = "Invalid verification code. Please try again."
+            print("Error verifying code: \(error)")
+        }
+        
+        isLoading = false
+    }
+    
+    private func resetPassword() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            guard let inProgressSignIn = clerk.client?.signIn else {
+                errorMessage = "No sign in session found"
+                isLoading = false
+                return
+            }
+            
+            try await inProgressSignIn.resetPassword(.init(password: newPassword, signOutOfOtherSessions: true))
+            successMessage = "Password reset successfully!"
+            
+            // Dismiss after a short delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                resetSignInState()
+                isPresented = false
+            }
+        } catch {
+            errorMessage = "Failed to reset password. Please ensure it meets the requirements."
+            print("Error resetting password: \(error)")
+        }
+        
+        isLoading = false
+    }
+    
+    private func resetSignInState() {
+        // Reset local state
+        email = ""
+        code = ""
+        newPassword = ""
+        errorMessage = nil
+        successMessage = nil
+        forceResetView = false
+    }
+}

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -28,7 +28,7 @@ struct ModularAuthenticationView: View {
     GeometryReader { geometry in
       ZStack {
         // Background
-        Color(UIColor.systemGroupedBackground)
+        (colorScheme == .dark ? Color.backgroundPrimary : Color(UIColor.systemGroupedBackground))
           .edgesIgnoringSafeArea(.all)
         
         VStack(spacing: 0) {
@@ -264,10 +264,7 @@ struct ModularAuthenticationView: View {
           Button(action: { dismiss() }) {
             Image(systemName: "xmark")
               .font(.system(size: 16, weight: .bold))
-              .foregroundColor(.gray)
-              .padding(8)
-              .background(Color.gray.opacity(0.15))
-              .clipShape(Circle())
+              .foregroundColor(Color(.systemGray))
           }
           .buttonStyle(PlainButtonStyle())
           .accessibilityLabel("Close authentication screen")

--- a/TinfoilChat/Views/Authentication/SignInView.swift
+++ b/TinfoilChat/Views/Authentication/SignInView.swift
@@ -21,6 +21,7 @@ struct SignInView: View {
   @State private var password = ""
   @State private var attemptedSubmit = false
   @State private var isEmailFormatInvalid = false
+  @State private var showForgotPassword = false
   
   private var emailIsEmpty: Bool {
     return email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -89,6 +90,15 @@ struct SignInView: View {
           .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
       }
       
+      Button(action: {
+        showForgotPassword = true
+      }) {
+        Text("Forgot Password?")
+          .font(.system(size: 15, weight: .medium))
+          .foregroundColor(.secondary)
+      }
+      .padding(.top, 8)
+      
       if isLoading {
         ProgressView()
           .progressViewStyle(CircularProgressViewStyle(tint: colorScheme == .dark ? .white : .black))
@@ -110,6 +120,9 @@ struct SignInView: View {
     .contentShape(Rectangle())
     .onTapGesture {
       UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+    .sheet(isPresented: $showForgotPassword) {
+      ForgotPasswordView(isPresented: $showForgotPassword)
     }
   }
   


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a full reset password flow, allowing users to request a reset code, verify it, and set a new password from the sign-in screen.

- **New Features**
  - Added ForgotPasswordView with email, code, and new password steps.
  - Linked "Forgot Password?" button in SignInView to open the reset flow.

<!-- End of auto-generated description by cubic. -->

