### PR TITLE
Fix various minor UX/UI nits

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -573,8 +573,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/textual";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.6;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {
@@ -613,8 +613,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
-				kind = exactVersion;
-				version = 0.0.5;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.5;
 			};
 		};
 		99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "0467d40594c2ab2ac0ad810fea07cbf740f309af",
-        "version" : "0.0.5"
+        "revision" : "fb076a51a97b56c3cc2ba4c9e8bcc9e88f59d53f",
+        "version" : "0.0.4"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "branch" : "main",
-        "revision" : "d3690cc9b64936694a2e7c1ccda16ebe873f8e02"
+        "revision" : "005baa6df114f7578c5ce82650ed0370be077954",
+        "version" : "0.0.6"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "d292922f503812a0a5489593d802cf437bae76b4",
-        "version" : "0.0.5"
+        "revision" : "daee5afb9ad2cbd3eabb537b0fbd5cec8882b4ae",
+        "version" : "0.4.8"
       }
     }
   ],

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -475,6 +475,101 @@ private struct LenientSegment: Decodable {
     }
 }
 
+private struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = String(intValue)
+        self.intValue = intValue
+    }
+}
+
+enum JSONValue: Codable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    var objectValue: [String: JSONValue]? {
+        if case .object(let value) = self { return value }
+        return nil
+    }
+
+    init(from decoder: Decoder) throws {
+        if let object = try? decoder.container(keyedBy: DynamicCodingKey.self) {
+            var values: [String: JSONValue] = [:]
+            for key in object.allKeys {
+                values[key.stringValue] = try object.decode(JSONValue.self, forKey: key)
+            }
+            self = .object(values)
+            return
+        }
+
+        if var array = try? decoder.unkeyedContainer() {
+            var values: [JSONValue] = []
+            while !array.isAtEnd {
+                values.append(try array.decode(JSONValue.self))
+            }
+            self = .array(values)
+            return
+        }
+
+        let single = try decoder.singleValueContainer()
+        if single.decodeNil() {
+            self = .null
+        } else if let value = try? single.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? single.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? single.decode(String.self) {
+            self = .string(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: single, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .null:
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        case .bool(let value):
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        case .number(let value):
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        case .string(let value):
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        case .array(let values):
+            var container = encoder.unkeyedContainer()
+            for value in values {
+                try container.encode(value)
+            }
+        case .object(let values):
+            var container = encoder.container(keyedBy: DynamicCodingKey.self)
+            for (key, value) in values {
+                guard let codingKey = DynamicCodingKey(stringValue: key) else { continue }
+                try container.encode(value, forKey: codingKey)
+            }
+        }
+    }
+}
+
 /// URL citation from web search results, matching React's Annotation type
 struct URLCitation: Codable, Equatable {
     let title: String
@@ -487,6 +582,12 @@ struct URLCitation: Codable, Equatable {
 struct Annotation: Codable, Equatable {
     let type: String
     let url_citation: URLCitation
+}
+
+struct GenUIToolCall: Codable, Equatable, Identifiable {
+    let id: String
+    let name: String
+    let arguments: String
 }
 
 /// Represents a single message in a chat
@@ -520,6 +621,14 @@ struct Message: Identifiable, Codable, Equatable {
     // order they streamed.
     var segments: [MessageSegment]? = nil
     var webSearches: [WebSearchInstance]? = nil
+    var toolCalls: [GenUIToolCall] = []
+    var timeline: [JSONValue]? = nil
+
+    var hasUnsupportedGenUI: Bool {
+        role == .assistant && (!toolCalls.isEmpty || (timeline?.contains { block in
+            block.objectValue?["type"]?.stringValue == "tool_call"
+        } ?? false))
+    }
 
     static let longMessageAttachmentThreshold = 1200
     var shouldDisplayAsAttachment: Bool {
@@ -562,7 +671,7 @@ struct Message: Identifiable, Codable, Equatable {
         case attachments
         case thinkingDuration, isError
         case webSearchBeforeThinking, annotations, searchReasoning
-        case segments, webSearches
+        case segments, webSearches, toolCalls, timeline
         // Legacy keys for decoding React messages that use the old format
         case documentContent, imageData, imageBase64, multimodalText, documents
     }
@@ -631,6 +740,8 @@ struct Message: Identifiable, Codable, Equatable {
             segments = nil
         }
         webSearches = (try? container.decodeIfPresent([WebSearchInstance].self, forKey: .webSearches)) ?? nil
+        toolCalls = (try? container.decodeIfPresent([GenUIToolCall].self, forKey: .toolCalls)) ?? []
+        timeline = try? container.decodeIfPresent([JSONValue].self, forKey: .timeline)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -667,6 +778,10 @@ struct Message: Identifiable, Codable, Equatable {
         try container.encodeIfPresent(searchReasoning, forKey: .searchReasoning)
         try container.encodeIfPresent(segments, forKey: .segments)
         try container.encodeIfPresent(webSearches, forKey: .webSearches)
+        if !toolCalls.isEmpty {
+            try container.encode(toolCalls, forKey: .toolCalls)
+        }
+        try container.encodeIfPresent(timeline, forKey: .timeline)
     }
 
     // MARK: - Legacy Format Reconstruction

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -435,6 +435,11 @@ struct MessageView: View {
                     }
                 }
 
+                if message.hasUnsupportedGenUI {
+                    UnsupportedGenUINoticeView(isDarkMode: isDarkMode)
+                        .padding(.top, message.content.isEmpty && message.thoughts == nil ? 0 : 8)
+                }
+
                 // Persistent streaming indicator at the bottom of the
                 // currently rendered assistant content. Only shown once
                 // initial content has started arriving so we don't double up
@@ -1448,6 +1453,39 @@ struct GeneratingTableView: View {
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isDarkMode ? Color.white.opacity(0.15) : Color.black.opacity(0.15), lineWidth: 1)
+        )
+    }
+}
+
+struct UnsupportedGenUINoticeView: View {
+    let isDarkMode: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.orange)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Interactive component unavailable")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(isDarkMode ? .white : .black)
+
+                Text("This message includes a GenUI component. Tinfoil for iOS doesn't support GenUI yet; open this chat on web to view it.")
+                    .font(.caption)
+                    .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.7))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.orange.opacity(0.1))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.orange.opacity(0.3), lineWidth: 1)
+                )
         )
     }
 }

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -104,26 +104,13 @@ struct WebSearchBox: View {
                         .font(.system(size: 14))
                         .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 5 }
 
