### PR TITLE
Refactor cloud sync and key set up to avoid split brain

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -151,6 +151,7 @@ enum Constants {
         static let kekByteCount = 32
         static let prfCacheKeychainAccount = "sh.tinfoil.passkey-prf-cache"
         static let syncCheckIntervalSeconds: TimeInterval = 30
+        static let credentialSaveMaxAttempts = 3
     }
 
     // MARK: - Centralized UserDefaults Storage Keys
@@ -220,6 +221,7 @@ enum Constants {
             static let encryptionKeySetUp = "tinfoil-secret-encryption-key-set-up"
             static let passkeyBackedUp = "tinfoil-secret-passkey-backed-up"
             static let passkeySyncVersion = "tinfoil-secret-passkey-sync-version"
+            static let passkeyBundleVersion = "tinfoil-secret-passkey-bundle-version"
 
             static func cloudKeyAuthorization(userId: String) -> String {
                 "tinfoil-secret-cloud-key-authorization-\(userId)"

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -95,6 +95,7 @@ enum Constants {
         static let backgroundTaskName = "CompleteStreamingResponse"
         static let maxReverseTimestamp: Int = 9999999999999
         static let reverseTimestampDigits: Int = String(maxReverseTimestamp).count
+        static let keyValidationProbeCount: Int = 3
 
         static let createdAtFallbackThresholdSeconds: TimeInterval = 5.0
         static let uploadBaseDelaySeconds: TimeInterval = 1.0
@@ -219,6 +220,10 @@ enum Constants {
             static let encryptionKeySetUp = "tinfoil-secret-encryption-key-set-up"
             static let passkeyBackedUp = "tinfoil-secret-passkey-backed-up"
             static let passkeySyncVersion = "tinfoil-secret-passkey-sync-version"
+
+            static func cloudKeyAuthorization(userId: String) -> String {
+                "tinfoil-secret-cloud-key-authorization-\(userId)"
+            }
         }
     }
 

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -109,6 +109,21 @@ struct ContentView: View {
                 },
                 onSkip: {
                     passkeyManager.showPasskeyRecoveryChoice = false
+                },
+                onManualKeyEntry: {
+                    passkeyManager.showPasskeyRecoveryChoice = false
+                    chatViewModel.showCloudSyncOnboarding = true
+                }
+            )
+        }
+        .sheet(isPresented: $chatViewModel.showCloudSyncOnboarding) {
+            CloudSyncOnboardingView(
+                onSetupComplete: { _ in
+                    chatViewModel.showCloudSyncOnboarding = false
+                    chatViewModel.resumeAfterManualKeySetup()
+                },
+                onDismissWithoutSetup: {
+                    chatViewModel.showCloudSyncOnboarding = false
                 }
             )
         }

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -63,30 +63,14 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showKeyInputModal) {
             EncryptionKeyInputView(isPresented: $showKeyInputModal) { importedKey in
-                Task {
-                    do {
-                        // Use ChatViewModel API so it retries decryption of failed chats immediately
-                        try await chatViewModel.setEncryptionKey(importedKey)
-                        
-                        // After setting key and decrypting, continue sign-in/sync flow
-                        await MainActor.run {
-                            chatViewModel.handleSignIn()
-                        }
-                    } catch {
-                        await MainActor.run {
-                            let alert = UIAlertController(
-                                title: "Invalid Key",
-                                message: "The encryption key format is invalid.",
-                                preferredStyle: .alert
-                            )
-                            alert.addAction(UIAlertAction(title: "OK", style: .default))
-                            
-                            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                               let rootViewController = windowScene.windows.first?.rootViewController {
-                                rootViewController.present(alert, animated: true)
-                            }
-                        }
+                do {
+                    try await chatViewModel.setEncryptionKey(importedKey, mode: .recoverExisting)
+                    await MainActor.run {
+                        chatViewModel.handleSignIn()
                     }
+                    return nil
+                } catch {
+                    return error.localizedDescription
                 }
             }
         }
@@ -112,15 +96,25 @@ struct ContentView: View {
                 },
                 onManualKeyEntry: {
                     passkeyManager.showPasskeyRecoveryChoice = false
+                    chatViewModel.cloudSyncOnboardingMode = .recovery
                     chatViewModel.showCloudSyncOnboarding = true
                 }
             )
         }
         .sheet(isPresented: $chatViewModel.showCloudSyncOnboarding) {
             CloudSyncOnboardingView(
-                onSetupComplete: { _ in
-                    chatViewModel.showCloudSyncOnboarding = false
-                    chatViewModel.resumeAfterManualKeySetup()
+                mode: chatViewModel.cloudSyncOnboardingMode,
+                onSetupComplete: { key, activationMode in
+                    do {
+                        try await chatViewModel.setEncryptionKey(key, mode: activationMode)
+                        await MainActor.run {
+                            chatViewModel.showCloudSyncOnboarding = false
+                        }
+                        chatViewModel.resumeAfterManualKeySetup()
+                        return nil
+                    } catch {
+                        return error.localizedDescription
+                    }
                 },
                 onDismissWithoutSetup: {
                     chatViewModel.showCloudSyncOnboarding = false

--- a/TinfoilChat/Models/CloudKeyRecoveryModes.swift
+++ b/TinfoilChat/Models/CloudKeyRecoveryModes.swift
@@ -1,0 +1,10 @@
+enum CloudSyncOnboardingMode {
+    case setup
+    case recovery
+}
+
+enum CloudKeyActivationMode {
+    case recoverExisting
+    case explicitStartFresh
+    case addRecoveryKey
+}

--- a/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
+++ b/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
@@ -11,15 +11,15 @@ enum CloudKeyAuthorizationMode: String, Codable {
 
 enum CloudKeyAuthorizationError: LocalizedError {
     case validationFailed(String)
-    case rollbackFailed
+    case rollbackFailed(underlying: Error)
     case authorizationUnavailable
 
     var errorDescription: String? {
         switch self {
         case .validationFailed(let message):
             return message
-        case .rollbackFailed:
-            return "Failed to restore the previous encryption key."
+        case .rollbackFailed(let underlying):
+            return "Failed to restore the previous encryption key: \(underlying.localizedDescription)"
         case .authorizationUnavailable:
             return "Failed to authorize the current encryption key."
         }
@@ -116,7 +116,17 @@ final class CloudKeyAuthorizationStore {
         failureMode: CloudKeyAuthorizationMode?
     ) async throws -> CloudKeyAuthorizationMode {
         let previousKeys = EncryptionService.shared.getAllKeys()
-        try await setKeys()
+        do {
+            try await setKeys()
+        } catch let setKeysError {
+            do {
+                try rollbackToPreviousKeys(previousKeys)
+            } catch let rollbackError {
+                throw rollbackError
+            }
+            throw setKeysError
+        }
+
         return try await authorizeCurrentPrimaryKeyAfterValidation(
             rollbackTo: previousKeys,
             successMode: successMode,
@@ -180,10 +190,10 @@ final class CloudKeyAuthorizationStore {
                 primary: previousKeys.primary,
                 alternatives: previousKeys.alternatives
             )
-        } catch {
+        } catch let rollbackError {
             EncryptionService.shared.clearKey()
             clearAuthorization()
-            throw CloudKeyAuthorizationError.rollbackFailed
+            throw CloudKeyAuthorizationError.rollbackFailed(underlying: rollbackError)
         }
     }
 }

--- a/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
+++ b/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
@@ -1,0 +1,84 @@
+import ClerkKit
+import CryptoKit
+import Foundation
+
+enum CloudKeyAuthorizationMode: String, Codable {
+    case validated
+    case explicitStartFresh
+}
+
+private struct CloudKeyAuthorizationRecord: Codable {
+    let fingerprint: String
+    let mode: CloudKeyAuthorizationMode
+}
+
+@MainActor
+final class CloudKeyAuthorizationStore {
+    static let shared = CloudKeyAuthorizationStore()
+
+    private init() {}
+
+    func currentMode(userId: String? = nil) -> CloudKeyAuthorizationMode? {
+        guard let resolvedUserId = resolveUserId(userId),
+              let record = loadRecord(userId: resolvedUserId),
+              let currentFingerprint = currentPrimaryKeyFingerprint(),
+              record.fingerprint == currentFingerprint else {
+            return nil
+        }
+
+        return record.mode
+    }
+
+    func hasAuthorizedCurrentPrimaryKey(userId: String? = nil) -> Bool {
+        currentMode(userId: userId) != nil
+    }
+
+    func authorizeCurrentPrimaryKey(
+        mode: CloudKeyAuthorizationMode,
+        userId: String? = nil
+    ) {
+        guard let resolvedUserId = resolveUserId(userId),
+              let currentFingerprint = currentPrimaryKeyFingerprint() else {
+            return
+        }
+
+        let record = CloudKeyAuthorizationRecord(
+            fingerprint: currentFingerprint,
+            mode: mode
+        )
+
+        do {
+            let data = try JSONEncoder().encode(record)
+            UserDefaults.standard.set(data, forKey: storageKey(userId: resolvedUserId))
+        } catch {
+            UserDefaults.standard.removeObject(forKey: storageKey(userId: resolvedUserId))
+        }
+    }
+
+    func clearAuthorization(userId: String? = nil) {
+        guard let resolvedUserId = resolveUserId(userId) else { return }
+        UserDefaults.standard.removeObject(forKey: storageKey(userId: resolvedUserId))
+    }
+
+    private func resolveUserId(_ userId: String?) -> String? {
+        userId ?? Clerk.shared.user?.id
+    }
+
+    private func storageKey(userId: String) -> String {
+        Constants.StorageKeys.Secret.cloudKeyAuthorization(userId: userId)
+    }
+
+    private func loadRecord(userId: String) -> CloudKeyAuthorizationRecord? {
+        guard let data = UserDefaults.standard.data(forKey: storageKey(userId: userId)) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(CloudKeyAuthorizationRecord.self, from: data)
+    }
+
+    private func currentPrimaryKeyFingerprint() -> String? {
+        guard let key = EncryptionService.shared.getKey() else { return nil }
+        let digest = SHA256.hash(data: Data(key.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
+++ b/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
@@ -12,6 +12,7 @@ enum CloudKeyAuthorizationMode: String, Codable {
 enum CloudKeyAuthorizationError: LocalizedError {
     case validationFailed(String)
     case rollbackFailed
+    case authorizationUnavailable
 
     var errorDescription: String? {
         switch self {
@@ -19,6 +20,8 @@ enum CloudKeyAuthorizationError: LocalizedError {
             return message
         case .rollbackFailed:
             return "Failed to restore the previous encryption key."
+        case .authorizationUnavailable:
+            return "Failed to authorize the current encryption key."
         }
     }
 }
@@ -52,10 +55,10 @@ final class CloudKeyAuthorizationStore {
     func authorizeCurrentPrimaryKey(
         mode: CloudKeyAuthorizationMode,
         userId: String? = nil
-    ) {
+    ) -> Bool {
         guard let resolvedUserId = resolveUserId(userId),
               let currentFingerprint = currentPrimaryKeyFingerprint() else {
-            return
+            return false
         }
 
         let record = CloudKeyAuthorizationRecord(
@@ -66,8 +69,10 @@ final class CloudKeyAuthorizationStore {
         do {
             let data = try JSONEncoder().encode(record)
             UserDefaults.standard.set(data, forKey: storageKey(userId: resolvedUserId))
+            return true
         } catch {
             UserDefaults.standard.removeObject(forKey: storageKey(userId: resolvedUserId))
+            return false
         }
     }
 
@@ -113,7 +118,10 @@ final class CloudKeyAuthorizationStore {
         let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
         guard validation.canWrite else {
             if let failureMode {
-                authorizeCurrentPrimaryKey(mode: failureMode)
+                guard authorizeCurrentPrimaryKey(mode: failureMode) else {
+                    try await rollbackToPreviousKeys(previousKeys)
+                    throw CloudKeyAuthorizationError.authorizationUnavailable
+                }
                 return failureMode
             }
 
@@ -123,7 +131,10 @@ final class CloudKeyAuthorizationStore {
             )
         }
 
-        authorizeCurrentPrimaryKey(mode: successMode)
+        guard authorizeCurrentPrimaryKey(mode: successMode) else {
+            try await rollbackToPreviousKeys(previousKeys)
+            throw CloudKeyAuthorizationError.authorizationUnavailable
+        }
         return successMode
     }
 

--- a/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
+++ b/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
@@ -87,10 +87,10 @@ final class CloudKeyAuthorizationStore {
         successMode: CloudKeyAuthorizationMode = .validated,
         failureMode: CloudKeyAuthorizationMode? = nil
     ) async throws -> CloudKeyAuthorizationMode {
-        let previousKeys = EncryptionService.shared.getAllKeys()
-        try await EncryptionService.shared.setAllKeys(primary: primary, alternatives: alternatives)
-        return try await authorizeCurrentPrimaryKeyAfterValidation(
-            rollbackTo: previousKeys,
+        return try await applyAndValidate(
+            setKeys: {
+                try await EncryptionService.shared.setAllKeys(primary: primary, alternatives: alternatives)
+            },
             successMode: successMode,
             failureMode: failureMode
         )
@@ -101,8 +101,22 @@ final class CloudKeyAuthorizationStore {
         successMode: CloudKeyAuthorizationMode = .validated,
         failureMode: CloudKeyAuthorizationMode? = nil
     ) async throws -> CloudKeyAuthorizationMode {
+        return try await applyAndValidate(
+            setKeys: {
+                try await EncryptionService.shared.setKey(key)
+            },
+            successMode: successMode,
+            failureMode: failureMode
+        )
+    }
+
+    private func applyAndValidate(
+        setKeys: () async throws -> Void,
+        successMode: CloudKeyAuthorizationMode,
+        failureMode: CloudKeyAuthorizationMode?
+    ) async throws -> CloudKeyAuthorizationMode {
         let previousKeys = EncryptionService.shared.getAllKeys()
-        try await EncryptionService.shared.setKey(key)
+        try await setKeys()
         return try await authorizeCurrentPrimaryKeyAfterValidation(
             rollbackTo: previousKeys,
             successMode: successMode,
@@ -119,20 +133,20 @@ final class CloudKeyAuthorizationStore {
         guard validation.canWrite else {
             if let failureMode {
                 guard authorizeCurrentPrimaryKey(mode: failureMode) else {
-                    try await rollbackToPreviousKeys(previousKeys)
+                    try rollbackToPreviousKeys(previousKeys)
                     throw CloudKeyAuthorizationError.authorizationUnavailable
                 }
                 return failureMode
             }
 
-            try await rollbackToPreviousKeys(previousKeys)
+            try rollbackToPreviousKeys(previousKeys)
             throw CloudKeyAuthorizationError.validationFailed(
                 validation.message ?? CloudKeyPreflightValidator.mismatchMessage
             )
         }
 
         guard authorizeCurrentPrimaryKey(mode: successMode) else {
-            try await rollbackToPreviousKeys(previousKeys)
+            try rollbackToPreviousKeys(previousKeys)
             throw CloudKeyAuthorizationError.authorizationUnavailable
         }
         return successMode
@@ -160,9 +174,9 @@ final class CloudKeyAuthorizationStore {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
-    private func rollbackToPreviousKeys(_ previousKeys: CloudKeySnapshot) async throws {
+    private func rollbackToPreviousKeys(_ previousKeys: CloudKeySnapshot) throws {
         do {
-            try await EncryptionService.shared.replaceKeyBundle(
+            try EncryptionService.shared.replaceKeyBundle(
                 primary: previousKeys.primary,
                 alternatives: previousKeys.alternatives
             )

--- a/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
+++ b/TinfoilChat/Services/CloudKeyAuthorizationStore.swift
@@ -2,9 +2,25 @@ import ClerkKit
 import CryptoKit
 import Foundation
 
+typealias CloudKeySnapshot = (primary: String?, alternatives: [String])
+
 enum CloudKeyAuthorizationMode: String, Codable {
     case validated
     case explicitStartFresh
+}
+
+enum CloudKeyAuthorizationError: LocalizedError {
+    case validationFailed(String)
+    case rollbackFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .validationFailed(let message):
+            return message
+        case .rollbackFailed:
+            return "Failed to restore the previous encryption key."
+        }
+    }
 }
 
 private struct CloudKeyAuthorizationRecord: Codable {
@@ -60,6 +76,57 @@ final class CloudKeyAuthorizationStore {
         UserDefaults.standard.removeObject(forKey: storageKey(userId: resolvedUserId))
     }
 
+    func applyKeyBundleWithValidation(
+        primary: String,
+        alternatives: [String],
+        successMode: CloudKeyAuthorizationMode = .validated,
+        failureMode: CloudKeyAuthorizationMode? = nil
+    ) async throws -> CloudKeyAuthorizationMode {
+        let previousKeys = EncryptionService.shared.getAllKeys()
+        try await EncryptionService.shared.setAllKeys(primary: primary, alternatives: alternatives)
+        return try await authorizeCurrentPrimaryKeyAfterValidation(
+            rollbackTo: previousKeys,
+            successMode: successMode,
+            failureMode: failureMode
+        )
+    }
+
+    func applyPrimaryKeyWithValidation(
+        _ key: String,
+        successMode: CloudKeyAuthorizationMode = .validated,
+        failureMode: CloudKeyAuthorizationMode? = nil
+    ) async throws -> CloudKeyAuthorizationMode {
+        let previousKeys = EncryptionService.shared.getAllKeys()
+        try await EncryptionService.shared.setKey(key)
+        return try await authorizeCurrentPrimaryKeyAfterValidation(
+            rollbackTo: previousKeys,
+            successMode: successMode,
+            failureMode: failureMode
+        )
+    }
+
+    func authorizeCurrentPrimaryKeyAfterValidation(
+        rollbackTo previousKeys: CloudKeySnapshot,
+        successMode: CloudKeyAuthorizationMode = .validated,
+        failureMode: CloudKeyAuthorizationMode? = nil
+    ) async throws -> CloudKeyAuthorizationMode {
+        let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+        guard validation.canWrite else {
+            if let failureMode {
+                authorizeCurrentPrimaryKey(mode: failureMode)
+                return failureMode
+            }
+
+            try await rollbackToPreviousKeys(previousKeys)
+            throw CloudKeyAuthorizationError.validationFailed(
+                validation.message ?? CloudKeyPreflightValidator.mismatchMessage
+            )
+        }
+
+        authorizeCurrentPrimaryKey(mode: successMode)
+        return successMode
+    }
+
     private func resolveUserId(_ userId: String?) -> String? {
         userId ?? Clerk.shared.user?.id
     }
@@ -80,5 +147,18 @@ final class CloudKeyAuthorizationStore {
         guard let key = EncryptionService.shared.getKey() else { return nil }
         let digest = SHA256.hash(data: Data(key.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func rollbackToPreviousKeys(_ previousKeys: CloudKeySnapshot) async throws {
+        do {
+            try await EncryptionService.shared.replaceKeyBundle(
+                primary: previousKeys.primary,
+                alternatives: previousKeys.alternatives
+            )
+        } catch {
+            EncryptionService.shared.clearKey()
+            clearAuthorization()
+            throw CloudKeyAuthorizationError.rollbackFailed
+        }
     }
 }

--- a/TinfoilChat/Services/CloudKeyPreflightValidator.swift
+++ b/TinfoilChat/Services/CloudKeyPreflightValidator.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+enum CloudRemoteState {
+    case empty
+    case exists
+    case unknown
+}
+
+enum CloudKeyValidationProbe {
+    case none
+    case profile
+    case chat
+}
+
+struct CloudKeyValidationResult {
+    let remoteState: CloudRemoteState
+    let canWrite: Bool
+    let probe: CloudKeyValidationProbe
+    let message: String?
+}
+
+@MainActor
+final class CloudKeyPreflightValidator {
+    static let shared = CloudKeyPreflightValidator()
+
+    private let profileSync = ProfileSyncService.shared
+    private let cloudStorage = CloudStorageService.shared
+    private let encryptionService = EncryptionService.shared
+
+    private init() {}
+
+    func inspectRemoteState() async -> CloudRemoteState {
+        guard let profileStatus = await profileSync.getSyncStatus() else {
+            return .unknown
+        }
+
+        if profileStatus.exists {
+            return .exists
+        }
+
+        do {
+            let chatStatus = try await cloudStorage.getChatSyncStatus()
+            return chatStatus.count > 0 ? .exists : .empty
+        } catch {
+            return .unknown
+        }
+    }
+
+    func validateCurrentPrimaryKey() async -> CloudKeyValidationResult {
+        guard encryptionService.getKey() != nil else {
+            return CloudKeyValidationResult(
+                remoteState: .unknown,
+                canWrite: false,
+                probe: .none,
+                message: "No encryption key is currently loaded."
+            )
+        }
+
+        guard let profileStatus = await profileSync.getSyncStatus() else {
+            return CloudKeyValidationResult(
+                remoteState: .unknown,
+                canWrite: false,
+                probe: .none,
+                message: "We couldn't verify whether encrypted cloud data already exists."
+            )
+        }
+
+        if profileStatus.exists {
+            return await validateProfileProbe()
+        }
+
+        do {
+            let chatStatus = try await cloudStorage.getChatSyncStatus()
+            if chatStatus.count > 0 {
+                return await validateChatProbe()
+            }
+        } catch {
+            return CloudKeyValidationResult(
+                remoteState: .unknown,
+                canWrite: false,
+                probe: .none,
+                message: "We couldn't verify whether encrypted cloud data already exists."
+            )
+        }
+
+        return CloudKeyValidationResult(
+            remoteState: .empty,
+            canWrite: true,
+            probe: .none,
+            message: nil
+        )
+    }
+
+    private func validateProfileProbe() async -> CloudKeyValidationResult {
+        let payload: String
+        do {
+            guard let fetchedPayload = try await profileSync.fetchEncryptedProfilePayload() else {
+                return CloudKeyValidationResult(
+                    remoteState: .unknown,
+                    canWrite: false,
+                    probe: .profile,
+                    message: "We couldn't verify your existing cloud profile."
+                )
+            }
+            payload = fetchedPayload
+        } catch {
+            return CloudKeyValidationResult(
+                remoteState: .unknown,
+                canWrite: false,
+                probe: .profile,
+                message: "We couldn't verify your existing cloud profile."
+            )
+        }
+
+        do {
+            guard let data = payload.data(using: .utf8) else {
+                return CloudKeyValidationResult(
+                    remoteState: .exists,
+                    canWrite: false,
+                    probe: .profile,
+                    message: "This key doesn't match your existing cloud data."
+                )
+            }
+
+            let encrypted = try JSONDecoder().decode(EncryptedData.self, from: data)
+            let result = try await encryptionService.decrypt(encrypted, as: ProfileData.self)
+
+            guard !result.usedFallbackKey else {
+                return CloudKeyValidationResult(
+                    remoteState: .exists,
+                    canWrite: false,
+                    probe: .profile,
+                    message: "This key doesn't match your existing cloud data."
+                )
+            }
+
+            return CloudKeyValidationResult(
+                remoteState: .exists,
+                canWrite: true,
+                probe: .profile,
+                message: nil
+            )
+        } catch {
+            return CloudKeyValidationResult(
+                remoteState: .exists,
+                canWrite: false,
+                probe: .profile,
+                message: "This key doesn't match your existing cloud data."
+            )
+        }
+    }
+
+    private func validateChatProbe() async -> CloudKeyValidationResult {
+        do {
+            let response = try await cloudStorage.listChats(
+                limit: Constants.Sync.keyValidationProbeCount,
+                includeContent: true
+            )
+
+            guard !response.conversations.isEmpty else {
+                return CloudKeyValidationResult(
+                    remoteState: .unknown,
+                    canWrite: false,
+                    probe: .chat,
+                    message: "We couldn't verify your existing cloud chats."
+                )
+            }
+
+            var sawMismatch = false
+
+            for conversation in response.conversations.prefix(Constants.Sync.keyValidationProbeCount) {
+                guard let content = conversation.content else { continue }
+
+                if conversation.formatVersion == 1 {
+                    guard let binary = Data(base64Encoded: content) else {
+                        sawMismatch = true
+                        continue
+                    }
+
+                    do {
+                        let result: DecryptionResult<Chat> = try encryptionService.decryptV1(binary, as: Chat.self)
+                        if !result.usedFallbackKey {
+                            return CloudKeyValidationResult(
+                                remoteState: .exists,
+                                canWrite: true,
+                                probe: .chat,
+                                message: nil
+                            )
+                        }
+                        sawMismatch = true
+                    } catch {
+                        sawMismatch = true
+                    }
+
+                    continue
+                }
+
+                do {
+                    let encryptedData = try JSONDecoder().decode(
+                        EncryptedData.self,
+                        from: Data(content.utf8)
+                    )
+                    let result = try await encryptionService.decrypt(encryptedData, as: Chat.self)
+                    if !result.usedFallbackKey {
+                        return CloudKeyValidationResult(
+                            remoteState: .exists,
+                            canWrite: true,
+                            probe: .chat,
+                            message: nil
+                        )
+                    }
+                    sawMismatch = true
+                } catch {
+                    sawMismatch = true
+                }
+            }
+
+            return CloudKeyValidationResult(
+                remoteState: sawMismatch ? .exists : .unknown,
+                canWrite: false,
+                probe: .chat,
+                message: sawMismatch
+                    ? "This key doesn't match your existing cloud data."
+                    : "We couldn't verify your existing cloud chats."
+            )
+        } catch {
+            return CloudKeyValidationResult(
+                remoteState: .unknown,
+                canWrite: false,
+                probe: .chat,
+                message: "We couldn't verify your existing cloud chats."
+            )
+        }
+    }
+}

--- a/TinfoilChat/Services/CloudKeyPreflightValidator.swift
+++ b/TinfoilChat/Services/CloudKeyPreflightValidator.swift
@@ -14,16 +14,9 @@ enum CloudRemoteState {
     case unknown
 }
 
-enum CloudKeyValidationProbe {
-    case none
-    case profile
-    case chat
-}
-
 struct CloudKeyValidationResult {
     let remoteState: CloudRemoteState
     let canWrite: Bool
-    let probe: CloudKeyValidationProbe
     let message: String?
 }
 
@@ -57,11 +50,11 @@ final class CloudKeyPreflightValidator {
 
     func validateCurrentPrimaryKey() async -> CloudKeyValidationResult {
         guard encryptionService.getKey() != nil else {
-            return unknownResult(probe: .none, message: CloudKeyValidationMessages.noEncryptionKey)
+            return unknownResult(message: CloudKeyValidationMessages.noEncryptionKey)
         }
 
         guard let profileStatus = await profileSync.getSyncStatus() else {
-            return unknownResult(probe: .none, message: CloudKeyValidationMessages.unknownRemoteState)
+            return unknownResult(message: CloudKeyValidationMessages.unknownRemoteState)
         }
 
         if profileStatus.exists {
@@ -74,28 +67,27 @@ final class CloudKeyPreflightValidator {
                 return await validateChatProbe()
             }
         } catch {
-            return unknownResult(probe: .none, message: CloudKeyValidationMessages.unknownRemoteState)
+            return unknownResult(message: CloudKeyValidationMessages.unknownRemoteState)
         }
 
         return CloudKeyValidationResult(
             remoteState: .empty,
             canWrite: true,
-            probe: .none,
             message: nil
         )
     }
 
     private func validateProfileProbe() async -> CloudKeyValidationResult {
-        let mismatchResult = blockedResult(probe: .profile)
+        let mismatchResult = blockedResult()
 
         let payload: String
         do {
             guard let fetchedPayload = try await profileSync.fetchEncryptedProfilePayload() else {
-                return unknownResult(probe: .profile, message: CloudKeyValidationMessages.unknownProfile)
+                return unknownResult(message: CloudKeyValidationMessages.unknownProfile)
             }
             payload = fetchedPayload
         } catch {
-            return unknownResult(probe: .profile, message: CloudKeyValidationMessages.unknownProfile)
+            return unknownResult(message: CloudKeyValidationMessages.unknownProfile)
         }
 
         do {
@@ -110,7 +102,7 @@ final class CloudKeyPreflightValidator {
                 return mismatchResult
             }
 
-            return validResult(probe: .profile)
+            return validResult()
         } catch {
             return mismatchResult
         }
@@ -124,7 +116,7 @@ final class CloudKeyPreflightValidator {
             )
 
             guard !response.conversations.isEmpty else {
-                return unknownResult(probe: .chat, message: CloudKeyValidationMessages.unknownChats)
+                return unknownResult(message: CloudKeyValidationMessages.unknownChats)
             }
 
             var sawMismatch = false
@@ -139,9 +131,12 @@ final class CloudKeyPreflightValidator {
                     }
 
                     do {
-                        let result: DecryptionResult<Chat> = try encryptionService.decryptV1(binary, as: Chat.self)
+                        let result: DecryptionResult<StoredChat> = try encryptionService.decryptV1(
+                            binary,
+                            as: StoredChat.self
+                        )
                         if !result.usedFallbackKey {
-                            return validResult(probe: .chat)
+                            return validResult()
                         }
                         sawMismatch = true
                     } catch {
@@ -156,9 +151,9 @@ final class CloudKeyPreflightValidator {
                         EncryptedData.self,
                         from: Data(content.utf8)
                     )
-                    let result = try await encryptionService.decrypt(encryptedData, as: Chat.self)
+                    let result = try await encryptionService.decrypt(encryptedData, as: StoredChat.self)
                     if !result.usedFallbackKey {
-                        return validResult(probe: .chat)
+                        return validResult()
                     }
                     sawMismatch = true
                 } catch {
@@ -169,42 +164,35 @@ final class CloudKeyPreflightValidator {
             return CloudKeyValidationResult(
                 remoteState: sawMismatch ? .exists : .unknown,
                 canWrite: false,
-                probe: .chat,
                 message: sawMismatch
                     ? CloudKeyValidationMessages.keyMismatch
                     : CloudKeyValidationMessages.unknownChats
             )
         } catch {
-            return unknownResult(probe: .chat, message: CloudKeyValidationMessages.unknownChats)
+            return unknownResult(message: CloudKeyValidationMessages.unknownChats)
         }
     }
 
-    private func unknownResult(
-        probe: CloudKeyValidationProbe,
-        message: String
-    ) -> CloudKeyValidationResult {
+    private func unknownResult(message: String) -> CloudKeyValidationResult {
         CloudKeyValidationResult(
             remoteState: .unknown,
             canWrite: false,
-            probe: probe,
             message: message
         )
     }
 
-    private func validResult(probe: CloudKeyValidationProbe) -> CloudKeyValidationResult {
+    private func validResult() -> CloudKeyValidationResult {
         CloudKeyValidationResult(
             remoteState: .exists,
             canWrite: true,
-            probe: probe,
             message: nil
         )
     }
 
-    private func blockedResult(probe: CloudKeyValidationProbe) -> CloudKeyValidationResult {
+    private func blockedResult() -> CloudKeyValidationResult {
         CloudKeyValidationResult(
             remoteState: .exists,
             canWrite: false,
-            probe: probe,
             message: CloudKeyValidationMessages.keyMismatch
         )
     }

--- a/TinfoilChat/Services/CloudKeyPreflightValidator.swift
+++ b/TinfoilChat/Services/CloudKeyPreflightValidator.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+private enum CloudKeyValidationMessages {
+    static let noEncryptionKey = "No encryption key is currently loaded."
+    static let unknownRemoteState = "We couldn't verify whether encrypted cloud data already exists."
+    static let unknownProfile = "We couldn't verify your existing cloud profile."
+    static let unknownChats = "We couldn't verify your existing cloud chats."
+    static let keyMismatch = "This key doesn't match your existing cloud data."
+}
+
 enum CloudRemoteState {
     case empty
     case exists
@@ -22,6 +30,7 @@ struct CloudKeyValidationResult {
 @MainActor
 final class CloudKeyPreflightValidator {
     static let shared = CloudKeyPreflightValidator()
+    static let mismatchMessage = CloudKeyValidationMessages.keyMismatch
 
     private let profileSync = ProfileSyncService.shared
     private let cloudStorage = CloudStorageService.shared
@@ -48,21 +57,11 @@ final class CloudKeyPreflightValidator {
 
     func validateCurrentPrimaryKey() async -> CloudKeyValidationResult {
         guard encryptionService.getKey() != nil else {
-            return CloudKeyValidationResult(
-                remoteState: .unknown,
-                canWrite: false,
-                probe: .none,
-                message: "No encryption key is currently loaded."
-            )
+            return unknownResult(probe: .none, message: CloudKeyValidationMessages.noEncryptionKey)
         }
 
         guard let profileStatus = await profileSync.getSyncStatus() else {
-            return CloudKeyValidationResult(
-                remoteState: .unknown,
-                canWrite: false,
-                probe: .none,
-                message: "We couldn't verify whether encrypted cloud data already exists."
-            )
+            return unknownResult(probe: .none, message: CloudKeyValidationMessages.unknownRemoteState)
         }
 
         if profileStatus.exists {
@@ -75,12 +74,7 @@ final class CloudKeyPreflightValidator {
                 return await validateChatProbe()
             }
         } catch {
-            return CloudKeyValidationResult(
-                remoteState: .unknown,
-                canWrite: false,
-                probe: .none,
-                message: "We couldn't verify whether encrypted cloud data already exists."
-            )
+            return unknownResult(probe: .none, message: CloudKeyValidationMessages.unknownRemoteState)
         }
 
         return CloudKeyValidationResult(
@@ -92,61 +86,33 @@ final class CloudKeyPreflightValidator {
     }
 
     private func validateProfileProbe() async -> CloudKeyValidationResult {
+        let mismatchResult = blockedResult(probe: .profile)
+
         let payload: String
         do {
             guard let fetchedPayload = try await profileSync.fetchEncryptedProfilePayload() else {
-                return CloudKeyValidationResult(
-                    remoteState: .unknown,
-                    canWrite: false,
-                    probe: .profile,
-                    message: "We couldn't verify your existing cloud profile."
-                )
+                return unknownResult(probe: .profile, message: CloudKeyValidationMessages.unknownProfile)
             }
             payload = fetchedPayload
         } catch {
-            return CloudKeyValidationResult(
-                remoteState: .unknown,
-                canWrite: false,
-                probe: .profile,
-                message: "We couldn't verify your existing cloud profile."
-            )
+            return unknownResult(probe: .profile, message: CloudKeyValidationMessages.unknownProfile)
         }
 
         do {
             guard let data = payload.data(using: .utf8) else {
-                return CloudKeyValidationResult(
-                    remoteState: .exists,
-                    canWrite: false,
-                    probe: .profile,
-                    message: "This key doesn't match your existing cloud data."
-                )
+                return mismatchResult
             }
 
             let encrypted = try JSONDecoder().decode(EncryptedData.self, from: data)
             let result = try await encryptionService.decrypt(encrypted, as: ProfileData.self)
 
             guard !result.usedFallbackKey else {
-                return CloudKeyValidationResult(
-                    remoteState: .exists,
-                    canWrite: false,
-                    probe: .profile,
-                    message: "This key doesn't match your existing cloud data."
-                )
+                return mismatchResult
             }
 
-            return CloudKeyValidationResult(
-                remoteState: .exists,
-                canWrite: true,
-                probe: .profile,
-                message: nil
-            )
+            return validResult(probe: .profile)
         } catch {
-            return CloudKeyValidationResult(
-                remoteState: .exists,
-                canWrite: false,
-                probe: .profile,
-                message: "This key doesn't match your existing cloud data."
-            )
+            return mismatchResult
         }
     }
 
@@ -158,12 +124,7 @@ final class CloudKeyPreflightValidator {
             )
 
             guard !response.conversations.isEmpty else {
-                return CloudKeyValidationResult(
-                    remoteState: .unknown,
-                    canWrite: false,
-                    probe: .chat,
-                    message: "We couldn't verify your existing cloud chats."
-                )
+                return unknownResult(probe: .chat, message: CloudKeyValidationMessages.unknownChats)
             }
 
             var sawMismatch = false
@@ -180,12 +141,7 @@ final class CloudKeyPreflightValidator {
                     do {
                         let result: DecryptionResult<Chat> = try encryptionService.decryptV1(binary, as: Chat.self)
                         if !result.usedFallbackKey {
-                            return CloudKeyValidationResult(
-                                remoteState: .exists,
-                                canWrite: true,
-                                probe: .chat,
-                                message: nil
-                            )
+                            return validResult(probe: .chat)
                         }
                         sawMismatch = true
                     } catch {
@@ -202,12 +158,7 @@ final class CloudKeyPreflightValidator {
                     )
                     let result = try await encryptionService.decrypt(encryptedData, as: Chat.self)
                     if !result.usedFallbackKey {
-                        return CloudKeyValidationResult(
-                            remoteState: .exists,
-                            canWrite: true,
-                            probe: .chat,
-                            message: nil
-                        )
+                        return validResult(probe: .chat)
                     }
                     sawMismatch = true
                 } catch {
@@ -220,16 +171,41 @@ final class CloudKeyPreflightValidator {
                 canWrite: false,
                 probe: .chat,
                 message: sawMismatch
-                    ? "This key doesn't match your existing cloud data."
-                    : "We couldn't verify your existing cloud chats."
+                    ? CloudKeyValidationMessages.keyMismatch
+                    : CloudKeyValidationMessages.unknownChats
             )
         } catch {
-            return CloudKeyValidationResult(
-                remoteState: .unknown,
-                canWrite: false,
-                probe: .chat,
-                message: "We couldn't verify your existing cloud chats."
-            )
+            return unknownResult(probe: .chat, message: CloudKeyValidationMessages.unknownChats)
         }
+    }
+
+    private func unknownResult(
+        probe: CloudKeyValidationProbe,
+        message: String
+    ) -> CloudKeyValidationResult {
+        CloudKeyValidationResult(
+            remoteState: .unknown,
+            canWrite: false,
+            probe: probe,
+            message: message
+        )
+    }
+
+    private func validResult(probe: CloudKeyValidationProbe) -> CloudKeyValidationResult {
+        CloudKeyValidationResult(
+            remoteState: .exists,
+            canWrite: true,
+            probe: probe,
+            message: nil
+        )
+    }
+
+    private func blockedResult(probe: CloudKeyValidationProbe) -> CloudKeyValidationResult {
+        CloudKeyValidationResult(
+            remoteState: .exists,
+            canWrite: false,
+            probe: probe,
+            message: CloudKeyValidationMessages.keyMismatch
+        )
     }
 }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1116,10 +1116,6 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated() else {
             return
         }
-
-        guard canWriteToCloud() else {
-            return
-        }
         
         do {
             try await cloudStorage.deleteChat(chatId)

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -153,6 +153,10 @@ class CloudSyncService: ObservableObject {
     private let allChatsSyncStatusKey = Constants.StorageKeys.Sync.allChatsStatus
 
     private init() {}
+
+    private func canWriteToCloud() -> Bool {
+        CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey()
+    }
     
     // MARK: - Initialization
     
@@ -207,6 +211,10 @@ class CloudSyncService: ObservableObject {
             return
         }
 
+        guard canWriteToCloud() else {
+            return
+        }
+
         await uploadCoalescer.enqueue(chatId)
 
         if ensureLatestUpload {
@@ -215,6 +223,8 @@ class CloudSyncService: ObservableObject {
     }
     
     private func doBackupChat(_ chatId: String) async throws {
+        guard canWriteToCloud() else { return }
+
         // Check if chat is currently streaming
         if streamingTracker.isStreaming(chatId) {
             // Check if we already have a callback registered for this chat
@@ -266,6 +276,10 @@ class CloudSyncService: ObservableObject {
     /// Backup all unsynced chats
     func backupUnsyncedChats() async -> SyncResult {
         var result = SyncResult()
+
+        guard canWriteToCloud() else {
+            return result
+        }
         
         let unsyncedChats = await getUnsyncedChats()
         
@@ -1102,6 +1116,10 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated() else {
             return
         }
+
+        guard canWriteToCloud() else {
+            return
+        }
         
         do {
             try await cloudStorage.deleteChat(chatId)
@@ -1333,6 +1351,10 @@ class CloudSyncService: ObservableObject {
     /// Re-encrypt all local chats with new key and upload to cloud
     func reencryptAndUploadChats() async -> (reencrypted: Int, uploaded: Int, errors: [String]) {
         var result = (reencrypted: 0, uploaded: 0, errors: [String]())
+
+        guard canWriteToCloud() else {
+            return result
+        }
         
         // Get all local chats
         let allChats = await getAllChatsFromStorage()

--- a/TinfoilChat/Services/EncryptionService.swift
+++ b/TinfoilChat/Services/EncryptionService.swift
@@ -154,7 +154,7 @@ class EncryptionService: ObservableObject, @unchecked Sendable {
     }
 
     /// Replace the full key bundle exactly, preserving only the provided primary and fallback keys.
-    func replaceKeyBundle(primary: String?, alternatives: [String]) async throws {
+    func replaceKeyBundle(primary: String?, alternatives: [String]) throws {
         if let primary {
             let (normalizedPrimary, keyData) = try normalizeKeyInput(primary)
             encryptionKey = SymmetricKey(data: keyData)

--- a/TinfoilChat/Services/EncryptionService.swift
+++ b/TinfoilChat/Services/EncryptionService.swift
@@ -112,6 +112,21 @@ class EncryptionService: ObservableObject, @unchecked Sendable {
         return (primary: loadKeyFromKeychain(), alternatives: loadKeyHistory())
     }
 
+    /// Add a decryption-only fallback key without changing the primary key.
+    func addDecryptionKey(_ keyString: String) throws {
+        let (normalizedKey, _) = try normalizeKeyInput(keyString)
+
+        if normalizedKey == loadKeyFromKeychain() {
+            return
+        }
+
+        var history = loadKeyHistory()
+        guard !history.contains(normalizedKey) else { return }
+
+        history.append(normalizedKey)
+        try saveKeyHistory(history)
+    }
+
     /// Bulk-load primary + alternative keys from an external source (e.g. passkey recovery).
     /// Sets the primary key and merges validated alternatives into key history.
     func setAllKeys(primary: String, alternatives: [String]) async throws {
@@ -136,6 +151,26 @@ class EncryptionService: ObservableObject, @unchecked Sendable {
         if addedNew {
             try saveKeyHistory(existingHistory)
         }
+    }
+
+    /// Replace the full key bundle exactly, preserving only the provided primary and fallback keys.
+    func replaceKeyBundle(primary: String?, alternatives: [String]) async throws {
+        if let primary {
+            let (normalizedPrimary, keyData) = try normalizeKeyInput(primary)
+            encryptionKey = SymmetricKey(data: keyData)
+            try saveKeyToKeychain(normalizedPrimary)
+
+            let normalizedAlternatives = alternatives.compactMap { key -> String? in
+                guard key != normalizedPrimary else { return nil }
+                return try? normalizeKeyInput(key).0
+            }
+
+            let deduplicatedAlternatives = Array(NSOrderedSet(array: normalizedAlternatives)) as? [String] ?? normalizedAlternatives
+            try saveKeyHistory(deduplicatedAlternatives)
+            return
+        }
+
+        clearKey()
     }
 
     /// Remove encryption key

--- a/TinfoilChat/Services/EncryptionService.swift
+++ b/TinfoilChat/Services/EncryptionService.swift
@@ -165,7 +165,10 @@ class EncryptionService: ObservableObject, @unchecked Sendable {
                 return try? normalizeKeyInput(key).0
             }
 
-            let deduplicatedAlternatives = Array(NSOrderedSet(array: normalizedAlternatives)) as? [String] ?? normalizedAlternatives
+            var seenAlternatives = Set<String>()
+            let deduplicatedAlternatives = normalizedAlternatives.filter {
+                seenAlternatives.insert($0).inserted
+            }
             try saveKeyHistory(deduplicatedAlternatives)
             return
         }

--- a/TinfoilChat/Services/Passkey/PasskeyKeyStorage.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyKeyStorage.swift
@@ -19,6 +19,17 @@ import Foundation
 struct KeyBundle: Codable {
     let primary: String
     let alternatives: [String]
+    let authorizationMode: CloudKeyAuthorizationMode?
+
+    init(
+        primary: String,
+        alternatives: [String],
+        authorizationMode: CloudKeyAuthorizationMode? = nil
+    ) {
+        self.primary = primary
+        self.alternatives = alternatives
+        self.authorizationMode = authorizationMode
+    }
 }
 
 /// A single passkey credential entry as stored in the backend JSONB array.

--- a/TinfoilChat/Services/Passkey/PasskeyKeyStorage.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyKeyStorage.swift
@@ -40,6 +40,31 @@ struct PasskeyCredentialEntry: Codable {
     let created_at: String
     let version: Int  // schema version (1 = AES-256-GCM + HKDF-SHA256 KEK)
     let sync_version: Int  // monotonic counter, incremented each time the key bundle is re-encrypted
+    let bundle_version: Int?  // logical key-bundle version shared across credential updates
+}
+
+struct PasskeyCredentialWriteOptions {
+    let expectedSyncVersion: Int?
+    let knownBundleVersion: Int?
+    let incrementBundleVersion: Bool
+    let enforceRemoteBundleVersion: Bool
+
+    init(
+        expectedSyncVersion: Int? = nil,
+        knownBundleVersion: Int? = nil,
+        incrementBundleVersion: Bool = false,
+        enforceRemoteBundleVersion: Bool = false
+    ) {
+        self.expectedSyncVersion = expectedSyncVersion
+        self.knownBundleVersion = knownBundleVersion
+        self.incrementBundleVersion = incrementBundleVersion
+        self.enforceRemoteBundleVersion = enforceRemoteBundleVersion
+    }
+}
+
+struct PasskeyCredentialSaveResult {
+    let syncVersion: Int
+    let bundleVersion: Int
 }
 
 private let currentCredentialVersion = 1
@@ -166,39 +191,68 @@ final class PasskeyKeyStorage {
 
     /// Encrypt the key bundle and upsert a credential entry, then save to backend.
     /// If a credential with the same ID already exists, it is replaced.
-    /// Returns the new sync_version of the stored entry.
+    /// Returns the stored sync and bundle versions after the save is verified.
     @discardableResult
     func storeEncryptedKeys(
         credentialId: String,
         kek: SymmetricKey,
-        keys: KeyBundle
-    ) async throws -> Int {
+        keys: KeyBundle,
+        options: PasskeyCredentialWriteOptions = PasskeyCredentialWriteOptions()
+    ) async throws -> PasskeyCredentialSaveResult {
         let encrypted = try encryptKeyBundle(kek: kek, keys: keys)
 
-        let existing = try await loadCredentials()
-        let previous = existing.first { $0.id == credentialId }
+        for _ in 0..<Constants.Passkey.credentialSaveMaxAttempts {
+            let existing = try await loadCredentials()
+            let previous = existing.first { $0.id == credentialId }
+            let remoteBundleVersion = highestBundleVersion(in: existing)
 
-        let nextSyncVersion: Int
-        if let previous {
-            nextSyncVersion = previous.sync_version + 1
-        } else {
-            nextSyncVersion = 1
+            if let expectedSyncVersion = options.expectedSyncVersion,
+               previous == nil || (previous?.sync_version ?? 0) > expectedSyncVersion {
+                throw PasskeyKeyStorageError.conflictDetected
+            }
+
+            if options.enforceRemoteBundleVersion {
+                if let knownBundleVersion = options.knownBundleVersion {
+                    if remoteBundleVersion > knownBundleVersion {
+                        throw PasskeyKeyStorageError.conflictDetected
+                    }
+                } else if remoteBundleVersion > 0 {
+                    throw PasskeyKeyStorageError.conflictDetected
+                }
+            }
+
+            let nextSyncVersion = (previous?.sync_version ?? 0) + 1
+            let baseBundleVersion = max(remoteBundleVersion, options.knownBundleVersion ?? 0)
+            let nextBundleVersion = options.incrementBundleVersion
+                ? max(baseBundleVersion + 1, 1)
+                : max(baseBundleVersion, 1)
+
+            let entry = PasskeyCredentialEntry(
+                id: credentialId,
+                encrypted_keys: encrypted.data,
+                iv: encrypted.iv,
+                created_at: previous?.created_at ?? ISO8601DateFormatter().string(from: Date()),
+                version: currentCredentialVersion,
+                sync_version: nextSyncVersion,
+                bundle_version: nextBundleVersion
+            )
+
+            var updated = existing.filter { $0.id != credentialId }
+            updated.append(entry)
+
+            try await saveCredentials(updated)
+
+            let verifiedEntries = try await loadCredentials()
+            if let verifiedEntry = verifiedEntries.first(where: { $0.id == credentialId }),
+               storedEntryMatches(verifiedEntry, expected: entry) {
+                return PasskeyCredentialSaveResult(
+                    syncVersion: nextSyncVersion,
+                    bundleVersion: nextBundleVersion
+                )
+            }
         }
 
-        let entry = PasskeyCredentialEntry(
-            id: credentialId,
-            encrypted_keys: encrypted.data,
-            iv: encrypted.iv,
-            created_at: previous?.created_at ?? ISO8601DateFormatter().string(from: Date()),
-            version: currentCredentialVersion,
-            sync_version: nextSyncVersion
-        )
-
-        var updated = existing.filter { $0.id != credentialId }
-        updated.append(entry)
-
-        try await saveCredentials(updated)
-        return nextSyncVersion
+        throw PasskeyKeyStorageError.verificationFailed
     }
 
     /// Decrypt the key bundle for a specific credential entry.
@@ -254,6 +308,22 @@ final class PasskeyKeyStorage {
             "Content-Type": "application/json"
         ]
     }
+
+    private func highestBundleVersion(in entries: [PasskeyCredentialEntry]) -> Int {
+        entries.reduce(0) { partialResult, entry in
+            max(partialResult, entry.bundle_version ?? 0)
+        }
+    }
+
+    private func storedEntryMatches(
+        _ entry: PasskeyCredentialEntry,
+        expected: PasskeyCredentialEntry
+    ) -> Bool {
+        entry.sync_version == expected.sync_version &&
+            (entry.bundle_version ?? 0) == (expected.bundle_version ?? 0) &&
+            entry.iv == expected.iv &&
+            entry.encrypted_keys == expected.encrypted_keys
+    }
 }
 
 // MARK: - Response Model
@@ -272,6 +342,8 @@ enum PasskeyKeyStorageError: LocalizedError {
     case networkError
     case apiError(statusCode: Int)
     case saveFailed
+    case verificationFailed
+    case conflictDetected
     case authenticationRequired
 
     var errorDescription: String? {
@@ -288,6 +360,10 @@ enum PasskeyKeyStorageError: LocalizedError {
             return "Backend API error (status \(statusCode))"
         case .saveFailed:
             return "Failed to save passkey credentials"
+        case .verificationFailed:
+            return "Failed to confirm that the latest passkey backup was saved."
+        case .conflictDetected:
+            return "A newer passkey backup already exists. Recover the latest backup before updating it."
         case .authenticationRequired:
             return "Authentication required for passkey operations"
         }

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -100,29 +100,16 @@ final class PasskeyManager: ObservableObject {
                 return .recoveryFailed
             }
 
-            let previousKeys = EncryptionService.shared.getAllKeys()
-
-            try await EncryptionService.shared.setAllKeys(
+            try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
                 primary: recovery.bundle.primary,
                 alternatives: recovery.bundle.alternatives
             )
-
-            let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
-            guard validation.canWrite else {
-                try? await EncryptionService.shared.replaceKeyBundle(
-                    primary: previousKeys.primary,
-                    alternatives: previousKeys.alternatives
-                )
-                showPasskeyRecoveryChoice = true
-                return .recoveryFailed
-            }
 
             // Record sync_version so the periodic check has a baseline
             if let entry = credentials.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
             }
 
-            CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
             activatePasskey()
             return .success
 
@@ -185,27 +172,15 @@ final class PasskeyManager: ObservableObject {
                 return false
             }
 
-            let previousKeys = EncryptionService.shared.getAllKeys()
-
-            try await EncryptionService.shared.setAllKeys(
+            try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
                 primary: recovery.bundle.primary,
                 alternatives: recovery.bundle.alternatives
             )
-
-            let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
-            guard validation.canWrite else {
-                try? await EncryptionService.shared.replaceKeyBundle(
-                    primary: previousKeys.primary,
-                    alternatives: previousKeys.alternatives
-                )
-                return false
-            }
 
             if let entry = entries.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
             }
 
-            CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
             activatePasskey()
             showPasskeyRecoveryChoice = false
 
@@ -477,6 +452,8 @@ final class PasskeyManager: ObservableObject {
     /// Uses the cached PRF to avoid biometric prompts. If no cached PRF
     /// is available, the check is skipped silently.
     private func refreshKeyFromPasskeyBackup() async {
+        var pendingSyncVersion: (credentialId: String, version: Int)?
+
         do {
             guard let cached = passkeyService.getCachedPrfResult() else { return }
 
@@ -501,36 +478,30 @@ final class PasskeyManager: ObservableObject {
                 return
             }
 
-            let previousKeys = EncryptionService.shared.getAllKeys()
+            pendingSyncVersion = (credentialId: cached.credentialId, version: entry.sync_version)
             let previousMode = CloudKeyAuthorizationStore.shared.currentMode()
 
-            // Key differs — apply the recovered key bundle
-            try await EncryptionService.shared.setAllKeys(
+            let appliedMode = try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
                 primary: bundle.primary,
-                alternatives: bundle.alternatives
+                alternatives: bundle.alternatives,
+                failureMode: previousMode == .explicitStartFresh ? .explicitStartFresh : nil
             )
-
-            let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
-            if validation.canWrite {
-                CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
-            } else if previousMode == .explicitStartFresh {
-                CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh)
-            } else {
-                try? await EncryptionService.shared.replaceKeyBundle(
-                    primary: previousKeys.primary,
-                    alternatives: previousKeys.alternatives
-                )
-                return
-            }
 
             setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
 
             #if DEBUG
-            print("[PasskeyManager] Refreshed encryption key from passkey backup (sync_version: \(entry.sync_version))")
+            print("[PasskeyManager] Refreshed encryption key from passkey backup (sync_version: \(entry.sync_version), mode: \(appliedMode.rawValue))")
             #endif
 
             onKeyRefreshedFromBackup?()
         } catch {
+            if error is CloudKeyAuthorizationError,
+               let pendingSyncVersion {
+                setLocalSyncVersion(
+                    credentialId: pendingSyncVersion.credentialId,
+                    version: pendingSyncVersion.version
+                )
+            }
             // Non-fatal — will retry on next interval
         }
     }

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -100,10 +100,7 @@ final class PasskeyManager: ObservableObject {
                 return .recoveryFailed
             }
 
-            try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
-                primary: recovery.bundle.primary,
-                alternatives: recovery.bundle.alternatives
-            )
+            _ = try await applyRecoveredKeyBundle(recovery.bundle)
 
             // Record sync_version so the periodic check has a baseline
             if let entry = credentials.first(where: { $0.id == recovery.credentialId }) {
@@ -134,7 +131,11 @@ final class PasskeyManager: ObservableObject {
 
         do {
             let (credentialId, kek) = try await createPasskeyAndDeriveKEK(for: user)
-            let bundle = KeyBundle(primary: newKey, alternatives: [])
+            let bundle = KeyBundle(
+                primary: newKey,
+                alternatives: [],
+                authorizationMode: authorizationMode
+            )
 
             let syncVersion = try await keyStorage.storeEncryptedKeys(
                 credentialId: credentialId,
@@ -175,10 +176,7 @@ final class PasskeyManager: ObservableObject {
                 return false
             }
 
-            try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
-                primary: recovery.bundle.primary,
-                alternatives: recovery.bundle.alternatives
-            )
+            _ = try await applyRecoveredKeyBundle(recovery.bundle)
 
             if let entry = entries.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
@@ -273,7 +271,11 @@ final class PasskeyManager: ObservableObject {
             guard let primary = keys.primary else { return }
 
             let (credentialId, kek) = try await createPasskeyAndDeriveKEK(for: user)
-            let bundle = KeyBundle(primary: primary, alternatives: keys.alternatives)
+            let bundle = KeyBundle(
+                primary: primary,
+                alternatives: keys.alternatives,
+                authorizationMode: CloudKeyAuthorizationStore.shared.currentMode() ?? .validated
+            )
 
             let syncVersion = try await keyStorage.storeEncryptedKeys(
                 credentialId: credentialId,
@@ -330,7 +332,11 @@ final class PasskeyManager: ObservableObject {
             }
             let kek = PasskeyService.deriveKeyEncryptionKey(from: result.prfOutput)
 
-            let bundle = KeyBundle(primary: primary, alternatives: keys.alternatives)
+            let bundle = KeyBundle(
+                primary: primary,
+                alternatives: keys.alternatives,
+                authorizationMode: CloudKeyAuthorizationStore.shared.currentMode()
+            )
 
             let syncVersion = try await keyStorage.storeEncryptedKeys(
                 credentialId: result.credentialId,
@@ -359,6 +365,17 @@ final class PasskeyManager: ObservableObject {
         SettingsManager.shared.isCloudSyncEnabled = true
         passkeyActive = true
         startSyncCheck()
+    }
+
+    private func applyRecoveredKeyBundle(_ bundle: KeyBundle) async throws -> CloudKeyAuthorizationMode {
+        let authorizationMode = bundle.authorizationMode ?? .validated
+
+        return try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
+            primary: bundle.primary,
+            alternatives: bundle.alternatives,
+            successMode: authorizationMode,
+            failureMode: authorizationMode == .explicitStartFresh ? .explicitStartFresh : nil
+        )
     }
 
     private func ensureCurrentPrimaryKeyAuthorized() async -> Bool {
@@ -481,13 +498,7 @@ final class PasskeyManager: ObservableObject {
             }
 
             pendingSyncVersion = (credentialId: cached.credentialId, version: entry.sync_version)
-            let previousMode = CloudKeyAuthorizationStore.shared.currentMode()
-
-            let appliedMode = try await CloudKeyAuthorizationStore.shared.applyKeyBundleWithValidation(
-                primary: bundle.primary,
-                alternatives: bundle.alternatives,
-                failureMode: previousMode == .explicitStartFresh ? .explicitStartFresh : nil
-            )
+            let appliedMode = try await applyRecoveredKeyBundle(bundle)
 
             setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
 

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -335,7 +335,7 @@ final class PasskeyManager: ObservableObject {
             let bundle = KeyBundle(
                 primary: primary,
                 alternatives: keys.alternatives,
-                authorizationMode: CloudKeyAuthorizationStore.shared.currentMode()
+                authorizationMode: CloudKeyAuthorizationStore.shared.currentMode() ?? .validated
             )
 
             let syncVersion = try await keyStorage.storeEncryptedKeys(

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -145,7 +145,10 @@ final class PasskeyManager: ObservableObject {
 
             // Passkey created and stored — persist the key
             try await EncryptionService.shared.setKey(newKey)
-            CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: authorizationMode)
+            guard CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: authorizationMode) else {
+                EncryptionService.shared.clearKey()
+                throw CloudKeyAuthorizationError.authorizationUnavailable
+            }
             activatePasskey()
             return true
 
@@ -366,8 +369,7 @@ final class PasskeyManager: ObservableObject {
         let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
         guard validation.canWrite else { return false }
 
-        CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
-        return true
+        return CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
     }
 
     /// Authenticate with a passkey, derive the KEK, and decrypt the stored key bundle.

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -66,6 +66,7 @@ final class PasskeyManager: ObservableObject {
         syncCheckTask = nil
         passkeyService.clearCachedPrfResult()
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Secret.passkeySyncVersion)
+        UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Secret.passkeyBundleVersion)
     }
 
     // MARK: - Recovery Flow
@@ -105,6 +106,7 @@ final class PasskeyManager: ObservableObject {
             // Record sync_version so the periodic check has a baseline
             if let entry = credentials.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
+                setLocalBundleVersion(entry.bundle_version ?? 0)
             }
 
             activatePasskey()
@@ -137,12 +139,18 @@ final class PasskeyManager: ObservableObject {
                 authorizationMode: authorizationMode
             )
 
-            let syncVersion = try await keyStorage.storeEncryptedKeys(
+            let saveResult = try await keyStorage.storeEncryptedKeys(
                 credentialId: credentialId,
                 kek: kek,
-                keys: bundle
+                keys: bundle,
+                options: PasskeyCredentialWriteOptions(
+                    knownBundleVersion: getLocalBundleVersion(),
+                    incrementBundleVersion: authorizationMode == .explicitStartFresh,
+                    enforceRemoteBundleVersion: authorizationMode != .explicitStartFresh
+                )
             )
-            setLocalSyncVersion(credentialId: credentialId, version: syncVersion)
+            setLocalSyncVersion(credentialId: credentialId, version: saveResult.syncVersion)
+            setLocalBundleVersion(saveResult.bundleVersion)
 
             // Passkey created and stored — persist the key
             try await EncryptionService.shared.setKey(newKey)
@@ -180,6 +188,7 @@ final class PasskeyManager: ObservableObject {
 
             if let entry = entries.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
+                setLocalBundleVersion(entry.bundle_version ?? 0)
             }
 
             activatePasskey()
@@ -277,12 +286,18 @@ final class PasskeyManager: ObservableObject {
                 authorizationMode: CloudKeyAuthorizationStore.shared.currentMode() ?? .validated
             )
 
-            let syncVersion = try await keyStorage.storeEncryptedKeys(
+            let saveResult = try await keyStorage.storeEncryptedKeys(
                 credentialId: credentialId,
                 kek: kek,
-                keys: bundle
+                keys: bundle,
+                options: PasskeyCredentialWriteOptions(
+                    knownBundleVersion: getLocalBundleVersion(),
+                    incrementBundleVersion: false,
+                    enforceRemoteBundleVersion: true
+                )
             )
-            setLocalSyncVersion(credentialId: credentialId, version: syncVersion)
+            setLocalSyncVersion(credentialId: credentialId, version: saveResult.syncVersion)
+            setLocalBundleVersion(saveResult.bundleVersion)
 
             // Mark intro as seen in Clerk unsafeMetadata
             await markPasskeyIntroSeen()
@@ -338,12 +353,40 @@ final class PasskeyManager: ObservableObject {
                 authorizationMode: CloudKeyAuthorizationStore.shared.currentMode() ?? .validated
             )
 
-            let syncVersion = try await keyStorage.storeEncryptedKeys(
+            var localSyncVersion = getLocalSyncVersion(credentialId: result.credentialId)
+            var localBundleVersion = getLocalBundleVersion()
+
+            if (localSyncVersion == nil || localBundleVersion == nil),
+               let currentEntry = entries.first(where: { $0.id == result.credentialId }) {
+                let currentRemoteBundle = try keyStorage.decryptKeyBundle(
+                    kek: kek,
+                    iv: currentEntry.iv,
+                    data: currentEntry.encrypted_keys
+                )
+
+                if await doesCurrentStateMatchBundle(currentRemoteBundle) {
+                    if localSyncVersion == nil {
+                        localSyncVersion = currentEntry.sync_version
+                    }
+                    if localBundleVersion == nil {
+                        localBundleVersion = currentEntry.bundle_version ?? 0
+                    }
+                }
+            }
+
+            let saveResult = try await keyStorage.storeEncryptedKeys(
                 credentialId: result.credentialId,
                 kek: kek,
-                keys: bundle
+                keys: bundle,
+                options: PasskeyCredentialWriteOptions(
+                    expectedSyncVersion: localSyncVersion,
+                    knownBundleVersion: localBundleVersion,
+                    incrementBundleVersion: true,
+                    enforceRemoteBundleVersion: true
+                )
             )
-            setLocalSyncVersion(credentialId: result.credentialId, version: syncVersion)
+            setLocalSyncVersion(credentialId: result.credentialId, version: saveResult.syncVersion)
+            setLocalBundleVersion(saveResult.bundleVersion)
         } catch {
             // Non-fatal — passkey backup is stale but user can re-backup from Settings
         }
@@ -451,6 +494,37 @@ final class PasskeyManager: ObservableObject {
         UserDefaults.standard.set(dict, forKey: Constants.StorageKeys.Secret.passkeySyncVersion)
     }
 
+    private func getLocalBundleVersion() -> Int? {
+        let value = UserDefaults.standard.object(forKey: Constants.StorageKeys.Secret.passkeyBundleVersion)
+        return value as? Int
+    }
+
+    private func setLocalBundleVersion(_ version: Int) {
+        UserDefaults.standard.set(version, forKey: Constants.StorageKeys.Secret.passkeyBundleVersion)
+    }
+
+    private func doesCurrentStateMatchBundle(_ bundle: KeyBundle) async -> Bool {
+        let currentKeys = EncryptionService.shared.getAllKeys()
+        guard currentKeys.primary == bundle.primary else {
+            return false
+        }
+
+        let normalizeAlternatives: (String, [String]) -> [String] = { primary, alternatives in
+            alternatives
+                .filter { $0 != primary }
+                .sorted()
+        }
+
+        let currentAlternatives = normalizeAlternatives(bundle.primary, currentKeys.alternatives)
+        let bundleAlternatives = normalizeAlternatives(bundle.primary, bundle.alternatives)
+        guard currentAlternatives == bundleAlternatives else {
+            return false
+        }
+
+        return CloudKeyAuthorizationStore.shared.currentMode() ==
+            (bundle.authorizationMode ?? .validated)
+    }
+
     // MARK: - Periodic Sync Check
 
     /// Start a repeating timer that checks whether another device has updated
@@ -471,7 +545,7 @@ final class PasskeyManager: ObservableObject {
     /// Uses the cached PRF to avoid biometric prompts. If no cached PRF
     /// is available, the check is skipped silently.
     private func refreshKeyFromPasskeyBackup() async {
-        var pendingSyncVersion: (credentialId: String, version: Int)?
+        var pendingRemoteVersion: (credentialId: String, syncVersion: Int, bundleVersion: Int)?
 
         do {
             guard let cached = passkeyService.getCachedPrfResult() else { return }
@@ -490,17 +564,25 @@ final class PasskeyManager: ObservableObject {
                 data: entry.encrypted_keys
             )
 
-            let localKey = EncryptionService.shared.getAllKeys().primary
-            if bundle.primary == localKey {
-                // Key matches — just record the version
+            if await doesCurrentStateMatchBundle(bundle) {
                 setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
+                if let bundleVersion = entry.bundle_version {
+                    setLocalBundleVersion(bundleVersion)
+                }
                 return
             }
 
-            pendingSyncVersion = (credentialId: cached.credentialId, version: entry.sync_version)
+            pendingRemoteVersion = (
+                credentialId: cached.credentialId,
+                syncVersion: entry.sync_version,
+                bundleVersion: entry.bundle_version ?? 0
+            )
             let appliedMode = try await applyRecoveredKeyBundle(bundle)
 
             setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
+            if let bundleVersion = entry.bundle_version {
+                setLocalBundleVersion(bundleVersion)
+            }
 
             #if DEBUG
             print("[PasskeyManager] Refreshed encryption key from passkey backup (sync_version: \(entry.sync_version), mode: \(appliedMode.rawValue))")
@@ -509,11 +591,12 @@ final class PasskeyManager: ObservableObject {
             onKeyRefreshedFromBackup?()
         } catch {
             if error is CloudKeyAuthorizationError,
-               let pendingSyncVersion {
+               let pendingRemoteVersion {
                 setLocalSyncVersion(
-                    credentialId: pendingSyncVersion.credentialId,
-                    version: pendingSyncVersion.version
+                    credentialId: pendingRemoteVersion.credentialId,
+                    version: pendingRemoteVersion.syncVersion
                 )
+                setLocalBundleVersion(pendingRemoteVersion.bundleVersion)
             }
             // Non-fatal — will retry on next interval
         }

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -15,7 +15,8 @@ import Foundation
 enum PasskeyRecoveryResult {
     case success
     case newUserSetupDone
-    case newUserSetupCancelled
+    case manualSetupRequired
+    case manualRecoveryRequired
     case recoveryFailed
 }
 
@@ -75,11 +76,17 @@ final class PasskeyManager: ObservableObject {
             let credentials = try await keyStorage.loadCredentials()
 
             if credentials.isEmpty {
-                let created = await attemptNewUserPasskeySetup()
-                if !created {
+                switch await CloudKeyPreflightValidator.shared.inspectRemoteState() {
+                case .empty:
+                    let created = await attemptNewUserPasskeySetup()
+                    if !created {
+                        passkeySetupAvailable = true
+                    }
+                    return created ? .newUserSetupDone : .manualSetupRequired
+                case .exists, .unknown:
                     passkeySetupAvailable = true
+                    return .manualRecoveryRequired
                 }
-                return created ? .newUserSetupDone : .newUserSetupCancelled
             }
 
             // Try recovery with all credential IDs — shows system passkey UI
@@ -93,17 +100,29 @@ final class PasskeyManager: ObservableObject {
                 return .recoveryFailed
             }
 
-            // Write recovered keys to keychain and enable cloud sync
+            let previousKeys = EncryptionService.shared.getAllKeys()
+
             try await EncryptionService.shared.setAllKeys(
                 primary: recovery.bundle.primary,
                 alternatives: recovery.bundle.alternatives
             )
+
+            let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+            guard validation.canWrite else {
+                try? await EncryptionService.shared.replaceKeyBundle(
+                    primary: previousKeys.primary,
+                    alternatives: previousKeys.alternatives
+                )
+                showPasskeyRecoveryChoice = true
+                return .recoveryFailed
+            }
 
             // Record sync_version so the periodic check has a baseline
             if let entry = credentials.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
             }
 
+            CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
             activatePasskey()
             return .success
 
@@ -119,7 +138,9 @@ final class PasskeyManager: ObservableObject {
     /// Auto-generate a key and create a passkey for a brand new user.
     /// Returns true if successful, false if passkey creation was cancelled (key is discarded).
     @discardableResult
-    private func attemptNewUserPasskeySetup() async -> Bool {
+    private func attemptNewUserPasskeySetup(
+        authorizationMode: CloudKeyAuthorizationMode = .validated
+    ) async -> Bool {
         guard let user = Clerk.shared.user else { return false }
 
         let newKey = EncryptionService.shared.generateKey()
@@ -137,6 +158,7 @@ final class PasskeyManager: ObservableObject {
 
             // Passkey created and stored — persist the key
             try await EncryptionService.shared.setKey(newKey)
+            CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: authorizationMode)
             activatePasskey()
             return true
 
@@ -163,15 +185,27 @@ final class PasskeyManager: ObservableObject {
                 return false
             }
 
+            let previousKeys = EncryptionService.shared.getAllKeys()
+
             try await EncryptionService.shared.setAllKeys(
                 primary: recovery.bundle.primary,
                 alternatives: recovery.bundle.alternatives
             )
 
+            let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+            guard validation.canWrite else {
+                try? await EncryptionService.shared.replaceKeyBundle(
+                    primary: previousKeys.primary,
+                    alternatives: previousKeys.alternatives
+                )
+                return false
+            }
+
             if let entry = entries.first(where: { $0.id == recovery.credentialId }) {
                 setLocalSyncVersion(credentialId: recovery.credentialId, version: entry.sync_version)
             }
 
+            CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
             activatePasskey()
             showPasskeyRecoveryChoice = false
 
@@ -189,7 +223,7 @@ final class PasskeyManager: ObservableObject {
     /// Generate a new key and create a new passkey (explicit split).
     /// Called from PasskeyRecoveryChoiceView's "Start Fresh" button.
     func startFreshWithNewKey() async -> Bool {
-        let success = await attemptNewUserPasskeySetup()
+        let success = await attemptNewUserPasskeySetup(authorizationMode: .explicitStartFresh)
         if success {
             showPasskeyRecoveryChoice = false
             onRecoveryComplete?()
@@ -203,11 +237,16 @@ final class PasskeyManager: ObservableObject {
     /// backup for it. When no key exists, runs the new-user flow that generates a key
     /// and creates a passkey in one step.
     /// Called from Settings when cloud sync toggle is turned ON without a passkey.
-    func retryPasskeySetup() async {
+    func retryPasskeySetup() async -> PasskeyRecoveryResult {
         if EncryptionService.shared.hasEncryptionKey() {
+            guard await ensureCurrentPrimaryKeyAuthorized() else {
+                passkeySetupAvailable = true
+                return .manualRecoveryRequired
+            }
             await createPasskeyBackup()
+            return .success
         } else {
-            await attemptNewUserPasskeySetup()
+            return await attemptPasskeyKeyRecovery()
         }
     }
 
@@ -249,6 +288,7 @@ final class PasskeyManager: ObservableObject {
     /// Called from PasskeyIntroView's onAccept and Settings backup button.
     func createPasskeyBackup() async {
         guard let user = Clerk.shared.user else { return }
+        guard await ensureCurrentPrimaryKeyAuthorized() else { return }
 
         do {
             let keys = EncryptionService.shared.getAllKeys()
@@ -288,6 +328,8 @@ final class PasskeyManager: ObservableObject {
     /// credential can still decrypt the keys it was last updated with — the user
     /// would need to create a new passkey on a replacement device.
     func updatePasskeyBackup() async {
+        guard CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey() else { return }
+
         do {
             let keys = EncryptionService.shared.getAllKeys()
             guard let primary = keys.primary else { return }
@@ -339,6 +381,18 @@ final class PasskeyManager: ObservableObject {
         SettingsManager.shared.isCloudSyncEnabled = true
         passkeyActive = true
         startSyncCheck()
+    }
+
+    private func ensureCurrentPrimaryKeyAuthorized() async -> Bool {
+        if CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey() {
+            return true
+        }
+
+        let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+        guard validation.canWrite else { return false }
+
+        CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
+        return true
     }
 
     /// Authenticate with a passkey, derive the KEK, and decrypt the stored key bundle.
@@ -447,11 +501,28 @@ final class PasskeyManager: ObservableObject {
                 return
             }
 
+            let previousKeys = EncryptionService.shared.getAllKeys()
+            let previousMode = CloudKeyAuthorizationStore.shared.currentMode()
+
             // Key differs — apply the recovered key bundle
             try await EncryptionService.shared.setAllKeys(
                 primary: bundle.primary,
                 alternatives: bundle.alternatives
             )
+
+            let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+            if validation.canWrite {
+                CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
+            } else if previousMode == .explicitStartFresh {
+                CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh)
+            } else {
+                try? await EncryptionService.shared.replaceKeyBundle(
+                    primary: previousKeys.primary,
+                    alternatives: previousKeys.alternatives
+                )
+                return
+            }
+
             setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
 
             #if DEBUG

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -566,9 +566,7 @@ final class PasskeyManager: ObservableObject {
 
             if await doesCurrentStateMatchBundle(bundle) {
                 setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
-                if let bundleVersion = entry.bundle_version {
-                    setLocalBundleVersion(bundleVersion)
-                }
+                setLocalBundleVersion(entry.bundle_version ?? 0)
                 return
             }
 
@@ -580,9 +578,7 @@ final class PasskeyManager: ObservableObject {
             let appliedMode = try await applyRecoveredKeyBundle(bundle)
 
             setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
-            if let bundleVersion = entry.bundle_version {
-                setLocalBundleVersion(bundleVersion)
-            }
+            setLocalBundleVersion(entry.bundle_version ?? 0)
 
             #if DEBUG
             print("[PasskeyManager] Refreshed encryption key from passkey backup (sync_version: \(entry.sync_version), mode: \(appliedMode.rawValue))")

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -338,6 +338,16 @@ class ProfileManager: ObservableObject {
             return
         }
 
+        let authorizationMode = CloudKeyAuthorizationStore.shared.currentMode()
+        guard authorizationMode != nil else {
+            return
+        }
+
+        if profileSync.hasFailedRemoteDecryption(),
+           authorizationMode != .explicitStartFresh {
+            return
+        }
+
         // Avoid overlapping uploads
         guard !isPushing else { return }
         

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -83,51 +83,58 @@ class ProfileSyncService: ObservableObject {
     }
     
     // MARK: - Profile Operations
-    
-    /// Fetch profile from cloud
-    func fetchProfile() async throws -> ProfileData? {
+
+    func fetchEncryptedProfilePayload() async throws -> String? {
         guard await isAuthenticated() else {
             return nil
         }
-        
-        
+
         guard let url = URL(string: "\(apiBaseURL)/api/profile/") else {
             throw ProfileSyncError.invalidURL
         }
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.allHTTPHeaderFields = try await getHeaders()
-        
+
         let (data, response): (Data, URLResponse)
         do {
             (data, response) = try await URLSession.shared.data(for: request)
         } catch {
             throw ProfileSyncError.fetchFailed(underlying: error)
         }
-        
+
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ProfileSyncError.invalidResponse
         }
-        
+
         if httpResponse.statusCode == 404 {
             return nil
         }
-        
+
         guard (200...299).contains(httpResponse.statusCode) else {
             let error = URLError(.badServerResponse, userInfo: [NSURLErrorFailingURLErrorKey: url, "statusCode": httpResponse.statusCode])
             throw ProfileSyncError.fetchFailed(underlying: error)
         }
-        
+
         let profileResponse = try JSONDecoder().decode(ProfileResponse.self, from: data)
-        
-        
+        return profileResponse.data
+    }
+    
+    /// Fetch profile from cloud
+    func fetchProfile() async throws -> ProfileData? {
+        guard let payload = try await fetchEncryptedProfilePayload() else {
+            failedDecryptionData = nil
+            return nil
+        }
+
         // Initialize encryption service
         _ = try await EncryptionService.shared.initialize()
         
         // Try to decrypt the profile data
         do {
             // Parse the encrypted data (JSON string format)
-            guard let encryptedData = profileResponse.data.data(using: .utf8) else {
+            guard let encryptedData = payload.data(using: .utf8) else {
                 throw ProfileSyncError.invalidDataFormat
             }
             
@@ -144,7 +151,7 @@ class ProfileSyncService: ObservableObject {
             return decrypted
         } catch {
             // Failed to decrypt - store for later retry
-            self.failedDecryptionData = profileResponse.data
+            self.failedDecryptionData = payload
             self.cachedProfile = nil
             
             
@@ -246,6 +253,10 @@ class ProfileSyncService: ObservableObject {
     /// Get cached profile (for quick access)
     func getCachedProfile() -> ProfileData? {
         return cachedProfile
+    }
+
+    func hasFailedRemoteDecryption() -> Bool {
+        failedDecryptionData != nil
     }
     
     /// Clear cache

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -124,7 +124,9 @@ class ProfileSyncService: ObservableObject {
     /// Fetch profile from cloud
     func fetchProfile() async throws -> ProfileData? {
         guard let payload = try await fetchEncryptedProfilePayload() else {
-            failedDecryptionData = nil
+            if await isAuthenticated() {
+                failedDecryptionData = nil
+            }
             return nil
         }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3010,6 +3010,7 @@ class ChatViewModel: ObservableObject {
     ) async throws {
         do {
             let oldKey = EncryptionService.shared.getKey()
+            let previousKeys = EncryptionService.shared.getAllKeys()
 
             switch mode {
             case .addRecoveryKey:
@@ -3019,7 +3020,14 @@ class ChatViewModel: ObservableObject {
             case .explicitStartFresh:
                 try await EncryptionService.shared.setKey(key)
                 guard CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh) else {
-                    EncryptionService.shared.clearKey()
+                    do {
+                        try await EncryptionService.shared.replaceKeyBundle(
+                            primary: previousKeys.primary,
+                            alternatives: previousKeys.alternatives
+                        )
+                    } catch {
+                        EncryptionService.shared.clearKey()
+                    }
                     throw CloudKeyAuthorizationError.authorizationUnavailable
                 }
             }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3020,7 +3020,7 @@ class ChatViewModel: ObservableObject {
                 try await EncryptionService.shared.setKey(key)
                 guard CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh) else {
                     do {
-                        try await EncryptionService.shared.replaceKeyBundle(
+                        try EncryptionService.shared.replaceKeyBundle(
                             primary: previousKeys.primary,
                             alternatives: previousKeys.alternatives
                         )

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3009,7 +3009,6 @@ class ChatViewModel: ObservableObject {
         mode: CloudKeyActivationMode = .explicitStartFresh
     ) async throws {
         do {
-            let oldKey = EncryptionService.shared.getKey()
             let previousKeys = EncryptionService.shared.getAllKeys()
 
             switch mode {
@@ -3040,21 +3039,6 @@ class ChatViewModel: ObservableObject {
             await ProfileManager.shared.retryDecryptionWithNewKey()
             await retryDecryptionAndReloadChats()
 
-            // If key changed, handle re-encryption
-            if mode != .addRecoveryKey && oldKey != key {
-                await MainActor.run {
-                    self.isSyncing = true
-                }
-
-                let _ = await cloudSync.reencryptAndUploadChats()
-                await performFullSync()
-
-                await MainActor.run {
-                    self.isSyncing = false
-                    self.lastSyncDate = Date()
-                }
-            }
-            
             // If this was first-time setup, initialize cloud sync and load chats
             if isFirstTimeUser {
                 await MainActor.run {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -38,6 +38,7 @@ class ChatViewModel: ObservableObject {
     @Published var showCamera: Bool = false
     @Published var showMessageSheet: Bool = false
     @Published var showSidebarSettings: Bool = false
+    @Published var showCloudSyncOnboarding: Bool = false
     @Published var shouldOpenCloudSync: Bool = false
     @Published var scrollTargetMessageId: String? = nil 
     @Published var scrollTargetOffset: CGFloat = 0 
@@ -1949,6 +1950,49 @@ class ChatViewModel: ObservableObject {
         self.showVerifierSheet = false
         self.verifierView = nil
     }
+
+    /// Resume the sign-in flow after the user completes manual key setup via CloudSyncOnboardingView.
+    func resumeAfterManualKeySetup() {
+        Task {
+            do {
+                let key = try await EncryptionService.shared.initialize()
+                self.encryptionKey = key
+
+                await self.passkeyManager.checkPasskeyStateForExistingKey()
+
+                let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
+                if decryptedCount > 0 {
+                    let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
+                    await MainActor.run {
+                        self.chats = result.chats
+                        if let currentId = self.currentChat?.id,
+                           let refreshed = result.chats.first(where: { $0.id == currentId }) {
+                            self.currentChat = refreshed
+                        }
+                        normalizeChatsArray()
+                    }
+                }
+
+                if SettingsManager.shared.isCloudSyncEnabled {
+                    await initializeCloudSync()
+                    await ProfileManager.shared.performFullSync()
+                }
+
+                await MainActor.run {
+                    let activeList = SettingsManager.shared.isCloudSyncEnabled ? self.chats : self.localChats
+                    if activeList.isEmpty {
+                        self.createNewChat()
+                    } else {
+                        self.ensureBlankChatAtTop()
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self.showEncryptionSetup = true
+                }
+            }
+        }
+    }
     
     // MARK: - Private Methods
 
@@ -2392,7 +2436,14 @@ class ChatViewModel: ObservableObject {
                         switch passkeyResult {
                         case .success, .newUserSetupDone:
                             break
-                        case .newUserSetupCancelled, .recoveryFailed:
+                        case .newUserSetupCancelled:
+                            // Passkey not available — show manual key setup and continue sign-in
+                            await MainActor.run {
+                                self.showCloudSyncOnboarding = true
+                                self.isSignInInProgress = false
+                            }
+                            return
+                        case .recoveryFailed:
                             await MainActor.run {
                                 self.isSignInInProgress = false
                             }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3006,7 +3006,7 @@ class ChatViewModel: ObservableObject {
     /// Set encryption key (for key rotation)
     func setEncryptionKey(
         _ key: String,
-        mode: CloudKeyActivationMode = .explicitStartFresh
+        mode: CloudKeyActivationMode = .recoverExisting
     ) async throws {
         do {
             let previousKeys = EncryptionService.shared.getAllKeys()

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3014,12 +3014,13 @@ class ChatViewModel: ObservableObject {
             switch mode {
             case .addRecoveryKey:
                 try EncryptionService.shared.addDecryptionKey(key)
-            case .recoverExisting, .explicitStartFresh:
-                if mode == .recoverExisting {
-                    _ = try await CloudKeyAuthorizationStore.shared.applyPrimaryKeyWithValidation(key)
-                } else {
-                    try await EncryptionService.shared.setKey(key)
-                    CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh)
+            case .recoverExisting:
+                _ = try await CloudKeyAuthorizationStore.shared.applyPrimaryKeyWithValidation(key)
+            case .explicitStartFresh:
+                try await EncryptionService.shared.setKey(key)
+                guard CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh) else {
+                    EncryptionService.shared.clearKey()
+                    throw CloudKeyAuthorizationError.authorizationUnavailable
                 }
             }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1961,18 +1961,7 @@ class ChatViewModel: ObservableObject {
 
                 await self.passkeyManager.checkPasskeyStateForExistingKey()
 
-                let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
-                if decryptedCount > 0 {
-                    let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
-                    await MainActor.run {
-                        self.chats = result.chats
-                        if let currentId = self.currentChat?.id,
-                           let refreshed = result.chats.first(where: { $0.id == currentId }) {
-                            self.currentChat = refreshed
-                        }
-                        normalizeChatsArray()
-                    }
-                }
+                await retryDecryptionAndReloadChats()
 
                 if SettingsManager.shared.isCloudSyncEnabled {
                     await initializeCloudSync()
@@ -1996,6 +1985,21 @@ class ChatViewModel: ObservableObject {
     }
     
     // MARK: - Private Methods
+
+    private func retryDecryptionAndReloadChats() async {
+        let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
+        guard decryptedCount > 0 else { return }
+
+        let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
+        await MainActor.run {
+            self.chats = result.chats
+            if let currentId = self.currentChat?.id,
+               let refreshed = result.chats.first(where: { $0.id == currentId }) {
+                self.currentChat = refreshed
+            }
+            normalizeChatsArray()
+        }
+    }
 
     private func endStreamingAndBackup(chatId: String) {
         guard authManager?.isAuthenticated == true else { return }
@@ -3005,33 +3009,16 @@ class ChatViewModel: ObservableObject {
         mode: CloudKeyActivationMode = .explicitStartFresh
     ) async throws {
         do {
-            let previousKeys = EncryptionService.shared.getAllKeys()
-            let oldKey = previousKeys.primary
+            let oldKey = EncryptionService.shared.getKey()
 
             switch mode {
             case .addRecoveryKey:
                 try EncryptionService.shared.addDecryptionKey(key)
             case .recoverExisting, .explicitStartFresh:
-                try await EncryptionService.shared.setKey(key)
-
                 if mode == .recoverExisting {
-                    let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
-                    guard validation.canWrite else {
-                        try? await EncryptionService.shared.replaceKeyBundle(
-                            primary: previousKeys.primary,
-                            alternatives: previousKeys.alternatives
-                        )
-                        throw NSError(
-                            domain: "CloudSync",
-                            code: 1,
-                            userInfo: [
-                                NSLocalizedDescriptionKey: validation.message
-                                    ?? "This key doesn't match your existing cloud data."
-                            ]
-                        )
-                    }
-                    CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
+                    _ = try await CloudKeyAuthorizationStore.shared.applyPrimaryKeyWithValidation(key)
                 } else {
+                    try await EncryptionService.shared.setKey(key)
                     CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh)
                 }
             }
@@ -3042,18 +3029,7 @@ class ChatViewModel: ObservableObject {
             }
 
             await ProfileManager.shared.retryDecryptionWithNewKey()
-
-            // Retry decryption with new key
-            let decryptedCount = await cloudSync.retryDecryptionWithNewKey { _, _ in }
-
-            // Reload chats immediately after decryption to show decrypted chats
-            if decryptedCount > 0 {
-                let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
-                await MainActor.run {
-                    self.chats = result.chats
-                    normalizeChatsArray()
-                }
-            }
+            await retryDecryptionAndReloadChats()
 
             // If key changed, handle re-encryption
             if mode != .addRecoveryKey && oldKey != key {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2471,10 +2471,10 @@ class ChatViewModel: ObservableObject {
                     // Ensure the current key is authorized for cloud writes.
                     // Existing users upgrading may have a valid key but no
                     // authorization record yet.
-                    if !CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey() {
+                    if !CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey(userId: userId) {
                         let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
                         if validation.canWrite {
-                            _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
+                            _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated, userId: userId)
                         }
                     }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2468,6 +2468,16 @@ class ChatViewModel: ObservableObject {
                     let key = try await EncryptionService.shared.initialize()
                     self.encryptionKey = key
 
+                    // Ensure the current key is authorized for cloud writes.
+                    // Existing users upgrading may have a valid key but no
+                    // authorization record yet.
+                    if !CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey() {
+                        let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+                        if validation.canWrite {
+                            _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
+                        }
+                    }
+
                     // Check passkey state for users who already have keys
                     await self.passkeyManager.checkPasskeyStateForExistingKey()
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -39,6 +39,7 @@ class ChatViewModel: ObservableObject {
     @Published var showMessageSheet: Bool = false
     @Published var showSidebarSettings: Bool = false
     @Published var showCloudSyncOnboarding: Bool = false
+    @Published var cloudSyncOnboardingMode: CloudSyncOnboardingMode = .setup
     @Published var shouldOpenCloudSync: Bool = false
     @Published var scrollTargetMessageId: String? = nil 
     @Published var scrollTargetOffset: CGFloat = 0 
@@ -2282,6 +2283,7 @@ class ChatViewModel: ObservableObject {
         // Clear sync caches so stale state doesn't leak into the next session
         cloudSync.clearSyncStatus()
         DeletedChatsTracker.shared.clear()
+        CloudKeyAuthorizationStore.shared.clearAuthorization(userId: currentUserId)
 
         // Reset to the default model when signing out
         let allModels = AppConfig.shared.filteredModelTypes()
@@ -2436,9 +2438,16 @@ class ChatViewModel: ObservableObject {
                         switch passkeyResult {
                         case .success, .newUserSetupDone:
                             break
-                        case .newUserSetupCancelled:
-                            // Passkey not available — show manual key setup and continue sign-in
+                        case .manualSetupRequired:
                             await MainActor.run {
+                                self.cloudSyncOnboardingMode = .setup
+                                self.showCloudSyncOnboarding = true
+                                self.isSignInInProgress = false
+                            }
+                            return
+                        case .manualRecoveryRequired:
+                            await MainActor.run {
+                                self.cloudSyncOnboardingMode = .recovery
                                 self.showCloudSyncOnboarding = true
                                 self.isSignInInProgress = false
                             }
@@ -2991,47 +3000,70 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Set encryption key (for key rotation)
-    func setEncryptionKey(_ key: String) async throws {
+    func setEncryptionKey(
+        _ key: String,
+        mode: CloudKeyActivationMode = .explicitStartFresh
+    ) async throws {
         do {
-            let oldKey = EncryptionService.shared.getKey()
-            try await EncryptionService.shared.setKey(key)
-            
+            let previousKeys = EncryptionService.shared.getAllKeys()
+            let oldKey = previousKeys.primary
+
+            switch mode {
+            case .addRecoveryKey:
+                try EncryptionService.shared.addDecryptionKey(key)
+            case .recoverExisting, .explicitStartFresh:
+                try await EncryptionService.shared.setKey(key)
+
+                if mode == .recoverExisting {
+                    let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+                    guard validation.canWrite else {
+                        try? await EncryptionService.shared.replaceKeyBundle(
+                            primary: previousKeys.primary,
+                            alternatives: previousKeys.alternatives
+                        )
+                        throw NSError(
+                            domain: "CloudSync",
+                            code: 1,
+                            userInfo: [
+                                NSLocalizedDescriptionKey: validation.message
+                                    ?? "This key doesn't match your existing cloud data."
+                            ]
+                        )
+                    }
+                    CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated)
+                } else {
+                    CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh)
+                }
+            }
+
             await MainActor.run {
-                self.encryptionKey = key
+                self.encryptionKey = EncryptionService.shared.getKey()
                 self.showEncryptionSetup = false
             }
-            
+
+            await ProfileManager.shared.retryDecryptionWithNewKey()
+
+            // Retry decryption with new key
+            let decryptedCount = await cloudSync.retryDecryptionWithNewKey { _, _ in }
+
+            // Reload chats immediately after decryption to show decrypted chats
+            if decryptedCount > 0 {
+                let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
+                await MainActor.run {
+                    self.chats = result.chats
+                    normalizeChatsArray()
+                }
+            }
+
             // If key changed, handle re-encryption
-            if oldKey != key {
-                
-                // Show syncing indicator while processing
+            if mode != .addRecoveryKey && oldKey != key {
                 await MainActor.run {
                     self.isSyncing = true
                 }
-                
-                // Retry decryption with new key
-                let decryptedCount = await cloudSync.retryDecryptionWithNewKey { current, total in
-                    Task { @MainActor in
-                        // Could add progress tracking here if needed
-                    }
-                }
-                
-                // Reload chats immediately after decryption to show decrypted chats
-                if decryptedCount > 0 {
-                    let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
-                    await MainActor.run {
-                        self.chats = result.chats
-                        normalizeChatsArray()
-                    }
-                }
-                
-                // Re-encrypt and upload all chats in background
+
                 let _ = await cloudSync.reencryptAndUploadChats()
-                
-                // Perform full sync
                 await performFullSync()
-                
-                // Hide syncing indicator
+
                 await MainActor.run {
                     self.isSyncing = false
                     self.lastSyncDate = Date()
@@ -3069,6 +3101,10 @@ class ChatViewModel: ObservableObject {
             }
             throw error  // Re-throw to let caller handle it
         }
+    }
+
+    func addRecoveryKey(_ key: String) async throws {
+        try await setEncryptionKey(key, mode: .addRecoveryKey)
     }
     
     /// Retry decryption of failed chats with the current key

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3012,6 +3012,11 @@ class ChatViewModel: ObservableObject {
     func getCurrentEncryptionKey() -> String? {
         return encryptionKey
     }
+
+    /// Reload the cached encryption key reference from the keychain.
+    func reloadEncryptionKey() {
+        encryptionKey = EncryptionService.shared.getKey()
+    }
     
     /// Set encryption key (for key rotation)
     func setEncryptionKey(

--- a/TinfoilChat/Views/CloudSyncOnboardingView.swift
+++ b/TinfoilChat/Views/CloudSyncOnboardingView.swift
@@ -53,12 +53,14 @@ struct CloudSyncOnboardingView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
 
-    var onSetupComplete: ((String) -> Void)?
+    var mode: CloudSyncOnboardingMode = .setup
+    var onSetupComplete: ((String, CloudKeyActivationMode) async -> String?)?
     var onDismissWithoutSetup: (() -> Void)?
 
     @State private var currentStep: CloudSyncOnboardingStep = .intro
     @State private var cloudSyncToggle: Bool = true
     @State private var generatedKey: String? = nil
+    @State private var generatedKeyMode: CloudKeyActivationMode = .recoverExisting
     @State private var inputKey: String = ""
     @State private var isProcessing: Bool = false
     @State private var isCopied: Bool = false
@@ -94,7 +96,7 @@ struct CloudSyncOnboardingView: View {
                 }
             }
         }
-        .interactiveDismissDisabled(currentStep == .keyDisplay)
+        .interactiveDismissDisabled(currentStep == .keyDisplay && keyError == nil)
         .fileImporter(
             isPresented: $showFilePicker,
             allowedContentTypes: [UTType(filenameExtension: "pem") ?? .plainText],
@@ -232,7 +234,11 @@ struct CloudSyncOnboardingView: View {
                     .fontWeight(.bold)
 
                 // Description
-                Text("Generate a new personal encryption key or restore an existing one. Your chats will be encrypted and synced with this personal key.")
+                Text(
+                    mode == .recovery
+                        ? "Restore your existing encryption key to unlock cloud data, or explicitly start fresh with a new key."
+                        : "Generate a new personal encryption key or restore an existing one. Your chats will be encrypted and synced with this personal key."
+                )
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -262,7 +268,7 @@ struct CloudSyncOnboardingView: View {
                                 ProgressView()
                                     .tint(.white)
                             } else {
-                                Text("Generate Key")
+                                Text(mode == .recovery ? "Start Fresh with New Key" : "Generate Key")
                             }
                         }
                         .onboardingPrimaryButton()
@@ -300,7 +306,11 @@ struct CloudSyncOnboardingView: View {
                     .fontWeight(.bold)
 
                 // Description
-                Text("Save this key securely. You'll need it to access your chats on other devices.")
+                Text(
+                    generatedKeyMode == .explicitStartFresh
+                        ? "Save this key securely. Using it will start a new encrypted cloud history on this device."
+                        : "Save this key securely. You'll need it to access your chats on other devices."
+                )
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -345,6 +355,14 @@ struct CloudSyncOnboardingView: View {
                 }
 
                 // Done button
+                if let keyError {
+                    Text(keyError)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+
                 Button(action: { handleComplete() }) {
                     Text("Done")
                         .onboardingPrimaryButton()
@@ -520,7 +538,7 @@ struct CloudSyncOnboardingView: View {
     }
 
     private func handleClose() {
-        if currentStep == .keyDisplay {
+        if currentStep == .keyDisplay && keyError == nil {
             handleComplete()
         } else {
             onDismissWithoutSetup?()
@@ -531,20 +549,14 @@ struct CloudSyncOnboardingView: View {
     private func handleGenerateKey() {
         isProcessing = true
         Task {
-            do {
-                let newKey = EncryptionService.shared.generateKey()
-                try await EncryptionService.shared.setKey(newKey)
+            let newKey = EncryptionService.shared.generateKey()
 
-                await MainActor.run {
-                    generatedKey = newKey
-                    isProcessing = false
-                    withAnimation { currentStep = .keyDisplay }
-                }
-            } catch {
-                await MainActor.run {
-                    isProcessing = false
-                    keyError = "Failed to generate encryption key"
-                }
+            await MainActor.run {
+                generatedKey = newKey
+                generatedKeyMode = mode == .recovery ? .explicitStartFresh : .recoverExisting
+                keyError = nil
+                isProcessing = false
+                withAnimation { currentStep = .keyDisplay }
             }
         }
     }
@@ -555,30 +567,31 @@ struct CloudSyncOnboardingView: View {
 
         isProcessing = true
         Task {
-            do {
-                try await EncryptionService.shared.setKey(trimmedKey)
-
-                await MainActor.run {
-                    SettingsManager.shared.isCloudSyncEnabled = true
-                    isProcessing = false
-                    onSetupComplete?(trimmedKey)
-                    dismiss()
-                }
-            } catch {
-                await MainActor.run {
-                    isProcessing = false
-                    keyError = "The encryption key you entered is invalid"
-                }
-            }
+            await completeSetup(with: trimmedKey, activationMode: .recoverExisting)
         }
     }
 
     private func handleComplete() {
-        SettingsManager.shared.isCloudSyncEnabled = true
-        if let key = generatedKey {
-            onSetupComplete?(key)
+        guard let key = generatedKey else { return }
+        isProcessing = true
+        Task {
+            await completeSetup(with: key, activationMode: generatedKeyMode)
         }
-        dismiss()
+    }
+
+    private func completeSetup(with key: String, activationMode: CloudKeyActivationMode) async {
+        let errorMessage = await onSetupComplete?(key, activationMode) ?? nil
+
+        await MainActor.run {
+            isProcessing = false
+            if let errorMessage {
+                keyError = errorMessage
+                return
+            }
+
+            SettingsManager.shared.isCloudSyncEnabled = true
+            dismiss()
+        }
     }
 
     private func copyKeyToClipboard() {

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -9,6 +9,11 @@ import SwiftUI
 import AVFoundation
 
 struct CloudSyncSettingsView: View {
+    private enum KeyInputMode {
+        case replacePrimary
+        case addRecovery
+    }
+
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
     @ObservedObject var viewModel: ChatViewModel
@@ -16,6 +21,7 @@ struct CloudSyncSettingsView: View {
     @ObservedObject private var settings = SettingsManager.shared
     
     @State private var showKeyInput: Bool = false
+    @State private var keyInputMode: KeyInputMode = .replacePrimary
     @State private var copiedToClipboard: Bool = false
     
     var body: some View {
@@ -64,6 +70,13 @@ struct CloudSyncSettingsView: View {
                                     .foregroundColor(.red)
                             }
                         }
+                    }
+
+                    if settings.isCloudSyncEnabled &&
+                        CloudKeyAuthorizationStore.shared.currentMode() == nil {
+                        Text("Cloud sync writes are paused until this device verifies the current encryption key.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
                     }
                     
                     Button(action: {
@@ -115,15 +128,24 @@ struct CloudSyncSettingsView: View {
                     }
                     
                     Button(action: {
+                        keyInputMode = .replacePrimary
                         showKeyInput = true
                     }) {
-                        Label("Change Encryption Key", systemImage: "key.fill")
+                        Label("Replace Primary Key", systemImage: "key.fill")
+                            .foregroundColor(.primary)
+                    }
+
+                    Button(action: {
+                        keyInputMode = .addRecovery
+                        showKeyInput = true
+                    }) {
+                        Label("Add Recovery Key", systemImage: "key.badge.plus")
                             .foregroundColor(.primary)
                     }
             } header: {
                 Text("Encryption")
             } footer: {
-                    Text("Your encryption key is used to secure all your chat data. Keep it safe and never share it with anyone.")
+                    Text("Recovery keys can decrypt older data without changing your current primary key. Replacing the primary key starts a new encrypted cloud history for future uploads.")
                         .font(.caption)
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
@@ -185,15 +207,23 @@ struct CloudSyncSettingsView: View {
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
             .sheet(isPresented: $showKeyInput) {
-                EncryptionKeyInputView(isPresented: $showKeyInput) { importedKey in
-                    Task {
-                        do {
-                            try await viewModel.setEncryptionKey(importedKey)
-                        } catch {
-                            #if DEBUG
-                            print("Failed to change encryption key: \(error)")
-                            #endif
+                EncryptionKeyInputView(
+                    isPresented: $showKeyInput,
+                    title: keyInputMode == .addRecovery ? "Add Recovery Key" : "Replace Primary Key",
+                    description: keyInputMode == .addRecovery
+                        ? "Add a fallback key that can decrypt older cloud data without changing your current primary key."
+                        : "Replacing the primary key will use this key for future cloud writes on this device.",
+                    submitLabel: keyInputMode == .addRecovery ? "Add Recovery Key" : "Replace Primary Key"
+                ) { importedKey in
+                    do {
+                        if keyInputMode == .addRecovery {
+                            try await viewModel.addRecoveryKey(importedKey)
+                        } else {
+                            try await viewModel.setEncryptionKey(importedKey, mode: .explicitStartFresh)
                         }
+                        return nil
+                    } catch {
+                        return error.localizedDescription
                     }
                 }
             }

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -19,6 +19,7 @@ struct CloudSyncSettingsView: View {
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var authManager: AuthManager
     @ObservedObject private var settings = SettingsManager.shared
+    @ObservedObject private var passkeyManager = PasskeyManager.shared
     
     @State private var showKeyInput: Bool = false
     @State private var showReplacePrimaryOptions: Bool = false
@@ -129,24 +130,36 @@ struct CloudSyncSettingsView: View {
                         }
                     }
                     
-                    Button(action: {
-                        showReplacePrimaryOptions = true
-                    }) {
-                        Label("Replace Primary Key", systemImage: "key.fill")
-                            .foregroundColor(.primary)
-                    }
+                    if passkeyManager.passkeyActive {
+                        Button(action: {
+                            keyInputMode = .addRecovery
+                            showKeyInput = true
+                        }) {
+                            Label("Add Decryption Key", systemImage: "key.badge.plus")
+                                .foregroundColor(.primary)
+                        }
+                    } else {
+                        Button(action: {
+                            showReplacePrimaryOptions = true
+                        }) {
+                            Label("Replace Primary Key", systemImage: "key.fill")
+                                .foregroundColor(.primary)
+                        }
 
-                    Button(action: {
-                        keyInputMode = .addRecovery
-                        showKeyInput = true
-                    }) {
-                        Label("Add Recovery Key", systemImage: "key.badge.plus")
-                            .foregroundColor(.primary)
+                        Button(action: {
+                            keyInputMode = .addRecovery
+                            showKeyInput = true
+                        }) {
+                            Label("Add Recovery Key", systemImage: "key.badge.plus")
+                                .foregroundColor(.primary)
+                        }
                     }
             } header: {
                 Text("Encryption")
             } footer: {
-                    Text("Recovery keys can decrypt older data without changing your current primary key. Use Recover Existing to verify a replacement key against your cloud data, or Start Fresh to only use it for future uploads on this device.")
+                    Text(passkeyManager.passkeyActive
+                         ? "Add an older key to decrypt data from before a key rotation. Your passkey manages the primary key."
+                         : "Recovery keys can decrypt older data without changing your current primary key. Use Recover Existing to verify a replacement key against your cloud data, or Start Fresh to only use it for future uploads on this device.")
                         .font(.caption)
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
@@ -258,7 +271,7 @@ struct CloudSyncSettingsView: View {
     private var keyInputTitle: String {
         switch keyInputMode {
         case .addRecovery:
-            return "Add Recovery Key"
+            return passkeyManager.passkeyActive ? "Add Decryption Key" : "Add Recovery Key"
         case .replacePrimary:
             return replacePrimaryMode == .recoverExisting
                 ? "Recover Existing Key"
@@ -269,7 +282,9 @@ struct CloudSyncSettingsView: View {
     private var keyInputDescription: String {
         switch keyInputMode {
         case .addRecovery:
-            return "Add a fallback key that can decrypt older cloud data without changing your current primary key."
+            return passkeyManager.passkeyActive
+                ? "Add an older key to decrypt data from before a key rotation. Your passkey manages the primary key."
+                : "Add a fallback key that can decrypt older cloud data without changing your current primary key."
         case .replacePrimary:
             return replacePrimaryMode == .recoverExisting
                 ? "Verify this key against your existing cloud data before future cloud writes resume on this device."
@@ -280,7 +295,7 @@ struct CloudSyncSettingsView: View {
     private var keyInputSubmitLabel: String {
         switch keyInputMode {
         case .addRecovery:
-            return "Add Recovery Key"
+            return passkeyManager.passkeyActive ? "Add Key" : "Add Recovery Key"
         case .replacePrimary:
             return replacePrimaryMode == .recoverExisting
                 ? "Recover Existing Data"

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -21,7 +21,9 @@ struct CloudSyncSettingsView: View {
     @ObservedObject private var settings = SettingsManager.shared
     
     @State private var showKeyInput: Bool = false
+    @State private var showReplacePrimaryOptions: Bool = false
     @State private var keyInputMode: KeyInputMode = .replacePrimary
+    @State private var replacePrimaryMode: CloudKeyActivationMode = .recoverExisting
     @State private var copiedToClipboard: Bool = false
     
     var body: some View {
@@ -128,8 +130,7 @@ struct CloudSyncSettingsView: View {
                     }
                     
                     Button(action: {
-                        keyInputMode = .replacePrimary
-                        showKeyInput = true
+                        showReplacePrimaryOptions = true
                     }) {
                         Label("Replace Primary Key", systemImage: "key.fill")
                             .foregroundColor(.primary)
@@ -145,7 +146,7 @@ struct CloudSyncSettingsView: View {
             } header: {
                 Text("Encryption")
             } footer: {
-                    Text("Recovery keys can decrypt older data without changing your current primary key. Replacing the primary key starts a new encrypted cloud history for future uploads.")
+                    Text("Recovery keys can decrypt older data without changing your current primary key. Use Recover Existing to verify a replacement key against your cloud data, or Start Fresh to only use it for future uploads on this device.")
                         .font(.caption)
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
@@ -206,20 +207,37 @@ struct CloudSyncSettingsView: View {
             UINavigationBar.appearance().compactAppearance = appearance
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
+        .alert("Replace Primary Key", isPresented: $showReplacePrimaryOptions) {
+            Button("Recover Existing Data") {
+                replacePrimaryMode = .recoverExisting
+                keyInputMode = .replacePrimary
+                DispatchQueue.main.async {
+                    showKeyInput = true
+                }
+            }
+            Button("Start Fresh") {
+                replacePrimaryMode = .explicitStartFresh
+                keyInputMode = .replacePrimary
+                DispatchQueue.main.async {
+                    showKeyInput = true
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Choose how this key should behave. Recover Existing verifies it against your existing cloud data. Start Fresh only uses it for future cloud writes on this device.")
+        }
             .sheet(isPresented: $showKeyInput) {
                 EncryptionKeyInputView(
                     isPresented: $showKeyInput,
-                    title: keyInputMode == .addRecovery ? "Add Recovery Key" : "Replace Primary Key",
-                    description: keyInputMode == .addRecovery
-                        ? "Add a fallback key that can decrypt older cloud data without changing your current primary key."
-                        : "Replacing the primary key will use this key for future cloud writes on this device.",
-                    submitLabel: keyInputMode == .addRecovery ? "Add Recovery Key" : "Replace Primary Key"
+                    title: keyInputTitle,
+                    description: keyInputDescription,
+                    submitLabel: keyInputSubmitLabel
                 ) { importedKey in
                     do {
                         if keyInputMode == .addRecovery {
                             try await viewModel.addRecoveryKey(importedKey)
                         } else {
-                            try await viewModel.setEncryptionKey(importedKey, mode: .explicitStartFresh)
+                            try await viewModel.setEncryptionKey(importedKey, mode: replacePrimaryMode)
                         }
                         return nil
                     } catch {
@@ -235,5 +253,38 @@ struct CloudSyncSettingsView: View {
         let prefix = String(key.prefix(visibleChars))
         let masked = String(repeating: "•", count: key.count - visibleChars)
         return "\(prefix)\(masked)"
+    }
+
+    private var keyInputTitle: String {
+        switch keyInputMode {
+        case .addRecovery:
+            return "Add Recovery Key"
+        case .replacePrimary:
+            return replacePrimaryMode == .recoverExisting
+                ? "Recover Existing Key"
+                : "Start Fresh with New Primary"
+        }
+    }
+
+    private var keyInputDescription: String {
+        switch keyInputMode {
+        case .addRecovery:
+            return "Add a fallback key that can decrypt older cloud data without changing your current primary key."
+        case .replacePrimary:
+            return replacePrimaryMode == .recoverExisting
+                ? "Verify this key against your existing cloud data before future cloud writes resume on this device."
+                : "Use this key for future cloud writes on this device without validating it against older cloud data."
+        }
+    }
+
+    private var keyInputSubmitLabel: String {
+        switch keyInputMode {
+        case .addRecovery:
+            return "Add Recovery Key"
+        case .replacePrimary:
+            return replacePrimaryMode == .recoverExisting
+                ? "Recover Existing Data"
+                : "Start Fresh"
+        }
     }
 }

--- a/TinfoilChat/Views/EncryptionKeyInputView.swift
+++ b/TinfoilChat/Views/EncryptionKeyInputView.swift
@@ -10,11 +10,15 @@ import AVFoundation
 
 struct EncryptionKeyInputView: View {
     @Binding var isPresented: Bool
-    let onKeyImported: ((String) -> Void)?
+    var title: String = "Import Encryption Key"
+    var description: String = "Your encryption key secures all your chat data. You can enter it manually or scan the QR code from your other device."
+    var submitLabel: String = "Import Key"
+    let onKeyImported: ((String) async -> String?)?
     
     @State private var keyInput: String = ""
     @State private var keyError: String? = nil
     @State private var isKeyVisible: Bool = false
+    @State private var isImporting: Bool = false
     @State private var showQRScanner = false
     @FocusState private var isKeyFieldFocused: Bool
     @Environment(\.dismiss) var dismiss
@@ -26,12 +30,12 @@ struct EncryptionKeyInputView: View {
                 VStack(spacing: 20) {
                     // Title and description
                     VStack(spacing: 8) {
-                        Text(isKeyFieldFocused ? "Enter your encryption key" : "Encryption Key")
+                        Text(isKeyFieldFocused ? "Enter your encryption key" : title)
                             .font(isKeyFieldFocused ? .headline : .title2)
                             .fontWeight(.semibold)
                         
                         if !isKeyFieldFocused {
-                            Text("Your encryption key secures all your chat data. You can enter it manually or scan the QR code from your other device.")
+                            Text(description)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
                                 .multilineTextAlignment(.center)
@@ -145,11 +149,19 @@ struct EncryptionKeyInputView: View {
                     
                     // Import button - always visible but repositioned when focused
                     Button(action: {
-                        if keyError == nil && !keyInput.isEmpty {
+                        if keyError == nil && !keyInput.isEmpty && !isImporting {
                             importKey()
                         }
                     }) {
-                        Text("Import Key")
+                        Group {
+                            if isImporting {
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                    .tint(.white)
+                            } else {
+                                Text(submitLabel)
+                            }
+                        }
                             .fontWeight(.semibold)
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
@@ -160,7 +172,7 @@ struct EncryptionKeyInputView: View {
                                           Color.gray.opacity(0.5) : Color.accentPrimary)
                             )
                     }
-                    .disabled(keyInput.isEmpty || keyError != nil)
+                    .disabled(keyInput.isEmpty || keyError != nil || isImporting)
                     .padding(.top, isKeyFieldFocused ? 8 : 0)
                 }
                 .padding(.horizontal, 20)
@@ -177,7 +189,7 @@ struct EncryptionKeyInputView: View {
                 }
             }
             .background(Color(UIColor.systemBackground))
-            .navigationTitle("Import Encryption Key")
+            .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -236,8 +248,20 @@ struct EncryptionKeyInputView: View {
     }
     
     private func importKey() {
-        onKeyImported?(keyInput)
-        isPresented = false
+        keyError = nil
+        isImporting = true
+
+        Task {
+            let errorMessage = await onKeyImported?(keyInput) ?? nil
+            await MainActor.run {
+                isImporting = false
+                if let errorMessage {
+                    keyError = errorMessage
+                } else {
+                    isPresented = false
+                }
+            }
+        }
     }
     
     private func requestCameraPermission(completion: @escaping (Bool) -> Void) {

--- a/TinfoilChat/Views/EncryptionKeyInputView.swift
+++ b/TinfoilChat/Views/EncryptionKeyInputView.swift
@@ -248,6 +248,7 @@ struct EncryptionKeyInputView: View {
     }
     
     private func importKey() {
+        guard !isImporting else { return }
         keyError = nil
         isImporting = true
 

--- a/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
+++ b/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
@@ -17,6 +17,8 @@ struct PasskeyRecoveryChoiceView: View {
     var onStartFresh: () async -> Bool
     /// Cloud sync OFF, dismiss. User can retry from Settings later.
     var onSkip: () -> Void
+    /// Enter encryption key manually without passkey.
+    var onManualKeyEntry: () -> Void
 
     @State private var isLoading = false
     @State private var loadingAction: LoadingAction?
@@ -98,6 +100,21 @@ struct PasskeyRecoveryChoiceView: View {
                 }
                 .disabled(isLoading)
 
+                // Manual key entry — bypass passkey entirely
+                Button(action: handleManualKeyEntry) {
+                    Label("Enter Key Manually", systemImage: "keyboard")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .strokeBorder(Color.secondary.opacity(0.3), lineWidth: 1)
+                        )
+                }
+                .disabled(isLoading)
+
                 // Skip — cloud sync off
                 Button(action: handleSkip) {
                     Text("Skip for Now")
@@ -141,6 +158,11 @@ struct PasskeyRecoveryChoiceView: View {
                 if success { dismiss() }
             }
         }
+    }
+
+    private func handleManualKeyEntry() {
+        onManualKeyEntry()
+        dismiss()
     }
 
     private func handleSkip() {

--- a/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
+++ b/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
@@ -30,7 +30,7 @@ struct PasskeyRecoveryChoiceView: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            Spacer().frame(height: 24)
+            Spacer().frame(height: 8)
 
             ZStack {
                 Circle()
@@ -127,7 +127,7 @@ struct PasskeyRecoveryChoiceView: View {
 
             Spacer().frame(height: 24)
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.height(520)])
         .presentationDragIndicator(.visible)
         .interactiveDismissDisabled(isLoading)
     }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -439,6 +439,7 @@ struct SettingsView: View {
                             if newValue {
                                 if EncryptionService.shared.hasEncryptionKey() {
                                     settings.isCloudSyncEnabled = true
+                                    chatViewModel.reloadEncryptionKey()
                                     Task {
                                         await chatViewModel.performFullSync()
                                     }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -444,7 +444,21 @@ struct SettingsView: View {
                                     }
                                 } else {
                                     Task {
-                                        await passkeyManager.retryPasskeySetup()
+                                        let result = await passkeyManager.retryPasskeySetup()
+                                        switch result {
+                                        case .manualSetupRequired:
+                                            await MainActor.run {
+                                                chatViewModel.cloudSyncOnboardingMode = .setup
+                                                chatViewModel.showCloudSyncOnboarding = true
+                                            }
+                                        case .manualRecoveryRequired:
+                                            await MainActor.run {
+                                                chatViewModel.cloudSyncOnboardingMode = .recovery
+                                                chatViewModel.showCloudSyncOnboarding = true
+                                            }
+                                        default:
+                                            break
+                                        }
                                     }
                                 }
                             } else {
@@ -520,7 +534,21 @@ struct SettingsView: View {
                 } else if passkeyManager.passkeySetupAvailable && !EncryptionService.shared.hasEncryptionKey() {
                     Button(action: {
                         Task {
-                            await passkeyManager.retryPasskeySetup()
+                            let result = await passkeyManager.retryPasskeySetup()
+                            switch result {
+                            case .manualSetupRequired:
+                                await MainActor.run {
+                                    chatViewModel.cloudSyncOnboardingMode = .setup
+                                    chatViewModel.showCloudSyncOnboarding = true
+                                }
+                            case .manualRecoveryRequired:
+                                await MainActor.run {
+                                    chatViewModel.cloudSyncOnboardingMode = .recovery
+                                    chatViewModel.showCloudSyncOnboarding = true
+                                }
+                            default:
+                                break
+                            }
                         }
                     }) {
                         VStack(alignment: .leading, spacing: 6) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors cloud sync to prevent split‑brain by validating and authorizing the active encryption key before any cloud writes. Adds manual key setup/recovery (no passkey required), explicit Recover Existing vs Start Fresh flows, and stronger passkey backups with versioning and conflict checks.

- **New Features**
  - Preflight key validation before writes (profile-first, then probe up to `Constants.Sync.keyValidationProbeCount` chats); UI shows a paused state until authorized, and existing keys are auto‑authorized on sign‑in with the explicit user ID when validation passes.
  - Cloud key authorization store records the current key’s fingerprint + mode; writes stay paused until authorized.
  - Explicit activation modes: `recoverExisting`, `explicitStartFresh`, `addRecoveryKey`. Settings offer “Replace Primary Key” (choose Recover Existing or Start Fresh) and “Add Recovery/Decryption Key.” Onboarding supports manual setup and recovery with inline async errors; when a passkey is active, Settings only shows “Add Decryption Key.”
  - Passkey backups include `authorizationMode` and monotonic `bundle_version`; saves verify persisted values, limit attempts, enforce remote bundle versions, and periodic refresh applies recovered bundles and updates local sync/bundle versions.

- **Bug Fixes**
  - Block all uploads/deletes/reencryptions and profile pushes until the device key is validated/authorized; fallback‑key decrypts count as mismatches.
  - Primary key changes are safe and reversible: on mismatch or failed trust saves, prior keys are restored or state is cleared; “Start Fresh” only affects future writes on this device.
  - Protect passkey backups from stale/conflicting updates with `sync_version`/`bundle_version` checks, post‑save verification, conflict detection, and seeded local versions; keep behavior consistent after recovery.
  - Sign‑out clears cloud key authorization; skip profile uploads when remote decryption previously failed unless `explicitStartFresh` was chosen; reload the cached encryption key when re‑enabling cloud sync; adjusted passkey recovery sheet height.

<sup>Written for commit 5ed6a85ccb3a5249a543af180d887189d7b5cc5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

