### PR TITLE
New citation format and websearch progress UI

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -20,8 +20,6 @@ enum ChatStorageTab: String {
 
 @MainActor
 class ChatViewModel: ObservableObject {
-    private static let citationMarkerRegex = try? NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-
     // Published properties for UI updates
     @Published var chats: [Chat] = []
     @Published var localChats: [Chat] = []
@@ -1516,16 +1514,14 @@ class ChatViewModel: ObservableObject {
                                 return
                             }
 
-                            // Process citations during streaming if we have sources
-                            let processedContent = self.processCitationMarkers(content, sources: currentSources)
-                            let processedChunks = self.processChunksWithCitations(currentChunks, sources: currentSources)
-
-                            chat.messages[lastIndex].content = processedContent
+                            // The router delivers citations as standard markdown links in the
+                            // assistant content, so the UI can render the message as-is.
+                            chat.messages[lastIndex].content = content
                             chat.messages[lastIndex].thoughts = thoughts
                             chat.messages[lastIndex].thinkingChunks = currentThinkingChunks
                             chat.messages[lastIndex].isThinking = thinking
                             chat.messages[lastIndex].generationTimeSeconds = genTime
-                            chat.messages[lastIndex].contentChunks = processedChunks
+                            chat.messages[lastIndex].contentChunks = currentChunks
 
                             // Merge collected sources into the message's current webSearchState (set by the callback)
                             if !currentSources.isEmpty {
@@ -1593,17 +1589,14 @@ class ChatViewModel: ObservableObject {
                     if !chat.messages.isEmpty, let lastIndex = chat.messages.indices.last {
                         chunker.finalize()
                         thinkingChunker.finalize()
-                        let processedContent = self.processCitationMarkers(responseContent, sources: collectedSources)
-                        chat.messages[lastIndex].content = processedContent
+                        chat.messages[lastIndex].content = responseContent
                         chat.messages[lastIndex].thoughts = currentThoughts
                         chat.messages[lastIndex].thinkingChunks = thinkingChunker.getAllChunks()
                         chat.messages[lastIndex].isThinking = false
                         chat.messages[lastIndex].generationTimeSeconds = generationTimeSeconds
                         chat.messages[lastIndex].thinkingDuration = generationTimeSeconds
                         chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
-                        // Process citation markers in chunks too since UI renders from chunks
-                        let processedChunks = self.processChunksWithCitations(chunker.getAllChunks(), sources: collectedSources)
-                        chat.messages[lastIndex].contentChunks = processedChunks
+                        chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
                         // Merge final collected sources into the message's webSearchState
                         if !collectedSources.isEmpty {
                             var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
@@ -3244,57 +3237,4 @@ extension ChatViewModel {
         AudioRecordingService.shared.cancelRecording()
     }
 
-    private func processChunksWithCitations(_ chunks: [ContentChunk], sources: [WebSearchSource]) -> [ContentChunk] {
-        chunks.map { chunk in
-            ContentChunk(
-                id: chunk.id,
-                type: chunk.type,
-                content: processCitationMarkers(chunk.content, sources: sources),
-                isComplete: chunk.isComplete
-            )
-        }
-    }
-
-    /// Process citation markers (e.g. 【1】) into markdown links.
-    /// Called at stream end to store processed content.
-    private func processCitationMarkers(_ content: String, sources: [WebSearchSource]) -> String {
-        guard !sources.isEmpty else { return content }
-        guard let regex = Self.citationMarkerRegex else { return content }
-
-        let nsContent = content as NSString
-        let matches = regex.matches(in: content, options: [], range: NSRange(location: 0, length: nsContent.length))
-        guard !matches.isEmpty else { return content }
-
-        var result = ""
-        var lastEnd = content.startIndex
-
-        for match in matches {
-            guard let matchRange = Range(match.range, in: content),
-                  let numRange = Range(match.range(at: 1), in: content),
-                  let num = Int(content[numRange]) else { continue }
-
-            let index = num - 1
-            guard index >= 0, index < sources.count else { continue }
-
-            let source = sources[index]
-
-            let encodedUrl = source.url
-                .replacingOccurrences(of: "(", with: "%28")
-                .replacingOccurrences(of: ")", with: "%29")
-                .replacingOccurrences(of: "|", with: "%7C")
-                .replacingOccurrences(of: "~", with: "%7E")
-            let encodedTitle = (source.title
-                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? source.title)
-                .replacingOccurrences(of: "(", with: "%28")
-                .replacingOccurrences(of: ")", with: "%29")
-                .replacingOccurrences(of: "~", with: "%7E")
-
-            result += content[lastEnd..<matchRange.lowerBound]
-            result += "[\(num)](#cite-\(num)~\(encodedUrl)~\(encodedTitle))"
-            lastEnd = matchRange.upperBound
-        }
-
-        result += content[lastEnd...]
-        return result
-    }
 }

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -29,13 +29,19 @@ private struct SegmentView: View {
     let isDarkMode: Bool
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    let citationUrls: Set<String>?
 
     var body: some View {
         switch segment.kind {
         case .markdown(let text):
             // Strip citation markers from text - sources shown separately at message level
             // Skip during streaming to avoid catastrophic regex backtracking on incomplete citations
-            let strippedText = isStreaming ? text : LaTeXMarkdownView.stripCitations(from: text)
+            let strippedText = isStreaming
+                ? text
+                : LaTeXMarkdownView.rewriteAnnotatedLinks(
+                    in: LaTeXMarkdownView.stripCitations(from: text),
+                    citationUrls: citationUrls
+                )
             StructuredText(markdown: strippedText)
                 .textual.structuredTextStyle(.gitHub)
                 .textual.highlighterTheme(isStreaming ? .plain : .default)
@@ -111,6 +117,10 @@ struct LaTeXMarkdownView: View, Equatable {
     let maxWidthAlignment: Alignment
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    // URLs the router annotated as web-search citations for the current message.
+    // Any standard markdown link whose href matches one of these URLs is rewritten
+    // to [domain](url) so it matches the visual style of legacy #cite- citations.
+    let citationUrls: Set<String>?
 
     @State private var segments: [ContentSegment]? = nil
 
@@ -125,16 +135,18 @@ struct LaTeXMarkdownView: View, Equatable {
         lhs.horizontalPadding == rhs.horizontalPadding &&
         lhs.maxWidthAlignment == rhs.maxWidthAlignment &&
         lhs.isStreaming == rhs.isStreaming &&
-        lhs.textSelectionEnabled == rhs.textSelectionEnabled
+        lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+        lhs.citationUrls == rhs.citationUrls
     }
 
-    init(content: String, isDarkMode: Bool, horizontalPadding: CGFloat = 0, maxWidthAlignment: Alignment = .leading, isStreaming: Bool = false, textSelectionEnabled: Bool = true) {
+    init(content: String, isDarkMode: Bool, horizontalPadding: CGFloat = 0, maxWidthAlignment: Alignment = .leading, isStreaming: Bool = false, textSelectionEnabled: Bool = true, citationUrls: Set<String>? = nil) {
         self.content = content
         self.isDarkMode = isDarkMode
         self.horizontalPadding = horizontalPadding
         self.maxWidthAlignment = maxWidthAlignment
         self.isStreaming = isStreaming
         self.textSelectionEnabled = textSelectionEnabled
+        self.citationUrls = citationUrls
 
         // Resolve segments synchronously from cache when available so the
         // first render already has the final view tree. This prevents
@@ -159,7 +171,8 @@ struct LaTeXMarkdownView: View, Equatable {
                         segment: segment,
                         isDarkMode: isDarkMode,
                         isStreaming: false,
-                        textSelectionEnabled: textSelectionEnabled
+                        textSelectionEnabled: textSelectionEnabled,
+                        citationUrls: citationUrls
                     )
                         .id(segment.id)
                 }
@@ -188,7 +201,12 @@ struct LaTeXMarkdownView: View, Equatable {
     }
 
     private func markdownFallback(content: String) -> some View {
-        let strippedText = LaTeXMarkdownView.stripCitations(from: content)
+        let strippedText = isStreaming
+            ? LaTeXMarkdownView.stripCitations(from: content)
+            : LaTeXMarkdownView.rewriteAnnotatedLinks(
+                in: LaTeXMarkdownView.stripCitations(from: content),
+                citationUrls: citationUrls
+            )
         return StructuredText(markdown: strippedText)
             .textual.structuredTextStyle(.gitHub)
             .textual.highlighterTheme(isStreaming ? .plain : .default)
@@ -197,6 +215,98 @@ struct LaTeXMarkdownView: View, Equatable {
             }
             .fixedSize(horizontal: false, vertical: true)
             .environment(\.colorScheme, isDarkMode ? .dark : .light)
+    }
+
+    /// Rewrite standard markdown links whose URL matches an annotated web-search
+    /// citation so the link text becomes the host domain. Mirrors the visual
+    /// treatment legacy `#cite-` citations get via `stripCitations`, keeping
+    /// inline citations consistent when the backend emits citations as plain
+    /// markdown links.
+    static func rewriteAnnotatedLinks(in text: String, citationUrls: Set<String>?) -> String {
+        guard let citationUrls, !citationUrls.isEmpty, !text.isEmpty else { return text }
+        let chars = Array(text.unicodeScalars)
+        let count = chars.count
+        var result = String.UnicodeScalarView()
+        result.reserveCapacity(count)
+        var i = 0
+
+        while i < count {
+            guard chars[i] == "[" else {
+                result.append(chars[i])
+                i += 1
+                continue
+            }
+
+            // Scan link text up to a matching `]` (allowing nested `[`/`]`).
+            var j = i + 1
+            var textDepth = 1
+            while j < count && textDepth > 0 {
+                let c = chars[j]
+                if c == "\\" && j + 1 < count {
+                    j += 2
+                    continue
+                }
+                if c == "[" { textDepth += 1 }
+                else if c == "]" { textDepth -= 1; if textDepth == 0 { break } }
+                else if c == "\n" { break }
+                j += 1
+            }
+            guard j < count, chars[j] == "]", j + 1 < count, chars[j + 1] == "(" else {
+                result.append(chars[i])
+                i += 1
+                continue
+            }
+
+            // Scan href up to a matching `)` (allowing one level of nested parens).
+            var k = j + 2
+            var hrefDepth = 1
+            while k < count && hrefDepth > 0 {
+                let c = chars[k]
+                if c == "\\" && k + 1 < count {
+                    k += 2
+                    continue
+                }
+                if c == "(" { hrefDepth += 1 }
+                else if c == ")" { hrefDepth -= 1; if hrefDepth == 0 { break } }
+                else if c == "\n" { break }
+                k += 1
+            }
+            guard k < count, chars[k] == ")" else {
+                result.append(chars[i])
+                i += 1
+                continue
+            }
+
+            var hrefView = String.UnicodeScalarView()
+            for idx in (j + 2)..<k { hrefView.append(chars[idx]) }
+            let href = String(hrefView).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Skip angle-bracketed autolinks: <https://...>
+            let bareHref: String
+            if href.hasPrefix("<") && href.hasSuffix(">") && href.count >= 2 {
+                bareHref = String(href.dropFirst().dropLast())
+            } else {
+                bareHref = href
+            }
+
+            if citationUrls.contains(bareHref) {
+                let domain: String
+                if let parsed = URL(string: bareHref), let host = parsed.host {
+                    domain = host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+                } else {
+                    domain = bareHref
+                }
+                for c in "[\(domain)](\(bareHref))".unicodeScalars {
+                    result.append(c)
+                }
+                i = k + 1
+            } else {
+                for idx in i...k { result.append(chars[idx]) }
+                i = k + 1
+            }
+        }
+
+        return String(result)
     }
 
     /// Strip citation markers from markdown text.

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -39,6 +39,25 @@ struct MessageView: View {
         !(isLoading && isLastMessage)
     }
 
+    /// URLs the router annotated as web-search citations on this message.
+    /// Used by the markdown renderer to rewrite plain markdown citation links
+    /// to use the host domain as their display text.
+    private var citationUrls: Set<String>? {
+        var urls: Set<String> = []
+        if let annotations = message.annotations {
+            for annotation in annotations where annotation.type == "url_citation" {
+                let url = annotation.url_citation.url
+                if !url.isEmpty { urls.insert(url) }
+            }
+        }
+        if let sources = message.webSearchState?.sources {
+            for source in sources where !source.url.isEmpty {
+                urls.insert(source.url)
+            }
+        }
+        return urls.isEmpty ? nil : urls
+    }
+
     var body: some View {
         HStack {
             if message.role == .user {
@@ -120,7 +139,8 @@ struct MessageView: View {
                                     chunks: message.contentChunks,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -129,7 +149,8 @@ struct MessageView: View {
                                     content: message.content,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -159,7 +180,8 @@ struct MessageView: View {
                                 content: parsed.remainderText,
                                 isDarkMode: isDarkMode,
                                 isStreaming: isLoading && isLastMessage,
-                                textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                citationUrls: citationUrls
                             )
                                 .equatable()
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -232,7 +254,8 @@ struct MessageView: View {
                                     chunks: message.contentChunks,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -241,7 +264,8 @@ struct MessageView: View {
                                     content: message.content,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1138,12 +1162,28 @@ struct ChunkedContentView: View, Equatable {
     let isDarkMode: Bool
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    let citationUrls: Set<String>?
+
+    init(
+        chunks: [ContentChunk],
+        isDarkMode: Bool,
+        isStreaming: Bool,
+        textSelectionEnabled: Bool,
+        citationUrls: Set<String>? = nil
+    ) {
+        self.chunks = chunks
+        self.isDarkMode = isDarkMode
+        self.isStreaming = isStreaming
+        self.textSelectionEnabled = textSelectionEnabled
+        self.citationUrls = citationUrls
+    }
 
     static func == (lhs: ChunkedContentView, rhs: ChunkedContentView) -> Bool {
         lhs.chunks == rhs.chunks &&
         lhs.isDarkMode == rhs.isDarkMode &&
         lhs.isStreaming == rhs.isStreaming &&
-        lhs.textSelectionEnabled == rhs.textSelectionEnabled
+        lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+        lhs.citationUrls == rhs.citationUrls
     }
 
     var body: some View {
@@ -1153,7 +1193,8 @@ struct ChunkedContentView: View, Equatable {
                     chunk: chunk,
                     isDarkMode: isDarkMode,
                     isStreaming: isStreaming,
-                    textSelectionEnabled: textSelectionEnabled
+                    textSelectionEnabled: textSelectionEnabled,
+                    citationUrls: citationUrls
                 )
             }
         }
@@ -1165,19 +1206,22 @@ struct ChunkView: View, Equatable {
     let isDarkMode: Bool
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    let citationUrls: Set<String>?
 
     static func == (lhs: ChunkView, rhs: ChunkView) -> Bool {
         if lhs.chunk.isComplete && rhs.chunk.isComplete {
             return lhs.chunk.id == rhs.chunk.id &&
                    lhs.isDarkMode == rhs.isDarkMode &&
-                   lhs.textSelectionEnabled == rhs.textSelectionEnabled
+                   lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+                   lhs.citationUrls == rhs.citationUrls
         }
         return lhs.chunk.id == rhs.chunk.id &&
                lhs.chunk.isComplete == rhs.chunk.isComplete &&
                lhs.chunk.content == rhs.chunk.content &&
                lhs.isDarkMode == rhs.isDarkMode &&
                lhs.isStreaming == rhs.isStreaming &&
-               lhs.textSelectionEnabled == rhs.textSelectionEnabled
+               lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+               lhs.citationUrls == rhs.citationUrls
     }
 
     var body: some View {
@@ -1188,7 +1232,8 @@ struct ChunkView: View, Equatable {
                 content: chunk.content,
                 isDarkMode: isDarkMode,
                 isStreaming: chunk.isComplete ? false : isStreaming,
-                textSelectionEnabled: textSelectionEnabled
+                textSelectionEnabled: textSelectionEnabled,
+                citationUrls: citationUrls
             )
             .equatable()
         }

--- a/TinfoilChatTests/CitationRegexTests.swift
+++ b/TinfoilChatTests/CitationRegexTests.swift
@@ -148,44 +148,81 @@ struct CitationRegexTests {
         }
     }
 
-    // MARK: - citationMarkerRegex (【1】 format used in ChatViewModel)
+    // MARK: - rewriteAnnotatedLinks: markdown citation links from the new backend format
 
-    @Test("Citation marker regex matches simple markers")
-    func citationMarkerMatchesSimple() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "Some text【1】more text"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 1)
+    @Test("Rewrites annotated link text to the host domain")
+    func rewriteAnnotatedLinkToDomain() {
+        let input = "See [some title](https://example.com/page) for details"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://example.com/page"]
+        )
+        #expect(result == "See [example.com](https://example.com/page) for details")
     }
 
-    @Test("Citation marker regex matches multiple markers")
-    func citationMarkerMatchesMultiple() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "First【1】second【2】third【3】"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 3)
+    @Test("Strips www. prefix from the host domain")
+    func rewriteAnnotatedLinkStripsWWW() {
+        let input = "[title](https://www.example.com/path)"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://www.example.com/path"]
+        )
+        #expect(result == "[example.com](https://www.example.com/path)")
     }
 
-    @Test("Citation marker regex captures the number")
-    func citationMarkerCapturesNumber() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "text【42】end"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 1)
-        if let match = matches.first, let numRange = Range(match.range(at: 1), in: input) {
-            #expect(String(input[numRange]) == "42")
-        }
+    @Test("Leaves non-annotated links unchanged")
+    func rewriteLeavesNonAnnotatedLinks() {
+        let input = "See [this article](https://unrelated.com) and [another](https://example.com/page)"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://example.com/page"]
+        )
+        #expect(result == "See [this article](https://unrelated.com) and [example.com](https://example.com/page)")
     }
 
-    @Test("Citation marker regex ignores text without markers")
-    func citationMarkerNoMatch() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "Regular text with [1] brackets"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 0)
+    @Test("Rewrites multiple annotated links in one pass")
+    func rewriteMultipleAnnotatedLinks() {
+        let input = "[a](https://one.com) and [b](https://two.org/path)"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://one.com", "https://two.org/path"]
+        )
+        #expect(result == "[one.com](https://one.com) and [two.org](https://two.org/path)")
+    }
+
+    @Test("Returns input unchanged when citation set is nil")
+    func rewriteNilCitationsNoOp() {
+        let input = "See [some title](https://example.com/page) for details"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(in: input, citationUrls: nil)
+        #expect(result == input)
+    }
+
+    @Test("Returns input unchanged when citation set is empty")
+    func rewriteEmptyCitationsNoOp() {
+        let input = "See [some title](https://example.com/page) for details"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(in: input, citationUrls: [])
+        #expect(result == input)
+    }
+
+    @Test("Handles parentheses inside annotated URL")
+    func rewriteAnnotatedLinkWithParensInURL() {
+        let input = "[title](https://en.wikipedia.org/wiki/Foo_(bar))"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://en.wikipedia.org/wiki/Foo_(bar)"]
+        )
+        #expect(result == "[en.wikipedia.org](https://en.wikipedia.org/wiki/Foo_(bar))")
+    }
+
+    @Test("Leaves legacy #cite- style links to stripCitations")
+    func rewriteLeavesLegacyCiteLinks() {
+        let input = "text [1](#cite-1~https://example.com~Title) end"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://example.com"]
+        )
+        // The href starts with `#cite-`, not the annotated URL, so this helper
+        // leaves it untouched; stripCitations handles the legacy format.
+        #expect(result == input)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches to the new citation format by rendering backend-provided markdown links as domain-labeled citations and removes regex-based citation rewriting from the view model. This makes citation display consistent and safer during streaming.

- **New Features**
  - Rewrites annotated citation links to show the host domain as the label (e.g., [example.com](https://example.com/page)).
  - Reads citation URLs from message annotations and `webSearchState.sources`, and passes them into markdown/chunk renderers for consistent display.
  - Legacy `#cite-` links remain supported via existing stripping logic.

- **Refactors**
  - Removed citation regex and processing in `ChatViewModel`; content and chunks use router-provided markdown as-is.
  - Added a linear-time link rewriter in `LaTeXMarkdownView` and skip rewriting while streaming to avoid backtracking issues.
  - Replaced old citation marker tests with unit tests for the new link rewriting behavior.

<sup>Written for commit 90cf5c5108fc86ffe6c4ab8fadbd58b4aae246f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

