### PR TITLE
Improve websearch UX

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.10;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.10;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -385,6 +385,68 @@ struct URLFetchState: Codable, Equatable, Identifiable {
     }
 }
 
+/// A single web search instance referenced by an inline message segment.
+/// Mirrors React's `WebSearchInstance`.
+struct WebSearchInstance: Codable, Equatable, Identifiable {
+    let id: String
+    var query: String?
+    var status: WebSearchStatus
+    var sources: [WebSearchSource]?
+    var reason: String?
+}
+
+/// An ordered segment of assistant content. Preserves the exact order in which
+/// text and inline events (web search, URL fetch) streamed.
+enum MessageSegment: Codable, Equatable {
+    case text(String)
+    case webSearch(searchId: String)
+    case urlFetch(fetchId: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case searchId
+        case fetchId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "text":
+            let text = try container.decode(String.self, forKey: .text)
+            self = .text(text)
+        case "web_search":
+            let searchId = try container.decode(String.self, forKey: .searchId)
+            self = .webSearch(searchId: searchId)
+        case "url_fetch":
+            let fetchId = try container.decode(String.self, forKey: .fetchId)
+            self = .urlFetch(fetchId: fetchId)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown segment type: \(type)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let text):
+            try container.encode("text", forKey: .type)
+            try container.encode(text, forKey: .text)
+        case .webSearch(let searchId):
+            try container.encode("web_search", forKey: .type)
+            try container.encode(searchId, forKey: .searchId)
+        case .urlFetch(let fetchId):
+            try container.encode("url_fetch", forKey: .type)
+            try container.encode(fetchId, forKey: .fetchId)
+        }
+    }
+}
+
 /// URL citation from web search results, matching React's Annotation type
 struct URLCitation: Codable, Equatable {
     let title: String
@@ -425,6 +487,11 @@ struct Message: Identifiable, Codable, Equatable {
     var webSearchBeforeThinking: Bool? = nil
     var annotations: [Annotation]? = nil
     var searchReasoning: String? = nil
+    // React's ordered content segments and per-search instances. iOS does not
+    // render from these yet but preserves them so messages authored on web
+    // round-trip through iOS without losing inline ordering.
+    var segments: [MessageSegment]? = nil
+    var webSearches: [WebSearchInstance]? = nil
 
     static let longMessageAttachmentThreshold = 1200
     var shouldDisplayAsAttachment: Bool {
@@ -467,6 +534,7 @@ struct Message: Identifiable, Codable, Equatable {
         case attachments
         case thinkingDuration, isError
         case webSearchBeforeThinking, annotations, searchReasoning
+        case segments, webSearches
         // Legacy keys for decoding React messages that use the old format
         case documentContent, imageData, imageBase64, multimodalText, documents
     }
@@ -521,6 +589,8 @@ struct Message: Identifiable, Codable, Equatable {
         webSearchBeforeThinking = try container.decodeIfPresent(Bool.self, forKey: .webSearchBeforeThinking)
         annotations = try container.decodeIfPresent([Annotation].self, forKey: .annotations)
         searchReasoning = try container.decodeIfPresent(String.self, forKey: .searchReasoning)
+        segments = try container.decodeIfPresent([MessageSegment].self, forKey: .segments)
+        webSearches = try container.decodeIfPresent([WebSearchInstance].self, forKey: .webSearches)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -555,6 +625,8 @@ struct Message: Identifiable, Codable, Equatable {
         try container.encodeIfPresent(webSearchBeforeThinking, forKey: .webSearchBeforeThinking)
         try container.encodeIfPresent(annotations, forKey: .annotations)
         try container.encodeIfPresent(searchReasoning, forKey: .searchReasoning)
+        try container.encodeIfPresent(segments, forKey: .segments)
+        try container.encodeIfPresent(webSearches, forKey: .webSearches)
     }
 
     // MARK: - Legacy Format Reconstruction

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -444,6 +444,35 @@ enum MessageSegment: Codable, Equatable {
             try container.encode(fetchId, forKey: .fetchId)
         }
     }
+
+    /// Decodes an array of segments while tolerating individual entries whose
+    /// shape is unknown to this client (e.g. a newer platform introduced a
+    /// segment type we don't understand). Unrecognized entries are skipped
+    /// instead of failing the whole decode.
+    static func decodeArrayLenient<K: CodingKey>(
+        from container: KeyedDecodingContainer<K>,
+        forKey key: K
+    ) throws -> [MessageSegment]? {
+        guard container.contains(key) else { return nil }
+        // Decode into a forgiving wrapper that accepts any JSON shape so the
+        // unkeyed container reliably advances past unknown entries, then
+        // attempt to re-decode each wrapper as a `MessageSegment` via its
+        // preserved raw value. Entries that still don't match are dropped.
+        let wrappers = try container.decode([LenientSegment].self, forKey: key)
+        return wrappers.compactMap { $0.segment }
+    }
+}
+
+/// Wrapper that decodes any JSON value into an intermediate form and then
+/// tries to re-interpret it as a `MessageSegment`. Unknown shapes decode
+/// successfully (advancing the unkeyed container) but yield a `nil`
+/// segment so callers can drop them.
+private struct LenientSegment: Decodable {
+    let segment: MessageSegment?
+
+    init(from decoder: Decoder) throws {
+        self.segment = try? MessageSegment(from: decoder)
+    }
 }
 
 /// URL citation from web search results, matching React's Annotation type
@@ -588,8 +617,20 @@ struct Message: Identifiable, Codable, Equatable {
         webSearchBeforeThinking = try container.decodeIfPresent(Bool.self, forKey: .webSearchBeforeThinking)
         annotations = try container.decodeIfPresent([Annotation].self, forKey: .annotations)
         searchReasoning = try container.decodeIfPresent(String.self, forKey: .searchReasoning)
-        segments = try container.decodeIfPresent([MessageSegment].self, forKey: .segments)
-        webSearches = try container.decodeIfPresent([WebSearchInstance].self, forKey: .webSearches)
+        // Segments and webSearches are forward-compatible: unknown segment
+        // shapes (e.g. a new `type` added by a future client) must not fail
+        // the entire message decode. Individual unknown entries are skipped
+        // by `MessageSegment.decodeArrayLenient`; if the whole field is
+        // otherwise malformed, treat it as missing.
+        if container.contains(.segments) {
+            segments = try? MessageSegment.decodeArrayLenient(
+                from: container,
+                forKey: .segments
+            )
+        } else {
+            segments = nil
+        }
+        webSearches = (try? container.decodeIfPresent([WebSearchInstance].self, forKey: .webSearches)) ?? nil
     }
     
     func encode(to encoder: Encoder) throws {

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -386,7 +386,6 @@ struct URLFetchState: Codable, Equatable, Identifiable {
 }
 
 /// A single web search instance referenced by an inline message segment.
-/// Mirrors React's `WebSearchInstance`.
 struct WebSearchInstance: Codable, Equatable, Identifiable {
     let id: String
     var query: String?
@@ -487,9 +486,9 @@ struct Message: Identifiable, Codable, Equatable {
     var webSearchBeforeThinking: Bool? = nil
     var annotations: [Annotation]? = nil
     var searchReasoning: String? = nil
-    // React's ordered content segments and per-search instances. iOS does not
-    // render from these yet but preserves them so messages authored on web
-    // round-trip through iOS without losing inline ordering.
+    // Ordered content segments and per-search instances so web-search and
+    // URL-fetch events render inline with the assistant text in the exact
+    // order they streamed.
     var segments: [MessageSegment]? = nil
     var webSearches: [WebSearchInstance]? = nil
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1183,6 +1183,45 @@ class ChatViewModel: ObservableObject {
                 // Track whether web search started before thinking (shared across callback and streaming loop)
                 let webSearchStartedFlag = OSAllocatedUnfairLock(initialState: false)
 
+                // Ordered content segments (text + inline event refs) that preserve
+                // the exact order in which events arrived relative to streamed text.
+                // Accessed only on the main actor (this Task and the
+                // applyWebSearchCallEvent closure both run MainActor-isolated).
+                var segments: [MessageSegment] = []
+                var webSearches: [WebSearchInstance] = []
+                var nextSearchId = 0
+
+                let allocateSearchId = { () -> String in
+                    defer { nextSearchId += 1 }
+                    return "ws-\(nextSearchId)"
+                }
+
+                let appendText: (String) -> Void = { text in
+                    guard !text.isEmpty else { return }
+                    if case .text(let existing) = segments.last {
+                        segments[segments.count - 1] = .text(existing + text)
+                    } else {
+                        segments.append(.text(text))
+                    }
+                }
+
+                let upsertWebSearch: (WebSearchInstance) -> Void = { instance in
+                    if let idx = webSearches.firstIndex(where: { $0.id == instance.id }) {
+                        webSearches[idx] = instance
+                    } else {
+                        webSearches.append(instance)
+                        segments.append(.webSearch(searchId: instance.id))
+                    }
+                }
+
+                let findLatestSearchInstance = { (eventId: String?) -> WebSearchInstance? in
+                    if let eventId = eventId,
+                       let hit = webSearches.first(where: { $0.id == eventId }) {
+                        return hit
+                    }
+                    return webSearches.last
+                }
+
                 // Web search progress now rides inline with the model's
                 // content as `<tinfoil-event>` markers (opted into via
                 // the `tinfoilEvents: [.webSearch]` flag on create).
@@ -1211,6 +1250,7 @@ class ChatViewModel: ObservableObject {
                                 chat.messages[lastIndex].urlFetches.append(
                                     URLFetchState(id: fetchId, url: url, status: .fetching)
                                 )
+                                segments.append(.urlFetch(fetchId: fetchId))
                             }
                         case .completed:
                             if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
@@ -1225,6 +1265,7 @@ class ChatViewModel: ObservableObject {
                                 chat.messages[lastIndex].urlFetches[idx].status = .blocked
                             }
                         }
+                        chat.messages[lastIndex].segments = segments
                         self.updateChat(chat, throttleForStreaming: true)
                         return
                     }
@@ -1233,6 +1274,16 @@ class ChatViewModel: ObservableObject {
                     switch event.status {
                     case .inProgress, .searching:
                         webSearchStartedFlag.withLock { $0 = true }
+                        let id = event.itemId ?? allocateSearchId()
+                        upsertWebSearch(
+                            WebSearchInstance(
+                                id: id,
+                                query: event.action?.query,
+                                status: .searching,
+                                sources: existingSources,
+                                reason: nil
+                            )
+                        )
                         chat.messages[lastIndex].webSearchState = WebSearchState(
                             query: event.action?.query,
                             status: .searching,
@@ -1240,12 +1291,45 @@ class ChatViewModel: ObservableObject {
                         )
                         self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
                     case .completed:
+                        if let existing = findLatestSearchInstance(event.itemId) {
+                            upsertWebSearch(
+                                WebSearchInstance(
+                                    id: existing.id,
+                                    query: existing.query,
+                                    status: .completed,
+                                    sources: existing.sources,
+                                    reason: existing.reason
+                                )
+                            )
+                        }
                         chat.messages[lastIndex].webSearchState?.status = .completed
                         self.webSearchSummary = ""
                     case .failed:
+                        if let existing = findLatestSearchInstance(event.itemId) {
+                            upsertWebSearch(
+                                WebSearchInstance(
+                                    id: existing.id,
+                                    query: existing.query,
+                                    status: .failed,
+                                    sources: [],
+                                    reason: existing.reason
+                                )
+                            )
+                        }
                         chat.messages[lastIndex].webSearchState?.status = .failed
                         self.webSearchSummary = ""
                     case .blocked:
+                        let existing = findLatestSearchInstance(event.itemId)
+                        let id = existing?.id ?? event.itemId ?? allocateSearchId()
+                        upsertWebSearch(
+                            WebSearchInstance(
+                                id: id,
+                                query: event.action?.query ?? existing?.query,
+                                status: .blocked,
+                                sources: nil,
+                                reason: event.error?.code
+                            )
+                        )
                         chat.messages[lastIndex].webSearchState = WebSearchState(
                             query: event.action?.query,
                             status: .blocked,
@@ -1253,6 +1337,8 @@ class ChatViewModel: ObservableObject {
                         )
                         self.webSearchSummary = ""
                     }
+                    chat.messages[lastIndex].segments = segments
+                    chat.messages[lastIndex].webSearches = webSearches
                     self.updateChat(chat, throttleForStreaming: true)
                 }
 
@@ -1352,6 +1438,7 @@ class ChatViewModel: ObservableObject {
 
                     // Collect sources from annotations (no deduplication to preserve citation index mapping)
                     if isWebSearchEnabled, let annotations = chunk.choices.first?.delta.annotations {
+                        var didCollectNewSource = false
                         for annotation in annotations where annotation.type == "url_citation" {
                             if let citation = annotation.urlCitation {
                                 let source = WebSearchSource(
@@ -1359,8 +1446,21 @@ class ChatViewModel: ObservableObject {
                                     url: citation.url
                                 )
                                 collectedSources.append(source)
+                                didCollectNewSource = true
                                 didMutateState = true
                             }
+                        }
+                        // Mirror the running sources onto the most recent WebSearchInstance
+                        // so inline rendering reflects the same state as the aggregate.
+                        if didCollectNewSource, let idx = webSearches.indices.last {
+                            let lastSearch = webSearches[idx]
+                            webSearches[idx] = WebSearchInstance(
+                                id: lastSearch.id,
+                                query: lastSearch.query,
+                                status: lastSearch.status,
+                                sources: collectedSources,
+                                reason: lastSearch.reason
+                            )
                         }
                     }
 
@@ -1417,6 +1517,7 @@ class ChatViewModel: ObservableObject {
                                 responseContent += content
                             }
                             chunker.appendToken(content)
+                            appendText(content)
                             didMutateState = true
                         } else if !content.isEmpty {
                             if responseContent.isEmpty {
@@ -1425,6 +1526,7 @@ class ChatViewModel: ObservableObject {
                                 responseContent += content
                             }
                             chunker.appendToken(content)
+                            appendText(content)
                             isInThinkingMode = false
                             didMutateState = true
                         }
@@ -1461,6 +1563,7 @@ class ChatViewModel: ObservableObject {
                                         responseContent += processContent
                                     }
                                     chunker.appendToken(processContent)
+                                    appendText(processContent)
                                     didMutateState = true
                                 }
                             }
@@ -1485,6 +1588,7 @@ class ChatViewModel: ObservableObject {
                                     responseContent += afterEnd
                                 }
                                 chunker.appendToken(afterEnd)
+                                appendText(afterEnd)
 
                                 if let startTime = thinkStartTime {
                                     generationTimeSeconds = Date().timeIntervalSince(startTime)
@@ -1515,6 +1619,7 @@ class ChatViewModel: ObservableObject {
                                 responseContent += content
                             }
                             chunker.appendToken(content)
+                            appendText(content)
                             didMutateState = true
                         }
                     }
@@ -1530,6 +1635,8 @@ class ChatViewModel: ObservableObject {
                         let thinking = isInThinkingMode
                         let genTime = generationTimeSeconds
                         let currentSources = collectedSources
+                        let currentSegments = segments
+                        let currentWebSearches = webSearches
 
                         Task { @MainActor [weak self] in
                             guard let self = self else { return }
@@ -1549,6 +1656,8 @@ class ChatViewModel: ObservableObject {
                             chat.messages[lastIndex].isThinking = thinking
                             chat.messages[lastIndex].generationTimeSeconds = genTime
                             chat.messages[lastIndex].contentChunks = currentChunks
+                            chat.messages[lastIndex].segments = currentSegments.isEmpty ? nil : currentSegments
+                            chat.messages[lastIndex].webSearches = currentWebSearches.isEmpty ? nil : currentWebSearches
 
                             // Merge collected sources into the message's current webSearchState (set by the callback)
                             if !currentSources.isEmpty {
@@ -1580,6 +1689,7 @@ class ChatViewModel: ObservableObject {
                             responseContent += sanitizedTail
                         }
                         _ = chunker.appendToken(sanitizedTail)
+                        appendText(sanitizedTail)
                     }
                 }
 
@@ -1592,6 +1702,7 @@ class ChatViewModel: ObservableObject {
                         if responseContent.isEmpty {
                             responseContent = thoughtsBuffer
                             currentThoughts = nil
+                            appendText(thoughtsBuffer)
                         }
                     }
                     if let startTime = thinkStartTime {
@@ -1605,6 +1716,7 @@ class ChatViewModel: ObservableObject {
                         responseContent += initialContentBuffer
                     }
                     _ = chunker.appendToken(initialContentBuffer)
+                    appendText(initialContentBuffer)
                     isInThinkingMode = false
                     currentThoughts = nil
                 }
@@ -1645,6 +1757,21 @@ class ChatViewModel: ObservableObject {
                         chat.messages[lastIndex].thinkingDuration = generationTimeSeconds
                         chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
                         chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
+                        chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
+                        // Mirror the final sources onto the most recent WebSearchInstance so
+                        // the inline segmented pill matches the aggregate webSearchState.
+                        if !collectedSources.isEmpty,
+                           let idx = webSearches.indices.last {
+                            let lastSearch = webSearches[idx]
+                            webSearches[idx] = WebSearchInstance(
+                                id: lastSearch.id,
+                                query: lastSearch.query,
+                                status: lastSearch.status,
+                                sources: collectedSources,
+                                reason: lastSearch.reason
+                            )
+                        }
+                        chat.messages[lastIndex].webSearches = webSearches.isEmpty ? nil : webSearches
                         // Merge final collected sources into the message's webSearchState
                         if !collectedSources.isEmpty {
                             var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1633,54 +1633,35 @@ class ChatViewModel: ObservableObject {
                     let now = Date()
                     if didMutateState && now.timeIntervalSince(lastUIUpdateTime) >= uiUpdateInterval {
                         lastUIUpdateTime = now
-                        let currentChunks = chunker.getAllChunks()
-                        let currentThinkingChunks = thinkingChunker.getAllChunks()
-                        let content = responseContent
-                        let thoughts = currentThoughts
-                        let thinking = isInThinkingMode
-                        let genTime = generationTimeSeconds
-                        let currentSources = collectedSources
-                        let currentSegments = segments
-                        let currentWebSearches = webSearches
-
-                        Task { @MainActor [weak self] in
-                            guard let self = self else { return }
-                            guard self.currentChat?.id == streamChatId else { return }
-                            guard var chat = self.currentChat,
-                                  chat.hasActiveStream,
-                                  !chat.messages.isEmpty,
-                                  let lastIndex = chat.messages.indices.last else {
-                                return
-                            }
-
-                            // The router delivers citations as standard markdown links in the
-                            // assistant content, so the UI can render the message as-is.
-                            chat.messages[lastIndex].content = content
-                            chat.messages[lastIndex].thoughts = thoughts
-                            chat.messages[lastIndex].thinkingChunks = currentThinkingChunks
-                            chat.messages[lastIndex].isThinking = thinking
-                            chat.messages[lastIndex].generationTimeSeconds = genTime
-                            chat.messages[lastIndex].contentChunks = currentChunks
-                            chat.messages[lastIndex].segments = currentSegments.isEmpty ? nil : currentSegments
-                            chat.messages[lastIndex].webSearches = currentWebSearches.isEmpty ? nil : currentWebSearches
-
-                            // Merge collected sources into the message's current webSearchState (set by the callback).
-                            // If the router already sent `.completed` but no sources were attached at the time,
-                            // the aggregate state was parked at `.searching` — promote it now.
-                            if !currentSources.isEmpty {
-                                var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
-                                searchState.sources = currentSources
-                                if searchState.status == .searching,
-                                   let latest = currentWebSearches.last,
-                                   latest.status == .completed {
-                                    searchState.status = .completed
-                                    self.webSearchSummary = ""
-                                }
-                                chat.messages[lastIndex].webSearchState = searchState
-                            }
-
-                            self.updateChat(chat, throttleForStreaming: true)
+                        // The streaming loop and `applyWebSearchCallEvent` both run on
+                        // MainActor, so this block executes synchronously with respect to
+                        // event dispatch; reading `segments` / `webSearches` directly here
+                        // is safe and gives the latest values (no stale snapshot race).
+                        guard self.currentChat?.id == streamChatId else { continue }
+                        guard var chat = self.currentChat,
+                              chat.hasActiveStream,
+                              !chat.messages.isEmpty,
+                              let lastIndex = chat.messages.indices.last else {
+                            continue
                         }
+
+                        chat.messages[lastIndex].content = responseContent
+                        chat.messages[lastIndex].thoughts = currentThoughts
+                        chat.messages[lastIndex].thinkingChunks = thinkingChunker.getAllChunks()
+                        chat.messages[lastIndex].isThinking = isInThinkingMode
+                        chat.messages[lastIndex].generationTimeSeconds = generationTimeSeconds
+                        chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
+                        chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
+                        chat.messages[lastIndex].webSearches = webSearches.isEmpty ? nil : webSearches
+
+                        // Merge collected sources into the message's current webSearchState.
+                        if !collectedSources.isEmpty {
+                            var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
+                            searchState.sources = collectedSources
+                            chat.messages[lastIndex].webSearchState = searchState
+                        }
+
+                        self.updateChat(chat, throttleForStreaming: true)
                     }
                 }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1291,31 +1291,19 @@ class ChatViewModel: ObservableObject {
                         )
                         self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
                     case .completed:
-                        // Only promote to `.completed` once at least one source
-                        // has landed; otherwise the UI would briefly show a
-                        // "Searched the web" pill with zero sources while
-                        // annotations are still in flight. Leaving the status
-                        // as `.searching` here is harmless: the annotation
-                        // path below promotes the state the moment the first
-                        // source arrives, and the final save always upgrades
-                        // whatever is set.
-                        let hasSources = !(chat.messages[lastIndex].webSearchState?.sources.isEmpty ?? true)
-                        let completedStatus: WebSearchStatus = hasSources ? .completed : .searching
                         if let existing = findLatestSearchInstance(event.itemId) {
                             upsertWebSearch(
                                 WebSearchInstance(
                                     id: existing.id,
                                     query: existing.query,
-                                    status: completedStatus,
+                                    status: .completed,
                                     sources: existing.sources,
                                     reason: existing.reason
                                 )
                             )
                         }
-                        chat.messages[lastIndex].webSearchState?.status = completedStatus
-                        if hasSources {
-                            self.webSearchSummary = ""
-                        }
+                        chat.messages[lastIndex].webSearchState?.status = .completed
+                        self.webSearchSummary = ""
                     case .failed:
                         if let existing = findLatestSearchInstance(event.itemId) {
                             upsertWebSearch(

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1291,19 +1291,31 @@ class ChatViewModel: ObservableObject {
                         )
                         self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
                     case .completed:
+                        // Only promote to `.completed` once at least one source
+                        // has landed; otherwise the UI would briefly show a
+                        // "Searched the web" pill with zero sources while
+                        // annotations are still in flight. Leaving the status
+                        // as `.searching` here is harmless: the annotation
+                        // path below promotes the state the moment the first
+                        // source arrives, and the final save always upgrades
+                        // whatever is set.
+                        let hasSources = !(chat.messages[lastIndex].webSearchState?.sources.isEmpty ?? true)
+                        let completedStatus: WebSearchStatus = hasSources ? .completed : .searching
                         if let existing = findLatestSearchInstance(event.itemId) {
                             upsertWebSearch(
                                 WebSearchInstance(
                                     id: existing.id,
                                     query: existing.query,
-                                    status: .completed,
+                                    status: completedStatus,
                                     sources: existing.sources,
                                     reason: existing.reason
                                 )
                             )
                         }
-                        chat.messages[lastIndex].webSearchState?.status = .completed
-                        self.webSearchSummary = ""
+                        chat.messages[lastIndex].webSearchState?.status = completedStatus
+                        if hasSources {
+                            self.webSearchSummary = ""
+                        }
                     case .failed:
                         if let existing = findLatestSearchInstance(event.itemId) {
                             upsertWebSearch(
@@ -1450,14 +1462,19 @@ class ChatViewModel: ObservableObject {
                                 didMutateState = true
                             }
                         }
-                        // Mirror the running sources onto the most recent WebSearchInstance
-                        // so inline rendering reflects the same state as the aggregate.
+                        // Mirror the running sources onto the most recent WebSearchInstance.
+                        // When the router sent `.completed` before any sources, we held the
+                        // instance at `.searching` to avoid a zero-source completed pill;
+                        // promote it now that a source has arrived.
                         if didCollectNewSource, let idx = webSearches.indices.last {
                             let lastSearch = webSearches[idx]
+                            let promotedStatus: WebSearchStatus = lastSearch.status == .searching
+                                ? .completed
+                                : lastSearch.status
                             webSearches[idx] = WebSearchInstance(
                                 id: lastSearch.id,
                                 query: lastSearch.query,
-                                status: lastSearch.status,
+                                status: promotedStatus,
                                 sources: collectedSources,
                                 reason: lastSearch.reason
                             )
@@ -1659,10 +1676,18 @@ class ChatViewModel: ObservableObject {
                             chat.messages[lastIndex].segments = currentSegments.isEmpty ? nil : currentSegments
                             chat.messages[lastIndex].webSearches = currentWebSearches.isEmpty ? nil : currentWebSearches
 
-                            // Merge collected sources into the message's current webSearchState (set by the callback)
+                            // Merge collected sources into the message's current webSearchState (set by the callback).
+                            // If the router already sent `.completed` but no sources were attached at the time,
+                            // the aggregate state was parked at `.searching` — promote it now.
                             if !currentSources.isEmpty {
                                 var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
                                 searchState.sources = currentSources
+                                if searchState.status == .searching,
+                                   let latest = currentWebSearches.last,
+                                   latest.status == .completed {
+                                    searchState.status = .completed
+                                    self.webSearchSummary = ""
+                                }
                                 chat.messages[lastIndex].webSearchState = searchState
                             }
 
@@ -1758,24 +1783,32 @@ class ChatViewModel: ObservableObject {
                         chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
                         chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
                         chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
-                        // Mirror the final sources onto the most recent WebSearchInstance so
-                        // the inline segmented pill matches the aggregate webSearchState.
+                        // Mirror the final sources onto the most recent WebSearchInstance,
+                        // promoting it out of the `.searching` holding state if the router
+                        // sent `.completed` before any sources landed.
                         if !collectedSources.isEmpty,
                            let idx = webSearches.indices.last {
                             let lastSearch = webSearches[idx]
+                            let finalStatus: WebSearchStatus = lastSearch.status == .searching
+                                ? .completed
+                                : lastSearch.status
                             webSearches[idx] = WebSearchInstance(
                                 id: lastSearch.id,
                                 query: lastSearch.query,
-                                status: lastSearch.status,
+                                status: finalStatus,
                                 sources: collectedSources,
                                 reason: lastSearch.reason
                             )
                         }
                         chat.messages[lastIndex].webSearches = webSearches.isEmpty ? nil : webSearches
-                        // Merge final collected sources into the message's webSearchState
+                        // Merge final collected sources into the aggregate webSearchState,
+                        // promoting the same way.
                         if !collectedSources.isEmpty {
                             var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
                             searchState.sources = collectedSources
+                            if searchState.status == .searching {
+                                searchState.status = .completed
+                            }
                             chat.messages[lastIndex].webSearchState = searchState
                         }
                     }

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -580,6 +580,8 @@ class ObservableMessageWrapper: ObservableObject {
                             self.message.streamError != message.streamError ||
                             self.message.webSearchState != message.webSearchState ||
                             self.message.urlFetches != message.urlFetches ||
+                            self.message.segments != message.segments ||
+                            self.message.webSearches != message.webSearches ||
                             self.isDarkMode != isDarkMode
 
         let metadataChanged = self.isLastMessage != isLastMessage ||

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -40,9 +40,10 @@ struct MessageView: View {
     @State private var showURLFetchSheet = false
     @State private var activeWebSearchGroup: IdentifiedGroup<WebSearchInstance>? = nil
     @State private var activeURLFetchGroup: IdentifiedGroup<URLFetchState>? = nil
+    @State private var activeSearchInstanceSources: IdentifiedGroup<WebSearchSource>? = nil
 
     private var isAnyMessageSheetPresented: Bool {
-        showLongMessageSheet || showRawContentModal || showSelectableText || showSourcesSheet || showShareSheet || showThoughtsSheet || showURLFetchSheet || activeWebSearchGroup != nil || activeURLFetchGroup != nil
+        showLongMessageSheet || showRawContentModal || showSelectableText || showSourcesSheet || showShareSheet || showThoughtsSheet || showURLFetchSheet || activeWebSearchGroup != nil || activeURLFetchGroup != nil || activeSearchInstanceSources != nil
     }
 
     private var inlineAssistantTextSelectionEnabled: Bool {
@@ -177,8 +178,9 @@ struct MessageView: View {
                         onTap: {
                             if group.count > 1 {
                                 activeWebSearchGroup = IdentifiedGroup(items: group)
-                            } else if !aggregate.sources.isEmpty {
-                                showSourcesSheet = true
+                            } else if let first = group.first,
+                                      !(first.sources ?? []).isEmpty {
+                                activeSearchInstanceSources = IdentifiedGroup(items: first.sources ?? [])
                             }
                         }
                     )
@@ -616,6 +618,12 @@ struct MessageView: View {
         }
         .sheet(item: $activeURLFetchGroup) { group in
             URLFetchSheetView(urlFetches: group.items, isDarkMode: isDarkMode)
+                .presentationDetents([.medium, .large])
+                .iPadSheetSizing()
+                .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
+        }
+        .sheet(item: $activeSearchInstanceSources) { group in
+            SourcesSheetView(sources: group.items, isDarkMode: isDarkMode)
                 .presentationDetents([.medium, .large])
                 .iPadSheetSizing()
                 .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -11,6 +11,14 @@ import Textual
 import SwiftMath
 import UIKit
 
+/// Identifiable wrapper used to present `.sheet(item:)` for a transient
+/// grouped run of events (searches or fetches) without needing a stable
+/// model-level id.
+struct IdentifiedGroup<T>: Identifiable {
+    let id = UUID()
+    let items: [T]
+}
+
 struct MessageView: View {
     let message: Message
     let isDarkMode: Bool
@@ -30,73 +38,158 @@ struct MessageView: View {
     @State private var showShareSheet = false
     @State private var showThoughtsSheet = false
     @State private var showURLFetchSheet = false
+    @State private var activeWebSearchGroup: IdentifiedGroup<WebSearchInstance>? = nil
+    @State private var activeURLFetchGroup: IdentifiedGroup<URLFetchState>? = nil
 
     private var isAnyMessageSheetPresented: Bool {
-        showLongMessageSheet || showRawContentModal || showSelectableText || showSourcesSheet || showShareSheet || showThoughtsSheet || showURLFetchSheet
+        showLongMessageSheet || showRawContentModal || showSelectableText || showSourcesSheet || showShareSheet || showThoughtsSheet || showURLFetchSheet || activeWebSearchGroup != nil || activeURLFetchGroup != nil
     }
 
     private var inlineAssistantTextSelectionEnabled: Bool {
         !(isLoading && isLastMessage)
     }
 
+    /// Runs of adjacent segments collapsed for inline rendering. Adjacent
+    /// searches/fetches are merged into one row so long tool-call chains
+    /// don't stack N full-height pills in the chat.
+    private enum InlineSegmentRun {
+        case text(String, isTrailing: Bool)
+        case webSearches([WebSearchInstance])
+        case urlFetches([URLFetchState])
+    }
+
+    private func inlineSegmentRuns(from segments: [MessageSegment]) -> [InlineSegmentRun] {
+        let lastTextIndex: Int? = {
+            for i in segments.indices.reversed() {
+                if case .text = segments[i] { return i }
+            }
+            return nil
+        }()
+
+        var runs: [InlineSegmentRun] = []
+        var searchBuffer: [WebSearchInstance] = []
+        var fetchBuffer: [URLFetchState] = []
+
+        func flushSearches() {
+            if !searchBuffer.isEmpty {
+                runs.append(.webSearches(searchBuffer))
+                searchBuffer.removeAll()
+            }
+        }
+        func flushFetches() {
+            if !fetchBuffer.isEmpty {
+                runs.append(.urlFetches(fetchBuffer))
+                fetchBuffer.removeAll()
+            }
+        }
+
+        for (index, segment) in segments.enumerated() {
+            switch segment {
+            case .text(let text):
+                flushSearches()
+                flushFetches()
+                if !text.isEmpty {
+                    runs.append(.text(text, isTrailing: index == lastTextIndex))
+                }
+            case .webSearch(let searchId):
+                flushFetches()
+                if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
+                    searchBuffer.append(instance)
+                }
+            case .urlFetch(let fetchId):
+                flushSearches()
+                if let fetch = message.urlFetches.first(where: { $0.id == fetchId }) {
+                    fetchBuffer.append(fetch)
+                }
+            }
+        }
+        flushSearches()
+        flushFetches()
+        return runs
+    }
+
+    /// Aggregates a group of web searches into a single `WebSearchState` for
+    /// display: the status rolls up to the "most interesting" state in the
+    /// group (searching wins, then failed/blocked, else completed), and
+    /// sources are merged, de-duplicated by URL.
+    private func aggregatedState(for group: [WebSearchInstance]) -> WebSearchState {
+        let status: WebSearchStatus
+        if group.contains(where: { $0.status == .searching }) {
+            status = .searching
+        } else if group.contains(where: { $0.status == .failed }) {
+            status = .failed
+        } else if group.contains(where: { $0.status == .blocked }) {
+            status = .blocked
+        } else {
+            status = .completed
+        }
+
+        var mergedSources: [WebSearchSource] = []
+        var seenUrls: Set<String> = []
+        for instance in group {
+            for source in instance.sources ?? [] {
+                if seenUrls.insert(source.url).inserted {
+                    mergedSources.append(source)
+                }
+            }
+        }
+
+        let reason = group.compactMap { $0.reason }.first
+        let primaryQuery = group.first?.query
+        return WebSearchState(query: primaryQuery, status: status, sources: mergedSources, reason: reason)
+    }
+
     /// Renders ordered message segments (text and inline event refs) in the
     /// order they streamed. Each text segment is rendered via the same
     /// markdown pipeline as the non-segmented path; event segments resolve
-    /// through the message's `webSearches` / `urlFetches` maps.
+    /// through the message's `webSearches` / `urlFetches` maps. Adjacent
+    /// same-kind event segments are grouped into one row.
     @ViewBuilder
     private func inlineSegmentsView(segments: [MessageSegment]) -> some View {
+        let runs = inlineSegmentRuns(from: segments)
         VStack(alignment: .leading, spacing: 4) {
-            let lastTextIndex: Int? = {
-                for i in segments.indices.reversed() {
-                    if case .text = segments[i] { return i }
-                }
-                return nil
-            }()
-
-            ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
-                switch segment {
-                case .text(let text):
-                    if !text.isEmpty {
-                        let isTrailingText = index == lastTextIndex
-                        let isStreamingText = isTrailingText && isLoading && isLastMessage
-                        LaTeXMarkdownView(
-                            content: text,
-                            isDarkMode: isDarkMode,
-                            isStreaming: isStreamingText,
-                            textSelectionEnabled: inlineAssistantTextSelectionEnabled,
-                            citationUrls: citationUrls
-                        )
-                            .equatable()
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .transaction { transaction in
-                                transaction.animation = nil
+            ForEach(Array(runs.enumerated()), id: \.offset) { _, run in
+                switch run {
+                case .text(let text, let isTrailing):
+                    let isStreamingText = isTrailing && isLoading && isLastMessage
+                    LaTeXMarkdownView(
+                        content: text,
+                        isDarkMode: isDarkMode,
+                        isStreaming: isStreamingText,
+                        textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                        citationUrls: citationUrls
+                    )
+                        .equatable()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .transaction { transaction in
+                            transaction.animation = nil
+                        }
+                case .webSearches(let group):
+                    let aggregate = aggregatedState(for: group)
+                    let isSearchInFlight = aggregate.status == .searching
+                        && isLoading
+                        && isLastMessage
+                    WebSearchBox(
+                        webSearchState: aggregate,
+                        isDarkMode: isDarkMode,
+                        webSearchSummary: isSearchInFlight ? viewModel.webSearchSummary : nil,
+                        groupSize: group.count,
+                        onTap: {
+                            if group.count > 1 {
+                                activeWebSearchGroup = IdentifiedGroup(items: group)
+                            } else if !aggregate.sources.isEmpty {
+                                showSourcesSheet = true
                             }
-                    }
-                case .webSearch(let searchId):
-                    if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
-                        let isSearchInFlight = instance.status == .searching
-                            && isLoading
-                            && isLastMessage
-                        WebSearchBox(
-                            webSearchState: WebSearchState(
-                                query: instance.query,
-                                status: instance.status,
-                                sources: instance.sources ?? [],
-                                reason: instance.reason
-                            ),
-                            isDarkMode: isDarkMode,
-                            webSearchSummary: isSearchInFlight ? viewModel.webSearchSummary : nil,
-                            onTap: { showSourcesSheet = true }
-                        )
-                    }
-                case .urlFetch(let fetchId):
-                    if let fetch = message.urlFetches.first(where: { $0.id == fetchId }) {
-                        URLFetchBox(
-                            urlFetches: [fetch],
-                            isDarkMode: isDarkMode,
-                            onTap: { showURLFetchSheet = true }
-                        )
-                    }
+                        }
+                    )
+                case .urlFetches(let group):
+                    URLFetchBox(
+                        urlFetches: group,
+                        isDarkMode: isDarkMode,
+                        onTap: {
+                            activeURLFetchGroup = IdentifiedGroup(items: group)
+                        }
+                    )
                 }
             }
         }
@@ -511,6 +604,18 @@ struct MessageView: View {
         }
         .sheet(isPresented: $showURLFetchSheet) {
             URLFetchSheetView(urlFetches: message.urlFetches, isDarkMode: isDarkMode)
+                .presentationDetents([.medium, .large])
+                .iPadSheetSizing()
+                .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
+        }
+        .sheet(item: $activeWebSearchGroup) { group in
+            WebSearchQueriesSheetView(instances: group.items, isDarkMode: isDarkMode)
+                .presentationDetents([.medium, .large])
+                .iPadSheetSizing()
+                .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
+        }
+        .sheet(item: $activeURLFetchGroup) { group in
+            URLFetchSheetView(urlFetches: group.items, isDarkMode: isDarkMode)
                 .presentationDetents([.medium, .large])
                 .iPadSheetSizing()
                 .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -74,6 +74,14 @@ struct MessageView: View {
                     }
                 case .webSearch(let searchId):
                     if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
+                        // `isStreaming` on WebSearchBox indicates whether THIS
+                        // search is still in flight, not whether the overall
+                        // message is still streaming. Otherwise the box's
+                        // effectiveStatus gate would keep the pill in the
+                        // searching state while sources trickle in later.
+                        let isSearchInFlight = instance.status == .searching
+                            && isLoading
+                            && isLastMessage
                         WebSearchBox(
                             webSearchState: WebSearchState(
                                 query: instance.query,
@@ -82,8 +90,8 @@ struct MessageView: View {
                                 reason: instance.reason
                             ),
                             isDarkMode: isDarkMode,
-                            isStreaming: isLoading && isLastMessage,
-                            webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
+                            isStreaming: isSearchInFlight,
+                            webSearchSummary: isSearchInFlight ? viewModel.webSearchSummary : nil,
                             onTap: { showSourcesSheet = true }
                         )
                     }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -39,6 +39,67 @@ struct MessageView: View {
         !(isLoading && isLastMessage)
     }
 
+    /// Renders ordered message segments (text and inline event refs) in the
+    /// order they streamed. Each text segment is rendered via the same
+    /// markdown pipeline as the non-segmented path; event segments resolve
+    /// through the message's `webSearches` / `urlFetches` maps.
+    @ViewBuilder
+    private func inlineSegmentsView(segments: [MessageSegment]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            let lastTextIndex: Int? = {
+                for i in segments.indices.reversed() {
+                    if case .text = segments[i] { return i }
+                }
+                return nil
+            }()
+
+            ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
+                switch segment {
+                case .text(let text):
+                    if !text.isEmpty {
+                        let isTrailingText = index == lastTextIndex
+                        let isStreamingText = isTrailingText && isLoading && isLastMessage
+                        LaTeXMarkdownView(
+                            content: text,
+                            isDarkMode: isDarkMode,
+                            isStreaming: isStreamingText,
+                            textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                            citationUrls: citationUrls
+                        )
+                            .equatable()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .transaction { transaction in
+                                transaction.animation = nil
+                            }
+                    }
+                case .webSearch(let searchId):
+                    if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
+                        WebSearchBox(
+                            webSearchState: WebSearchState(
+                                query: instance.query,
+                                status: instance.status,
+                                sources: instance.sources ?? [],
+                                reason: instance.reason
+                            ),
+                            isDarkMode: isDarkMode,
+                            isStreaming: isLoading && isLastMessage,
+                            webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
+                            onTap: { showSourcesSheet = true }
+                        )
+                    }
+                case .urlFetch(let fetchId):
+                    if let fetch = message.urlFetches.first(where: { $0.id == fetchId }) {
+                        URLFetchBox(
+                            urlFetches: [fetch],
+                            isDarkMode: isDarkMode,
+                            onTap: { showURLFetchSheet = true }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     /// URLs the router annotated as web-search citations on this message.
     /// Used by the markdown renderer to rewrite plain markdown citation links
     /// to use the host domain as their display text.
@@ -109,21 +170,6 @@ struct MessageView: View {
                 // If the message is thinking or has thoughts, display them in a thinking box
                 else if message.isThinking || message.thoughts != nil {
                     VStack(alignment: .leading, spacing: 4) {
-                        if !message.urlFetches.isEmpty {
-                            URLFetchBox(urlFetches: message.urlFetches, isDarkMode: isDarkMode, onTap: { showURLFetchSheet = true })
-                        }
-
-                        // Web search box (if applicable) - shown before thoughts since search happens first
-                        if let webSearchState = message.webSearchState {
-                            WebSearchBox(
-                                webSearchState: webSearchState,
-                                isDarkMode: isDarkMode,
-                                isStreaming: isLoading && isLastMessage,
-                                webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
-                                onTap: { showSourcesSheet = true }
-                            )
-                        }
-
                         CollapsibleThinkingBox(
                             thinkingText: message.thoughts ?? "",
                             isDarkMode: isDarkMode,
@@ -133,30 +179,48 @@ struct MessageView: View {
                             onTap: { showThoughtsSheet = true }
                         )
 
-                        if !message.content.isEmpty {
-                            if !message.contentChunks.isEmpty {
-                                ChunkedContentView(
-                                    chunks: message.contentChunks,
+                        if let segments = message.segments, !segments.isEmpty {
+                            inlineSegmentsView(segments: segments)
+                        } else {
+                            if !message.urlFetches.isEmpty {
+                                URLFetchBox(urlFetches: message.urlFetches, isDarkMode: isDarkMode, onTap: { showURLFetchSheet = true })
+                            }
+
+                            if let webSearchState = message.webSearchState {
+                                WebSearchBox(
+                                    webSearchState: webSearchState,
                                     isDarkMode: isDarkMode,
                                     isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
-                                    citationUrls: citationUrls
+                                    webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
+                                    onTap: { showSourcesSheet = true }
                                 )
-                                    .equatable()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            } else {
-                                LaTeXMarkdownView(
-                                    content: message.content,
-                                    isDarkMode: isDarkMode,
-                                    isStreaming: isLoading && isLastMessage,
-                                    textSelectionEnabled: inlineAssistantTextSelectionEnabled,
-                                    citationUrls: citationUrls
-                                )
-                                    .equatable()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .transaction { transaction in
-                                        transaction.animation = nil
-                                    }
+                            }
+
+                            if !message.content.isEmpty {
+                                if !message.contentChunks.isEmpty {
+                                    ChunkedContentView(
+                                        chunks: message.contentChunks,
+                                        isDarkMode: isDarkMode,
+                                        isStreaming: isLoading && isLastMessage,
+                                        textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                        citationUrls: citationUrls
+                                    )
+                                        .equatable()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                } else {
+                                    LaTeXMarkdownView(
+                                        content: message.content,
+                                        isDarkMode: isDarkMode,
+                                        isStreaming: isLoading && isLastMessage,
+                                        textSelectionEnabled: inlineAssistantTextSelectionEnabled,
+                                        citationUrls: citationUrls
+                                    )
+                                        .equatable()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .transaction { transaction in
+                                            transaction.animation = nil
+                                        }
+                                }
                             }
                         }
                     }
@@ -232,6 +296,9 @@ struct MessageView: View {
                         } else {
                             AdaptiveMarkdownText(content: message.content, isDarkMode: isDarkMode)
                         }
+                    } else if let segments = message.segments, !segments.isEmpty {
+                        // Render events inline in the order they streamed.
+                        inlineSegmentsView(segments: segments)
                     } else {
                         VStack(alignment: .leading, spacing: 4) {
                             if !message.urlFetches.isEmpty {

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -74,11 +74,6 @@ struct MessageView: View {
                     }
                 case .webSearch(let searchId):
                     if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
-                        // `isStreaming` on WebSearchBox indicates whether THIS
-                        // search is still in flight, not whether the overall
-                        // message is still streaming. Otherwise the box's
-                        // effectiveStatus gate would keep the pill in the
-                        // searching state while sources trickle in later.
                         let isSearchInFlight = instance.status == .searching
                             && isLoading
                             && isLastMessage
@@ -90,7 +85,6 @@ struct MessageView: View {
                                 reason: instance.reason
                             ),
                             isDarkMode: isDarkMode,
-                            isStreaming: isSearchInFlight,
                             webSearchSummary: isSearchInFlight ? viewModel.webSearchSummary : nil,
                             onTap: { showSourcesSheet = true }
                         )
@@ -160,7 +154,6 @@ struct MessageView: View {
                             WebSearchBox(
                                 webSearchState: webSearchState,
                                 isDarkMode: isDarkMode,
-                                isStreaming: true,
                                 webSearchSummary: viewModel.webSearchSummary,
                                 onTap: { showSourcesSheet = true }
                             )
@@ -198,7 +191,6 @@ struct MessageView: View {
                                 WebSearchBox(
                                     webSearchState: webSearchState,
                                     isDarkMode: isDarkMode,
-                                    isStreaming: isLoading && isLastMessage,
                                     webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
                                     onTap: { showSourcesSheet = true }
                                 )
@@ -318,7 +310,6 @@ struct MessageView: View {
                                 WebSearchBox(
                                     webSearchState: webSearchState,
                                     isDarkMode: isDarkMode,
-                                    isStreaming: isLoading && isLastMessage,
                                     webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
                                     onTap: { showSourcesSheet = true }
                                 )

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -41,14 +41,16 @@ struct WebSearchBox: View {
                     Text(summary)
                         .font(.subheadline)
                         .foregroundColor(isDarkMode ? .white : .black.opacity(0.8))
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 } else if let query = webSearchState.query {
                     Text("Searching the web: \(query)")
                         .font(.subheadline)
                         .foregroundColor(isDarkMode ? .white : .black.opacity(0.8))
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 } else {
                     Text("Searching the web")
                         .font(.subheadline)

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -7,19 +7,37 @@
 
 import SwiftUI
 
-/// Inline row showing web search status; tapping opens sources sheet
+/// Inline row showing web search status; tapping opens sources sheet.
+/// When `groupSize > 1`, the row summarizes an adjacent run of searches
+/// (e.g. "Searched the web on 4 queries") so the chat isn't vertically
+/// polluted by one pill per search.
 struct WebSearchBox: View {
     let webSearchState: WebSearchState
     let isDarkMode: Bool
     let webSearchSummary: String?
+    let groupSize: Int
     let onTap: () -> Void
+
+    init(
+        webSearchState: WebSearchState,
+        isDarkMode: Bool,
+        webSearchSummary: String?,
+        groupSize: Int = 1,
+        onTap: @escaping () -> Void
+    ) {
+        self.webSearchState = webSearchState
+        self.isDarkMode = isDarkMode
+        self.webSearchSummary = webSearchSummary
+        self.groupSize = groupSize
+        self.onTap = onTap
+    }
 
     var body: some View {
         Button(action: onTap) {
             HStack {
                 headerContent
                 Spacer()
-                if webSearchState.status != .searching && !webSearchState.sources.isEmpty {
+                if showsChevron {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(isDarkMode ? .white.opacity(0.4) : .black.opacity(0.4))
@@ -29,7 +47,19 @@ struct WebSearchBox: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(NoHighlightButtonStyle())
-        .disabled(webSearchState.status == .searching || webSearchState.sources.isEmpty)
+        .disabled(!isInteractive)
+    }
+
+    private var isGroup: Bool { groupSize > 1 }
+
+    private var showsChevron: Bool {
+        guard webSearchState.status != .searching else { return false }
+        return isGroup || !webSearchState.sources.isEmpty
+    }
+
+    private var isInteractive: Bool {
+        guard webSearchState.status != .searching else { return false }
+        return isGroup || !webSearchState.sources.isEmpty
     }
 
     @ViewBuilder
@@ -37,7 +67,11 @@ struct WebSearchBox: View {
         switch webSearchState.status {
         case .searching:
             HStack(spacing: 8) {
-                if let summary = webSearchSummary, !summary.isEmpty {
+                if isGroup {
+                    Text("Searching the web on \(groupSize) queries")
+                        .font(.subheadline)
+                        .foregroundColor(isDarkMode ? .white : .black.opacity(0.8))
+                } else if let summary = webSearchSummary, !summary.isEmpty {
                     Text(summary)
                         .font(.subheadline)
                         .foregroundColor(isDarkMode ? .white : .black.opacity(0.8))
@@ -65,7 +99,14 @@ struct WebSearchBox: View {
                     .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
                     .font(.system(size: 14))
 
-                if webSearchState.sources.isEmpty {
+                if isGroup {
+                    Text("Searched the web on \(groupSize) quer\(groupSize == 1 ? "y" : "ies")")
+                        .font(.subheadline)
+                        .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
+                    if !webSearchState.sources.isEmpty {
+                        sourceFavicons
+                    }
+                } else if webSearchState.sources.isEmpty {
                     Text("Web search completed")
                         .font(.subheadline)
                         .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
@@ -222,5 +263,141 @@ struct SourceRowView: View {
     private func openURL() {
         guard let url = URL(string: source.url) else { return }
         UIApplication.shared.open(url)
+    }
+}
+
+/// Sheet listing every query in a grouped run of web searches, each
+/// expandable to reveal its individual sources.
+struct WebSearchQueriesSheetView: View {
+    let instances: [WebSearchInstance]
+    let isDarkMode: Bool
+    @Environment(\.dismiss) private var dismiss
+    @State private var expandedIds: Set<String> = []
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(instances) { instance in
+                    WebSearchQueryRow(
+                        instance: instance,
+                        isDarkMode: isDarkMode,
+                        isExpanded: expandedIds.contains(instance.id),
+                        onToggle: { toggle(instance.id) }
+                    )
+                    .listRowBackground(Color.clear)
+                }
+            }
+            .listStyle(.plain)
+            .navigationTitle("Searches")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .preferredColorScheme(isDarkMode ? .dark : .light)
+    }
+
+    private func toggle(_ id: String) {
+        if expandedIds.contains(id) {
+            expandedIds.remove(id)
+        } else {
+            expandedIds.insert(id)
+        }
+    }
+}
+
+private struct WebSearchQueryRow: View {
+    let instance: WebSearchInstance
+    let isDarkMode: Bool
+    let isExpanded: Bool
+    let onToggle: () -> Void
+
+    private var canExpand: Bool { !(instance.sources?.isEmpty ?? true) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: { if canExpand { onToggle() } }) {
+                HStack(spacing: 10) {
+                    statusIcon
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(instance.query ?? "Web search")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(isDarkMode ? .white : .black.opacity(0.85))
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                        Text(statusLabel)
+                            .font(.system(size: 12))
+                            .foregroundColor(statusColor)
+                    }
+                    Spacer()
+                    if canExpand {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(isDarkMode ? .white.opacity(0.4) : .black.opacity(0.4))
+                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    }
+                }
+                .padding(.vertical, 4)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(PlainButtonStyle())
+            .disabled(!canExpand)
+
+            if isExpanded, let sources = instance.sources, !sources.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(sources) { source in
+                        SourceRowView(source: source, isDarkMode: isDarkMode)
+                    }
+                }
+                .padding(.leading, 26)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch instance.status {
+        case .searching:
+            ProgressView()
+                .scaleEffect(0.6)
+                .frame(width: 16, height: 16)
+        case .completed:
+            Image(systemName: "globe")
+                .font(.system(size: 13))
+                .foregroundColor(isDarkMode ? .white.opacity(0.6) : .black.opacity(0.5))
+                .frame(width: 16, height: 16)
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 13))
+                .foregroundColor(.red.opacity(0.8))
+                .frame(width: 16, height: 16)
+        case .blocked:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 13))
+                .foregroundColor(.orange.opacity(0.8))
+                .frame(width: 16, height: 16)
+        }
+    }
+
+    private var statusLabel: String {
+        switch instance.status {
+        case .searching: return "Searching..."
+        case .completed:
+            let count = instance.sources?.count ?? 0
+            return count == 0 ? "Completed" : "\(count) source\(count == 1 ? "" : "s")"
+        case .failed: return "Failed"
+        case .blocked: return instance.reason ?? "Blocked"
+        }
+    }
+
+    private var statusColor: Color {
+        switch instance.status {
+        case .searching, .completed:
+            return isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5)
+        case .failed: return .red.opacity(0.7)
+        case .blocked: return .orange.opacity(0.7)
+        }
     }
 }

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -272,19 +272,14 @@ struct WebSearchQueriesSheetView: View {
     let instances: [WebSearchInstance]
     let isDarkMode: Bool
     @Environment(\.dismiss) private var dismiss
-    @State private var expandedIds: Set<String> = []
 
     var body: some View {
         NavigationStack {
             List {
                 ForEach(instances) { instance in
-                    WebSearchQueryRow(
-                        instance: instance,
-                        isDarkMode: isDarkMode,
-                        isExpanded: expandedIds.contains(instance.id),
-                        onToggle: { toggle(instance.id) }
-                    )
-                    .listRowBackground(Color.clear)
+                    WebSearchQueryRow(instance: instance, isDarkMode: isDarkMode)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
                 }
             }
             .listStyle(.plain)
@@ -298,54 +293,39 @@ struct WebSearchQueriesSheetView: View {
         }
         .preferredColorScheme(isDarkMode ? .dark : .light)
     }
-
-    private func toggle(_ id: String) {
-        if expandedIds.contains(id) {
-            expandedIds.remove(id)
-        } else {
-            expandedIds.insert(id)
-        }
-    }
 }
 
+/// Flat row for a single search inside the grouped queries sheet: the
+/// query stands as the heading with its sources listed directly beneath
+/// (when attributed). Mirrors the webapp's grouped-search expansion.
 private struct WebSearchQueryRow: View {
     let instance: WebSearchInstance
     let isDarkMode: Bool
-    let isExpanded: Bool
-    let onToggle: () -> Void
 
-    private var canExpand: Bool { !(instance.sources?.isEmpty ?? true) }
+    private var sources: [WebSearchSource] {
+        instance.sources ?? []
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Button(action: { if canExpand { onToggle() } }) {
-                HStack(spacing: 10) {
-                    statusIcon
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(instance.query ?? "Web search")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(isDarkMode ? .white : .black.opacity(0.85))
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
-                        Text(statusLabel)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+                statusIcon
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(instance.query ?? "Web search")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(isDarkMode ? .white : .black.opacity(0.85))
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let subtitle = statusSubtitle {
+                        Text(subtitle)
                             .font(.system(size: 12))
                             .foregroundColor(statusColor)
                     }
-                    Spacer()
-                    if canExpand {
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(isDarkMode ? .white.opacity(0.4) : .black.opacity(0.4))
-                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    }
                 }
-                .padding(.vertical, 4)
-                .contentShape(Rectangle())
+                Spacer(minLength: 0)
             }
-            .buttonStyle(PlainButtonStyle())
-            .disabled(!canExpand)
 
-            if isExpanded, let sources = instance.sources, !sources.isEmpty {
+            if !sources.isEmpty {
                 VStack(alignment: .leading, spacing: 2) {
                     ForEach(sources) { source in
                         SourceRowView(source: source, isDarkMode: isDarkMode)
@@ -354,6 +334,7 @@ private struct WebSearchQueryRow: View {
                 .padding(.leading, 26)
             }
         }
+        .padding(.vertical, 6)
     }
 
     @ViewBuilder
@@ -381,12 +362,12 @@ private struct WebSearchQueryRow: View {
         }
     }
 
-    private var statusLabel: String {
+    private var statusSubtitle: String? {
         switch instance.status {
-        case .searching: return "Searching..."
+        case .searching: return "Searching…"
         case .completed:
-            let count = instance.sources?.count ?? 0
-            return count == 0 ? "Completed" : "\(count) source\(count == 1 ? "" : "s")"
+            let count = sources.count
+            return count > 0 ? "\(count) source\(count == 1 ? "" : "s")" : nil
         case .failed: return "Failed"
         case .blocked: return instance.reason ?? "Blocked"
         }

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct WebSearchBox: View {
     let webSearchState: WebSearchState
     let isDarkMode: Bool
-    let isStreaming: Bool
     let webSearchSummary: String?
     let onTap: () -> Void
 
@@ -20,7 +19,7 @@ struct WebSearchBox: View {
             HStack {
                 headerContent
                 Spacer()
-                if effectiveStatus != .searching && !webSearchState.sources.isEmpty {
+                if webSearchState.status != .searching && !webSearchState.sources.isEmpty {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(isDarkMode ? .white.opacity(0.4) : .black.opacity(0.4))
@@ -30,19 +29,12 @@ struct WebSearchBox: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(NoHighlightButtonStyle())
-        .disabled(effectiveStatus == .searching || webSearchState.sources.isEmpty)
-    }
-
-    private var effectiveStatus: WebSearchStatus {
-        if webSearchState.status == .completed && webSearchState.sources.isEmpty && isStreaming {
-            return .searching
-        }
-        return webSearchState.status
+        .disabled(webSearchState.status == .searching || webSearchState.sources.isEmpty)
     }
 
     @ViewBuilder
     private var headerContent: some View {
-        switch effectiveStatus {
+        switch webSearchState.status {
         case .searching:
             HStack(spacing: 8) {
                 if let summary = webSearchSummary, !summary.isEmpty {

--- a/TinfoilChatTests/MessageSegmentDecodeTests.swift
+++ b/TinfoilChatTests/MessageSegmentDecodeTests.swift
@@ -1,0 +1,75 @@
+//
+//  MessageSegmentDecodeTests.swift
+//  TinfoilChatTests
+//
+//  Verifies Message JSON decoding is forward-compatible: a message whose
+//  `segments` array contains unknown segment types (e.g. added by a future
+//  client version) still decodes successfully, with unknown entries
+//  dropped rather than failing the whole message.
+//
+
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct MessageSegmentDecodeTests {
+
+    @Test func decodesMessageWithMixOfKnownAndUnknownSegments() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "hello",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "segments": [
+            { "type": "text", "text": "hi" },
+            { "type": "future_tool_call", "foo": "bar" },
+            { "type": "web_search", "searchId": "ws_1" },
+            { "type": "another_unknown", "data": { "nested": true } },
+            { "type": "url_fetch", "fetchId": "uf_1" }
+          ]
+        }
+        """
+
+        let data = Data(json.utf8)
+        let message = try JSONDecoder().decode(Message.self, from: data)
+        let segments = try #require(message.segments)
+
+        #expect(segments.count == 3)
+        #expect(segments[0] == .text("hi"))
+        #expect(segments[1] == .webSearch(searchId: "ws_1"))
+        #expect(segments[2] == .urlFetch(fetchId: "uf_1"))
+    }
+
+    @Test func decodesMessageWhenSegmentsArrayIsMissing() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "hello",
+          "timestamp": "2026-04-21T12:00:00.000Z"
+        }
+        """
+
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        #expect(message.segments == nil)
+    }
+
+    @Test func decodesMessageWhenAllSegmentsAreUnknown() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "hello",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "segments": [
+            { "type": "future_a" },
+            { "type": "future_b", "extra": 1 }
+          ]
+        }
+        """
+
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        #expect(message.segments?.isEmpty == true)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Render web search and URL fetch events inline with assistant text in the exact streaming order, and collapse adjacent events to cut clutter. Streaming status is now accurate and pills become interactive as soon as results arrive.

- **New Features**
  - Add ordered message segments (`MessageSegment`) and per-search instances (`WebSearchInstance`) to preserve stream order across platforms.
  - Show web searches and URL fetches inline; merge adjacent same‑type events into a single row with a group count.
  - Grouped searches open a sheet listing each query with its own sources; single‑search pills open only that search’s sources. Grouped fetches open a details sheet.
  - Update web search pill with group summaries, chevron only when interactive, and 2‑line wrapping for long queries.

- **Bug Fixes**
  - Prevent stale snapshots from overwriting live search status by updating segments/searches on the MainActor.
  - Keep completed search pills as completed mid‑stream; hold at “searching” until the first source lands; promote immediately when results arrive.
  - Render URL fetch markers at the right position with streamed text and reduce flicker by grouping.
  - Skip unknown `MessageSegment` types when decoding messages to stay forward‑compatible.

<sup>Written for commit acfe47345c7d06173a871c34018460eb581bb005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

