### PR TITLE
chore: remove unused fields from config parsing

### DIFF
--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -11,16 +11,12 @@ import Foundation
 struct AppModelConfig: Codable {
     let modelName: String
     let image: String
-    let repo: String
-    let endpoint: String
     let name: String
     let nameShort: String
     let description: String
     let details: String
     let parameters: String
     let contextWindow: String
-    let recommendedUse: String
-    let supportedLanguages: String
     let type: String
     let chat: Bool?
     let paid: Bool
@@ -93,6 +89,7 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
     var type: String { appConfig.type }
     var isMultimodal: Bool { appConfig.multimodal }
     var isChat: Bool { appConfig.chat ?? (appConfig.type == "chat") }
+
 
     // For Hashable conformance
     func hash(into hasher: inout Hasher) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unused fields from AppModelConfig to simplify config parsing and reduce maintenance. No functional changes; configs with extra keys continue to decode.

- **Refactors**
  - Dropped fields: repo, endpoint, recommendedUse, supportedLanguages.

<sup>Written for commit 3a50dd2d9c0c142b789488ebd0b76c9fc29e853d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

