### PR TITLE
Implement Tinfoil websearch event parsing

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -613,8 +613,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = exactVersion;
+				version = 0.0.5;
 			};
 		};
 		99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "fb076a51a97b56c3cc2ba4c9e8bcc9e88f59d53f",
-        "version" : "0.0.4"
+        "revision" : "0467d40594c2ab2ac0ad810fea07cbf740f309af",
+        "version" : "0.0.5"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "branch" : "main",
-        "revision" : "daee5afb9ad2cbd3eabb537b0fbd5cec8882b4ae"
+        "revision" : "d292922f503812a0a5489593d802cf437bae76b4",
+        "version" : "0.0.5"
       }
     }
   ],

--- a/TinfoilChat/Utilities/TinfoilEventParser.swift
+++ b/TinfoilChat/Utilities/TinfoilEventParser.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// Payload shipped inside a `<tinfoil-event>...</tinfoil-event>` marker.
+///
+/// The router emits these inline with the model's assistant text when
+/// the caller opts into the marker stream via the `X-Tinfoil-Events`
+/// request header. Strict OpenAI SDKs render the surrounding tags as
+/// literal text; this app parses and strips them so the same
+/// `webSearchState` / `URLFetchState` UI keeps working after the
+/// legacy top-level `web_search_call` SSE records were removed from
+/// the router.
+struct TinfoilWebSearchCallEvent: Decodable, Sendable {
+    enum Status: String, Decodable, Sendable {
+        case inProgress = "in_progress"
+        case searching
+        case completed
+        case failed
+        case blocked
+    }
+
+    struct Action: Decodable, Sendable {
+        let type: String?
+        let query: String?
+        let url: String?
+    }
+
+    struct ErrorInfo: Decodable, Sendable {
+        let code: String?
+    }
+
+    let type: String
+    let itemId: String?
+    let status: Status
+    let action: Action?
+    let error: ErrorInfo?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case itemId = "item_id"
+        case status
+        case action
+        case error
+    }
+}
+
+/// Streaming parser that extracts `<tinfoil-event>...</tinfoil-event>`
+/// markers from arbitrary content chunks and returns the visible text
+/// with every complete marker removed. The parser is chunk-tolerant:
+/// markers may be split across any byte boundary (inside the opening
+/// tag, the JSON body, or the closing tag).
+///
+/// The router pairs this with the `X-Tinfoil-Events: web_search` opt-in
+/// header. When a client does not opt in no markers are emitted, the
+/// parser is a pure pass-through.
+struct TinfoilEventParser {
+    private static let openTag = "<tinfoil-event>"
+    private static let closeTag = "</tinfoil-event>"
+
+    /// Holds bytes the parser has not yet classified: either a potential
+    /// prefix of the opening tag (held back in case the next chunk
+    /// completes the match) or the inside of a marker whose closing
+    /// tag has not yet landed.
+    private var buffer: String = ""
+    private var insideMarker: Bool = false
+
+    /// One `consume` result: the visible text for this chunk (with
+    /// completed markers removed) plus zero or more decoded events.
+    struct Result {
+        var text: String
+        var events: [TinfoilWebSearchCallEvent]
+    }
+
+    /// Feed a content chunk through the parser. Chunks must arrive in
+    /// order; calling `consume` on interleaved chunks from different
+    /// streams will corrupt the parser state.
+    mutating func consume(_ chunk: String) -> Result {
+        buffer += chunk
+        var text = ""
+        var events: [TinfoilWebSearchCallEvent] = []
+
+        while !buffer.isEmpty {
+            if !insideMarker {
+                if let openRange = buffer.range(of: Self.openTag) {
+                    text += buffer[..<openRange.lowerBound]
+                    buffer = String(buffer[openRange.upperBound...])
+                    insideMarker = true
+                    continue
+                }
+                // No full open tag yet. Emit everything except any
+                // trailing bytes that could still grow into a real
+                // `<tinfoil-event>` opener on the next chunk.
+                let hold = openTagPrefixSuffixLength(buffer)
+                let split = buffer.index(buffer.endIndex, offsetBy: -hold)
+                text += buffer[..<split]
+                buffer = String(buffer[split...])
+                break
+            }
+
+            guard let closeRange = buffer.range(of: Self.closeTag) else {
+                // The payload has not fully landed yet; wait for more.
+                break
+            }
+            let payload = String(buffer[..<closeRange.lowerBound])
+            buffer = String(buffer[closeRange.upperBound...])
+            insideMarker = false
+            if let decoded = Self.decode(payload) {
+                events.append(decoded)
+            }
+        }
+
+        return Result(text: text, events: events)
+    }
+
+    /// Drain any bytes the parser is still holding. Call at stream end
+    /// so unterminated marker bodies and held-back open-tag prefixes
+    /// are not silently dropped. The returned text is a best-effort
+    /// surface: the opening `<tinfoil-event>` is never leaked, but an
+    /// unterminated JSON body will flow through as plain text so the
+    /// UI has something to show if the router mid-stream errored out.
+    mutating func flush() -> String {
+        let tail = buffer
+        buffer = ""
+        insideMarker = false
+        return tail
+    }
+
+    /// Returns the length of the longest suffix of `s` that is a
+    /// proper prefix of the opening tag. Used to hold back trailing
+    /// bytes like `<tinfoil-` that might still grow into a marker
+    /// opener when the next chunk arrives.
+    private func openTagPrefixSuffixLength(_ s: String) -> Int {
+        let max = Swift.min(s.count, Self.openTag.count - 1)
+        guard max > 0 else { return 0 }
+        var len = max
+        while len > 0 {
+            let suffix = s.suffix(len)
+            if Self.openTag.hasPrefix(suffix) {
+                return len
+            }
+            len -= 1
+        }
+        return 0
+    }
+
+    private static func decode(_ payload: String) -> TinfoilWebSearchCallEvent? {
+        let trimmed = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        do {
+            return try JSONDecoder().decode(TinfoilWebSearchCallEvent.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/TinfoilChat/Utilities/TinfoilEventParser.swift
+++ b/TinfoilChat/Utilities/TinfoilEventParser.swift
@@ -81,7 +81,20 @@ struct TinfoilEventParser {
         while !buffer.isEmpty {
             if !insideMarker {
                 if let openRange = buffer.range(of: Self.openTag) {
-                    text += buffer[..<openRange.lowerBound]
+                    // The router pads each marker with a leading
+                    // newline so raw SSE captures stay readable. Drop
+                    // a single `\n` directly abutting the open tag so
+                    // the marker round-trips invisibly in the rendered
+                    // text instead of producing an empty line where
+                    // the marker used to be.
+                    var preTagEnd = openRange.lowerBound
+                    if preTagEnd > buffer.startIndex {
+                        let charBefore = buffer.index(before: preTagEnd)
+                        if buffer[charBefore] == "\n" {
+                            preTagEnd = charBefore
+                        }
+                    }
+                    text += buffer[..<preTagEnd]
                     buffer = String(buffer[openRange.upperBound...])
                     insideMarker = true
                     continue
@@ -102,6 +115,11 @@ struct TinfoilEventParser {
             }
             let payload = String(buffer[..<closeRange.lowerBound])
             buffer = String(buffer[closeRange.upperBound...])
+            // Match the leading-newline strip on the trailing side so a
+            // `\n<marker>\n` pad collapses to nothing, not to `\n`.
+            if let first = buffer.first, first == "\n" {
+                buffer = String(buffer.dropFirst())
+            }
             insideMarker = false
             if let decoded = Self.decode(payload) {
                 events.append(decoded)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -20,8 +20,6 @@ enum ChatStorageTab: String {
 
 @MainActor
 class ChatViewModel: ObservableObject {
-    private static let citationMarkerRegex = try? NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-
     // Published properties for UI updates
     @Published var chats: [Chat] = []
     @Published var localChats: [Chat] = []
@@ -1516,16 +1514,14 @@ class ChatViewModel: ObservableObject {
                                 return
                             }
 
-                            // Process citations during streaming if we have sources
-                            let processedContent = self.processCitationMarkers(content, sources: currentSources)
-                            let processedChunks = self.processChunksWithCitations(currentChunks, sources: currentSources)
-
-                            chat.messages[lastIndex].content = processedContent
+                            // The router delivers citations as standard markdown links in the
+                            // assistant content, so the UI can render the message as-is.
+                            chat.messages[lastIndex].content = content
                             chat.messages[lastIndex].thoughts = thoughts
                             chat.messages[lastIndex].thinkingChunks = currentThinkingChunks
                             chat.messages[lastIndex].isThinking = thinking
                             chat.messages[lastIndex].generationTimeSeconds = genTime
-                            chat.messages[lastIndex].contentChunks = processedChunks
+                            chat.messages[lastIndex].contentChunks = currentChunks
 
                             // Merge collected sources into the message's current webSearchState (set by the callback)
                             if !currentSources.isEmpty {
@@ -1593,17 +1589,14 @@ class ChatViewModel: ObservableObject {
                     if !chat.messages.isEmpty, let lastIndex = chat.messages.indices.last {
                         chunker.finalize()
                         thinkingChunker.finalize()
-                        let processedContent = self.processCitationMarkers(responseContent, sources: collectedSources)
-                        chat.messages[lastIndex].content = processedContent
+                        chat.messages[lastIndex].content = responseContent
                         chat.messages[lastIndex].thoughts = currentThoughts
                         chat.messages[lastIndex].thinkingChunks = thinkingChunker.getAllChunks()
                         chat.messages[lastIndex].isThinking = false
                         chat.messages[lastIndex].generationTimeSeconds = generationTimeSeconds
                         chat.messages[lastIndex].thinkingDuration = generationTimeSeconds
                         chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
-                        // Process citation markers in chunks too since UI renders from chunks
-                        let processedChunks = self.processChunksWithCitations(chunker.getAllChunks(), sources: collectedSources)
-                        chat.messages[lastIndex].contentChunks = processedChunks
+                        chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
                         // Merge final collected sources into the message's webSearchState
                         if !collectedSources.isEmpty {
                             var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
@@ -3244,57 +3237,4 @@ extension ChatViewModel {
         AudioRecordingService.shared.cancelRecording()
     }
 
-    private func processChunksWithCitations(_ chunks: [ContentChunk], sources: [WebSearchSource]) -> [ContentChunk] {
-        chunks.map { chunk in
-            ContentChunk(
-                id: chunk.id,
-                type: chunk.type,
-                content: processCitationMarkers(chunk.content, sources: sources),
-                isComplete: chunk.isComplete
-            )
-        }
-    }
-
-    /// Process citation markers (e.g. 【1】) into markdown links.
-    /// Called at stream end to store processed content.
-    private func processCitationMarkers(_ content: String, sources: [WebSearchSource]) -> String {
-        guard !sources.isEmpty else { return content }
-        guard let regex = Self.citationMarkerRegex else { return content }
-
-        let nsContent = content as NSString
-        let matches = regex.matches(in: content, options: [], range: NSRange(location: 0, length: nsContent.length))
-        guard !matches.isEmpty else { return content }
-
-        var result = ""
-        var lastEnd = content.startIndex
-
-        for match in matches {
-            guard let matchRange = Range(match.range, in: content),
-                  let numRange = Range(match.range(at: 1), in: content),
-                  let num = Int(content[numRange]) else { continue }
-
-            let index = num - 1
-            guard index >= 0, index < sources.count else { continue }
-
-            let source = sources[index]
-
-            let encodedUrl = source.url
-                .replacingOccurrences(of: "(", with: "%28")
-                .replacingOccurrences(of: ")", with: "%29")
-                .replacingOccurrences(of: "|", with: "%7C")
-                .replacingOccurrences(of: "~", with: "%7E")
-            let encodedTitle = (source.title
-                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? source.title)
-                .replacingOccurrences(of: "(", with: "%28")
-                .replacingOccurrences(of: ")", with: "%29")
-                .replacingOccurrences(of: "~", with: "%7E")
-
-            result += content[lastEnd..<matchRange.lowerBound]
-            result += "[\(num)](#cite-\(num)~\(encodedUrl)~\(encodedTitle))"
-            lastEnd = matchRange.upperBound
-        }
-
-        result += content[lastEnd...]
-        return result
-    }
 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1335,16 +1335,14 @@ class ChatViewModel: ObservableObject {
                     // Strip router-emitted `<tinfoil-event>` markers
                     // from the delta before any downstream logic sees
                     // it, and dispatch the decoded events so the same
-                    // UI surfaces the legacy callback populated.
+                    // UI surfaces the legacy callback populated. The
+                    // enclosing class is @MainActor and Task inherits
+                    // that isolation, so applyWebSearchCallEvent runs
+                    // synchronously on the main actor here.
                     if !content.isEmpty {
                         let parsed = tinfoilEventParser.consume(content)
-                        if !parsed.events.isEmpty {
-                            let events = parsed.events
-                            await MainActor.run {
-                                for event in events {
-                                    applyWebSearchCallEvent(event)
-                                }
-                            }
+                        for event in parsed.events {
+                            applyWebSearchCallEvent(event)
                         }
                         content = parsed.text
                     }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -542,6 +542,12 @@ class ChatViewModel: ObservableObject {
 
                 client = try await TinfoilAI.create(
                     apiKey: sessionToken,
+                    // Opt into the router's inline progress markers so
+                    // live web search and URL-fetch status drives the
+                    // same WebSearchState / URLFetchState UI the app
+                    // already renders, without requiring a separate
+                    // auxiliary stream.
+                    tinfoilEvents: [.webSearch],
                     onVerification: { [weak self] verificationDoc in
                         DispatchQueue.main.async {
                             guard let self = self else { return }
@@ -1177,78 +1183,85 @@ class ChatViewModel: ObservableObject {
                 // Track whether web search started before thinking (shared across callback and streaming loop)
                 let webSearchStartedFlag = OSAllocatedUnfairLock(initialState: false)
 
-                // Create stream with web search callback if enabled
-                let stream: AsyncThrowingStream<ChatStreamResult, Error>
-                if isWebSearchEnabled {
-                    stream = client.chatsStream(query: chatQuery) { [weak self] event in
-                        Task { @MainActor in
-                            guard let self = self else { return }
-                            guard var chat = self.currentChat,
-                                  !chat.messages.isEmpty,
-                                  let lastIndex = chat.messages.indices.last else { return }
+                // Web search progress now rides inline with the model's
+                // content as `<tinfoil-event>` markers (opted into via
+                // the `tinfoilEvents: [.webSearch]` flag on create).
+                // Decoding happens inside the chunk loop below via
+                // TinfoilEventParser; the SDK-level callback variant is
+                // no longer needed because the router emits nothing
+                // auxiliary on the chat stream.
+                let stream: AsyncThrowingStream<ChatStreamResult, Error> = client.chatsStream(query: chatQuery)
 
-                            // Handle URL fetch events (open_page actions)
-                            if event.action?.type == "open_page", let url = event.action?.url {
-                                let fetchId = event.itemId ?? url
-                                switch event.status {
-                                case .inProgress, .searching:
-                                    if !chat.messages[lastIndex].urlFetches.contains(where: { $0.id == fetchId }) {
-                                        chat.messages[lastIndex].urlFetches.append(
-                                            URLFetchState(id: fetchId, url: url, status: .fetching)
-                                        )
-                                    }
-                                case .completed:
-                                    if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
-                                        chat.messages[lastIndex].urlFetches[idx].status = .completed
-                                    }
-                                case .failed:
-                                    if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
-                                        chat.messages[lastIndex].urlFetches[idx].status = .failed
-                                    }
-                                case .blocked:
-                                    if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
-                                        chat.messages[lastIndex].urlFetches[idx].status = .blocked
-                                    }
-                                }
+                // Applies one decoded marker event to the current chat.
+                // Mirrors the behavior the legacy SDK onWebSearchEvent
+                // callback used to provide, but driven off the inline
+                // marker stream so the app stays in sync with router
+                // progress without a second SSE channel.
+                let applyWebSearchCallEvent: @MainActor (TinfoilWebSearchCallEvent) -> Void = { [weak self] event in
+                    guard let self = self else { return }
+                    guard var chat = self.currentChat,
+                          !chat.messages.isEmpty,
+                          let lastIndex = chat.messages.indices.last else { return }
 
-                                self.updateChat(chat, throttleForStreaming: true)
-                                return
-                            }
-
-                            // Read current state from the message to preserve sources added by the streaming loop
-                            let existingSources = chat.messages[lastIndex].webSearchState?.sources ?? []
-
-                            // Update web search state based on event
-                            switch event.status {
-                            case .inProgress, .searching:
-                                webSearchStartedFlag.withLock { $0 = true }
-                                chat.messages[lastIndex].webSearchState = WebSearchState(
-                                    query: event.action?.query,
-                                    status: .searching,
-                                    sources: existingSources
+                    if event.action?.type == "open_page", let url = event.action?.url {
+                        let fetchId = event.itemId ?? url
+                        switch event.status {
+                        case .inProgress, .searching:
+                            if !chat.messages[lastIndex].urlFetches.contains(where: { $0.id == fetchId }) {
+                                chat.messages[lastIndex].urlFetches.append(
+                                    URLFetchState(id: fetchId, url: url, status: .fetching)
                                 )
-                                self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
-                            case .completed:
-                                chat.messages[lastIndex].webSearchState?.status = .completed
-                                self.webSearchSummary = ""
-                            case .failed:
-                                chat.messages[lastIndex].webSearchState?.status = .failed
-                                self.webSearchSummary = ""
-                            case .blocked:
-                                chat.messages[lastIndex].webSearchState = WebSearchState(
-                                    query: event.action?.query,
-                                    status: .blocked,
-                                    reason: event.reason
-                                )
-                                self.webSearchSummary = ""
                             }
-
-                            self.updateChat(chat, throttleForStreaming: true)
+                        case .completed:
+                            if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
+                                chat.messages[lastIndex].urlFetches[idx].status = .completed
+                            }
+                        case .failed:
+                            if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
+                                chat.messages[lastIndex].urlFetches[idx].status = .failed
+                            }
+                        case .blocked:
+                            if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
+                                chat.messages[lastIndex].urlFetches[idx].status = .blocked
+                            }
                         }
+                        self.updateChat(chat, throttleForStreaming: true)
+                        return
                     }
-                } else {
-                    stream = client.chatsStream(query: chatQuery)
+
+                    let existingSources = chat.messages[lastIndex].webSearchState?.sources ?? []
+                    switch event.status {
+                    case .inProgress, .searching:
+                        webSearchStartedFlag.withLock { $0 = true }
+                        chat.messages[lastIndex].webSearchState = WebSearchState(
+                            query: event.action?.query,
+                            status: .searching,
+                            sources: existingSources
+                        )
+                        self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
+                    case .completed:
+                        chat.messages[lastIndex].webSearchState?.status = .completed
+                        self.webSearchSummary = ""
+                    case .failed:
+                        chat.messages[lastIndex].webSearchState?.status = .failed
+                        self.webSearchSummary = ""
+                    case .blocked:
+                        chat.messages[lastIndex].webSearchState = WebSearchState(
+                            query: event.action?.query,
+                            status: .blocked,
+                            reason: event.error?.code
+                        )
+                        self.webSearchSummary = ""
+                    }
+                    self.updateChat(chat, throttleForStreaming: true)
                 }
+
+                // Stateful parser for `<tinfoil-event>` markers embedded
+                // in the content stream. `isWebSearchEnabled` has no
+                // effect on parsing: when the router isn't asked to
+                // emit markers it sends none, so the parser is a pure
+                // pass-through.
+                var tinfoilEventParser = TinfoilEventParser()
 
                 var thinkStartTime: Date? = nil
                 var hasThinkTag = false
@@ -1318,7 +1331,23 @@ class ChatViewModel: ObservableObject {
                         }
                     }
 
-                    let content = chunk.choices.first?.delta.content ?? ""
+                    var content = chunk.choices.first?.delta.content ?? ""
+                    // Strip router-emitted `<tinfoil-event>` markers
+                    // from the delta before any downstream logic sees
+                    // it, and dispatch the decoded events so the same
+                    // UI surfaces the legacy callback populated.
+                    if !content.isEmpty {
+                        let parsed = tinfoilEventParser.consume(content)
+                        if !parsed.events.isEmpty {
+                            let events = parsed.events
+                            await MainActor.run {
+                                for event in events {
+                                    applyWebSearchCallEvent(event)
+                                }
+                            }
+                        }
+                        content = parsed.text
+                    }
                     let hasReasoningContent = chunk.choices.first?.delta.reasoning != nil
                     let reasoningContent = chunk.choices.first?.delta.reasoning ?? ""
                     var didMutateState = false
@@ -1532,6 +1561,27 @@ class ChatViewModel: ObservableObject {
 
                             self.updateChat(chat, throttleForStreaming: true)
                         }
+                    }
+                }
+
+                // Drain any bytes the tinfoil-event parser is still
+                // holding back at the stream boundary. Anything in the
+                // tail is either an unterminated marker body (router
+                // bug) or a trailing open-tag prefix; surface it as
+                // plain assistant content minus any stray tag bytes so
+                // no characters the model emitted are silently lost.
+                let tinfoilEventTail = tinfoilEventParser.flush()
+                if !tinfoilEventTail.isEmpty {
+                    let sanitizedTail = tinfoilEventTail
+                        .replacingOccurrences(of: "<tinfoil-event>", with: "")
+                        .replacingOccurrences(of: "</tinfoil-event>", with: "")
+                    if !sanitizedTail.isEmpty {
+                        if responseContent.isEmpty {
+                            responseContent = sanitizedTail
+                        } else {
+                            responseContent += sanitizedTail
+                        }
+                        _ = chunker.appendToken(sanitizedTail)
                     }
                 }
 

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -29,13 +29,19 @@ private struct SegmentView: View {
     let isDarkMode: Bool
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    let citationUrls: Set<String>?
 
     var body: some View {
         switch segment.kind {
         case .markdown(let text):
             // Strip citation markers from text - sources shown separately at message level
             // Skip during streaming to avoid catastrophic regex backtracking on incomplete citations
-            let strippedText = isStreaming ? text : LaTeXMarkdownView.stripCitations(from: text)
+            let strippedText = isStreaming
+                ? text
+                : LaTeXMarkdownView.rewriteAnnotatedLinks(
+                    in: LaTeXMarkdownView.stripCitations(from: text),
+                    citationUrls: citationUrls
+                )
             StructuredText(markdown: strippedText)
                 .textual.structuredTextStyle(.gitHub)
                 .textual.highlighterTheme(isStreaming ? .plain : .default)
@@ -111,6 +117,10 @@ struct LaTeXMarkdownView: View, Equatable {
     let maxWidthAlignment: Alignment
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    // URLs the router annotated as web-search citations for the current message.
+    // Any standard markdown link whose href matches one of these URLs is rewritten
+    // to [domain](url) so it matches the visual style of legacy #cite- citations.
+    let citationUrls: Set<String>?
 
     @State private var segments: [ContentSegment]? = nil
 
@@ -125,16 +135,18 @@ struct LaTeXMarkdownView: View, Equatable {
         lhs.horizontalPadding == rhs.horizontalPadding &&
         lhs.maxWidthAlignment == rhs.maxWidthAlignment &&
         lhs.isStreaming == rhs.isStreaming &&
-        lhs.textSelectionEnabled == rhs.textSelectionEnabled
+        lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+        lhs.citationUrls == rhs.citationUrls
     }
 
-    init(content: String, isDarkMode: Bool, horizontalPadding: CGFloat = 0, maxWidthAlignment: Alignment = .leading, isStreaming: Bool = false, textSelectionEnabled: Bool = true) {
+    init(content: String, isDarkMode: Bool, horizontalPadding: CGFloat = 0, maxWidthAlignment: Alignment = .leading, isStreaming: Bool = false, textSelectionEnabled: Bool = true, citationUrls: Set<String>? = nil) {
         self.content = content
         self.isDarkMode = isDarkMode
         self.horizontalPadding = horizontalPadding
         self.maxWidthAlignment = maxWidthAlignment
         self.isStreaming = isStreaming
         self.textSelectionEnabled = textSelectionEnabled
+        self.citationUrls = citationUrls
 
         // Resolve segments synchronously from cache when available so the
         // first render already has the final view tree. This prevents
@@ -159,7 +171,8 @@ struct LaTeXMarkdownView: View, Equatable {
                         segment: segment,
                         isDarkMode: isDarkMode,
                         isStreaming: false,
-                        textSelectionEnabled: textSelectionEnabled
+                        textSelectionEnabled: textSelectionEnabled,
+                        citationUrls: citationUrls
                     )
                         .id(segment.id)
                 }
@@ -188,7 +201,12 @@ struct LaTeXMarkdownView: View, Equatable {
     }
 
     private func markdownFallback(content: String) -> some View {
-        let strippedText = LaTeXMarkdownView.stripCitations(from: content)
+        let strippedText = isStreaming
+            ? LaTeXMarkdownView.stripCitations(from: content)
+            : LaTeXMarkdownView.rewriteAnnotatedLinks(
+                in: LaTeXMarkdownView.stripCitations(from: content),
+                citationUrls: citationUrls
+            )
         return StructuredText(markdown: strippedText)
             .textual.structuredTextStyle(.gitHub)
             .textual.highlighterTheme(isStreaming ? .plain : .default)
@@ -197,6 +215,98 @@ struct LaTeXMarkdownView: View, Equatable {
             }
             .fixedSize(horizontal: false, vertical: true)
             .environment(\.colorScheme, isDarkMode ? .dark : .light)
+    }
+
+    /// Rewrite standard markdown links whose URL matches an annotated web-search
+    /// citation so the link text becomes the host domain. Mirrors the visual
+    /// treatment legacy `#cite-` citations get via `stripCitations`, keeping
+    /// inline citations consistent when the backend emits citations as plain
+    /// markdown links.
+    static func rewriteAnnotatedLinks(in text: String, citationUrls: Set<String>?) -> String {
+        guard let citationUrls, !citationUrls.isEmpty, !text.isEmpty else { return text }
+        let chars = Array(text.unicodeScalars)
+        let count = chars.count
+        var result = String.UnicodeScalarView()
+        result.reserveCapacity(count)
+        var i = 0
+
+        while i < count {
+            guard chars[i] == "[" else {
+                result.append(chars[i])
+                i += 1
+                continue
+            }
+
+            // Scan link text up to a matching `]` (allowing nested `[`/`]`).
+            var j = i + 1
+            var textDepth = 1
+            while j < count && textDepth > 0 {
+                let c = chars[j]
+                if c == "\\" && j + 1 < count {
+                    j += 2
+                    continue
+                }
+                if c == "[" { textDepth += 1 }
+                else if c == "]" { textDepth -= 1; if textDepth == 0 { break } }
+                else if c == "\n" { break }
+                j += 1
+            }
+            guard j < count, chars[j] == "]", j + 1 < count, chars[j + 1] == "(" else {
+                result.append(chars[i])
+                i += 1
+                continue
+            }
+
+            // Scan href up to a matching `)` (allowing one level of nested parens).
+            var k = j + 2
+            var hrefDepth = 1
+            while k < count && hrefDepth > 0 {
+                let c = chars[k]
+                if c == "\\" && k + 1 < count {
+                    k += 2
+                    continue
+                }
+                if c == "(" { hrefDepth += 1 }
+                else if c == ")" { hrefDepth -= 1; if hrefDepth == 0 { break } }
+                else if c == "\n" { break }
+                k += 1
+            }
+            guard k < count, chars[k] == ")" else {
+                result.append(chars[i])
+                i += 1
+                continue
+            }
+
+            var hrefView = String.UnicodeScalarView()
+            for idx in (j + 2)..<k { hrefView.append(chars[idx]) }
+            let href = String(hrefView).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Skip angle-bracketed autolinks: <https://...>
+            let bareHref: String
+            if href.hasPrefix("<") && href.hasSuffix(">") && href.count >= 2 {
+                bareHref = String(href.dropFirst().dropLast())
+            } else {
+                bareHref = href
+            }
+
+            if citationUrls.contains(bareHref) {
+                let domain: String
+                if let parsed = URL(string: bareHref), let host = parsed.host {
+                    domain = host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+                } else {
+                    domain = bareHref
+                }
+                for c in "[\(domain)](\(bareHref))".unicodeScalars {
+                    result.append(c)
+                }
+                i = k + 1
+            } else {
+                for idx in i...k { result.append(chars[idx]) }
+                i = k + 1
+            }
+        }
+
+        return String(result)
     }
 
     /// Strip citation markers from markdown text.

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -39,6 +39,25 @@ struct MessageView: View {
         !(isLoading && isLastMessage)
     }
 
+    /// URLs the router annotated as web-search citations on this message.
+    /// Used by the markdown renderer to rewrite plain markdown citation links
+    /// to use the host domain as their display text.
+    private var citationUrls: Set<String>? {
+        var urls: Set<String> = []
+        if let annotations = message.annotations {
+            for annotation in annotations where annotation.type == "url_citation" {
+                let url = annotation.url_citation.url
+                if !url.isEmpty { urls.insert(url) }
+            }
+        }
+        if let sources = message.webSearchState?.sources {
+            for source in sources where !source.url.isEmpty {
+                urls.insert(source.url)
+            }
+        }
+        return urls.isEmpty ? nil : urls
+    }
+
     var body: some View {
         HStack {
             if message.role == .user {
@@ -120,7 +139,8 @@ struct MessageView: View {
                                     chunks: message.contentChunks,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -129,7 +149,8 @@ struct MessageView: View {
                                     content: message.content,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -159,7 +180,8 @@ struct MessageView: View {
                                 content: parsed.remainderText,
                                 isDarkMode: isDarkMode,
                                 isStreaming: isLoading && isLastMessage,
-                                textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                citationUrls: citationUrls
                             )
                                 .equatable()
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -232,7 +254,8 @@ struct MessageView: View {
                                     chunks: message.contentChunks,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -241,7 +264,8 @@ struct MessageView: View {
                                     content: message.content,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled
+                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                    citationUrls: citationUrls
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1138,12 +1162,28 @@ struct ChunkedContentView: View, Equatable {
     let isDarkMode: Bool
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    let citationUrls: Set<String>?
+
+    init(
+        chunks: [ContentChunk],
+        isDarkMode: Bool,
+        isStreaming: Bool,
+        textSelectionEnabled: Bool,
+        citationUrls: Set<String>? = nil
+    ) {
+        self.chunks = chunks
+        self.isDarkMode = isDarkMode
+        self.isStreaming = isStreaming
+        self.textSelectionEnabled = textSelectionEnabled
+        self.citationUrls = citationUrls
+    }
 
     static func == (lhs: ChunkedContentView, rhs: ChunkedContentView) -> Bool {
         lhs.chunks == rhs.chunks &&
         lhs.isDarkMode == rhs.isDarkMode &&
         lhs.isStreaming == rhs.isStreaming &&
-        lhs.textSelectionEnabled == rhs.textSelectionEnabled
+        lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+        lhs.citationUrls == rhs.citationUrls
     }
 
     var body: some View {
@@ -1153,7 +1193,8 @@ struct ChunkedContentView: View, Equatable {
                     chunk: chunk,
                     isDarkMode: isDarkMode,
                     isStreaming: isStreaming,
-                    textSelectionEnabled: textSelectionEnabled
+                    textSelectionEnabled: textSelectionEnabled,
+                    citationUrls: citationUrls
                 )
             }
         }
@@ -1165,19 +1206,22 @@ struct ChunkView: View, Equatable {
     let isDarkMode: Bool
     let isStreaming: Bool
     let textSelectionEnabled: Bool
+    let citationUrls: Set<String>?
 
     static func == (lhs: ChunkView, rhs: ChunkView) -> Bool {
         if lhs.chunk.isComplete && rhs.chunk.isComplete {
             return lhs.chunk.id == rhs.chunk.id &&
                    lhs.isDarkMode == rhs.isDarkMode &&
-                   lhs.textSelectionEnabled == rhs.textSelectionEnabled
+                   lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+                   lhs.citationUrls == rhs.citationUrls
         }
         return lhs.chunk.id == rhs.chunk.id &&
                lhs.chunk.isComplete == rhs.chunk.isComplete &&
                lhs.chunk.content == rhs.chunk.content &&
                lhs.isDarkMode == rhs.isDarkMode &&
                lhs.isStreaming == rhs.isStreaming &&
-               lhs.textSelectionEnabled == rhs.textSelectionEnabled
+               lhs.textSelectionEnabled == rhs.textSelectionEnabled &&
+               lhs.citationUrls == rhs.citationUrls
     }
 
     var body: some View {
@@ -1188,7 +1232,8 @@ struct ChunkView: View, Equatable {
                 content: chunk.content,
                 isDarkMode: isDarkMode,
                 isStreaming: chunk.isComplete ? false : isStreaming,
-                textSelectionEnabled: textSelectionEnabled
+                textSelectionEnabled: textSelectionEnabled,
+                citationUrls: citationUrls
             )
             .equatable()
         }

--- a/TinfoilChatTests/CitationRegexTests.swift
+++ b/TinfoilChatTests/CitationRegexTests.swift
@@ -148,44 +148,81 @@ struct CitationRegexTests {
         }
     }
 
-    // MARK: - citationMarkerRegex (【1】 format used in ChatViewModel)
+    // MARK: - rewriteAnnotatedLinks: markdown citation links from the new backend format
 
-    @Test("Citation marker regex matches simple markers")
-    func citationMarkerMatchesSimple() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "Some text【1】more text"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 1)
+    @Test("Rewrites annotated link text to the host domain")
+    func rewriteAnnotatedLinkToDomain() {
+        let input = "See [some title](https://example.com/page) for details"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://example.com/page"]
+        )
+        #expect(result == "See [example.com](https://example.com/page) for details")
     }
 
-    @Test("Citation marker regex matches multiple markers")
-    func citationMarkerMatchesMultiple() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "First【1】second【2】third【3】"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 3)
+    @Test("Strips www. prefix from the host domain")
+    func rewriteAnnotatedLinkStripsWWW() {
+        let input = "[title](https://www.example.com/path)"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://www.example.com/path"]
+        )
+        #expect(result == "[example.com](https://www.example.com/path)")
     }
 
-    @Test("Citation marker regex captures the number")
-    func citationMarkerCapturesNumber() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "text【42】end"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 1)
-        if let match = matches.first, let numRange = Range(match.range(at: 1), in: input) {
-            #expect(String(input[numRange]) == "42")
-        }
+    @Test("Leaves non-annotated links unchanged")
+    func rewriteLeavesNonAnnotatedLinks() {
+        let input = "See [this article](https://unrelated.com) and [another](https://example.com/page)"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://example.com/page"]
+        )
+        #expect(result == "See [this article](https://unrelated.com) and [example.com](https://example.com/page)")
     }
 
-    @Test("Citation marker regex ignores text without markers")
-    func citationMarkerNoMatch() {
-        let regex = try! NSRegularExpression(pattern: "【(\\d+)[^】]*】", options: [])
-        let input = "Regular text with [1] brackets"
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: nsInput.length))
-        #expect(matches.count == 0)
+    @Test("Rewrites multiple annotated links in one pass")
+    func rewriteMultipleAnnotatedLinks() {
+        let input = "[a](https://one.com) and [b](https://two.org/path)"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://one.com", "https://two.org/path"]
+        )
+        #expect(result == "[one.com](https://one.com) and [two.org](https://two.org/path)")
+    }
+
+    @Test("Returns input unchanged when citation set is nil")
+    func rewriteNilCitationsNoOp() {
+        let input = "See [some title](https://example.com/page) for details"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(in: input, citationUrls: nil)
+        #expect(result == input)
+    }
+
+    @Test("Returns input unchanged when citation set is empty")
+    func rewriteEmptyCitationsNoOp() {
+        let input = "See [some title](https://example.com/page) for details"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(in: input, citationUrls: [])
+        #expect(result == input)
+    }
+
+    @Test("Handles parentheses inside annotated URL")
+    func rewriteAnnotatedLinkWithParensInURL() {
+        let input = "[title](https://en.wikipedia.org/wiki/Foo_(bar))"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://en.wikipedia.org/wiki/Foo_(bar)"]
+        )
+        #expect(result == "[en.wikipedia.org](https://en.wikipedia.org/wiki/Foo_(bar))")
+    }
+
+    @Test("Leaves legacy #cite- style links to stripCitations")
+    func rewriteLeavesLegacyCiteLinks() {
+        let input = "text [1](#cite-1~https://example.com~Title) end"
+        let result = LaTeXMarkdownView.rewriteAnnotatedLinks(
+            in: input,
+            citationUrls: ["https://example.com"]
+        )
+        // The href starts with `#cite-`, not the annotated URL, so this helper
+        // leaves it untouched; stripCitations handles the legacy format.
+        #expect(result == input)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Parse inline `<tinfoil-event>` markers from assistant deltas to power live web search and URL fetch UI without the legacy SSE callback. Also render web-search citation links with host-domain labels and stop rewriting numeric citation markers.

- **New Features**
  - Added `TinfoilEventParser` to remove markers from streamed text and emit decoded web search events (chunk-safe; trims pad newlines).
  - `ChatViewModel`: opts into `tinfoilEvents: [.webSearch]`, applies parsed events to `WebSearchState`/`URLFetchState`, strips markers during streaming, and flushes parser at end.
  - Citation handling: use backend’s markdown links; `LaTeXMarkdownView.rewriteAnnotatedLinks(...)` displays `[domain](url)` for annotated citations; `MessageView` passes `citationUrls`.
  - Removed “【n】” citation rewriting; assistant content/chunks now render as provided.

- **Dependencies**
  - Pin `tinfoil-swift` to `0.0.5`.
  - Update `openai-swift-fork` to `0.0.5`.

<sup>Written for commit 1117f150c337b2b120625bdb2c67f0c59d756329. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

