### PR TITLE
Improve chat deletion robustness logic

### DIFF
--- a/TinfoilChat/Services/CloudKeyPreflightValidator.swift
+++ b/TinfoilChat/Services/CloudKeyPreflightValidator.swift
@@ -96,9 +96,14 @@ final class CloudKeyPreflightValidator {
             }
 
             let encrypted = try JSONDecoder().decode(EncryptedData.self, from: data)
-            let result = try await encryptionService.decrypt(encrypted, as: ProfileData.self)
+            // Decrypt to raw bytes only: a successful AES-GCM open with the primary
+            // key proves the key matches the cloud data. Avoid decoding into a
+            // typed Swift schema here — the JS web client writes blobs whose
+            // schema may evolve, and a Swift decode failure must not be treated
+            // as "wrong key".
+            let (_, usedFallback) = try await encryptionService.decryptRawWithFallbackInfo(encrypted)
 
-            guard !result.usedFallbackKey else {
+            guard !usedFallback else {
                 return mismatchResult
             }
 
@@ -131,11 +136,13 @@ final class CloudKeyPreflightValidator {
                     }
 
                     do {
-                        let result: DecryptionResult<StoredChat> = try encryptionService.decryptV1(
-                            binary,
-                            as: StoredChat.self
-                        )
-                        if !result.usedFallbackKey {
+                        // Schema-free probe: a successful raw decrypt proves the
+                        // primary key works. Decoding into StoredChat here would
+                        // false-positive a "key mismatch" whenever the JS web
+                        // client uploads a chat blob with a slightly different
+                        // shape (e.g. missing optional sync metadata fields).
+                        let (_, usedFallback) = try encryptionService.decryptRawV1WithFallbackInfo(binary)
+                        if !usedFallback {
                             return validResult()
                         }
                         sawMismatch = true
@@ -151,8 +158,8 @@ final class CloudKeyPreflightValidator {
                         EncryptedData.self,
                         from: Data(content.utf8)
                     )
-                    let result = try await encryptionService.decrypt(encryptedData, as: StoredChat.self)
-                    if !result.usedFallbackKey {
+                    let (_, usedFallback) = try await encryptionService.decryptRawWithFallbackInfo(encryptedData)
+                    if !usedFallback {
                         return validResult()
                     }
                     sawMismatch = true

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -571,11 +571,19 @@ class CloudSyncService: ObservableObject {
     private func doSyncAllChats() async -> SyncResult {
         var result = SyncResult()
 
+        // Delete local chats that were deleted on another device
+        var deletedCount = 0
+        if let cachedStatus = getCachedSyncStatus(),
+           let lastUpdated = cachedStatus.lastUpdated {
+            deletedCount = await deleteRemotelyDeletedChats(since: lastUpdated)
+        }
+
         // First, backup any unsynced local changes
         let backupResult = await backupUnsyncedChats()
         result = SyncResult(
             uploaded: backupResult.uploaded,
             downloaded: 0,
+            deleted: deletedCount,
             errors: backupResult.errors
         )
 
@@ -644,6 +652,7 @@ class CloudSyncService: ObservableObject {
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
+                                deleted: result.deleted,
                                 errors: result.errors
                             )
                         } else {
@@ -662,6 +671,7 @@ class CloudSyncService: ObservableObject {
                                 result = SyncResult(
                                     uploaded: result.uploaded,
                                     downloaded: result.downloaded + 1,
+                                    deleted: result.deleted,
                                     errors: result.errors
                                 )
                             }
@@ -673,32 +683,20 @@ class CloudSyncService: ObservableObject {
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
+                                deleted: result.deleted,
                                 errors: result.errors
                             )
                         } catch {
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded,
+                                deleted: result.deleted,
                                 errors: result.errors + ["Failed to download chat \(remoteChat.id): \(error.localizedDescription)"]
                             )
                         }
                     }
                 }
             }
-
-            // Delete local chats that were deleted on another device
-            var deletedCount = 0
-            if let cachedStatus = getCachedSyncStatus(),
-               let lastUpdated = cachedStatus.lastUpdated {
-                deletedCount = await deleteRemotelyDeletedChats(since: lastUpdated)
-            }
-
-            result = SyncResult(
-                uploaded: result.uploaded,
-                downloaded: result.downloaded,
-                deleted: result.deleted + deletedCount,
-                errors: result.errors
-            )
 
             // Refresh cached sync status so subsequent smart-syncs have up-to-date info
             await refreshSyncStatusCache()
@@ -793,11 +791,15 @@ class CloudSyncService: ObservableObject {
     private func syncChangedChats(since: String) async -> SyncResult {
         var result = SyncResult()
 
+        // Delete local chats that were deleted on another device
+        let deletedCount = await deleteRemotelyDeletedChats(since: since)
+
         // Backup any unsynced local changes first (matches doSyncAllChats behavior)
         let backupResult = await backupUnsyncedChats()
         result = SyncResult(
             uploaded: backupResult.uploaded,
             downloaded: 0,
+            deleted: deletedCount,
             errors: backupResult.errors
         )
 
@@ -845,6 +847,7 @@ class CloudSyncService: ObservableObject {
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
+                                deleted: result.deleted,
                                 errors: result.errors
                             )
                         } else {
@@ -860,6 +863,7 @@ class CloudSyncService: ObservableObject {
                                 result = SyncResult(
                                     uploaded: result.uploaded,
                                     downloaded: result.downloaded + 1,
+                                    deleted: result.deleted,
                                     errors: result.errors
                                 )
                             }
@@ -871,12 +875,14 @@ class CloudSyncService: ObservableObject {
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
+                                deleted: result.deleted,
                                 errors: result.errors
                             )
                         } catch {
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded,
+                                deleted: result.deleted,
                                 errors: result.errors + ["Failed to download chat \(remoteChat.id): \(error.localizedDescription)"]
                             )
                         }
@@ -887,15 +893,6 @@ class CloudSyncService: ObservableObject {
                 hasMore = changedChats.hasMore && nextToken != nil
                 continuationToken = nextToken
             }
-
-            // Delete local chats that were deleted on another device
-            let deletedCount = await deleteRemotelyDeletedChats(since: since)
-            result = SyncResult(
-                uploaded: result.uploaded,
-                downloaded: result.downloaded,
-                deleted: result.deleted + deletedCount,
-                errors: result.errors
-            )
 
             // Refresh cached sync status so subsequent smart-syncs have up-to-date info
             await refreshSyncStatusCache()
@@ -948,6 +945,7 @@ class CloudSyncService: ObservableObject {
             result = SyncResult(
                 uploaded: result.uploaded + deltaResult.uploaded,
                 downloaded: result.downloaded + deltaResult.downloaded,
+                deleted: result.deleted + deltaResult.deleted,
                 errors: result.errors + deltaResult.errors
             )
 
@@ -957,6 +955,7 @@ class CloudSyncService: ObservableObject {
                 result = SyncResult(
                     uploaded: result.uploaded + fullResult.uploaded,
                     downloaded: result.downloaded + fullResult.downloaded,
+                    deleted: result.deleted + fullResult.deleted,
                     errors: fullResult.errors
                 )
             }
@@ -966,6 +965,7 @@ class CloudSyncService: ObservableObject {
             result = SyncResult(
                 uploaded: result.uploaded + fullResult.uploaded,
                 downloaded: result.downloaded + fullResult.downloaded,
+                deleted: result.deleted + fullResult.deleted,
                 errors: result.errors + fullResult.errors
             )
         }
@@ -1114,7 +1114,8 @@ class CloudSyncService: ObservableObject {
         
         // Don't attempt deletion if not authenticated
         guard await cloudStorage.isAuthenticated() else {
-            return
+            deletedChatsTracker.removeFromDeleted(chatId)
+            throw CloudStorageError.authenticationRequired
         }
         
         do {
@@ -1124,11 +1125,7 @@ class CloudSyncService: ObservableObject {
             deletedChatsTracker.removeFromDeleted(chatId)
             
         } catch {
-            // Silently fail if no auth token set
-            if let error = error as? CloudStorageError,
-               error == .authenticationRequired {
-                return
-            }
+            deletedChatsTracker.removeFromDeleted(chatId)
             throw error
         }
     }
@@ -1202,6 +1199,7 @@ class CloudSyncService: ObservableObject {
         do {
             let deleted = try await cloudStorage.getDeletedChatsSince(since: since)
             for id in deleted.deletedIds {
+                deletedChatsTracker.markAsDeleted(id)
                 await deleteChatFromStorage(id)
             }
             return deleted.deletedIds.count

--- a/TinfoilChat/Services/EncryptionService.swift
+++ b/TinfoilChat/Services/EncryptionService.swift
@@ -465,6 +465,20 @@ extension EncryptionService: ChatEncryptor {
         return data
     }
 
+    /// Decrypt to raw bytes, exposing whether a fallback key was used.
+    /// Used by the cloud-key preflight to answer "does this key work?" without
+    /// requiring the decrypted payload to conform to a specific Swift schema.
+    func decryptRawWithFallbackInfo(_ encrypted: EncryptedData) async throws -> (Data, Bool) {
+        return try await decryptDataWithFallbackInfo(encrypted)
+    }
+
+    /// Decrypt v1 binary content to raw bytes, exposing whether a fallback key was used.
+    func decryptRawV1WithFallbackInfo(_ binary: Data) throws -> (Data, Bool) {
+        return try decryptWithKeyFallback { key in
+            try BinaryCodec.decryptRaw(binary, using: key)
+        }
+    }
+
     /// Shared decryption that tries the primary key, then falls back to key history.
     /// Returns the decrypted data and whether a fallback key was used.
     private func decryptDataWithFallbackInfo(_ encrypted: EncryptedData) async throws -> (Data, Bool) {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -804,40 +804,45 @@ class ChatViewModel: ObservableObject {
         guard hasChatAccess else { return }
 
         let isLocal: Bool
-
-        if let index = localChats.firstIndex(where: { $0.id == id }) {
-            localChats.remove(at: index)
+        if localChats.contains(where: { $0.id == id }) {
             isLocal = true
-        } else if let index = chats.firstIndex(where: { $0.id == id }) {
-            chats.remove(at: index)
+        } else if chats.contains(where: { $0.id == id }) {
             isLocal = false
         } else {
             return
         }
 
-        // Mark as deleted for cloud sync (local-only chats are never uploaded)
-        if !isLocal {
-            DeletedChatsTracker.shared.markAsDeleted(id)
-        }
-
-        // If the deleted chat was the current chat, select another one
-        if currentChat?.id == id {
-            let activeList = isLocal ? localChats : chats
-            if let first = activeList.first {
-                currentChat = first
-            } else {
-                createNewChat(isLocalOnly: isLocal)
-            }
-        }
+        let userId = currentUserId
 
         // Delete from file storage and cloud
-        let userId = currentUserId
         Task {
-            await Chat.deleteChatFromStorage(chatId: id, userId: userId)
             if !isLocal && SettingsManager.shared.isCloudSyncEnabled {
                 do {
                     try await cloudSync.deleteFromCloud(id)
                 } catch {
+                    syncErrors.append("Failed to delete chat: \(error.localizedDescription)")
+                    return
+                }
+            } else if !isLocal {
+                // Mark as deleted for cloud sync (local-only chats are never uploaded)
+                DeletedChatsTracker.shared.markAsDeleted(id)
+            }
+
+            await Chat.deleteChatFromStorage(chatId: id, userId: userId)
+
+            if let index = localChats.firstIndex(where: { $0.id == id }) {
+                localChats.remove(at: index)
+            } else if let index = chats.firstIndex(where: { $0.id == id }) {
+                chats.remove(at: index)
+            }
+
+            // If the deleted chat was the current chat, select another one
+            if currentChat?.id == id {
+                let activeList = isLocal ? localChats : chats
+                if let first = activeList.first {
+                    currentChat = first
+                } else {
+                    createNewChat(isLocalOnly: isLocal)
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make chat deletion reliable across devices and stop rejecting valid cloud keys when blob shapes differ. Deletions now run early in sync, surface auth errors, and no longer resurrect; key preflight checks the key without schema decoding.

- **Bug Fixes**
  - Prevent deleted chats from reappearing: process remote deletions at the start of sync, carry `deleted` in `SyncResult`, and require auth for cloud deletes instead of silently ignoring.
  - Safer local deletion flow: don’t remove a chat from UI/disk if cloud delete fails; mark for deletion only when cloud sync is off; remove from storage and lists after success.
  - Reliable key validation: preflight uses raw decrypt to verify the primary key and checks fallback use, avoiding false “key mismatch” when the JS client uploads blobs with slightly different shapes; added `decryptRawWithFallbackInfo` and `decryptRawV1WithFallbackInfo` in `EncryptionService`.

<sup>Written for commit 874def6c1c87e36aa38e398aa479614120a77503. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

