### PR TITLE
Fix: persist citation annotations

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1179,6 +1179,7 @@ class ChatViewModel: ObservableObject {
 
                 // Web search state tracking
                 var collectedSources: [WebSearchSource] = []
+                var collectedAnnotations: [Annotation] = []
                 let isWebSearchEnabled = self.isWebSearchEnabled
                 // Track whether web search started before thinking (shared across callback and streaming loop)
                 let webSearchStartedFlag = OSAllocatedUnfairLock(initialState: false)
@@ -1471,6 +1472,17 @@ class ChatViewModel: ObservableObject {
                                     url: citation.url
                                 )
                                 collectedSources.append(source)
+                                collectedAnnotations.append(
+                                    Annotation(
+                                        type: "url_citation",
+                                        url_citation: URLCitation(
+                                            title: citation.title ?? citation.url,
+                                            url: citation.url,
+                                            start_index: nil,
+                                            end_index: nil
+                                        )
+                                    )
+                                )
                                 didCollectNewSource = true
                                 didMutateState = true
                             }
@@ -1685,6 +1697,9 @@ class ChatViewModel: ObservableObject {
                             searchState.sources = collectedSources
                             chat.messages[lastIndex].webSearchState = searchState
                         }
+                        if !collectedAnnotations.isEmpty {
+                            chat.messages[lastIndex].annotations = collectedAnnotations
+                        }
 
                         self.updateChat(chat, throttleForStreaming: true)
                     }
@@ -1804,6 +1819,9 @@ class ChatViewModel: ObservableObject {
                                 searchState.status = .completed
                             }
                             chat.messages[lastIndex].webSearchState = searchState
+                        }
+                        if !collectedAnnotations.isEmpty {
+                            chat.messages[lastIndex].annotations = collectedAnnotations
                         }
                     }
 

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -97,30 +97,35 @@ struct WebSearchBox: View {
             }
 
         case .completed:
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Image(systemName: "globe")
-                    .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
-                    .font(.system(size: 14))
-                    .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 5 }
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "globe")
+                        .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
+                        .font(.system(size: 14))
+                        .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 5 }
 
-                if isGroup {
-                    Text("Searched the web on \(groupSize) quer\(groupSize == 1 ? "y" : "ies")")
-                        .font(.subheadline)
-                        .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
-                } else if let query = webSearchState.query, !query.isEmpty {
-                    Text("Searched the web for \"\(query)\"")
-                        .font(.subheadline)
-                        .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
-                        .lineLimit(3)
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                } else {
-                    Text("Searched the web")
-                        .font(.subheadline)
-                        .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
+                    if isGroup {
+                        Text("Searched the web on \(groupSize) quer\(groupSize == 1 ? "y" : "ies")")
+                            .font(.subheadline)
+                            .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
+                    } else if let query = webSearchState.query, !query.isEmpty {
+                        Text("Searched the web for \"\(query)\"")
+                            .font(.subheadline)
+                            .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
+                            .lineLimit(3)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Text("Searched the web")
+                            .font(.subheadline)
+                            .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
+                    }
                 }
-                if !webSearchState.sources.isEmpty {
+                if !isGroup && !webSearchState.sources.isEmpty {
+                    // Indent favicons under the query text so they visually
+                    // group with the query rather than the leading globe icon.
                     sourceFavicons
+                        .padding(.leading, 22)
                 }
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persisted web search citation annotations in chat messages so they sync across reloads and devices. Also moved source favicons under the query text for clearer grouping.

- Bug Fixes
  - Collect and save `url_citation` annotations during streaming and on completion to `chat.messages[lastIndex].annotations`.
  - Show source favicons below the query (indented) to group them with the query instead of the globe icon.

<sup>Written for commit 25eeee67292f9c4aa4a133cc7ed23b9e303a4588. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

