### PR TITLE
Feat: small improvements to UI

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1107,7 +1107,17 @@ class ChatViewModel: ObservableObject {
             saveChats()
         }
         
-        // Clear current chats and create a new empty one
+        // Reset to a free model when signing out
+        let freeModels = AppConfig.shared.filteredModelTypes(
+            isAuthenticated: false,
+            hasActiveSubscription: false
+        )
+        if let defaultFreeModel = freeModels.first {
+            currentModel = defaultFreeModel
+            AppConfig.shared.currentModel = defaultFreeModel
+        }
+        
+        // Clear current chats and create a new empty one with the free model
         chats = []
         let newChat = Chat.create(modelType: currentModel)
         currentChat = newChat

--- a/TinfoilChat/Views/AnimatedConfidentialTitle.swift
+++ b/TinfoilChat/Views/AnimatedConfidentialTitle.swift
@@ -17,7 +17,7 @@ struct AnimatedConfidentialTitle: View {
     @State private var animationTimer: Timer?
     @ObservedObject private var settings = SettingsManager.shared
     
-    private let fullText = "Confidential Chat"
+    private let fullText = "Private Chat"
     private let typingSpeed = 0.05 // seconds per character
     private let hapticGenerator = UIImpactFeedbackGenerator(style: .light)
     

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -97,8 +97,10 @@ struct MessageView: View {
                     }
                 }
                 
-                // Add copy button for assistant messages
-                if message.role == .assistant && (!message.content.isEmpty || message.thoughts != nil) {
+                // Add copy button for assistant messages (only when not streaming)
+                if message.role == .assistant && 
+                   (!message.content.isEmpty || message.thoughts != nil) &&
+                   !(viewModel.isLoading && message.id == viewModel.messages.last?.id) {
                     HStack {
                         Button(action: copyMessage) {
                             HStack(spacing: 4) {

--- a/TinfoilChat/Views/VerifierViewController.swift
+++ b/TinfoilChat/Views/VerifierViewController.swift
@@ -792,18 +792,25 @@ struct MeasurementDiffView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Measurement Comparison").font(.headline)
                 
-            Label(isVerified ? "Source and runtime measurements match" : "Measurement mismatch detected",
-                  systemImage: isVerified ? "checkmark.shield.fill" : "exclamationmark.triangle.fill")
-                .foregroundColor(isVerified ? .green : .red)
-                .font(.subheadline)
-                .padding(.vertical, 6)
-                .padding(.horizontal, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(isVerified ? 
-                              Color.green.opacity(colorScheme == .dark ? 0.2 : 0.1) : 
-                              Color.red.opacity(colorScheme == .dark ? 0.2 : 0.1))
-                )
+            HStack(spacing: 8) {
+                Image(systemName: isVerified ? "checkmark.shield.fill" : "exclamationmark.triangle.fill")
+                    .foregroundColor(isVerified ? .green : .red)
+                Text(isVerified ? "Source and runtime measurements match" : "Measurement mismatch detected")
+                    .foregroundColor(isVerified ? .green : .red)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                Spacer()
+            }
+            .font(.subheadline)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isVerified ? 
+                          Color.green.opacity(colorScheme == .dark ? 0.2 : 0.1) : 
+                          Color.red.opacity(colorScheme == .dark ? 0.2 : 0.1))
+            )
             
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .center, spacing: 8) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Polishes chat and verifier UI and fixes model state on sign out. Hides the assistant copy button while streaming for a cleaner experience.

- **Bug Fixes**
  - Reset current model to a free default on sign out and start a new chat with it.
  - Show the assistant copy button only after the final message is rendered.
  - Rename animated header to “Private Chat”.
  - Refine measurement diff banner layout for better spacing, full-width background, and readable text.

<!-- End of auto-generated description by cubic. -->

