### PR TITLE
Upgrade clerk and add support for 2FA

### DIFF
--- a/TinfoilChat/Views/Authentication/AuthenticationHelpers.swift
+++ b/TinfoilChat/Views/Authentication/AuthenticationHelpers.swift
@@ -57,6 +57,36 @@ func userProfileImage(imageURL: URL?, userId: String? = nil, hasImage: Bool = tr
   }
 }
 
+// MARK: - Error Banner
+
+struct AuthErrorBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 14))
+                .foregroundColor(.red)
+
+            Text(message)
+                .font(.caption)
+                .foregroundColor(.primary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.red.opacity(0.1))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Color.red.opacity(0.2), lineWidth: 1)
+        )
+    }
+}
+
 // MARK: - Helper Functions
 
 /// Handle authentication errors and provide user-friendly messages

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -21,8 +21,6 @@ struct ModularAuthenticationView: View {
   @State private var authCheckTask: Task<Void, Never>? = nil
   @State private var isInVerificationMode = false
   @State private var isKeyboardVisible = false
-  @State private var showDeleteConfirmation = false
-  @State private var deleteError: String? = nil
   
   var body: some View {
     NavigationView {
@@ -41,7 +39,6 @@ struct ModularAuthenticationView: View {
                     .padding(.horizontal)
                 }
               }
-              .scrollDisabled(clerk.user != nil || authManager.localUserData != nil)
 
               // Third-party authentication options at the bottom
               if shouldShowThirdPartyAuth && !isKeyboardVisible {
@@ -126,93 +123,11 @@ struct ModularAuthenticationView: View {
   
   private var authenticationContent: some View {
     VStack(spacing: 16) {
-      if clerk.user != nil {
-        authenticatedUserView
-      } else if authManager.localUserData != nil {
-        storedUserInfoView()
-      } else {
-        authenticationForms
-      }
+      authenticationForms
     }
-  }
-  
-  private var authenticatedUserView: some View {
-    VStack(spacing: 24) {
-      // User profile information at the top
-      VStack(spacing: 16) {
-        userProfileImage(imageURL: URL(string: clerk.user!.imageUrl), userId: clerk.user!.id, hasImage: clerk.user!.hasImage)
-          .frame(width: 80, height: 80)
-        
-        Text("\(clerk.user!.firstName ?? "") \(clerk.user!.lastName ?? "")")
-          .font(.title2)
-          .fontWeight(.semibold)
-      }
-      .padding(.top, 20)
-      
-      // Action buttons
-      VStack(spacing: 12) {
-        signOutButton
-          
-        Button(action: {
-          showDeleteConfirmation = true
-        }) {
-          HStack {
-            Spacer()
-            Text("Delete Account")
-              .font(.headline)
-              .foregroundColor(.red)
-            Spacer()
-          }
-          .frame(height: 50)
-          .background(Color(UIColor.systemBackground).opacity(0.2))
-          .cornerRadius(8)
-          .overlay(
-            RoundedRectangle(cornerRadius: 8)
-              .stroke(Color.red.opacity(0.5), lineWidth: 1)
-          )
-        }
-      }
-      .padding(.horizontal)
-      
-      // Subscription management text
-      VStack(spacing: 8) { 
-        Link("Go to www.tinfoil.sh to manage your account settings and subscriptions.", destination: URL(string: "https://www.tinfoil.sh")!)
-          .font(.body)
-          .multilineTextAlignment(.center)
-          .foregroundColor(.secondary)
-      }
-      .padding(.top, 12)
-      
-      Spacer()
-    }
-    .padding(.horizontal)
-    .alert("Delete Account", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {
-        showDeleteConfirmation = false
-      }
-      Button("Delete", role: .destructive) {
-        Task {
-          do {
-            try await authManager.deleteAccount()
-            dismiss()
-          } catch {
-            deleteError = error.localizedDescription
-          }
-        }
-      }
-    } message: {
-      Text("Are you sure you want to delete your account? This action cannot be undone.")
-    }
-    .alert("Error", isPresented: .init(
-      get: { deleteError != nil },
-      set: { if !$0 { deleteError = nil } }
-    )) {
-      Button("OK", role: .cancel) {
-        deleteError = nil
-      }
-    } message: {
-      if let error = deleteError {
-        Text(error)
+    .onChange(of: clerk.user != nil) { _, isSignedIn in
+      if isSignedIn {
+        dismiss()
       }
     }
   }
@@ -234,7 +149,7 @@ struct ModularAuthenticationView: View {
           Button("Already have an account? Sign In") {
             isSignUp = false
           }
-          .font(.footnote)
+          .font(.subheadline)
           .foregroundColor(.secondary)
           .padding(.top, 4)
         }
@@ -253,7 +168,7 @@ struct ModularAuthenticationView: View {
           Button("Don't have an account? Sign Up") {
             isSignUp = true
           }
-          .font(.footnote)
+          .font(.subheadline)
           .foregroundColor(.secondary)
           .padding(.top, 4)
         }
@@ -285,83 +200,6 @@ struct ModularAuthenticationView: View {
     UINavigationBar.appearance().compactAppearance = appearance
     UINavigationBar.appearance().scrollEdgeAppearance = appearance
     UINavigationBar.appearance().tintColor = tintColor
-  }
-  
-  // MARK: - User Profile Components
-  
-  @ViewBuilder
-  private func accountInfoView(user: User) -> some View {
-    VStack(spacing: 16) {
-      userProfileImage(imageURL: URL(string: user.imageUrl), userId: user.id, hasImage: user.hasImage)
-      
-      Text("\(user.firstName ?? "") \(user.lastName ?? "")")
-        .font(.title2)
-        .fontWeight(.semibold)
-        .foregroundColor(.white)
-      
-      Text(user.emailAddresses.first?.emailAddress ?? "")
-        .font(.body)
-        .foregroundColor(.gray)
-    }
-  }
-  
-  @ViewBuilder
-  private func storedUserInfoView() -> some View {
-    VStack(spacing: 16) {
-      if let userData = authManager.localUserData {
-        // User profile information at the top
-        userProfileImage(imageURL: (userData["imageUrl"] as? String).flatMap { URL(string: $0) }, userId: userData["id"] as? String, hasImage: (userData["hasImage"] as? Bool) ?? false)
-        
-        Text((userData["fullName"] as? String) ?? (userData["name"] as? String) ?? "User")
-          .font(.title2)
-          .fontWeight(.semibold)
-          .foregroundColor(.white)
-        
-        if let email = userData["email"] as? String, !email.isEmpty {
-          Text(email)
-            .font(.body)
-            .foregroundColor(.gray)
-        }
-        
-        Spacer().frame(height: 20)
-        
-        // Subscription management in the middle
-        VStack(spacing: 8) {
-          Text("Manage your account settings.")
-            .font(.body)
-            .multilineTextAlignment(.center)
-            .foregroundColor(.secondary)
-          
-          Link("Go to www.tinfoil.sh to manage your subscriptions.", destination: URL(string: "https://www.tinfoil.sh")!)
-            .font(.body)
-            .multilineTextAlignment(.center)
-            .foregroundColor(.secondary)
-        }
-        
-        Spacer().frame(height: 20)
-        
-        // Sign out button at the bottom
-        signOutButton
-      }
-    }
-    .padding(.horizontal)
-  }
-  
-  private var signOutButton: some View {
-    Button {
-      Task { await authManager.signOut() }
-    } label: {
-      HStack {
-        Spacer()
-        Text("Sign Out")
-          .font(.headline)
-          .foregroundColor(.white)
-        Spacer()
-      }
-      .frame(height: 50)
-      .background(Color.red.opacity(0.8))
-      .cornerRadius(8)
-    }
   }
   
   // MARK: - Authentication Components

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -181,7 +181,7 @@ struct ModularAuthenticationView: View {
   }
   
   private var shouldShowThirdPartyAuth: Bool {
-    clerk.user == nil && !isInVerificationMode && authManager.localUserData == nil
+    clerk.user == nil && !isInVerificationMode
   }
 
   private func setupNavigationBarAppearance() {

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -243,7 +243,11 @@ struct ModularAuthenticationView: View {
           errorMessage: $errorMessage,
           isLoading: $isLoading,
           onDismiss: { DispatchQueue.main.async { self.dismiss() } }
-        ).padding(.top, 20)
+        )
+        .onPreferenceChange(VerificationModePreferenceKey.self) { inVerificationMode in
+          isInVerificationMode = inVerificationMode
+        }
+        .padding(.top, 20)
         
         if !isInVerificationMode {
           Button("Don't have an account? Sign Up") {

--- a/TinfoilChat/Views/Authentication/SignInView.swift
+++ b/TinfoilChat/Views/Authentication/SignInView.swift
@@ -19,9 +19,14 @@ struct SignInView: View {
   
   @State private var email = ""
   @State private var password = ""
+  @State private var mfaCode = ""
   @State private var attemptedSubmit = false
   @State private var isEmailFormatInvalid = false
   @State private var showForgotPassword = false
+  @State private var needsMfa = false
+  @State private var mfaType: SignIn.MfaType = .totp
+  @State private var availableMfaTypes: [SignIn.MfaType] = []
+  @State private var isVerifyingMfa = false
   
   private var emailIsEmpty: Bool {
     return email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -39,6 +44,32 @@ struct SignInView: View {
   
   var body: some View {
     VStack(spacing: 12) {
+      if needsMfa {
+        mfaVerificationView
+          .transition(.move(edge: .trailing).combined(with: .opacity))
+      } else {
+        signInFormView
+          .transition(.move(edge: .leading).combined(with: .opacity))
+      }
+    }
+    .animation(.easeInOut(duration: 0.25), value: needsMfa)
+    .padding(.horizontal, 16)
+    .padding(.top, 0)
+    .padding(.bottom, 16)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+    .sheet(isPresented: $showForgotPassword) {
+      ForgotPasswordView(isPresented: $showForgotPassword)
+    }
+    .preference(key: VerificationModePreferenceKey.self, value: needsMfa)
+  }
+  
+  // MARK: - Sign In Form
+  
+  private var signInFormView: some View {
+    Group {
       UIKitTextField(text: $email, placeholder: "Email", keyboardType: .emailAddress, textContentType: .emailAddress)
         .frame(height: 50)
         .overlay(
@@ -114,17 +145,138 @@ struct SignInView: View {
           .padding(.top, 12)
       }
     }
-    .padding(.horizontal, 16)
-    .padding(.top, 0)
-    .padding(.bottom, 16)
-    .contentShape(Rectangle())
-    .onTapGesture {
-      UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-    }
-    .sheet(isPresented: $showForgotPassword) {
-      ForgotPasswordView(isPresented: $showForgotPassword)
+  }
+  
+  // MARK: - MFA Verification
+  
+  private var mfaVerificationView: some View {
+    VStack(spacing: 12) {
+      Text("Two-factor authentication")
+        .font(.headline)
+      
+      Text(mfaPromptText)
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+      
+      UIKitTextField(
+        text: $mfaCode,
+        placeholder: mfaType == .backupCode ? "Backup Code" : "Verification Code",
+        keyboardType: mfaType == .backupCode ? .default : .numberPad,
+        textContentType: .oneTimeCode
+      )
+        .frame(height: 50)
+        .overlay(
+          RoundedRectangle(cornerRadius: 8)
+            .stroke(Color(UIColor.systemGray4), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 1)
+        .padding(.bottom, 10)
+        .disabled(isVerifyingMfa)
+      
+      Button {
+        guard !isVerifyingMfa else { return }
+        Task {
+          await verifyMfaCode()
+        }
+      } label: {
+        HStack {
+          if isVerifyingMfa {
+            ProgressView()
+              .progressViewStyle(CircularProgressViewStyle(tint: colorScheme == .dark ? .black : .white))
+              .padding(.trailing, 8)
+          }
+          Text(isVerifyingMfa ? "Verifying..." : "Verify")
+        }
+        .font(.headline)
+        .foregroundColor(colorScheme == .dark ? .black : .white)
+        .frame(maxWidth: .infinity)
+        .frame(height: 50)
+        .background(
+          colorScheme == .dark ?
+            (isVerifyingMfa ? Color.white.opacity(0.7) : Color.white) :
+            (isVerifyingMfa ? Color.black.opacity(0.7) : Color.black)
+        )
+        .cornerRadius(8)
+        .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+      }
+      .buttonStyle(PressableButtonStyle())
+      .disabled(isVerifyingMfa)
+      
+      if hasAlternativeMfaMethod {
+        Button("Try another method") {
+          switchToAlternativeMfaMethod()
+        }
+        .font(.subheadline)
+        .foregroundColor(.blue)
+        .padding(.top, 8)
+        .disabled(isVerifyingMfa)
+      }
+      
+      Button("Cancel") {
+        needsMfa = false
+        mfaCode = ""
+        errorMessage = nil
+      }
+      .font(.system(size: 15, weight: .medium))
+      .foregroundColor(.secondary)
+      .padding(.top, hasAlternativeMfaMethod ? 0 : 8)
+      .disabled(isVerifyingMfa)
+      
+      if let errorMessage = errorMessage {
+        Text(errorMessage)
+          .foregroundColor(.red)
+          .font(.caption)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.top, 12)
+      }
     }
   }
+  
+  private var hasAlternativeMfaMethod: Bool {
+    return availableMfaTypes.count > 1
+  }
+  
+  private func switchToAlternativeMfaMethod() {
+    guard let nextType = availableMfaTypes.first(where: { $0 != mfaType }) else { return }
+    mfaCode = ""
+    errorMessage = nil
+    mfaType = nextType
+    
+    if nextType == .phoneCode || nextType == .emailCode {
+      Task {
+        do {
+          if var currentSignIn = clerk.auth.currentSignIn {
+            if nextType == .phoneCode {
+              currentSignIn = try await currentSignIn.sendMfaPhoneCode()
+            } else {
+              currentSignIn = try await currentSignIn.sendMfaEmailCode()
+            }
+          }
+        } catch {
+          await MainActor.run {
+            errorMessage = "Failed to send code: \(error.localizedDescription)"
+          }
+        }
+      }
+    }
+  }
+  
+  private var mfaPromptText: String {
+    switch mfaType {
+    case .totp:
+      return "Enter the code from your authenticator app"
+    case .phoneCode:
+      return "Enter the code sent to your phone"
+    case .emailCode:
+      return "Enter the code sent to your email"
+    case .backupCode:
+      return "Enter one of your backup codes"
+    }
+  }
+  
+  // MARK: - Actions
   
   private func signIn(email: String, password: String) async {
     await MainActor.run {
@@ -133,13 +285,43 @@ struct SignInView: View {
     }
     
     do {
-      try await clerk.auth.signInWithPassword(identifier: email, password: password)
-      try await clerk.refreshClient()
-      await authManager.initializeAuthState()
-      await MainActor.run {
-        // Post notification to close sidebar and go to main chat view
-        NotificationCenter.default.post(name: NSNotification.Name("AuthenticationCompleted"), object: nil)
-        onDismiss()
+      let signIn = try await clerk.auth.signInWithPassword(identifier: email, password: password)
+      
+      switch signIn.status {
+      case .needsSecondFactor:
+        let resolvedTypes = resolveAvailableMfaTypes(from: signIn.supportedSecondFactors)
+        let preferredType = resolvedTypes.first ?? .totp
+        
+        if preferredType == .phoneCode {
+          if var currentSignIn = clerk.auth.currentSignIn {
+            currentSignIn = try await currentSignIn.sendMfaPhoneCode()
+          }
+        } else if preferredType == .emailCode {
+          if var currentSignIn = clerk.auth.currentSignIn {
+            currentSignIn = try await currentSignIn.sendMfaEmailCode()
+          }
+        }
+        
+        await MainActor.run {
+          availableMfaTypes = resolvedTypes
+          mfaType = preferredType
+          needsMfa = true
+          isLoading = false
+        }
+        
+      case .complete:
+        try await clerk.refreshClient()
+        await authManager.initializeAuthState()
+        await MainActor.run {
+          NotificationCenter.default.post(name: NSNotification.Name("AuthenticationCompleted"), object: nil)
+          onDismiss()
+        }
+        
+      default:
+        await MainActor.run {
+          errorMessage = "Sign-in could not be completed. Please try again."
+          isLoading = false
+        }
       }
     } catch {
       await MainActor.run {
@@ -147,5 +329,55 @@ struct SignInView: View {
         isLoading = false
       }
     }
+  }
+  
+  private func verifyMfaCode() async {
+    await MainActor.run {
+      isVerifyingMfa = true
+      errorMessage = nil
+    }
+    
+    do {
+      guard var signIn = clerk.auth.currentSignIn else {
+        throw NSError(domain: "ClerkError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Sign-in session expired. Please try again."])
+      }
+      
+      signIn = try await signIn.verifyMfaCode(mfaCode, type: mfaType)
+      
+      if signIn.status == .complete {
+        try await clerk.refreshClient()
+        await authManager.initializeAuthState()
+        await MainActor.run {
+          isVerifyingMfa = false
+          NotificationCenter.default.post(name: NSNotification.Name("AuthenticationCompleted"), object: nil)
+          onDismiss()
+        }
+      } else {
+        await MainActor.run {
+          errorMessage = "Verification could not be completed. Please try again."
+          isVerifyingMfa = false
+        }
+      }
+    } catch {
+      await MainActor.run {
+        errorMessage = "Verification failed: \(error.localizedDescription)"
+        isVerifyingMfa = false
+      }
+    }
+  }
+  
+  private func resolveAvailableMfaTypes(from factors: [Factor]?) -> [SignIn.MfaType] {
+    guard let factors = factors else { return [.totp] }
+    let strategies = Set(factors.map { $0.strategy.rawValue })
+    
+    let preferenceOrder: [(String, SignIn.MfaType)] = [
+      ("totp", .totp),
+      ("phone_code", .phoneCode),
+      ("email_code", .emailCode),
+      ("backup_code", .backupCode),
+    ]
+    
+    let available = preferenceOrder.compactMap { strategies.contains($0.0) ? $0.1 : nil }
+    return available.isEmpty ? [.totp] : available
   }
 } 

--- a/TinfoilChat/Views/Authentication/SignInView.swift
+++ b/TinfoilChat/Views/Authentication/SignInView.swift
@@ -231,7 +231,9 @@ struct SignInView: View {
   }
   
   private func switchToAlternativeMfaMethod() {
-    guard let nextType = availableMfaTypes.first(where: { $0 != mfaType }) else { return }
+    guard let currentIndex = availableMfaTypes.firstIndex(where: { $0 == mfaType }) else { return }
+    let nextIndex = (currentIndex + 1) % availableMfaTypes.count
+    let nextType = availableMfaTypes[nextIndex]
     mfaCode = ""
     errorMessage = nil
     mfaType = nextType

--- a/TinfoilChat/Views/Authentication/SignInView.swift
+++ b/TinfoilChat/Views/Authentication/SignInView.swift
@@ -125,7 +125,7 @@ struct SignInView: View {
         showForgotPassword = true
       }) {
         Text("Forgot Password?")
-          .font(.system(size: 15, weight: .medium))
+          .font(.subheadline)
           .foregroundColor(.secondary)
       }
       .padding(.top, 8)
@@ -137,12 +137,8 @@ struct SignInView: View {
       }
       
       if let errorMessage = errorMessage {
-        Text(errorMessage)
-          .foregroundColor(.red)
-          .font(.caption)
-          .multilineTextAlignment(.center)
-          .fixedSize(horizontal: false, vertical: true)
-          .padding(.top, 12)
+        AuthErrorBanner(message: errorMessage)
+          .padding(.top, 8)
       }
     }
   }
@@ -208,7 +204,7 @@ struct SignInView: View {
           switchToAlternativeMfaMethod()
         }
         .font(.subheadline)
-        .foregroundColor(.blue)
+        .foregroundColor(.secondary)
         .padding(.top, 8)
         .disabled(isVerifyingMfa)
       }
@@ -218,18 +214,14 @@ struct SignInView: View {
         mfaCode = ""
         errorMessage = nil
       }
-      .font(.system(size: 15, weight: .medium))
+      .font(.subheadline)
       .foregroundColor(.secondary)
       .padding(.top, hasAlternativeMfaMethod ? 0 : 8)
       .disabled(isVerifyingMfa)
       
       if let errorMessage = errorMessage {
-        Text(errorMessage)
-          .foregroundColor(.red)
-          .font(.caption)
-          .multilineTextAlignment(.center)
-          .fixedSize(horizontal: false, vertical: true)
-          .padding(.top, 12)
+        AuthErrorBanner(message: errorMessage)
+          .padding(.top, 8)
       }
     }
   }

--- a/TinfoilChat/Views/Authentication/SignUpView.swift
+++ b/TinfoilChat/Views/Authentication/SignUpView.swift
@@ -111,18 +111,13 @@ struct SignUpView: View {
                         }
                     }
                     .font(.subheadline)
-                    .foregroundColor(.blue)
+                    .foregroundColor(.secondary)
                     .padding(.top, 8)
                     .disabled(isVerifyingCode || isLoading)
                     
-                    // Error message moved to the bottom of verification view
                     if let errorMessage = errorMessage {
-                        Text(errorMessage)
-                            .foregroundColor(.red)
-                            .font(.caption)
-                            .multilineTextAlignment(.center)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(.top, 12)
+                        AuthErrorBanner(message: errorMessage)
+                            .padding(.top, 8)
                     }
                     
                     if isLoading && !isVerifyingCode {
@@ -185,12 +180,8 @@ struct SignUpView: View {
                 }
                 
                 if let errorMessage = errorMessage {
-                    Text(errorMessage)
-                        .foregroundColor(.red)
-                        .font(.caption)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, 12)
+                    AuthErrorBanner(message: errorMessage)
+                        .padding(.top, 8)
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two-factor authentication to sign-in using the `Clerk` SDK and closes the auth modal on success instead of showing account details.

- **New Features**
  - MFA support: TOTP, phone code, email code, and backup codes with animated step transition.
  - Auto-sends phone/email codes when needed; users can cycle through all available methods.
  - Unified error banner for clearer auth errors in sign-in and sign-up.

- **Refactors**
  - Removed in-modal account management; modal now focuses on auth only.
  - Dismisses on successful sign-in and restores third-party options when not verifying (even with cached user data); posts completion notification.

<sup>Written for commit 01d7c1fbaebc8f200479b14d3df66278f1af7f5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

