### PR TITLE
Thinking mode and selection UI

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -8,10 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		99DDBFA42F6869250038A729 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 99DDBFA32F6869250038A729 /* Textual */; };
+		99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */ = {isa = PBXBuildFile; productRef = 99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */; };
 		99F154692F4F60C500E9174E /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154682F4F60C500E9174E /* ClerkKit */; };
 		99F1546B2F4F60C500E9174E /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1546A2F4F60C500E9174E /* ClerkKitUI */; };
 		99F154702F4F610000E9174E /* SwiftMath in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1546F2F4F610000E9174E /* SwiftMath */; };
-		99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */ = {isa = PBXBuildFile; productRef = 99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */; };
 		99F1547C2F4F614400E9174E /* Gzip in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1547B2F4F614400E9174E /* Gzip */; };
 		99F154822F4F632500E9174E /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154812F4F632500E9174E /* Sentry */; };
 		99F154842F4F632E00E9174E /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154832F4F632E00E9174E /* RevenueCat */; };
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -633,6 +633,11 @@
 			package = 99DDBFA22F68667C0038A729 /* XCRemoteSwiftPackageReference "textual" */;
 			productName = Textual;
 		};
+		99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */;
+			productName = TinfoilAI;
+		};
 		99F154682F4F60C500E9174E /* ClerkKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */;
@@ -667,11 +672,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 99F1546D2F4F60F600E9174E /* XCRemoteSwiftPackageReference "purchases-ios-spm" */;
 			productName = RevenueCatUI;
-		};
-		99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */;
-			productName = TinfoilAI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		99F154692F4F60C500E9174E /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154682F4F60C500E9174E /* ClerkKit */; };
 		99F1546B2F4F60C500E9174E /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1546A2F4F60C500E9174E /* ClerkKitUI */; };
 		99F154702F4F610000E9174E /* SwiftMath in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1546F2F4F610000E9174E /* SwiftMath */; };
-		99F154732F4F611A00E9174E /* TinfoilAI in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154722F4F611A00E9174E /* TinfoilAI */; };
+		99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */ = {isa = PBXBuildFile; productRef = 99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */; };
 		99F1547C2F4F614400E9174E /* Gzip in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1547B2F4F614400E9174E /* Gzip */; };
 		99F154822F4F632500E9174E /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154812F4F632500E9174E /* Sentry */; };
 		99F154842F4F632E00E9174E /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154832F4F632E00E9174E /* RevenueCat */; };
@@ -71,7 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				99F154732F4F611A00E9174E /* TinfoilAI in Frameworks */,
+				99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */,
 				99F1547C2F4F614400E9174E /* Gzip in Frameworks */,
 				99F154822F4F632500E9174E /* Sentry in Frameworks */,
 				99DDBFA42F6869250038A729 /* Textual in Frameworks */,
@@ -159,7 +159,7 @@
 				99F154682F4F60C500E9174E /* ClerkKit */,
 				99F1546A2F4F60C500E9174E /* ClerkKitUI */,
 				99F1546F2F4F610000E9174E /* SwiftMath */,
-				99F154722F4F611A00E9174E /* TinfoilAI */,
+				99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */,
 				99F1547B2F4F614400E9174E /* Gzip */,
 				99F154812F4F632500E9174E /* Sentry */,
 				99F154832F4F632E00E9174E /* RevenueCat */,
@@ -203,9 +203,9 @@
 				99F1546C2F4F60E900E9174E /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				99F1546D2F4F60F600E9174E /* XCRemoteSwiftPackageReference "purchases-ios-spm" */,
 				99F1546E2F4F610000E9174E /* XCRemoteSwiftPackageReference "SwiftMath" */,
-				99F154712F4F611A00E9174E /* XCRemoteSwiftPackageReference "tinfoil-swift" */,
 				99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */,
 				99DDBFA22F68667C0038A729 /* XCRemoteSwiftPackageReference "textual" */,
+				99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 99F153C32F4F5F0200E9174E /* Products */;
@@ -577,6 +577,14 @@
 				minimumVersion = 0.0.6;
 			};
 		};