-                    if isGroup {
-                        Text("Searched the web on \(groupSize) quer\(groupSize == 1 ? "y" : "ies")")
-                            .font(.subheadline)
-                            .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
-                    } else if let query = webSearchState.query, !query.isEmpty {
-                        Text("Searched the web for \"\(query)\"")
-                            .font(.subheadline)
-                            .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
-                            .lineLimit(3)
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
-                    } else {
-                        Text("Searched the web")
-                            .font(.subheadline)
-                            .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
-                    }
+                    Text("Searched the web on \(groupSize) quer\(groupSize == 1 ? "y" : "ies")")
+                        .font(.subheadline)
+                        .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
                 }
                 if !isGroup && !webSearchState.sources.isEmpty {
-                    // Indent favicons under the query text so they visually
-                    // group with the query rather than the leading globe icon.
+                    // Indent favicons under the label so they visually
+                    // group with the label rather than the leading globe icon.
                     sourceFavicons
                         .padding(.leading, 22)
                 }

--- a/TinfoilChatTests/MessageSegmentDecodeTests.swift
+++ b/TinfoilChatTests/MessageSegmentDecodeTests.swift
@@ -72,4 +72,67 @@ struct MessageSegmentDecodeTests {
         let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
         #expect(message.segments?.isEmpty == true)
     }
+
+    @Test func decodesAndPreservesGenUIToolCalls() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "toolCalls": [
+            {
+              "id": "call_1",
+              "name": "render_info_card",
+              "arguments": "{\\"title\\":\\"Hello\\"}"
+            }
+          ],
+          "timeline": [
+            {
+              "type": "tool_call",
+              "id": "tool-call-0",
+              "toolCallId": "call_1",
+              "name": "render_info_card",
+              "arguments": "{\\"title\\":\\"Hello\\"}"
+            }
+          ]
+        }
+        """
+
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        #expect(message.hasUnsupportedGenUI)
+        #expect(message.toolCalls.count == 1)
+        #expect(message.toolCalls[0].name == "render_info_card")
+
+        let encoded = try JSONEncoder().encode(message)
+        let roundTripped = try JSONDecoder().decode(Message.self, from: encoded)
+        #expect(roundTripped.hasUnsupportedGenUI)
+        #expect(roundTripped.toolCalls == message.toolCalls)
+        #expect(roundTripped.timeline == message.timeline)
+    }
+
+    @Test func detectsGenUIFromTimelineWhenToolCallsAreMissing() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "timeline": [
+            { "type": "content", "id": "content-0", "content": "" },
+            {
+              "type": "tool_call",
+              "id": "tool-call-1",
+              "toolCallId": "call_1",
+              "name": "render_link_preview",
+              "arguments": "{\\"url\\":\\"https://example.com\\"}"
+            }
+          ]
+        }
+        """
+
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        #expect(message.toolCalls.isEmpty)
+        #expect(message.hasUnsupportedGenUI)
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies the web search label to always show “Searched the web on N quer(y/ies)”. Adds an inline iOS notice when assistant messages include GenUI tool calls or timeline entries, guiding users to open the chat on web.

- **Dependencies**
  - Switch SPM constraints for `textual` and `tinfoil-swift` to upToNextMajor.
  - Update `textual` to 0.0.6.
  - Update `tinfoil-swift` to 0.4.8.
  - Set `openai-swift-fork` to 0.0.4.

<sup>Written for commit d682f916436fcb1e12581bf3803c2289748b767f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

