### PR TITLE
feat: make user avatars

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -9,6 +9,11 @@ import Foundation
 
 /// Application-wide constants
 enum Constants {
+    enum Avatar {
+        static let primaryColorHex = "004444"
+        static let secondaryColorHex = "F9F8F6"
+    }
+
     enum Clerk {
         static let publishableKey = "pk_live_Y2xlcmsudGluZm9pbC5zaCQ"
     }

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -119,7 +119,8 @@ class AuthManager: ObservableObject {
             "email": user.primaryEmailAddress?.emailAddress ?? "",
             "name": user.firstName ?? "",
             "fullName": "\(user.firstName ?? "") \(user.lastName ?? "")",
-            "imageUrl": user.imageUrl
+            "imageUrl": user.imageUrl,
+            "hasImage": user.hasImage
         ]
         
         // Store subscription status if it exists

--- a/TinfoilChat/Views/Authentication/AuthenticationHelpers.swift
+++ b/TinfoilChat/Views/Authentication/AuthenticationHelpers.swift
@@ -39,25 +39,21 @@ func authButton(icon: String? = nil, systemIcon: String? = nil, text: String, ac
   .shadow(color: Color.black.opacity(0.15), radius: 6, x: 0, y: 3)
 }
 
-/// User profile image view with fallback to system icon
+/// User profile image view with fallback to pixel avatar
 @ViewBuilder
-func userProfileImage(imageURL: URL?) -> some View {
-  if let url = imageURL, !url.absoluteString.isEmpty {
+func userProfileImage(imageURL: URL?, userId: String? = nil, hasImage: Bool = true) -> some View {
+  if hasImage, let url = imageURL, !url.absoluteString.isEmpty {
     AsyncImage(url: url) { image in
       image
         .resizable()
         .aspectRatio(contentMode: .fill)
     } placeholder: {
-      Image(systemName: "person.circle.fill")
-        .resizable()
+      PixelAvatarView(name: userId ?? "user", size: 80)
     }
     .frame(width: 80, height: 80)
     .clipShape(Circle())
   } else {
-    Image(systemName: "person.circle.fill")
-      .resizable()
-      .frame(width: 80, height: 80)
-      .foregroundColor(.white)
+    PixelAvatarView(name: userId ?? "user", size: 80)
   }
 }
 

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -140,7 +140,7 @@ struct ModularAuthenticationView: View {
     VStack(spacing: 24) {
       // User profile information at the top
       VStack(spacing: 16) {
-        userProfileImage(imageURL: URL(string: clerk.user!.imageUrl))
+        userProfileImage(imageURL: URL(string: clerk.user!.imageUrl), userId: clerk.user!.id, hasImage: clerk.user!.hasImage)
           .frame(width: 80, height: 80)
         
         Text("\(clerk.user!.firstName ?? "") \(clerk.user!.lastName ?? "")")
@@ -288,7 +288,7 @@ struct ModularAuthenticationView: View {
   @ViewBuilder
   private func accountInfoView(user: User) -> some View {
     VStack(spacing: 16) {
-      userProfileImage(imageURL: URL(string: user.imageUrl))
+      userProfileImage(imageURL: URL(string: user.imageUrl), userId: user.id, hasImage: user.hasImage)
       
       Text("\(user.firstName ?? "") \(user.lastName ?? "")")
         .font(.title2)
@@ -306,7 +306,7 @@ struct ModularAuthenticationView: View {
     VStack(spacing: 16) {
       if let userData = authManager.localUserData {
         // User profile information at the top
-        userProfileImage(imageURL: (userData["imageUrl"] as? String).flatMap { URL(string: $0) })
+        userProfileImage(imageURL: (userData["imageUrl"] as? String).flatMap { URL(string: $0) }, userId: userData["id"] as? String, hasImage: (userData["hasImage"] as? Bool) ?? false)
         
         Text((userData["fullName"] as? String) ?? (userData["name"] as? String) ?? "User")
           .font(.title2)

--- a/TinfoilChat/Views/PixelAvatarView.swift
+++ b/TinfoilChat/Views/PixelAvatarView.swift
@@ -68,6 +68,6 @@ struct PixelAvatarView: View {
         for char in name.unicodeScalars {
             hash = ((hash &<< 5) &- hash) &+ Int32(char.value)
         }
-        return Int(abs(hash))
+        return Int(hash.magnitude)
     }
 }

--- a/TinfoilChat/Views/PixelAvatarView.swift
+++ b/TinfoilChat/Views/PixelAvatarView.swift
@@ -1,0 +1,73 @@
+//
+//  PixelAvatarView.swift
+//  TinfoilChat
+//
+//  Deterministic pixel avatar matching the boring-avatars "pixel" variant
+//  used on the landing site for users without a profile image.
+
+import SwiftUI
+
+struct PixelAvatarView: View {
+    let name: String
+    let size: CGFloat
+
+    private let baseSize: CGFloat = 80
+    private let baseCellSize: CGFloat = 10
+    private let colors: [Color] = [
+        Color(hex: Constants.Avatar.primaryColorHex),
+        Color(hex: Constants.Avatar.secondaryColorHex)
+    ]
+    private let pixelPositions: [(x: CGFloat, y: CGFloat)] = [
+        (0, 0), (20, 0), (40, 0), (60, 0), (10, 0), (30, 0), (50, 0), (70, 0),
+        (0, 10), (0, 20), (0, 30), (0, 40), (0, 50), (0, 60), (0, 70),
+        (20, 10), (20, 20), (20, 30), (20, 40), (20, 50), (20, 60), (20, 70),
+        (40, 10), (40, 20), (40, 30), (40, 40), (40, 50), (40, 60), (40, 70),
+        (60, 10), (60, 20), (60, 30), (60, 40), (60, 50), (60, 60), (60, 70),
+        (10, 10), (10, 20), (10, 30), (10, 40), (10, 50), (10, 60), (10, 70),
+        (30, 10), (30, 20), (30, 30), (30, 40), (30, 50), (30, 60), (30, 70),
+        (50, 10), (50, 20), (50, 30), (50, 40), (50, 50), (50, 60), (50, 70),
+        (70, 10), (70, 20), (70, 30), (70, 40), (70, 50), (70, 60), (70, 70)
+    ]
+
+    var body: some View {
+        let pixelColors = generateColors(name: name)
+
+        Canvas { context, canvasSize in
+            let scaleX = canvasSize.width / baseSize
+            let scaleY = canvasSize.height / baseSize
+            let cellWidth = baseCellSize * scaleX
+            let cellHeight = baseCellSize * scaleY
+
+            for (index, position) in pixelPositions.enumerated() {
+                let rect = CGRect(
+                    x: position.x * scaleX,
+                    y: position.y * scaleY,
+                    width: cellWidth,
+                    height: cellHeight
+                )
+                context.fill(
+                    Path(rect),
+                    with: .color(pixelColors[index])
+                )
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+    }
+
+    private func generateColors(name: String) -> [Color] {
+        let hash = hashCode(name)
+        let range = colors.count
+        return (0..<pixelPositions.count).map { i in
+            colors[(hash % (i + 1)) % range]
+        }
+    }
+
+    private func hashCode(_ name: String) -> Int {
+        var hash: Int32 = 0
+        for char in name.unicodeScalars {
+            hash = ((hash &<< 5) &- hash) &+ Int32(char.value)
+        }
+        return Int(abs(hash))
+    }
+}

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -284,29 +284,24 @@ struct SettingsView: View {
     
     @ViewBuilder
     private var userAvatar: some View {
-        if let user = clerk.user, !user.imageUrl.isEmpty {
+        if let user = clerk.user, user.hasImage, !user.imageUrl.isEmpty {
             AsyncImage(url: URL(string: user.imageUrl)) { image in
                 image.resizable().aspectRatio(contentMode: .fill)
             } placeholder: {
-                Image(systemName: "person.circle.fill")
-                    .resizable()
-                    .foregroundColor(.secondary)
+                PixelAvatarView(name: user.id, size: 40)
             }
         } else if let userData = authManager.localUserData,
+                  (userData["hasImage"] as? Bool) == true,
                   let imageUrlString = userData["imageUrl"] as? String,
                   !imageUrlString.isEmpty,
                   let url = URL(string: imageUrlString) {
             AsyncImage(url: url) { image in
                 image.resizable().aspectRatio(contentMode: .fill)
             } placeholder: {
-                Image(systemName: "person.circle.fill")
-                    .resizable()
-                    .foregroundColor(.secondary)
+                PixelAvatarView(name: (userData["id"] as? String) ?? "user", size: 40)
             }
         } else {
-            Image(systemName: "person.circle.fill")
-                .resizable()
-                .foregroundColor(.secondary)
+            PixelAvatarView(name: clerk.user?.id ?? (authManager.localUserData?["id"] as? String) ?? "user", size: 40)
         }
     }
     


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add deterministic pixel avatars for users without profile images. Avatars are seeded by user ID and match the boring-avatars “pixel” style for a consistent look.

- **New Features**
  - Added PixelAvatarView with size control; seeded by user ID for stable output.
  - Introduced Constants.Avatar colors to style the pixels.
  - Updated userProfileImage to accept hasImage and userId and fall back to PixelAvatarView.
  - Replaced system icon placeholders with PixelAvatarView in auth and settings views.
  - Stored hasImage in local user data to drive avatar fallback logic.

- **Bug Fixes**
  - Reworked avatar hash to avoid Int32 abs edge cases, ensuring stable seeding without overflow.

<sup>Written for commit 11839d0abaabccb282f190a8a911c91496392a60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