+		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/clerk/clerk-ios";
@@ -607,14 +615,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.7.3;
-			};
-		};
-		99F154712F4F611A00E9174E /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.0;
 			};
 		};
 		99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */ = {
@@ -648,11 +648,6 @@
 			package = 99F1546E2F4F610000E9174E /* XCRemoteSwiftPackageReference "SwiftMath" */;
 			productName = SwiftMath;
 		};
-		99F154722F4F611A00E9174E /* TinfoilAI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 99F154712F4F611A00E9174E /* XCRemoteSwiftPackageReference "tinfoil-swift" */;
-			productName = TinfoilAI;
-		};
 		99F1547B2F4F614400E9174E /* Gzip */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */;
@@ -672,6 +667,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 99F1546D2F4F60F600E9174E /* XCRemoteSwiftPackageReference "purchases-ios-spm" */;
 			productName = RevenueCatUI;
+		};
+		99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */;
+			productName = TinfoilAI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.5;
+				minimumVersion = 0.5.0;
 			};
 		};
 		99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clerk/clerk-ios",
       "state" : {
-        "revision" : "ccd1ed598edcd83d9fd2b3ea78598fbc71a77fd0",
-        "version" : "1.0.8"
+        "revision" : "74b48c126a0de46d519ef87b74fc5b2f61dfc46d",
+        "version" : "1.1.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "a414c7138a6018bf8e20fa7f2533287091e35b03",
-        "version" : "0.0.6"
+        "revision" : "baa3ae77cdd4f329225ec34bb480b009ace35ebf",
+        "version" : "0.0.7"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/marmelroy/PhoneNumberKit",
       "state" : {
-        "revision" : "8cba2258060e356d5fc4836d4ff8549faa2409dd",
-        "version" : "4.1.4"
+        "revision" : "c15542f373a8593fc0cbeac443b0efb2cea4aff0",
+        "version" : "4.2.10"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm.git",
       "state" : {
-        "revision" : "828a464d12ff8fe4f633ef1b0116e76fd2a1e462",
-        "version" : "5.59.2"
+        "revision" : "a06accc1543fcedc3094d4b5b9a40b84e2213e8e",
+        "version" : "5.69.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa/",
       "state" : {
-        "revision" : "7e77c22816c024d7385d7ab5fbf4b00130853a43",
-        "version" : "9.5.1"
+        "revision" : "a49e7c2148ac9e38bd35ef4f13bc9d6ea3ff0b81",
+        "version" : "9.11.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
-        "version" : "1.4.0"
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "8f33cc5dfe81169fb167da73584b9c72c3e8bc23",
-        "version" : "1.8.2"
+        "revision" : "f039fa6d6338aab5164f3d1be16281524c9a8f89",
+        "version" : "1.11.0"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "f29b7010738aa32c8e6ba10928034e769b02f445",
-        "version" : "0.5.0"
+        "revision" : "95ccaf65bd716fbe8d66b39aeeab7548724096ba",
+        "version" : "0.5.2"
       }
     }
   ],

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/encrypted-http-body-protocol.git",
       "state" : {
-        "revision" : "6668fb608c11e903d4a0b64a8e37a8398e305dc1",
-        "version" : "0.1.5"
+        "revision" : "332a577e06706c925264669f36b35697b27ca637",
+        "version" : "0.2.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "fb076a51a97b56c3cc2ba4c9e8bcc9e88f59d53f",
-        "version" : "0.0.4"
+        "revision" : "a414c7138a6018bf8e20fa7f2533287091e35b03",
+        "version" : "0.0.6"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "daee5afb9ad2cbd3eabb537b0fbd5cec8882b4ae",
-        "version" : "0.4.8"
+        "revision" : "f29b7010738aa32c8e6ba10928034e769b02f445",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -6,6 +6,44 @@
 //  Copyright © 2025 Tinfoil. All rights reserved.
 
 import Foundation
+import OpenAI
+
+/// Per-endpoint enable/disable parameter blocks for thinking mode.
+/// Keyed by full endpoint path (e.g. "/v1/chat/completions"). Each block is
+/// shallow-merged into the request body when the toggle is in the
+/// corresponding state. Mirrors the webapp's `ReasoningEndpointParams`.
+///
+/// `OpenAIJSON` is the OpenAI SDK's recursive Codable representation of any
+/// JSON value, used here to carry arbitrary vendor-specific fields like
+/// `chat_template_kwargs` without a typed property per shape. The SDK uses
+/// this distinct name so it does not collide with the app's local
+/// `JSONValue` enum (used for streaming-event payloads).
+struct ReasoningEndpointParams: Codable, Equatable {
+    let enable: OpenAIJSON?
+    let disable: OpenAIJSON?
+}
+
+/// Reasoning capability descriptor returned by the controlplane.
+///
+/// - `supportsEffort: true` — model accepts a graded effort parameter
+///   (low/medium/high).
+/// - `supportsToggle: true` — thinking mode can be turned on or off per
+///   request via `params[endpoint].enable` / `params[endpoint].disable`.
+/// - `defaultEnabled` — initial state of the toggle when `supportsToggle`
+///   is true.
+/// - `effortMap` — optional translation from the UI's effort vocabulary to
+///   the model's actual accepted values (e.g. DeepSeek V4 only accepts
+///   `high`/`max`).
+///
+/// The presence of a `reasoningConfig` object is itself the capability
+/// flag — there is no separate boolean.
+struct ReasoningConfig: Codable, Equatable {
+    let supportsEffort: Bool?
+    let supportsToggle: Bool?
+    let defaultEnabled: Bool?
+    let effortMap: [String: String]?
+    let params: [String: ReasoningEndpointParams]?
+}
 
 /// Model configuration from the new /api/app/models endpoint
 struct AppModelConfig: Codable {
@@ -21,6 +59,7 @@ struct AppModelConfig: Codable {
     let chat: Bool?
     let paid: Bool
     let multimodal: Bool
+    let reasoningConfig: ReasoningConfig?
 }
 
 // The /api/app/models endpoint returns an array directly, not wrapped in an object
@@ -89,6 +128,26 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
     var type: String { appConfig.type }
     var isMultimodal: Bool { appConfig.multimodal }
     var isChat: Bool { appConfig.chat ?? (appConfig.type == "chat") }
+
+    // MARK: - Reasoning capabilities
+
+    /// Full reasoning config for this model, or nil if the model is not a
+    /// reasoning model.
+    var reasoningConfig: ReasoningConfig? { appConfig.reasoningConfig }
+
+    /// True iff the model exposes any reasoning controls. Used to gate the
+    /// reasoning selector visibility.
+    var isReasoningModel: Bool { appConfig.reasoningConfig != nil }
+
+    /// True iff the model exposes a graded effort parameter.
+    var supportsReasoningEffort: Bool {
+        appConfig.reasoningConfig?.supportsEffort == true
+    }
+
+    /// True iff the model exposes an on/off thinking toggle.
+    var supportsThinkingToggle: Bool {
+        appConfig.reasoningConfig?.supportsToggle == true
+    }
 
 
     // For Hashable conformance

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -181,6 +181,8 @@ enum Constants {
             static let selectedLanguage = "tinfoil-settings-selected-language"
             static let maxPromptMessages = "tinfoil-settings-max-prompt-messages"
             static let webSearchEnabled = "tinfoil-settings-web-search-enabled"
+            static let reasoningEffort = "tinfoil-settings-reasoning-effort"
+            static let thinkingEnabled = "tinfoil-settings-thinking-enabled"
             static let cloudSyncEnabled = "tinfoil-settings-cloud-sync-enabled"
             static let cloudSyncActiveTab = "tinfoil-settings-cloud-sync-active-tab"
             static let localOnlyModeEnabled = "tinfoil-settings-local-only-mode-enabled"

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -15,6 +15,15 @@ import OpenAI
 /// For models that don't support it, we prepend to the first user message.
 struct ChatQueryBuilder {
 
+    /// Endpoint key for the chat completions API; matches the controlplane
+    /// `reasoningConfig.params` keying.
+    static let chatCompletionsEndpoint = "/v1/chat/completions"
+
+    /// Placeholder substituted with the user-selected reasoning effort when
+    /// expanding `reasoningConfig.params[endpoint].enable`. Mirrors the
+    /// webapp's `EFFORT_PLACEHOLDER`.
+    static let effortPlaceholder = "$EFFORT"
+
     /// Build ChatQuery with model-appropriate system prompt and rules injection
     /// - Parameters:
     ///   - modelId: The model identifier
@@ -25,6 +34,15 @@ struct ChatQueryBuilder {
     ///   - stream: Whether to stream the response (default: true)
     ///   - webSearchEnabled: Whether to enable web search for this query (default: false)
     ///   - isMultimodal: Whether the current model supports image content parts
+    ///   - reasoningConfig: Optional per-model reasoning configuration. When
+    ///     present, the matching enable/disable block from
+    ///     `params[chatCompletionsEndpoint]` is merged into the request body
+    ///     via `extraBody`, with `$EFFORT` substituted using `reasoningEffort`
+    ///     (translated through `effortMap` when provided).
+    ///   - reasoningEffort: User-selected effort tier for models that expose
+    ///     graded effort. Ignored for models that do not.
+    ///   - thinkingEnabled: Whether thinking is on for models that support a
+    ///     toggle. Ignored for models that do not.
     /// - Returns: A configured ChatQuery
     static func buildQuery(
         modelId: String,
@@ -34,7 +52,10 @@ struct ChatQueryBuilder {
         maxMessages: Int,
         stream: Bool = true,
         webSearchEnabled: Bool = false,
-        isMultimodal: Bool = false
+        isMultimodal: Bool = false,
+        reasoningConfig: ReasoningConfig? = nil,
+        reasoningEffort: ReasoningEffort = .medium,
+        thinkingEnabled: Bool = true
     ) -> ChatQuery {
 
         var messages: [ChatQuery.ChatCompletionMessageParam] = []
@@ -114,12 +135,77 @@ struct ChatQueryBuilder {
             }
         }
 
+        let extraBody = makeReasoningExtraBody(
+            reasoningConfig: reasoningConfig,
+            reasoningEffort: reasoningEffort,
+            thinkingEnabled: thinkingEnabled
+        )
+
         return ChatQuery(
             messages: messages,
             model: modelId,
             webSearchOptions: webSearchEnabled ? .init() : nil,
-            stream: stream
+            stream: stream,
+            extraBody: extraBody
         )
+    }
+
+    /// Build the `extraBody` map to splice into the ChatQuery for a reasoning
+    /// model. Returns nil for non-reasoning models or when the config has no
+    /// chat-completions params block.
+    static func makeReasoningExtraBody(
+        reasoningConfig: ReasoningConfig?,
+        reasoningEffort: ReasoningEffort,
+        thinkingEnabled: Bool
+    ) -> [String: OpenAIJSON]? {
+        guard let cfg = reasoningConfig else { return nil }
+        guard let endpointParams = cfg.params?[chatCompletionsEndpoint] else {
+            return nil
+        }
+
+        // Pick enable vs disable based on the toggle. Models that don't
+        // support a toggle always take the enable block.
+        let supportsToggle = cfg.supportsToggle == true
+        let rawBlock: OpenAIJSON?
+        if supportsToggle {
+            rawBlock = thinkingEnabled ? endpointParams.enable : endpointParams.disable
+        } else {
+            rawBlock = endpointParams.enable
+        }
+        guard let block = rawBlock else { return nil }
+
+        // Translate the UI effort through `effortMap` when present (e.g.
+        // DeepSeek V4 only accepts `high`/`max`). Skipped for models that
+        // do not support graded effort, but keeping the substitution
+        // unconditional is harmless because the placeholder will simply not
+        // appear in the block.
+        let supportsEffort = cfg.supportsEffort == true
+        let uiEffort = supportsEffort ? reasoningEffort.rawValue : ReasoningEffort.medium.rawValue
+        let effort = cfg.effortMap?[uiEffort] ?? uiEffort
+
+        let expanded = substituteEffort(block, effort: effort)
+        guard case .object(let dict) = expanded, !dict.isEmpty else { return nil }
+        return dict
+    }
+
+    /// Recursively clone an `OpenAIJSON`, replacing any string equal to
+    /// `effortPlaceholder` with `effort`. Mirrors the webapp's
+    /// `substituteEffort` helper.
+    private static func substituteEffort(_ value: OpenAIJSON, effort: String) -> OpenAIJSON {
+        switch value {
+        case .string(let s):
+            return s == effortPlaceholder ? .string(effort) : .string(s)
+        case .array(let items):
+            return .array(items.map { substituteEffort($0, effort: effort) })
+        case .object(let dict):
+            var out: [String: OpenAIJSON] = [:]
+            for (k, v) in dict {
+                out[k] = substituteEffort(v, effort: effort)
+            }
+            return .object(out)
+        case .null, .bool, .int, .double:
+            return value
+        }
     }
 
 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -18,6 +18,15 @@ enum ChatStorageTab: String {
     case local
 }
 
+/// Graded reasoning effort exposed to the user. Maps directly onto the
+/// webapp vocabulary; per-model translation (e.g. DeepSeek's `low|medium →
+/// high`, `high → max`) is handled by `ChatQueryBuilder` via `effortMap`.
+enum ReasoningEffort: String, CaseIterable, Sendable {
+    case low
+    case medium
+    case high
+}
+
 @MainActor
 class ChatViewModel: ObservableObject {
     // Published properties for UI updates
@@ -49,6 +58,22 @@ class ChatViewModel: ObservableObject {
     @Published var scrollToUserMessageTrigger: UUID = UUID()
     @Published var isClientInitializing: Bool = false
     @Published var isWebSearchEnabled: Bool = false
+    @Published var reasoningEffort: ReasoningEffort = .medium {
+        didSet {
+            UserDefaults.standard.set(
+                reasoningEffort.rawValue,
+                forKey: Constants.StorageKeys.Settings.reasoningEffort
+            )
+        }
+    }
+    @Published var thinkingEnabled: Bool = true {
+        didSet {
+            UserDefaults.standard.set(
+                thinkingEnabled,
+                forKey: Constants.StorageKeys.Settings.thinkingEnabled
+            )
+        }
+    }
     @Published var imageViewerImages: [Attachment] = []
     @Published var imageViewerIndex: Int = 0
     @Published var showImageViewer: Bool = false
@@ -289,6 +314,23 @@ class ChatViewModel: ObservableObject {
         }
         self.currentModel = model
         self.isWebSearchEnabled = SettingsManager.shared.webSearchEnabled
+
+        // Load persisted reasoning preferences. Both default to the most
+        // permissive setting (thinking on, medium effort) when no value has
+        // been saved yet, matching the webapp.
+        if let savedEffortRaw = UserDefaults.standard.string(
+            forKey: Constants.StorageKeys.Settings.reasoningEffort
+        ), let savedEffort = ReasoningEffort(rawValue: savedEffortRaw) {
+            self.reasoningEffort = savedEffort
+        }
+        if UserDefaults.standard.object(
+            forKey: Constants.StorageKeys.Settings.thinkingEnabled
+        ) != nil {
+            self.thinkingEnabled = UserDefaults.standard.bool(
+                forKey: Constants.StorageKeys.Settings.thinkingEnabled
+            )
+        }
+
         if let savedTab = UserDefaults.standard.string(forKey: Constants.StorageKeys.Settings.cloudSyncActiveTab),
            let tab = ChatStorageTab(rawValue: savedTab) {
             self.activeStorageTab = tab
@@ -1174,7 +1216,10 @@ class ChatViewModel: ObservableObject {
                     conversationMessages: self.messages,
                     maxMessages: maxMessages,
                     webSearchEnabled: self.isWebSearchEnabled,
-                    isMultimodal: self.currentModel.isMultimodal
+                    isMultimodal: self.currentModel.isMultimodal,
+                    reasoningConfig: self.currentModel.reasoningConfig,
+                    reasoningEffort: self.reasoningEffort,
+                    thinkingEnabled: self.thinkingEnabled
                 )
 
                 // Web search state tracking

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -221,6 +221,16 @@ struct MessageInputView: View {
 
                     modelSelectorButton
 
+                    if viewModel.currentModel.isReasoningModel {
+                        ReasoningEffortSelector(
+                            supportsEffort: viewModel.currentModel.supportsReasoningEffort,
+                            supportsToggle: viewModel.currentModel.supportsThinkingToggle,
+                            reasoningEffort: $viewModel.reasoningEffort,
+                            thinkingEnabled: $viewModel.thinkingEnabled
+                        )
+                        .padding(.leading, 4)
+                    }
+
                     Spacer()
 
                     // Microphone button
@@ -313,6 +323,16 @@ struct MessageInputView: View {
                     attachButton
 
                     modelSelectorButton
+
+                    if viewModel.currentModel.isReasoningModel {
+                        ReasoningEffortSelector(
+                            supportsEffort: viewModel.currentModel.supportsReasoningEffort,
+                            supportsToggle: viewModel.currentModel.supportsThinkingToggle,
+                            reasoningEffort: $viewModel.reasoningEffort,
+                            thinkingEnabled: $viewModel.thinkingEnabled
+                        )
+                        .padding(.leading, 4)
+                    }
 
                     Spacer()
 

--- a/TinfoilChat/Views/ReasoningEffortSelector.swift
+++ b/TinfoilChat/Views/ReasoningEffortSelector.swift
@@ -1,0 +1,133 @@
+//
+//  ReasoningEffortSelector.swift
+//  TinfoilChat
+//
+//  Icon-only pill that opens a menu for picking reasoning effort and (for
+//  models that support it) toggling thinking on/off. The button label is
+//  intentionally just the brain icon — the current effort/state is
+//  surfaced via the menu's checkmarks rather than the button text.
+//
+//   - Toggle-only (e.g. Gemma): tapping the icon flips `thinkingEnabled`
+//     directly, no menu needed.
+//   - Effort + optional toggle (e.g. DeepSeek, GPT-OSS): tapping opens a
+//     menu with Low / Medium / High plus an "Off" entry when the model
+//     also supports a toggle.
+//
+
+import SwiftUI
+
+private enum EffortOption: String, CaseIterable, Identifiable {
+    case low
+    case medium
+    case high
+
+    var id: String { rawValue }
+
+    var displayLabel: String {
+        switch self {
+        case .low: return "Low"
+        case .medium: return "Medium"
+        case .high: return "High"
+        }
+    }
+
+    var asReasoningEffort: ReasoningEffort {
+        switch self {
+        case .low: return .low
+        case .medium: return .medium
+        case .high: return .high
+        }
+    }
+
+    init(_ effort: ReasoningEffort) {
+        switch effort {
+        case .low: self = .low
+        case .medium: self = .medium
+        case .high: self = .high
+        }
+    }
+}
+
+struct ReasoningEffortSelector: View {
+    /// Whether the model exposes graded effort (low/medium/high).
+    let supportsEffort: Bool
+    /// Whether the model exposes an on/off thinking toggle.
+    let supportsToggle: Bool
+    @Binding var reasoningEffort: ReasoningEffort
+    @Binding var thinkingEnabled: Bool
+
+    var body: some View {
+        if !supportsEffort && !supportsToggle {
+            EmptyView()
+        } else if supportsToggle && !supportsEffort {
+            toggleOnlyButton
+        } else {
+            effortMenu
+        }
+    }
+
+    /// Icon-only pill for models that only expose on/off thinking. Tapping
+    /// flips `thinkingEnabled` immediately without a menu.
+    private var toggleOnlyButton: some View {
+        Button {
+            thinkingEnabled.toggle()
+        } label: {
+            iconLabel(active: thinkingEnabled)
+        }
+        .accessibilityLabel(thinkingEnabled ? "Thinking on" : "Thinking off")
+    }
+
+    /// Icon-only menu for models with graded effort. When the model also
+    /// supports a toggle, an "Off" item is included.
+    private var effortMenu: some View {
+        Menu {
+            if supportsToggle {
+                Button {
+                    thinkingEnabled = false
+                } label: {
+                    Label("Off", systemImage: thinkingEnabled ? "" : "checkmark")
+                }
+            }
+            ForEach(EffortOption.allCases) { option in
+                Button {
+                    if supportsToggle && !thinkingEnabled {
+                        thinkingEnabled = true
+                    }
+                    reasoningEffort = option.asReasoningEffort
+                } label: {
+                    let isActive = (!supportsToggle || thinkingEnabled)
+                        && EffortOption(reasoningEffort) == option
+                    Label(option.displayLabel, systemImage: isActive ? "checkmark" : "")
+                }
+            }
+        } label: {
+            iconLabel(active: !supportsToggle || thinkingEnabled)
+        }
+        .accessibilityLabel("Reasoning effort")
+    }
+
+    /// Shared icon-only pill body used by both the toggle button and the
+    /// effort menu. When inactive, a diagonal slash is drawn through the
+    /// brain to indicate thinking is disabled (SF Symbols has no
+    /// `brain.slash` glyph, so the slash is overlaid manually). The slash
+    /// is rendered as a single solid `.primary` capsule on top of the
+    /// brain, which adapts correctly to both light and dark modes.
+    private func iconLabel(active: Bool) -> some View {
+        Image(systemName: "brain")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundColor(active ? .primary : .primary.opacity(0.9))
+            .overlay(alignment: .center) {
+                if !active {
+                    Capsule()
+                        .fill(Color.primary)
+                        .frame(width: 22, height: 2.5)
+                        .rotationEffect(.degrees(-45))
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.secondary.opacity(0.12))
+            .clipShape(Capsule())
+    }
+}

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -1,0 +1,187 @@
+//
+//  ChatQueryBuilderReasoningTests.swift
+//  TinfoilChatTests
+//
+//  Verifies that ChatQueryBuilder turns a model's `reasoningConfig` plus the
+//  user's selected effort/toggle into the right top-level extra body fields,
+//  matching the webapp's behavior. Covers:
+//
+//   - DeepSeek-shaped config: nested `chat_template_kwargs` with effortMap
+//     translating low/medium → high, high → max.
+//   - Toggle-off path: the disable block is emitted instead of enable.
+//   - GPT-OSS-shaped config: top-level `reasoning_effort`, no effortMap.
+//   - Models without `reasoningConfig`: no extra body.
+//
+
+import Foundation
+import OpenAI
+import Testing
+@testable import TinfoilChat
+
+struct ChatQueryBuilderReasoningTests {
+
+    private func deepseekConfig() -> ReasoningConfig {
+        ReasoningConfig(
+            supportsEffort: true,
+            supportsToggle: true,
+            defaultEnabled: true,
+            effortMap: ["low": "high", "medium": "high", "high": "max"],
+            params: [
+                "/v1/chat/completions": ReasoningEndpointParams(
+                    enable: .object([
+                        "chat_template_kwargs": .object([
+                            "thinking": .bool(true),
+                            "reasoning_effort": .string("$EFFORT"),
+                        ])
+                    ]),
+                    disable: .object([
+                        "chat_template_kwargs": .object([
+                            "thinking": .bool(false)
+                        ])
+                    ])
+                )
+            ]
+        )
+    }
+
+    private func gptOssConfig() -> ReasoningConfig {
+        ReasoningConfig(
+            supportsEffort: true,
+            supportsToggle: false,
+            defaultEnabled: nil,
+            effortMap: nil,
+            params: [
+                "/v1/chat/completions": ReasoningEndpointParams(
+                    enable: .object([
+                        "reasoning_effort": .string("$EFFORT")
+                    ]),
+                    disable: nil
+                )
+            ]
+        )
+    }
+
+    private func gemmaConfig() -> ReasoningConfig {
+        ReasoningConfig(
+            supportsEffort: false,
+            supportsToggle: true,
+            defaultEnabled: true,
+            effortMap: nil,
+            params: [
+                "/v1/chat/completions": ReasoningEndpointParams(
+                    enable: .object([
+                        "chat_template_kwargs": .object([
+                            "enable_thinking": .bool(true)
+                        ])
+                    ]),
+                    disable: .object([
+                        "chat_template_kwargs": .object([
+                            "enable_thinking": .bool(false)
+                        ])
+                    ])
+                )
+            ]
+        )
+    }
+
+    @Test func deepseekLowEffortMapsToHighInsideChatTemplateKwargs() {
+        let body = ChatQueryBuilder.makeReasoningExtraBody(
+            reasoningConfig: deepseekConfig(),
+            reasoningEffort: .low,
+            thinkingEnabled: true
+        )
+
+        #expect(body == [
+            "chat_template_kwargs": .object([
+                "thinking": .bool(true),
+                "reasoning_effort": .string("high"),
+            ])
+        ])
+    }
+
+    @Test func deepseekHighEffortMapsToMax() {
+        let body = ChatQueryBuilder.makeReasoningExtraBody(
+            reasoningConfig: deepseekConfig(),
+            reasoningEffort: .high,
+            thinkingEnabled: true
+        )
+
+        #expect(body == [
+            "chat_template_kwargs": .object([
+                "thinking": .bool(true),
+                "reasoning_effort": .string("max"),
+            ])
+        ])
+    }
+
+    @Test func toggleOffEmitsDisableBlock() {
+        let body = ChatQueryBuilder.makeReasoningExtraBody(
+            reasoningConfig: deepseekConfig(),
+            reasoningEffort: .high,
+            thinkingEnabled: false
+        )
+
+        #expect(body == [
+            "chat_template_kwargs": .object([
+                "thinking": .bool(false)
+            ])
+        ])
+    }
+
+    @Test func gptOssEmitsTopLevelReasoningEffortWithoutMapping() {
+        let body = ChatQueryBuilder.makeReasoningExtraBody(
+            reasoningConfig: gptOssConfig(),
+            reasoningEffort: .medium,
+            thinkingEnabled: true
+        )
+
+        #expect(body == [
+            "reasoning_effort": .string("medium")
+        ])
+    }
+
+    @Test func gemmaToggleOnlyEmitsEnableWithoutEffort() {
+        let body = ChatQueryBuilder.makeReasoningExtraBody(
+            reasoningConfig: gemmaConfig(),
+            reasoningEffort: .high,
+            thinkingEnabled: true
+        )
+
+        #expect(body == [
+            "chat_template_kwargs": .object([
+                "enable_thinking": .bool(true)
+            ])
+        ])
+    }
+
+    @Test func nilReasoningConfigYieldsNoExtraBody() {
+        let body = ChatQueryBuilder.makeReasoningExtraBody(
+            reasoningConfig: nil,
+            reasoningEffort: .medium,
+            thinkingEnabled: true
+        )
+
+        #expect(body == nil)
+    }
+
+    @Test func extraBodyMakesItIntoEncodedChatQuery() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "deepseek-v4-pro",
+            systemPrompt: "you are tin",
+            rules: "",
+            conversationMessages: [],
+            maxMessages: 10,
+            stream: false,
+            reasoningConfig: deepseekConfig(),
+            reasoningEffort: .high,
+            thinkingEnabled: true
+        )
+
+        let data = try JSONEncoder().encode(query)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let kwargs = object?["chat_template_kwargs"] as? [String: Any]
+
+        #expect(kwargs?["thinking"] as? Bool == true)
+        #expect(kwargs?["reasoning_effort"] as? String == "max")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds model-driven thinking mode with a compact selector and per-request parameterization. Users can toggle thinking and set effort; requests include vendor-specific fields based on the server-provided reasoningConfig.

- New Features
  - New ReasoningEffortSelector (brain icon): tap toggles for toggle-only models, or opens Off/Low/Medium/High menu for graded models; shown only when the model declares reasoning.
  - Persists thinkingEnabled and reasoningEffort to UserDefaults; defaults to thinking on and medium effort.
  - ChatQueryBuilder merges reasoningConfig.params["/v1/chat/completions"] into extraBody, picks enable/disable by toggle, substitutes $EFFORT, and applies effortMap when present.
  - App model config extended with ReasoningConfig and ReasoningEndpointParams; ModelType exposes isReasoningModel, supportsReasoningEffort, supportsThinkingToggle.
  - Added tests covering DeepSeek/GPT-OSS/gemma shapes, toggle paths, effort mapping, and encoded query output.

- Dependencies
  - Updated `tinfoil-swift` to 0.5.x and restored `TinfoilAI` linkage; bumped app version to 2.2.2.
  - Other SPM bumps: `clerk-ios` 1.1.0, `purchases-ios-spm` 5.69.0, `sentry-cocoa` 9.11.0, `swift-asn1` 1.7.0, `swift-http-types` 1.5.1, `swift-openapi-runtime` 1.11.0, `PhoneNumberKit` 4.2.10, `openai-swift-fork` 0.0.7, `encrypted-http-body-protocol` 0.2.0.

<sup>Written for commit 3ab603b905a70a2e5f2109da429788d7b30bd6d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

