### PR TITLE
Implement generative AI widgets

### DIFF
--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -395,17 +395,23 @@ struct WebSearchInstance: Codable, Equatable, Identifiable {
 }
 
 /// An ordered segment of assistant content. Preserves the exact order in which
-/// text and inline events (web search, URL fetch) streamed.
+/// text and inline events (thinking, web search, URL fetch, tool call) streamed.
 enum MessageSegment: Codable, Equatable {
     case text(String)
+    case thinking(content: String, isThinking: Bool, duration: Double?)
     case webSearch(searchId: String)
     case urlFetch(fetchId: String)
+    case toolCall(toolCallId: String)
 
     private enum CodingKeys: String, CodingKey {
         case type
         case text
+        case content
+        case isThinking
+        case duration
         case searchId
         case fetchId
+        case toolCallId
     }
 
     init(from decoder: Decoder) throws {
@@ -415,12 +421,20 @@ enum MessageSegment: Codable, Equatable {
         case "text":
             let text = try container.decode(String.self, forKey: .text)
             self = .text(text)
+        case "thinking":
+            let content = try container.decodeIfPresent(String.self, forKey: .content) ?? ""
+            let isThinking = try container.decodeIfPresent(Bool.self, forKey: .isThinking) ?? false
+            let duration = try container.decodeIfPresent(Double.self, forKey: .duration)
+            self = .thinking(content: content, isThinking: isThinking, duration: duration)
         case "web_search":
             let searchId = try container.decode(String.self, forKey: .searchId)
             self = .webSearch(searchId: searchId)
         case "url_fetch":
             let fetchId = try container.decode(String.self, forKey: .fetchId)
             self = .urlFetch(fetchId: fetchId)
+        case "tool_call":
+            let toolCallId = try container.decode(String.self, forKey: .toolCallId)
+            self = .toolCall(toolCallId: toolCallId)
         default:
             throw DecodingError.dataCorruptedError(
                 forKey: .type,
@@ -436,12 +450,20 @@ enum MessageSegment: Codable, Equatable {
         case .text(let text):
             try container.encode("text", forKey: .type)
             try container.encode(text, forKey: .text)
+        case .thinking(let content, let isThinking, let duration):
+            try container.encode("thinking", forKey: .type)
+            try container.encode(content, forKey: .content)
+            try container.encode(isThinking, forKey: .isThinking)
+            try container.encodeIfPresent(duration, forKey: .duration)
         case .webSearch(let searchId):
             try container.encode("web_search", forKey: .type)
             try container.encode(searchId, forKey: .searchId)
         case .urlFetch(let fetchId):
             try container.encode("url_fetch", forKey: .type)
             try container.encode(fetchId, forKey: .fetchId)
+        case .toolCall(let toolCallId):
+            try container.encode("tool_call", forKey: .type)
+            try container.encode(toolCallId, forKey: .toolCallId)
         }
     }
 
@@ -505,6 +527,16 @@ enum JSONValue: Codable, Equatable {
 
     var objectValue: [String: JSONValue]? {
         if case .object(let value) = self { return value }
+        return nil
+    }
+
+    var arrayValue: [JSONValue]? {
+        if case .array(let value) = self { return value }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
         return nil
     }
 
@@ -590,6 +622,12 @@ struct GenUIToolCall: Codable, Equatable, Identifiable {
     let arguments: String
 }
 
+// `GenUIResolution` (defined in `Views/GenUI/GenUIWidget.swift`) is used
+// both as the in-memory render input and the on-disk storage shape. Its
+// JSON representation matches the webapp's
+// `TimelineToolCallBlock.resolution` so chats round-trip across
+// platforms.
+
 /// Represents a single message in a chat
 struct Message: Identifiable, Codable, Equatable {
     let id: String
@@ -622,12 +660,45 @@ struct Message: Identifiable, Codable, Equatable {
     var segments: [MessageSegment]? = nil
     var webSearches: [WebSearchInstance]? = nil
     var toolCalls: [GenUIToolCall] = []
+    /// Cross-platform timeline blocks. The webapp persists tool-call
+    /// resolution state on individual `tool_call` blocks here
+    /// (`resolvedAt` + `resolution`); iOS reads and writes the same
+    /// shape so chats round-trip losslessly. Other block types
+    /// (thinking, content, web_search, url_fetches) are preserved
+    /// verbatim even though iOS renders the chat off its own
+    /// `segments` representation.
     var timeline: [JSONValue]? = nil
 
+    /// True when this assistant message has at least one tool call whose
+    /// widget is not registered on this client. Used to surface the
+    /// "interactive component unavailable" notice for forward
+    /// compatibility (e.g. a newly-added widget that web supports but
+    /// iOS hasn't shipped yet).
+    @MainActor
     var hasUnsupportedGenUI: Bool {
-        role == .assistant && (!toolCalls.isEmpty || (timeline?.contains { block in
-            block.objectValue?["type"]?.stringValue == "tool_call"
-        } ?? false))
+        guard role == .assistant else { return false }
+        for toolCall in toolCalls {
+            if !GenUIRegistry.shared.isGenUIToolName(toolCall.name) {
+                return true
+            }
+        }
+        if let timeline = timeline {
+            for block in timeline {
+                guard let object = block.objectValue,
+                      object["type"]?.stringValue == "tool_call",
+                      let name = object["name"]?.stringValue else { continue }
+                if !GenUIRegistry.shared.isGenUIToolName(name) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    /// Resolution for the given tool-call id, read from the timeline.
+    /// Mirrors how the webapp reads `block.resolvedAt` / `block.resolution`.
+    func genUIResolution(for toolCallId: String) -> GenUIResolution? {
+        TimelineToolCalls.resolution(in: timeline, toolCallId: toolCallId)
     }
 
     static let longMessageAttachmentThreshold = 1200
@@ -742,6 +813,119 @@ struct Message: Identifiable, Codable, Equatable {
         webSearches = (try? container.decodeIfPresent([WebSearchInstance].self, forKey: .webSearches)) ?? nil
         toolCalls = (try? container.decodeIfPresent([GenUIToolCall].self, forKey: .toolCalls)) ?? []
         timeline = try? container.decodeIfPresent([JSONValue].self, forKey: .timeline)
+
+        // For cross-platform parity: webapp messages persist a `timeline`
+        // (chronological array of blocks) but no `segments`. Without
+        // segments, iOS falls into flat-field rendering which loses the
+        // original interleaving of thinking, web search, content, and
+        // tool calls. Synthesize segments + per-search instances from
+        // the timeline so the standard segments rendering pipeline can
+        // reproduce the webapp's chronological layout faithfully.
+        if role == .assistant,
+           segments == nil,
+           let timeline,
+           !timeline.isEmpty {
+            let derived = Self.deriveFromTimeline(timeline)
+            if !derived.segments.isEmpty {
+                segments = derived.segments
+            }
+            if webSearches == nil, !derived.webSearches.isEmpty {
+                webSearches = derived.webSearches
+            }
+            if toolCalls.isEmpty, !derived.toolCalls.isEmpty {
+                toolCalls = derived.toolCalls
+            }
+            if urlFetches.isEmpty, !derived.urlFetches.isEmpty {
+                urlFetches = derived.urlFetches
+            }
+        }
+    }
+
+    /// Walks a webapp-style timeline and produces the iOS-side render
+    /// inputs (segments + web-search instances) in chronological order.
+    /// Mirrors the webapp's `MessageAssembler.toMessage` plus the
+    /// chronological ordering used by `DefaultMessageRenderer`.
+    private static func deriveFromTimeline(
+        _ timeline: [JSONValue]
+    ) -> (
+        segments: [MessageSegment],
+        webSearches: [WebSearchInstance],
+        urlFetches: [URLFetchState],
+        toolCalls: [GenUIToolCall]
+    ) {
+        var segments: [MessageSegment] = []
+        var searches: [WebSearchInstance] = []
+        var fetches: [URLFetchState] = []
+        var calls: [GenUIToolCall] = []
+
+        for block in timeline {
+            guard let object = block.objectValue,
+                  let type = object["type"]?.stringValue else { continue }
+            switch type {
+            case "thinking":
+                let content = object["content"]?.stringValue ?? ""
+                let isThinking = (object["isThinking"]?.boolValue) ?? false
+                let duration = object["duration"]?.numberValue
+                segments.append(.thinking(content: content, isThinking: isThinking, duration: duration))
+
+            case "content":
+                let text = object["content"]?.stringValue ?? ""
+                if !text.isEmpty {
+                    segments.append(.text(text))
+                }
+
+            case "web_search":
+                guard let stateObject = object["state"]?.objectValue else { continue }
+                let id = object["id"]?.stringValue ?? "web-search-\(searches.count)"
+                let query = stateObject["query"]?.stringValue
+                let statusRaw = stateObject["status"]?.stringValue ?? "completed"
+                let status = WebSearchStatus(rawValue: statusRaw) ?? .completed
+                let reason = stateObject["reason"]?.stringValue
+                var sources: [WebSearchSource]? = nil
+                if let array = stateObject["sources"]?.arrayValue {
+                    sources = array.compactMap { value in
+                        guard let item = value.objectValue,
+                              let url = item["url"]?.stringValue else { return nil }
+                        let title = item["title"]?.stringValue ?? url
+                        return WebSearchSource(title: title, url: url)
+                    }
+                }
+                let instance = WebSearchInstance(
+                    id: id,
+                    query: query,
+                    status: status,
+                    sources: sources,
+                    reason: reason
+                )
+                searches.append(instance)
+                segments.append(.webSearch(searchId: id))
+
+            case "url_fetches":
+                guard let array = object["fetches"]?.arrayValue else { continue }
+                for value in array {
+                    guard let item = value.objectValue,
+                          let id = item["id"]?.stringValue,
+                          let url = item["url"]?.stringValue else { continue }
+                    let statusRaw = item["status"]?.stringValue ?? "completed"
+                    let status = URLFetchStatus(rawValue: statusRaw) ?? .completed
+                    let fetch = URLFetchState(id: id, url: url, status: status)
+                    fetches.append(fetch)
+                    segments.append(.urlFetch(fetchId: id))
+                }
+
+            case "tool_call":
+                guard let toolCallId = object["toolCallId"]?.stringValue else { continue }
+                let name = object["name"]?.stringValue ?? ""
+                let arguments = object["arguments"]?.stringValue ?? ""
+                calls.append(GenUIToolCall(id: toolCallId, name: name, arguments: arguments))
+                segments.append(.toolCall(toolCallId: toolCallId))
+
+            default:
+                continue
+            }
+        }
+
+        return (segments, searches, fetches, calls)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/TinfoilChat/Services/LinkMetadataService.swift
+++ b/TinfoilChat/Services/LinkMetadataService.swift
@@ -1,0 +1,94 @@
+//
+//  LinkMetadataService.swift
+//  TinfoilChat
+//
+//  Fetches OpenGraph metadata (title/description/site_name/image/favicon)
+//  for a URL from the `opengraph-metadata.tinfoil.sh` endpoint. Mirrors the
+//  webapp's `metadata-client.ts` so the iOS link-preview widget surfaces
+//  the same rich card (hero image + favicon + title + description) as the
+//  web build.
+//
+//  In-flight requests for the same URL are deduplicated so multiple
+//  `LinkPreviewView` instances rendering the same link share a single
+//  network round-trip.
+
+import Foundation
+
+struct LinkMetadata: Equatable, Sendable {
+    let url: String
+    let title: String?
+    let description: String?
+    let siteName: String?
+    let image: String?
+    let favicon: String?
+    let cached: Bool
+}
+
+private struct MetadataResponse: Decodable {
+    let url: String
+    let title: String?
+    let description: String?
+    let site_name: String?
+    let image: String?
+    let favicon: String?
+    let cached: Bool?
+}
+
+enum LinkMetadataError: Error {
+    case invalidURL
+    case badStatus(Int)
+    case decodingFailed
+}
+
+actor LinkMetadataService {
+    static let shared = LinkMetadataService()
+
+    private static let endpoint = URL(string: "https://opengraph-metadata.tinfoil.sh/metadata")!
+
+    private var cache: [String: LinkMetadata] = [:]
+    private var inFlight: [String: Task<LinkMetadata, Error>] = [:]
+
+    func metadata(for url: String) async throws -> LinkMetadata {
+        if let cached = cache[url] { return cached }
+        if let existing = inFlight[url] { return try await existing.value }
+
+        let task = Task<LinkMetadata, Error> { [endpoint = LinkMetadataService.endpoint] in
+            try await Self.fetch(url: url, endpoint: endpoint)
+        }
+        inFlight[url] = task
+
+        defer { inFlight[url] = nil }
+        let result = try await task.value
+        cache[url] = result
+        return result
+    }
+
+    private static func fetch(url: String, endpoint: URL) async throws -> LinkMetadata {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["url": url])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LinkMetadataError.badStatus(0)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LinkMetadataError.badStatus(http.statusCode)
+        }
+        do {
+            let decoded = try JSONDecoder().decode(MetadataResponse.self, from: data)
+            return LinkMetadata(
+                url: decoded.url,
+                title: decoded.title,
+                description: decoded.description,
+                siteName: decoded.site_name,
+                image: decoded.image,
+                favicon: decoded.favicon,
+                cached: decoded.cached ?? false
+            )
+        } catch {
+            throw LinkMetadataError.decodingFailed
+        }
+    }
+}

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -44,6 +44,7 @@ struct ChatQueryBuilder {
     ///   - thinkingEnabled: Whether thinking is on for models that support a
     ///     toggle. Ignored for models that do not.
     /// - Returns: A configured ChatQuery
+    @MainActor
     static func buildQuery(
         modelId: String,
         systemPrompt: String,
@@ -55,7 +56,8 @@ struct ChatQueryBuilder {
         isMultimodal: Bool = false,
         reasoningConfig: ReasoningConfig? = nil,
         reasoningEffort: ReasoningEffort = .medium,
-        thinkingEnabled: Bool = true
+        thinkingEnabled: Bool = true,
+        genUIEnabled: Bool = true
     ) -> ChatQuery {
 
         var messages: [ChatQuery.ChatCompletionMessageParam] = []
@@ -63,8 +65,19 @@ struct ChatQueryBuilder {
         // Most models support system role; DeepSeek is the known exception
         let useSystemRole = !modelId.hasPrefix("deepseek")
 
+        // Append the GenUI prompt hint so the model knows it can call
+        // render_* tools instead of replying with markdown for structured
+        // content. The hint is appended to the system prompt regardless
+        // of which transport carries the system instructions (system role
+        // vs synthetic <system> user message).
+        var effectiveSystemPrompt = systemPrompt
+        if genUIEnabled {
+            let hint = GenUIRegistry.shared.buildPromptHint()
+            effectiveSystemPrompt = systemPrompt.isEmpty ? hint : systemPrompt + "\n\n" + hint
+        }
+
         if useSystemRole {
-            let fullPrompt = rules.isEmpty ? systemPrompt : systemPrompt + "\n\n" + rules
+            let fullPrompt = rules.isEmpty ? effectiveSystemPrompt : effectiveSystemPrompt + "\n\n" + rules
             messages.append(.system(.init(content: .textContent(fullPrompt))))
         }
 
@@ -78,7 +91,7 @@ struct ChatQueryBuilder {
 
                 // For models that don't use system role (e.g. DeepSeek): inject system instructions as a separate user message
                 if !hasAddedSystemInstructions {
-                    let rawInstructions = rules.isEmpty ? systemPrompt : systemPrompt + "\n\n" + rules
+                    let rawInstructions = rules.isEmpty ? effectiveSystemPrompt : effectiveSystemPrompt + "\n\n" + rules
                     let systemContent = "<system>\n\(rawInstructions)\n</system>"
                     messages.append(.user(.init(content: .string(systemContent))))
                     hasAddedSystemInstructions = true
@@ -130,10 +143,55 @@ struct ChatQueryBuilder {
                 } else {
                     messages.append(.user(.init(content: .string(userContent))))
                 }
-            } else if !msg.content.isEmpty {
-                messages.append(.assistant(.init(content: .textContent(msg.content))))
+            } else if !msg.content.isEmpty || !msg.toolCalls.isEmpty {
+                // Emit `tool_calls` on the assistant message so the model
+                // sees its previously-rendered widgets, then synthesize
+                // `role: 'tool'` results so the API's tool-call/tool-result
+                // pairing rule is satisfied. GenUI tools are display-only
+                // (the client rendered the component); we acknowledge with
+                // a constant payload that mirrors the webapp.
+                let toolCallParams: [ChatQuery.ChatCompletionMessageParam.AssistantMessageParam.ToolCallParam]? = msg.toolCalls.isEmpty
+                    ? nil
+                    : msg.toolCalls.map { tc in
+                        .init(
+                            id: tc.id,
+                            function: .init(
+                                arguments: tc.arguments.isEmpty ? "{}" : tc.arguments,
+                                name: tc.name
+                            )
+                        )
+                    }
+                let assistantContent: ChatQuery.ChatCompletionMessageParam.TextOrRefusalContent? =
+                    msg.content.isEmpty && toolCallParams != nil
+                        ? nil
+                        : .textContent(msg.content)
+                messages.append(.assistant(.init(
+                    content: assistantContent,
+                    toolCalls: toolCallParams
+                )))
+                if let toolCallParams {
+                    for param in toolCallParams {
+                        messages.append(.tool(.init(
+                            content: .textContent("displayed"),
+                            toolCallId: param.id
+                        )))
+                    }
+                }
             }
         }
+
+        let tools: [ChatQuery.ChatCompletionToolParam]? = genUIEnabled
+            ? GenUIRegistry.shared.buildToolParams()
+            : nil
+
+        // Mirror the webapp: when GenUI tools are present, send
+        // `tool_choice: "auto"` and opt in to parallel tool calls so the
+        // model can emit multiple `render_*` calls in a single response
+        // (e.g., timer + chart + recipe + map at once). Without these
+        // flags some providers return only a single tool call.
+        let toolChoice: ChatQuery.ChatCompletionFunctionCallOptionParam? =
+            (tools?.isEmpty == false) ? .auto : nil
+        let parallelToolCalls: Bool? = (tools?.isEmpty == false) ? true : nil
 
         let extraBody = makeReasoningExtraBody(
             reasoningConfig: reasoningConfig,
@@ -144,6 +202,9 @@ struct ChatQueryBuilder {
         return ChatQuery(
             messages: messages,
             model: modelId,
+            parallelToolCalls: parallelToolCalls,
+            toolChoice: toolChoice,
+            tools: tools,
             webSearchOptions: webSearchEnabled ? .init() : nil,
             stream: stream,
             extraBody: extraBody

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -920,6 +920,60 @@ class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Resolves a pending input-surface GenUI tool call: writes the
+    /// resolution onto the matching `tool_call` block on the message's
+    /// timeline (the cross-platform wire shape) and submits the result
+    /// text as a new user message so the conversation continues
+    /// naturally. Mirrors the webapp's `resolveInputToolCall`.
+    func resolveGenUIToolCall(
+        toolCallId: String,
+        resultText: String,
+        resultData: JSONValue?
+    ) {
+        guard !isLoading else { return }
+        guard var chat = currentChat else { return }
+
+        var didResolve = false
+        for index in chat.messages.indices.reversed() {
+            guard chat.messages[index].role == .assistant else { continue }
+            guard chat.messages[index].toolCalls.contains(where: { $0.id == toolCallId }) else {
+                break
+            }
+            var timeline = chat.messages[index].timeline ?? []
+            // If the timeline is missing this tool_call block (e.g. an
+            // older message reconstructed from `toolCalls` only), seed
+            // a block first so `resolve` has something to update.
+            if !timeline.contains(where: {
+                guard let object = $0.objectValue else { return false }
+                return object["type"]?.stringValue == "tool_call"
+                    && object["toolCallId"]?.stringValue == toolCallId
+            }) {
+                if let toolCall = chat.messages[index].toolCalls.first(where: { $0.id == toolCallId }) {
+                    TimelineToolCalls.upsertStreamingBlock(
+                        in: &timeline,
+                        toolCallId: toolCallId,
+                        name: toolCall.name,
+                        arguments: toolCall.arguments
+                    )
+                }
+            }
+            TimelineToolCalls.resolve(
+                in: &timeline,
+                toolCallId: toolCallId,
+                text: resultText,
+                data: resultData
+            )
+            chat.messages[index].timeline = timeline
+            didResolve = true
+            break
+        }
+
+        guard didResolve else { return }
+
+        updateChat(chat)
+        sendMessage(text: resultText)
+    }
+
     /// Sends a user message and generates a response
     func sendMessage(text: String) {
         guard !isLoading else { return }
@@ -1425,6 +1479,32 @@ class ChatViewModel: ObservableObject {
                 // pass-through.
                 var tinfoilEventParser = TinfoilEventParser()
 
+                // GenUI tool-call accumulator. The OpenAI streaming
+                // protocol sends a sequence of partial deltas keyed by
+                // `index`; each delta may carry an `id`, a `name`, and
+                // an `arguments` fragment. We coalesce them by index
+                // and write both:
+                //   - the flat `Message.toolCalls` array (mirrored from
+                //     webapp `MessageAssembler.toMessage`), and
+                //   - the canonical `Message.timeline` tool_call blocks
+                //     that the webapp uses to track resolution state.
+                var streamingToolCalls: [Int: GenUIToolCall] = [:]
+                var timelineBlocks: [JSONValue] = []
+                // Once the assistant has emitted a tool call on this
+                // turn, drop subsequent `delta.content` — providers
+                // sometimes trail serialization noise (fragments of the
+                // tool name) through the content channel. Mirrors the
+                // webapp event-normalizer's `sawToolCall` gate.
+                var sawToolCall = false
+                let appendToolCallSegment: (String) -> Void = { toolCallId in
+                    if !segments.contains(where: {
+                        if case .toolCall(let id) = $0, id == toolCallId { return true }
+                        return false
+                    }) {
+                        segments.append(.toolCall(toolCallId: toolCallId))
+                    }
+                }
+
                 var thinkStartTime: Date? = nil
                 var hasThinkTag = false
                 var thoughtsBuffer = ""
@@ -1494,6 +1574,12 @@ class ChatViewModel: ObservableObject {
                     }
 
                     var content = chunk.choices.first?.delta.content ?? ""
+                    // Once a tool call has been seen on this turn, drop
+                    // any further `delta.content` to suppress provider
+                    // serialization noise. Mirrors the webapp.
+                    if sawToolCall {
+                        content = ""
+                    }
                     // Strip router-emitted `<tinfoil-event>` markers
                     // from the delta before any downstream logic sees
                     // it, and dispatch the decoded events so the same
@@ -1511,6 +1597,39 @@ class ChatViewModel: ObservableObject {
                     let hasReasoningContent = chunk.choices.first?.delta.reasoning != nil
                     let reasoningContent = chunk.choices.first?.delta.reasoning ?? ""
                     var didMutateState = false
+
+                    // Accumulate GenUI tool-call deltas. Mirrors the
+                    // webapp's normalizer: deltas may carry only
+                    // partial fragments and we merge them by index.
+                    // Each merged tool call is also reflected on the
+                    // canonical `timeline` so the wire format matches
+                    // `TimelineToolCallBlock` exactly.
+                    if let deltas = chunk.choices.first?.delta.toolCalls {
+                        for delta in deltas {
+                            let index = delta.index ?? 0
+                            let existing = streamingToolCalls[index]
+                            let mergedId = delta.id ?? existing?.id ?? ""
+                            let mergedName = delta.function?.name ?? existing?.name ?? ""
+                            let mergedArgs = (existing?.arguments ?? "") + (delta.function?.arguments ?? "")
+                            let updated = GenUIToolCall(
+                                id: mergedId,
+                                name: mergedName,
+                                arguments: mergedArgs
+                            )
+                            streamingToolCalls[index] = updated
+                            if !mergedId.isEmpty {
+                                appendToolCallSegment(mergedId)
+                                TimelineToolCalls.upsertStreamingBlock(
+                                    in: &timelineBlocks,
+                                    toolCallId: mergedId,
+                                    name: mergedName,
+                                    arguments: mergedArgs
+                                )
+                                sawToolCall = true
+                            }
+                            didMutateState = true
+                        }
+                    }
 
                     // Collect sources from annotations (no deduplication to preserve citation index mapping)
                     if isWebSearchEnabled, let annotations = chunk.choices.first?.delta.annotations {
@@ -1740,6 +1859,13 @@ class ChatViewModel: ObservableObject {
                         chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
                         chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
                         chat.messages[lastIndex].webSearches = webSearches.isEmpty ? nil : webSearches
+                        chat.messages[lastIndex].toolCalls = streamingToolCalls
+                            .sorted(by: { $0.key < $1.key })
+                            .map { $0.value }
+                            .filter { !$0.id.isEmpty }
+                        if !timelineBlocks.isEmpty {
+                            chat.messages[lastIndex].timeline = timelineBlocks
+                        }
 
                         // Merge collected sources into the message's current webSearchState.
                         if !collectedSources.isEmpty {
@@ -1842,6 +1968,13 @@ class ChatViewModel: ObservableObject {
                         chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
                         chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
                         chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
+                        chat.messages[lastIndex].toolCalls = streamingToolCalls
+                            .sorted(by: { $0.key < $1.key })
+                            .map { $0.value }
+                            .filter { !$0.id.isEmpty }
+                        if !timelineBlocks.isEmpty {
+                            chat.messages[lastIndex].timeline = timelineBlocks
+                        }
                         // Mirror the final sources onto the most recent WebSearchInstance,
                         // promoting it out of the `.searching` holding state if the router
                         // sent `.completed` before any sources landed.

--- a/TinfoilChat/Views/GenUI/GenUIInputAreaView.swift
+++ b/TinfoilChat/Views/GenUI/GenUIInputAreaView.swift
@@ -1,0 +1,81 @@
+//
+//  GenUIInputAreaView.swift
+//  TinfoilChat
+//
+//  Mounts an input-surface widget inside `MessageInputView`. The wrapper
+//  owns the resolve/cancel plumbing so individual widgets only deal with
+//  their own UI.
+
+import Foundation
+import SwiftUI
+
+/// Pending input-surface tool call descriptor. Mirrors the webapp's
+/// `PendingInputToolCall` selector logic.
+struct PendingInputToolCall: Equatable {
+    let messageIndex: Int
+    let toolCallId: String
+    let name: String
+    let arguments: String
+}
+
+extension Chat {
+    /// The single pending input-surface tool call on the most recent
+    /// assistant message, or `nil` when no widget is awaiting input.
+    /// Mirrors the webapp's `selectPendingInputToolCall`: walks the
+    /// last assistant message's `toolCalls` in reverse and returns the
+    /// first input-surface widget whose timeline block has not been
+    /// resolved.
+    @MainActor
+    func pendingInputToolCall() -> PendingInputToolCall? {
+        for index in messages.indices.reversed() {
+            let message = messages[index]
+            guard message.role == .assistant else { continue }
+            for toolCall in message.toolCalls.reversed() {
+                guard let widget = GenUIRegistry.shared.widget(named: toolCall.name),
+                      widget.surface == .input else { continue }
+                if message.genUIResolution(for: toolCall.id) != nil { continue }
+                guard let data = toolCall.arguments.data(using: .utf8),
+                      widget.canRender(rawArgs: data) else { continue }
+                return PendingInputToolCall(
+                    messageIndex: index,
+                    toolCallId: toolCall.id,
+                    name: toolCall.name,
+                    arguments: toolCall.arguments
+                )
+            }
+            // Only the latest assistant message is considered.
+            return nil
+        }
+        return nil
+    }
+}
+
+@MainActor
+struct GenUIInputAreaView: View {
+    let pending: PendingInputToolCall
+    let isDarkMode: Bool
+    let onResolve: (_ toolCallId: String, _ resultText: String, _ resultData: JSONValue?) -> Void
+    let onCancel: ((String) -> Void)?
+
+    var body: some View {
+        let widget = GenUIRegistry.shared.widget(named: pending.name)
+        let context = GenUIInputContext(
+            toolCallId: pending.toolCallId,
+            isDarkMode: isDarkMode,
+            resolve: { resultText, resultData in
+                onResolve(pending.toolCallId, resultText, resultData)
+            },
+            cancel: onCancel.map { handler in { handler(pending.toolCallId) } }
+        )
+        let data = pending.arguments.data(using: .utf8) ?? Data()
+
+        if let widget, let view = widget.renderInputArea(rawArgs: data, context: context) {
+            view
+        } else {
+            Text("Unable to render component: \(pending.name)")
+                .font(.caption)
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                .padding(.vertical, 8)
+        }
+    }
+}

--- a/TinfoilChat/Views/GenUI/GenUIRegistry.swift
+++ b/TinfoilChat/Views/GenUI/GenUIRegistry.swift
@@ -1,0 +1,75 @@
+//
+//  GenUIRegistry.swift
+//  TinfoilChat
+//
+//  Central registry of every renderable widget. Adding a widget is one
+//  Swift file under `Widgets/` plus one entry in `widgets`.
+
+import Foundation
+import OpenAI
+
+@MainActor
+final class GenUIRegistry {
+    static let shared = GenUIRegistry()
+
+    /// Order influences only the order of prompt hints presented to the
+    /// model. Keep frequently-useful widgets near the top so the model
+    /// reaches for them first.
+    let widgets: [AnyGenUIWidget] = [
+        StatCardsWidget(),
+        TimelineWidget(),
+        ChartWidget(),
+        ImageWidget(),
+        LinkPreviewWidget(),
+        ArtifactPreviewWidget(),
+        ClockWidget(),
+        RecipeCardWidget(),
+        MessageComposeWidget(),
+        SportsDataWidget(),
+        MapWidget(),
+    ]
+
+    private lazy var widgetsByName: [String: AnyGenUIWidget] = {
+        var dict: [String: AnyGenUIWidget] = [:]
+        for widget in widgets {
+            dict[widget.name] = widget
+        }
+        return dict
+    }()
+
+    /// Lookup by tool name.
+    func widget(named name: String) -> AnyGenUIWidget? {
+        widgetsByName[name]
+    }
+
+    /// True when `name` corresponds to a registered widget.
+    func isGenUIToolName(_ name: String) -> Bool {
+        widgetsByName[name] != nil
+    }
+
+    /// Build the OpenAI `tools` array used on chat completion requests.
+    func buildToolParams() -> [ChatQuery.ChatCompletionToolParam] {
+        widgets.map { widget in
+            ChatQuery.ChatCompletionToolParam(
+                function: .init(
+                    name: widget.name,
+                    description: widget.description,
+                    parameters: widget.schema,
+                    strict: nil
+                )
+            )
+        }
+    }
+
+    /// Build the system-prompt hint block describing all registered
+    /// widgets. Mirrors `buildGenUIPromptHint()` on the webapp side.
+    func buildPromptHint() -> String {
+        let header =
+            "You have render_* tools that produce rich interactive components instead " +
+            "of markdown. Prefer them whenever the content is structured (tables, " +
+            "charts, timelines, previews, comparisons, lists of sources, etc.). You " +
+            "may call multiple render tools in one response."
+        let lines = widgets.map { "- \($0.name): \($0.promptHint)" }
+        return header + "\n" + lines.joined(separator: "\n")
+    }
+}

--- a/TinfoilChat/Views/GenUI/GenUIStyle.swift
+++ b/TinfoilChat/Views/GenUI/GenUIStyle.swift
@@ -1,0 +1,141 @@
+//
+//  GenUIStyle.swift
+//  TinfoilChat
+//
+//  Shared SwiftUI styling primitives used across all GenUI widgets so the
+//  rendered components feel like a coherent set.
+
+import SwiftUI
+
+enum GenUIStyle {
+    static let cornerRadius: CGFloat = 12
+    static let smallCornerRadius: CGFloat = 8
+    static let chartHeight: CGFloat = 240
+
+    static func borderColor(_ isDarkMode: Bool) -> Color {
+        isDarkMode ? Color.white.opacity(0.15) : Color.black.opacity(0.12)
+    }
+
+    static func cardBackground(_ isDarkMode: Bool) -> Color {
+        isDarkMode ? Color.white.opacity(0.04) : Color.black.opacity(0.025)
+    }
+
+    static func subtleBackground(_ isDarkMode: Bool) -> Color {
+        isDarkMode ? Color.white.opacity(0.06) : Color.black.opacity(0.04)
+    }
+
+    static func primaryText(_ isDarkMode: Bool) -> Color {
+        isDarkMode ? Color.white : Color.black.opacity(0.9)
+    }
+
+    static func mutedText(_ isDarkMode: Bool) -> Color {
+        isDarkMode ? Color.white.opacity(0.6) : Color.black.opacity(0.55)
+    }
+
+    /// Default categorical palette mirroring the webapp's pie-chart palette.
+    static let palette: [Color] = [
+        Color(red: 0.23, green: 0.51, blue: 0.96), // blue
+        Color(red: 0.06, green: 0.72, blue: 0.51), // green
+        Color(red: 0.96, green: 0.62, blue: 0.04), // amber
+        Color(red: 0.94, green: 0.27, blue: 0.27), // red
+        Color(red: 0.55, green: 0.36, blue: 0.97), // violet
+        Color(red: 0.93, green: 0.28, blue: 0.60), // pink
+        Color(red: 0.02, green: 0.71, blue: 0.83), // cyan
+        Color(red: 0.98, green: 0.45, blue: 0.09), // orange
+    ]
+
+    static func paletteColor(_ index: Int) -> Color {
+        palette[((index % palette.count) + palette.count) % palette.count]
+    }
+
+    /// Default accent (matches webapp's `#3b82f6`).
+    static let accent: Color = Color(red: 0.23, green: 0.51, blue: 0.96)
+}
+
+/// Standard rounded card container used by most widgets.
+struct GenUICardModifier: ViewModifier {
+    let isDarkMode: Bool
+    var padding: CGFloat = 14
+
+    func body(content: Content) -> some View {
+        content
+            .padding(padding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                    .fill(GenUIStyle.cardBackground(isDarkMode))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                    .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+            )
+    }
+}
+
+extension View {
+    func genUICard(isDarkMode: Bool, padding: CGFloat = 14) -> some View {
+        modifier(GenUICardModifier(isDarkMode: isDarkMode, padding: padding))
+    }
+}
+
+/// Optional title row with consistent typography across widgets.
+struct GenUITitle: View {
+    let text: String
+    let isDarkMode: Bool
+
+    var body: some View {
+        Text(text)
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Renders a remote image URL with a placeholder. Uses `AsyncImage` (iOS 15+).
+struct GenUIRemoteImage: View {
+    let url: String
+    let isDarkMode: Bool
+    var contentMode: ContentMode = .fill
+
+    var body: some View {
+        if let parsed = URL(string: url), parsed.scheme?.lowercased() == "https" {
+            AsyncImage(url: parsed) { phase in
+                switch phase {
+                case .empty:
+                    Rectangle()
+                        .fill(GenUIStyle.subtleBackground(isDarkMode))
+                        .overlay(ProgressView().scaleEffect(0.7))
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: contentMode)
+                case .failure:
+                    Rectangle()
+                        .fill(GenUIStyle.subtleBackground(isDarkMode))
+                        .overlay(
+                            Image(systemName: "photo")
+                                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                        )
+                @unknown default:
+                    Rectangle().fill(GenUIStyle.subtleBackground(isDarkMode))
+                }
+            }
+        } else {
+            Rectangle()
+                .fill(GenUIStyle.subtleBackground(isDarkMode))
+                .overlay(
+                    Image(systemName: "photo")
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                )
+        }
+    }
+}
+
+/// Opens a URL only when its scheme is https or mailto — never `http://`,
+/// `file://`, `javascript:`, or other unsafe schemes the model could emit.
+enum GenUIURLOpener {
+    static func open(_ urlString: String) {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "mailto" else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/TinfoilChat/Views/GenUI/GenUIToolCallView.swift
+++ b/TinfoilChat/Views/GenUI/GenUIToolCallView.swift
@@ -1,0 +1,122 @@
+//
+//  GenUIToolCallView.swift
+//  TinfoilChat
+//
+//  Renders a single GenUI tool call inline in the chat. Mirrors the
+//  webapp's `GenUIToolCallRenderer`: while streaming, shows a tracer
+//  placeholder; once the assistant turn completes, swaps in the real
+//  widget. Input-surface widgets render through `GenUIInputAreaView`
+//  inside `MessageInputView` and produce a compact stamp here once
+//  resolved.
+
+import SwiftUI
+
+struct GenUIToolCallView: View {
+    let toolCall: GenUIToolCall
+    let isStreaming: Bool
+    let isDarkMode: Bool
+    let resolution: GenUIResolution?
+    let onRetry: (() -> Void)?
+
+    var body: some View {
+        let widget = GenUIRegistry.shared.widget(named: toolCall.name)
+        let parsed = parsedArgs()
+        let context = GenUIRenderContext(isDarkMode: isDarkMode)
+
+        // Input-surface widgets only show inline once they've been
+        // resolved; the live UI lives in the input area.
+        if widget?.surface == .input {
+            if let widget, let resolution, let data = parsed,
+               let resolvedView = widget.renderResolved(
+                rawArgs: data,
+                resolution: resolution,
+                context: context
+               ) {
+                return AnyView(resolvedView)
+            }
+            return AnyView(EmptyView())
+        }
+
+        if isStreaming {
+            return AnyView(streamingPlaceholder)
+        }
+
+        if let widget, let data = parsed,
+           let rendered = widget.renderInline(rawArgs: data, context: context) {
+            return AnyView(rendered)
+        }
+
+        // When the widget itself isn't registered on this client (e.g. a
+        // tool call recorded before the widget was added or after it was
+        // removed) defer to `UnsupportedGenUINoticeView`, which is rendered
+        // once per message at the bubble level.
+        if widget == nil {
+            return AnyView(EmptyView())
+        }
+
+        return AnyView(parseFailureCard)
+    }
+
+    private func parsedArgs() -> Data? {
+        guard !toolCall.arguments.isEmpty else { return nil }
+        guard let data = toolCall.arguments.data(using: .utf8) else { return nil }
+        // Validate it is at least a JSON object before handing to the widget.
+        guard let json = try? JSONSerialization.jsonObject(with: data),
+              json is [String: Any] else { return nil }
+        return data
+    }
+
+    @ViewBuilder
+    private var streamingPlaceholder: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(GenUIStyle.primaryText(isDarkMode))
+                .frame(width: 8, height: 8)
+                .opacity(0.7)
+            Text("Generating component")
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+            ProgressView().scaleEffect(0.7)
+            Spacer(minLength: 0)
+        }
+        .frame(height: 44)
+        .padding(.horizontal, 14)
+        .background(
+            RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius)
+                .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var parseFailureCard: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Couldn't display this widget")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                Text("The response didn't match the \(toolCall.name) widget's expected shape.")
+                    .font(.caption)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+            if let onRetry {
+                Button(action: onRetry) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise").font(.caption)
+                        Text("Try again").font(.caption.weight(.semibold))
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .genUICard(isDarkMode: isDarkMode, padding: 12)
+    }
+}

--- a/TinfoilChat/Views/GenUI/GenUIWidget.swift
+++ b/TinfoilChat/Views/GenUI/GenUIWidget.swift
@@ -1,0 +1,252 @@
+//
+//  GenUIWidget.swift
+//  TinfoilChat
+//
+//  Generative UI widget abstraction. Mirrors the webapp's `GenUIWidget` so
+//  widget definitions, tool-schema generation, runtime rendering, and the
+//  prompt-hint block stay in lockstep across platforms.
+
+import Foundation
+import OpenAI
+import SwiftUI
+
+/// Where a widget renders.
+///
+/// - `inline`: inside the assistant message body in the chat scroll.
+/// - `input`: replaces the `MessageInputView` until the user resolves it.
+enum GenUIWidgetSurface {
+    case inline
+    case input
+}
+
+/// Read-only context passed to inline-surface widgets.
+struct GenUIRenderContext {
+    let isDarkMode: Bool
+}
+
+/// Context passed to input-surface widgets. The widget calls `resolve` to
+/// submit a synthetic user message and `cancel` to dismiss without
+/// answering.
+struct GenUIInputContext {
+    let toolCallId: String
+    let isDarkMode: Bool
+    let resolve: (_ resultText: String, _ resultData: JSONValue?) -> Void
+    let cancel: (() -> Void)?
+}
+
+/// A single resolved choice for an input-surface widget. Mirrors the data
+/// the webapp passes to `widget.renderResolved(args, resolution)`. The
+/// canonical persisted shape lives on `TimelineToolCallBlock` (block-level
+/// `resolvedAt` + inner `resolution { text, data }`); see
+/// `TimelineToolCalls` for serialization helpers. This struct is the
+/// in-memory view used by widget render code.
+struct GenUIResolution: Equatable {
+    let text: String
+    let data: JSONValue?
+    let resolvedAt: Date
+
+    init(text: String, data: JSONValue?, resolvedAt: Date = Date()) {
+        self.text = text
+        self.data = data
+        self.resolvedAt = resolvedAt
+    }
+}
+
+/// Erased widget protocol used by the registry. Concrete widgets conform via
+/// `GenUIWidget` which adds typed `Args` decoding.
+protocol AnyGenUIWidget {
+    var name: String { get }
+    var description: String { get }
+    var schema: JSONSchema { get }
+    var surface: GenUIWidgetSurface { get }
+    var promptHint: String { get }
+
+    /// Returns true if `rawArgs` parse + validate against the widget's
+    /// schema. Used to decide whether to show a real widget or a parse
+    /// failure card.
+    func canRender(rawArgs: Data) -> Bool
+
+    /// Inline render. Widgets with `surface == .input` return `nil`.
+    @MainActor
+    func renderInline(rawArgs: Data, context: GenUIRenderContext) -> AnyView?
+
+    /// Input-area render. Widgets with `surface == .inline` return `nil`.
+    @MainActor
+    func renderInputArea(rawArgs: Data, context: GenUIInputContext) -> AnyView?
+
+    /// Compact stamp shown after the user resolves an input-surface widget.
+    /// Returning `nil` means the widget leaves no trace.
+    @MainActor
+    func renderResolved(rawArgs: Data, resolution: GenUIResolution, context: GenUIRenderContext) -> AnyView?
+}
+
+/// Typed widget definition. Implementations decode the streamed JSON into
+/// `Args` and render SwiftUI views with strong typing. Widgets are
+/// registered via `GenUIRegistry.shared`.
+protocol GenUIWidget: AnyGenUIWidget {
+    associatedtype Args: Decodable
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView?
+
+    @MainActor
+    func renderInputArea(args: Args, context: GenUIInputContext) -> AnyView?
+
+    @MainActor
+    func renderResolved(args: Args, resolution: GenUIResolution, context: GenUIRenderContext) -> AnyView?
+}
+
+extension GenUIWidget {
+    var surface: GenUIWidgetSurface { .inline }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? { nil }
+
+    @MainActor
+    func renderInputArea(args: Args, context: GenUIInputContext) -> AnyView? { nil }
+
+    @MainActor
+    func renderResolved(args: Args, resolution: GenUIResolution, context: GenUIRenderContext) -> AnyView? { nil }
+
+    func canRender(rawArgs: Data) -> Bool {
+        return decodeArgs(rawArgs) != nil
+    }
+
+    @MainActor
+    func renderInline(rawArgs: Data, context: GenUIRenderContext) -> AnyView? {
+        guard let args = decodeArgs(rawArgs) else { return nil }
+        return renderInline(args: args, context: context)
+    }
+
+    @MainActor
+    func renderInputArea(rawArgs: Data, context: GenUIInputContext) -> AnyView? {
+        guard let args = decodeArgs(rawArgs) else { return nil }
+        return renderInputArea(args: args, context: context)
+    }
+
+    @MainActor
+    func renderResolved(rawArgs: Data, resolution: GenUIResolution, context: GenUIRenderContext) -> AnyView? {
+        guard let args = decodeArgs(rawArgs) else { return nil }
+        return renderResolved(args: args, resolution: resolution, context: context)
+    }
+
+    private func decodeArgs(_ data: Data) -> Args? {
+        let decoder = JSONDecoder()
+        return try? decoder.decode(Args.self, from: data)
+    }
+}
+
+/// Helper for declaring an OpenAI function-tool JSON Schema in Swift using
+/// the fork's `JSONSchema` type. Mirrors the shape Zod produces in the
+/// webapp.
+enum GenUISchema {
+    static func object(
+        properties: [String: JSONSchema],
+        required: [String] = [],
+        description: String? = nil
+    ) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.object), .properties(properties)]
+        if !required.isEmpty {
+            fields.append(.required(required))
+        }
+        if let description {
+            fields.append(.description(description))
+        }
+        return JSONSchema(fields: fields)
+    }
+
+    static func string(description: String? = nil, enumValues: [String]? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.string)]
+        if let description { fields.append(.description(description)) }
+        if let enumValues { fields.append(.enumValues(enumValues)) }
+        return JSONSchema(fields: fields)
+    }
+
+    static func number(description: String? = nil, minimum: Double? = nil, maximum: Double? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.number)]
+        if let description { fields.append(.description(description)) }
+        if let minimum { fields.append(.minimum(minimum)) }
+        if let maximum { fields.append(.maximum(maximum)) }
+        return JSONSchema(fields: fields)
+    }
+
+    static func integer(description: String? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.integer)]
+        if let description { fields.append(.description(description)) }
+        return JSONSchema(fields: fields)
+    }
+
+    static func boolean(description: String? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.boolean)]
+        if let description { fields.append(.description(description)) }
+        return JSONSchema(fields: fields)
+    }
+
+    static func array(items: JSONSchema, description: String? = nil, minItems: Int? = nil, maxItems: Int? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.array), .items(items)]
+        if let description { fields.append(.description(description)) }
+        if let minItems { fields.append(.minItems(minItems)) }
+        if let maxItems { fields.append(.maxItems(maxItems)) }
+        return JSONSchema(fields: fields)
+    }
+
+    /// `string | number` union — used by widgets like StatCards / SportsData.
+    static func stringOrNumber(description: String? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [.type(.types(["string", "number"]))]
+        if let description { fields.append(.description(description)) }
+        return JSONSchema(fields: fields)
+    }
+
+    /// Object whose values are `string | number` and whose property names
+    /// are unconstrained. Mirrors the webapp's
+    /// `z.record(z.string(), z.union([z.string(), z.number()]))` shape used
+    /// by chart-row arrays.
+    static func openObjectOfStringOrNumber(description: String? = nil) -> JSONSchema {
+        var fields: [JSONSchemaField] = [
+            .type(.object),
+            .additionalProperties(stringOrNumber()),
+        ]
+        if let description { fields.append(.description(description)) }
+        return JSONSchema(fields: fields)
+    }
+}
+
+/// `Decodable` shim that accepts either a `String` or a numeric value and
+/// surfaces a `String`. Mirrors the webapp's `z.union([z.string(), z.number()])`
+/// idiom used by stats / sports-data fields.
+struct StringOrNumber: Codable, Equatable {
+    let stringValue: String
+    let isNumber: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let intValue = try? container.decode(Int.self) {
+            self.stringValue = String(intValue)
+            self.isNumber = true
+        } else if let doubleValue = try? container.decode(Double.self) {
+            // Render integers without trailing ".0".
+            if doubleValue.isFinite,
+               doubleValue >= Double(Int.min),
+               doubleValue <= Double(Int.max),
+               doubleValue.truncatingRemainder(dividingBy: 1) == 0 {
+                self.stringValue = String(Int(doubleValue))
+            } else {
+                self.stringValue = String(doubleValue)
+            }
+            self.isNumber = true
+        } else if let stringValue = try? container.decode(String.self) {
+            self.stringValue = stringValue
+            self.isNumber = false
+        } else {
+            throw DecodingError.typeMismatch(
+                StringOrNumber.self,
+                .init(codingPath: decoder.codingPath, debugDescription: "Expected String or Number")
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(stringValue)
+    }
+}

--- a/TinfoilChat/Views/GenUI/TimelineToolCalls.swift
+++ b/TinfoilChat/Views/GenUI/TimelineToolCalls.swift
@@ -1,0 +1,113 @@
+//
+//  TimelineToolCalls.swift
+//  TinfoilChat
+//
+//  Helpers for reading and writing GenUI tool-call blocks on the
+//  message timeline. The timeline is the cross-platform wire format
+//  the webapp persists on `Message.timeline`; this file keeps iOS in
+//  lockstep so chats round-trip cleanly between platforms.
+//
+//  Wire shape (per webapp `TimelineToolCallBlock`):
+//      {
+//        "type": "tool_call",
+//        "id": "tool-call-3",
+//        "toolCallId": "<provider-id>",
+//        "name": "render_chart",
+//        "arguments": "<accumulated JSON>",
+//        "resolvedAt": 1714060800000,                  // optional, ms epoch
+//        "resolution": { "text": "...", "data": ... } // optional
+//      }
+
+import Foundation
+
+enum TimelineToolCalls {
+    /// Reads the resolution off a tool_call block keyed by `toolCallId`.
+    /// Returns `nil` if the block isn't found or hasn't been resolved.
+    /// The timestamp lives at the block level (`resolvedAt`) on the
+    /// wire while `text` and `data` live in the inner `resolution`
+    /// object — this helper reunites them.
+    static func resolution(in timeline: [JSONValue]?, toolCallId: String) -> GenUIResolution? {
+        guard let timeline else { return nil }
+        for block in timeline {
+            guard let object = block.objectValue,
+                  object["type"]?.stringValue == "tool_call",
+                  object["toolCallId"]?.stringValue == toolCallId else { continue }
+            guard let resolvedAtMillis = object["resolvedAt"]?.numberValue else { return nil }
+            let inner = object["resolution"]?.objectValue ?? [:]
+            let text = inner["text"]?.stringValue ?? ""
+            return GenUIResolution(
+                text: text,
+                data: inner["data"],
+                resolvedAt: Date(timeIntervalSince1970: resolvedAtMillis / 1000.0)
+            )
+        }
+        return nil
+    }
+
+    /// Inserts or replaces the tool_call block for the given
+    /// `toolCallId` with the latest accumulated `arguments`. Blocks are
+    /// matched by `toolCallId`; new blocks are appended in stream order.
+    static func upsertStreamingBlock(
+        in timeline: inout [JSONValue],
+        toolCallId: String,
+        name: String,
+        arguments: String
+    ) {
+        let index = timeline.firstIndex { block in
+            guard let object = block.objectValue else { return false }
+            return object["type"]?.stringValue == "tool_call"
+                && object["toolCallId"]?.stringValue == toolCallId
+        }
+
+        if let index {
+            // Preserve any existing fields (e.g. id, resolvedAt) and only
+            // update the streaming arguments / name.
+            var existing = timeline[index].objectValue ?? [:]
+            existing["arguments"] = .string(arguments)
+            if !name.isEmpty { existing["name"] = .string(name) }
+            timeline[index] = .object(existing)
+            return
+        }
+
+        let block: [String: JSONValue] = [
+            "type": .string("tool_call"),
+            "id": .string("tool-call-\(timeline.count)"),
+            "toolCallId": .string(toolCallId),
+            "name": .string(name),
+            "arguments": .string(arguments),
+        ]
+        timeline.append(.object(block))
+    }
+
+    /// Marks the matching tool_call block as resolved by writing the
+    /// outer `resolvedAt` and the inner `resolution` object. Mirrors
+    /// the webapp's `TimelineBuilder.resolveToolCall` shape exactly.
+    static func resolve(
+        in timeline: inout [JSONValue],
+        toolCallId: String,
+        text: String,
+        data: JSONValue?,
+        at date: Date = Date()
+    ) {
+        let millis = date.timeIntervalSince1970 * 1000.0
+        for index in timeline.indices {
+            guard var object = timeline[index].objectValue,
+                  object["type"]?.stringValue == "tool_call",
+                  object["toolCallId"]?.stringValue == toolCallId else { continue }
+            object["resolvedAt"] = .number(millis)
+            var inner: [String: JSONValue] = ["text": .string(text)]
+            if let data { inner["data"] = data }
+            object["resolution"] = .object(inner)
+            timeline[index] = .object(object)
+            return
+        }
+    }
+}
+
+extension JSONValue {
+    /// Convenience accessor for numeric values.
+    var numberValue: Double? {
+        if case .number(let value) = self { return value }
+        return nil
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
@@ -1,0 +1,200 @@
+//
+//  ArtifactPreviewWidget.swift
+//  TinfoilChat
+//
+//  iOS rendering of the webapp's `render_artifact_preview` widget. The
+//  webapp version slides a full preview pane over the chat; the iOS
+//  version surfaces a tappable summary card that opens a sheet with the
+//  artifact contents (URL via in-app browser, HTML/markdown via plain
+//  text view).
+
+import OpenAI
+import SwiftUI
+
+struct ArtifactPreviewWidget: GenUIWidget {
+    enum SourceKind: String, Decodable { case url, html, markdown }
+
+    struct Source: Decodable {
+        let type: SourceKind
+        let url: String?
+        let html: String?
+        let markdown: String?
+    }
+
+    struct Args: Decodable {
+        let title: String?
+        let description: String?
+        let source: Source
+        let footer: String?
+    }
+
+    let name = "render_artifact_preview"
+    let description = "Display a visual artifact in a side panel: a hosted URL, a self-contained HTML snippet, or Markdown. Use for content worth inspecting at full size."
+    let promptHint = "large artifacts (markdown/html/url) opened in a side panel"
+
+    var schema: JSONSchema {
+        let urlSource = GenUISchema.object(
+            properties: [
+                "type": GenUISchema.string(enumValues: ["url"]),
+                "url": GenUISchema.string(),
+            ],
+            required: ["type", "url"]
+        )
+        let htmlSource = GenUISchema.object(
+            properties: [
+                "type": GenUISchema.string(enumValues: ["html"]),
+                "html": GenUISchema.string(),
+            ],
+            required: ["type", "html"]
+        )
+        let markdownSource = GenUISchema.object(
+            properties: [
+                "type": GenUISchema.string(enumValues: ["markdown"]),
+                "markdown": GenUISchema.string(),
+            ],
+            required: ["type", "markdown"]
+        )
+        let source = JSONSchema(fields: [.oneOf([urlSource, htmlSource, markdownSource])])
+        return GenUISchema.object(
+            properties: [
+                "title": GenUISchema.string(),
+                "description": GenUISchema.string(),
+                "source": source,
+                "footer": GenUISchema.string(),
+            ],
+            required: ["source"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(ArtifactPreviewView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct ArtifactPreviewView: View {
+    let args: ArtifactPreviewWidget.Args
+    let isDarkMode: Bool
+
+    @State private var showSheet: Bool = false
+
+    private var sourceLabel: String {
+        switch args.source.type {
+        case .url: return "Hosted preview"
+        case .html: return "HTML artifact"
+        case .markdown: return "Markdown artifact"
+        }
+    }
+
+    var body: some View {
+        Button(action: openArtifact) {
+            HStack(spacing: 12) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 22, weight: .regular))
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(args.title ?? sourceLabel)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        .lineLimit(1)
+                    Text(args.description ?? sourceLabel)
+                        .font(.caption)
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+            .genUICard(isDarkMode: isDarkMode, padding: 14)
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showSheet) {
+            ArtifactDetailSheet(args: args, isDarkMode: isDarkMode)
+        }
+    }
+
+    private func openArtifact() {
+        if args.source.type == .url, let url = args.source.url {
+            GenUIURLOpener.open(url)
+        } else {
+            showSheet = true
+        }
+    }
+}
+
+private struct ArtifactDetailSheet: View {
+    let args: ArtifactPreviewWidget.Args
+    let isDarkMode: Bool
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let description = args.description, !description.isEmpty {
+                        Text(description)
+                            .font(.subheadline)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    }
+                    Divider()
+                    contentBody
+                    if let footer = args.footer, !footer.isEmpty {
+                        Divider()
+                        Text(footer)
+                            .font(.caption)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle(args.title ?? "Artifact")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentBody: some View {
+        switch args.source.type {
+        case .markdown:
+            if let markdown = args.source.markdown {
+                if let attributed = try? AttributedString(markdown: markdown) {
+                    Text(attributed)
+                        .font(.body)
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                } else {
+                    Text(markdown)
+                        .font(.body)
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                }
+            }
+        case .html:
+            if let html = args.source.html {
+                Text(html)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .url:
+            if let url = args.source.url {
+                Button(action: { GenUIURLOpener.open(url) }) {
+                    Text(url)
+                        .font(.subheadline)
+                        .underline()
+                        .foregroundColor(GenUIStyle.accent)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/ChartWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ChartWidget.swift
@@ -1,0 +1,371 @@
+//
+//  ChartWidget.swift
+//  TinfoilChat
+//
+//  Unified chart widget. Renders a bar / line / pie chart from tabular
+//  data driven by an explicit `type` field, mirroring the webapp's
+//  `render_chart` widget.
+
+import Charts
+import OpenAI
+import SwiftUI
+
+/// A `Decodable` shim that captures arbitrary `[String: String|Number]`
+/// dictionaries as `JSONValue` so chart widgets can decode the shape the
+/// model emits without locking down property names.
+struct ChartRow: Decodable {
+    let values: [String: JSONValue]
+
+    init(from decoder: Decoder) throws {
+        let raw = try JSONValue(from: decoder)
+        if case .object(let dict) = raw {
+            self.values = dict
+        } else {
+            self.values = [:]
+        }
+    }
+
+    func string(_ key: String) -> String? {
+        guard let value = values[key] else { return nil }
+        switch value {
+        case .string(let s): return s
+        case .number(let n):
+            if n.isFinite,
+               n >= Double(Int.min),
+               n <= Double(Int.max),
+               n.truncatingRemainder(dividingBy: 1) == 0 {
+                return String(Int(n))
+            }
+            return String(n)
+        default: return nil
+        }
+    }
+
+    func double(_ key: String) -> Double? {
+        guard let value = values[key] else { return nil }
+        switch value {
+        case .number(let n): return n
+        case .string(let s): return Double(s)
+        default: return nil
+        }
+    }
+
+    var allKeys: [String] { Array(values.keys) }
+
+    func isString(_ key: String) -> Bool {
+        if case .string = values[key] { return true }
+        return false
+    }
+
+    func isNumber(_ key: String) -> Bool {
+        if case .number = values[key] { return true }
+        return false
+    }
+}
+
+/// Picks an x/y key pair, preferring caller hints, then the first
+/// string/number columns. Mirrors the webapp's `inferChartKeys`.
+func inferChartKeys(_ rows: [ChartRow], preferredX: String?, preferredY: String?) -> (x: String, y: String) {
+    let firstKeys = rows.first?.allKeys ?? []
+    var allKeys: [String] = []
+    var seen: Set<String> = []
+    for row in rows {
+        for key in row.allKeys where !seen.contains(key) {
+            seen.insert(key)
+            allKeys.append(key)
+        }
+    }
+    let order = firstKeys + allKeys.filter { !firstKeys.contains($0) }
+
+    var x = preferredX.flatMap { allKeys.contains($0) ? $0 : nil }
+    var y = preferredY.flatMap { allKeys.contains($0) ? $0 : nil }
+    if x == nil {
+        x = order.first(where: { key in rows.contains(where: { $0.isString(key) }) }) ?? order.first
+    }
+    if y == nil {
+        y = order.first(where: { key in
+            key != x && rows.contains(where: { $0.isNumber(key) })
+        })
+    }
+    if y == nil {
+        y = order.first(where: { $0 != x }) ?? order.first
+    }
+    return (x ?? "label", y ?? "value")
+}
+
+func parseHex(_ hex: String?) -> Color? {
+    guard let hex = hex?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+    let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+    guard cleaned.count == 6 || cleaned.count == 8 else { return nil }
+    var rgba: UInt64 = 0
+    guard Scanner(string: cleaned).scanHexInt64(&rgba) else { return nil }
+    let r, g, b, a: Double
+    if cleaned.count == 8 {
+        r = Double((rgba >> 24) & 0xFF) / 255.0
+        g = Double((rgba >> 16) & 0xFF) / 255.0
+        b = Double((rgba >> 8) & 0xFF) / 255.0
+        a = Double(rgba & 0xFF) / 255.0
+    } else {
+        r = Double((rgba >> 16) & 0xFF) / 255.0
+        g = Double((rgba >> 8) & 0xFF) / 255.0
+        b = Double(rgba & 0xFF) / 255.0
+        a = 1.0
+    }
+    return Color(.sRGB, red: r, green: g, blue: b, opacity: a)
+}
+
+private let maxVisibleXAxisLabels = 6
+
+private func visibleXAxisLabels(_ labels: [String]) -> [String] {
+    guard labels.count > maxVisibleXAxisLabels else { return labels }
+    let stride = Int(ceil(Double(labels.count) / Double(maxVisibleXAxisLabels)))
+    var selected: [String] = []
+    for (index, label) in labels.enumerated() where index % stride == 0 {
+        selected.append(label)
+    }
+    if let last = labels.last, selected.last != last {
+        selected.append(last)
+    }
+    return selected
+}
+
+private func compactXAxisLabel(_ label: String) -> String {
+    let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count > 10 else { return trimmed }
+    return String(trimmed.prefix(9)) + "…"
+}
+
+struct ChartWidget: GenUIWidget {
+    enum ChartKind: String, Decodable {
+        case bar
+        case line
+        case pie
+    }
+
+    struct Args: Decodable {
+        let type: ChartKind
+        let data: [ChartRow]
+        let xKey: String?
+        let yKey: String?
+        let title: String?
+        let color: String?
+    }
+
+    let name = "render_chart"
+    let description = """
+        Render a chart from tabular data. Choose `type`: "bar" for categorical \
+        comparisons, "line" for trends or sequences over time, "pie" for \
+        proportions / parts of a whole.
+        """
+    let promptHint = "a chart from tabular data — pass type \"bar\" | \"line\" | \"pie\" depending on whether you are comparing categories, showing a trend, or showing parts of a whole"
+
+    var schema: JSONSchema {
+        GenUISchema.object(
+            properties: [
+                "type": GenUISchema.string(
+                    description: "Chart type. \"bar\" for categorical comparisons, \"line\" for trends or sequences, \"pie\" for parts of a whole.",
+                    enumValues: ["bar", "line", "pie"]
+                ),
+                "data": GenUISchema.array(
+                    items: GenUISchema.openObjectOfStringOrNumber(),
+                    description: "Data points sharing the same keys, e.g. [{\"label\":\"A\",\"value\":10}, ...]",
+                    minItems: 1
+                ),
+                "xKey": GenUISchema.string(description: "For bar/line: key for the category axis. For pie: key for slice names."),
+                "yKey": GenUISchema.string(description: "For bar/line: key for the numeric axis. For pie: key for slice values."),
+                "title": GenUISchema.string(),
+                "color": GenUISchema.string(description: "Primary series color hex string (bar/line). Pie slices use a built-in palette."),
+            ],
+            required: ["type", "data"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        switch args.type {
+        case .bar:
+            return AnyView(BarChartView(args: args, isDarkMode: context.isDarkMode))
+        case .line:
+            return AnyView(LineChartView(args: args, isDarkMode: context.isDarkMode))
+        case .pie:
+            return AnyView(PieChartView(args: args, isDarkMode: context.isDarkMode))
+        }
+    }
+}
+
+private struct ChartEntry: Identifiable {
+    let id: Int
+    let label: String
+    let value: Double
+}
+
+/// Shared categorical X-axis modifier so bar and line charts use the
+/// same downsampling and label formatting.
+private struct CategoricalXAxisModifier: ViewModifier {
+    let labels: [String]
+
+    func body(content: Content) -> some View {
+        content
+            .chartXAxis {
+                AxisMarks(values: visibleXAxisLabels(labels)) { value in
+                    AxisGridLine()
+                    AxisTick()
+                    AxisValueLabel {
+                        if let label = value.as(String.self) {
+                            Text(compactXAxisLabel(label))
+                                .font(.caption2)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+    }
+}
+
+private extension View {
+    func categoricalXAxis(labels: [String]) -> some View {
+        modifier(CategoricalXAxisModifier(labels: labels))
+    }
+}
+
+private func resolvedChartEntries(_ args: ChartWidget.Args) -> (entries: [ChartEntry], keys: (x: String, y: String)) {
+    let keys = inferChartKeys(args.data, preferredX: args.xKey, preferredY: args.yKey)
+    let entries: [ChartEntry] = args.data
+        .enumerated()
+        .compactMap { index, row in
+            guard let label = row.string(keys.x) ?? row.string(row.allKeys.first ?? "") else { return nil }
+            guard let value = row.double(keys.y) else { return nil }
+            return ChartEntry(id: index, label: label, value: value)
+        }
+    return (entries, keys)
+}
+
+private struct BarChartView: View {
+    let args: ChartWidget.Args
+    let isDarkMode: Bool
+
+    var body: some View {
+        let resolved = resolvedChartEntries(args)
+        let color = parseHex(args.color) ?? GenUIStyle.accent
+
+        VStack(alignment: .leading, spacing: 8) {
+            if let title = args.title, !title.isEmpty {
+                GenUITitle(text: title, isDarkMode: isDarkMode)
+            }
+
+            Chart(resolved.entries) { entry in
+                BarMark(
+                    x: .value(resolved.keys.x, entry.label),
+                    y: .value(resolved.keys.y, entry.value)
+                )
+                .foregroundStyle(color)
+                .cornerRadius(4)
+            }
+            .categoricalXAxis(labels: resolved.entries.map(\.label))
+            .frame(height: GenUIStyle.chartHeight)
+        }
+        .genUICard(isDarkMode: isDarkMode)
+    }
+}
+
+private struct LineChartView: View {
+    let args: ChartWidget.Args
+    let isDarkMode: Bool
+
+    var body: some View {
+        let resolved = resolvedChartEntries(args)
+        let color = parseHex(args.color) ?? GenUIStyle.accent
+
+        VStack(alignment: .leading, spacing: 8) {
+            if let title = args.title, !title.isEmpty {
+                GenUITitle(text: title, isDarkMode: isDarkMode)
+            }
+
+            Chart(resolved.entries) { entry in
+                LineMark(
+                    x: .value(resolved.keys.x, entry.label),
+                    y: .value(resolved.keys.y, entry.value)
+                )
+                .foregroundStyle(color)
+                .interpolationMethod(.monotone)
+
+                PointMark(
+                    x: .value(resolved.keys.x, entry.label),
+                    y: .value(resolved.keys.y, entry.value)
+                )
+                .foregroundStyle(color)
+                .symbolSize(40)
+            }
+            .categoricalXAxis(labels: resolved.entries.map(\.label))
+            .frame(height: GenUIStyle.chartHeight)
+        }
+        .genUICard(isDarkMode: isDarkMode)
+    }
+}
+
+private struct PieChartView: View {
+    let args: ChartWidget.Args
+    let isDarkMode: Bool
+
+    private struct Slice: Identifiable {
+        let id: Int
+        let name: String
+        let value: Double
+    }
+
+    var body: some View {
+        let keys = inferChartKeys(args.data, preferredX: args.xKey, preferredY: args.yKey)
+        let slices: [Slice] = args.data
+            .enumerated()
+            .compactMap { index, row in
+                guard let name = row.string(keys.x) ?? row.string(row.allKeys.first ?? "") else { return nil }
+                guard let value = row.double(keys.y), value > 0 else { return nil }
+                return Slice(id: index, name: name, value: value)
+            }
+        let total = slices.reduce(0) { $0 + $1.value }
+
+        VStack(alignment: .leading, spacing: 8) {
+            if let title = args.title, !title.isEmpty {
+                GenUITitle(text: title, isDarkMode: isDarkMode)
+            }
+
+            HStack(alignment: .center, spacing: 12) {
+                Chart(slices) { slice in
+                    SectorMark(
+                        angle: .value(keys.y, slice.value),
+                        innerRadius: .ratio(0.55),
+                        angularInset: 1.5
+                    )
+                    .foregroundStyle(GenUIStyle.paletteColor(slice.id))
+                    .cornerRadius(2)
+                }
+                .frame(width: 180, height: 180)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(slices) { slice in
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(GenUIStyle.paletteColor(slice.id))
+                                .frame(width: 8, height: 8)
+                            Text(slice.name)
+                                .font(.caption)
+                                .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                                .lineLimit(1)
+                            Spacer(minLength: 4)
+                            Text(percentLabel(slice.value, total: total))
+                                .font(.caption.weight(.medium))
+                                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                        }
+                    }
+                }
+            }
+        }
+        .genUICard(isDarkMode: isDarkMode)
+    }
+
+    private func percentLabel(_ value: Double, total: Double) -> String {
+        guard total > 0 else { return "0%" }
+        let pct = Int(((value / total) * 100).rounded())
+        return "\(pct)%"
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
@@ -1,0 +1,648 @@
+//
+//  ClockWidget.swift
+//  TinfoilChat
+//
+//  Unified clock widget. Displays either a live analog clock or a
+//  countdown timer driven by `mode`. Mirrors the webapp's `render_clock`
+//  widget.
+
+import AVFoundation
+import OpenAI
+import SwiftUI
+import UIKit
+
+private let minTimerSeconds: Double = 1
+private let maxTimerSeconds: Double = 604_800
+
+struct ClockWidget: GenUIWidget {
+    enum ClockMode: String, Decodable {
+        case clock
+        case timer
+    }
+
+    struct Args: Decodable {
+        let mode: ClockMode?
+        let label: String?
+        let title: String?
+        let description: String?
+        let timeZone: String?
+        let showSeconds: Bool?
+        let showDate: Bool?
+        let durationSeconds: Double?
+        let target: String?
+        let completedMessage: String?
+        let alarmMode: String?
+    }
+
+    let name = "render_clock"
+    let description = """
+        Display either a live analog clock (mode "clock") or an interactive \
+        countdown timer (mode "timer"). Use "clock" for the current time in a \
+        time zone. Use "timer" for "set a 5 minute timer", reminders, breaks, \
+        workouts, cooking, etc.
+        """
+    let promptHint = "a live analog clock OR a countdown timer — pass mode \"clock\" with optional timeZone for time display, or mode \"timer\" with durationSeconds (or target ISO date) for countdowns"
+
+    var schema: JSONSchema {
+        GenUISchema.object(
+            properties: [
+                "mode": GenUISchema.string(
+                    description: "What to display. \"clock\" shows the current time as an analog face. \"timer\" counts down from a duration or to a target time. Defaults to \"clock\".",
+                    enumValues: ["clock", "timer"]
+                ),
+                "label": GenUISchema.string(description: "Short label, e.g. \"New York\" for a clock or \"Tea\" for a timer."),
+                "title": GenUISchema.string(description: "Main title (timer mode)"),
+                "description": GenUISchema.string(description: "Optional description"),
+                "timeZone": GenUISchema.string(description: "Clock mode only. IANA time zone, e.g. \"America/New_York\". Defaults to local."),
+                "showSeconds": GenUISchema.boolean(description: "Clock mode: include the second hand (default true)."),
+                "showDate": GenUISchema.boolean(description: "Clock mode: include date line (default true)."),
+                "durationSeconds": GenUISchema.number(
+                    description: "Timer mode. Duration in seconds. Prefer for requests like \"set a 5 minute timer\".",
+                    minimum: minTimerSeconds,
+                    maximum: maxTimerSeconds
+                ),
+                "target": GenUISchema.string(description: "Timer mode. ISO date-time when the timer should end."),
+                "completedMessage": GenUISchema.string(description: "Timer mode. Message shown when the timer finishes."),
+                "alarmMode": GenUISchema.string(
+                    description: "Timer mode. Alarm behavior when done. \"sound\" beeps; \"flash\" stays silent and flashes visually. Defaults to sound.",
+                    enumValues: ["sound", "flash"]
+                ),
+            ]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        let resolved = resolveMode(args)
+        switch resolved {
+        case .timer:
+            return AnyView(CountdownView(args: args, isDarkMode: context.isDarkMode))
+        case .clock:
+            return AnyView(ClockFaceView(args: args, isDarkMode: context.isDarkMode))
+        }
+    }
+
+    private func resolveMode(_ args: Args) -> ClockMode {
+        if let mode = args.mode { return mode }
+        if let duration = args.durationSeconds, duration > 0 { return .timer }
+        if let target = args.target, !target.isEmpty { return .timer }
+        return .clock
+    }
+}
+
+// MARK: - Clock face
+
+private struct ClockFaceView: View {
+    let args: ClockWidget.Args
+    let isDarkMode: Bool
+
+    private var timeZone: TimeZone {
+        if let id = args.timeZone, let zone = TimeZone(identifier: id) { return zone }
+        return TimeZone.current
+    }
+
+    private var showSeconds: Bool { args.showSeconds ?? true }
+    private var showDate: Bool { args.showDate ?? true }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let label = args.label, !label.isEmpty {
+                Text(label.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .tracking(1.0)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+
+            TimelineView(.animation(minimumInterval: showSeconds ? 0.05 : 1.0, paused: false)) { context in
+                let date = context.date
+                ClockDial(date: date, timeZone: timeZone, showSeconds: showSeconds, isDarkMode: isDarkMode)
+                    .frame(width: 160, height: 160)
+            }
+
+            TimelineView(.periodic(from: .now, by: 1.0)) { context in
+                VStack(spacing: 2) {
+                    Text(timeString(for: context.date))
+                        .font(.title3.weight(.semibold).monospacedDigit())
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                    if showDate {
+                        Text(dateString(for: context.date))
+                            .font(.caption)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .genUICard(isDarkMode: isDarkMode, padding: 16)
+    }
+
+    private func timeString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.dateFormat = showSeconds ? "HH:mm:ss" : "HH:mm"
+        return formatter.string(from: date)
+    }
+
+    private func dateString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "EEE, MMM d, yyyy"
+        let zoneSuffix = args.timeZone.map { " \u{00B7} \($0)" } ?? ""
+        return formatter.string(from: date) + zoneSuffix
+    }
+}
+
+private struct ClockDial: View {
+    let date: Date
+    let timeZone: TimeZone
+    let showSeconds: Bool
+    let isDarkMode: Bool
+
+    var body: some View {
+        GeometryReader { geo in
+            let size = min(geo.size.width, geo.size.height)
+            let center = CGPoint(x: size / 2, y: size / 2)
+            let radius = size / 2 - 4
+
+            ZStack {
+                Circle()
+                    .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                    .frame(width: radius * 2, height: radius * 2)
+                    .position(center)
+
+                ForEach(0..<60, id: \.self) { tick in
+                    tickMark(tick: tick, center: center, radius: radius)
+                }
+
+                ForEach(1...12, id: \.self) { hour in
+                    let angle = Angle.degrees(Double(hour) * 30 - 90)
+                    let pos = polar(center: center, radius: radius - 16, angle: angle)
+                    Text("\(hour)")
+                        .font(.caption.weight(.semibold).monospacedDigit())
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        .position(pos)
+                }
+
+                let parts = timeParts(for: date)
+                let hourAngle = ((Double(parts.hour % 12) + parts.minute / 60.0 + parts.second / 3600.0) * 30) - 90
+                let minuteAngle = ((parts.minute + parts.second / 60.0) * 6) - 90
+                let secondAngle = (parts.second * 6) - 90
+
+                hand(center: center, length: radius - 55, angle: .degrees(hourAngle), width: 4,
+                     color: GenUIStyle.primaryText(isDarkMode))
+                hand(center: center, length: radius - 25, angle: .degrees(minuteAngle), width: 2.5,
+                     color: GenUIStyle.primaryText(isDarkMode))
+                if showSeconds {
+                    hand(center: center, length: radius - 18, angle: .degrees(secondAngle), width: 1.5,
+                         color: .red)
+                }
+
+                Circle()
+                    .fill(GenUIStyle.primaryText(isDarkMode))
+                    .frame(width: 7, height: 7)
+                    .position(center)
+                if showSeconds {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 3, height: 3)
+                        .position(center)
+                }
+            }
+        }
+    }
+
+    private func tickMark(tick: Int, center: CGPoint, radius: CGFloat) -> some View {
+        let isMajor = tick % 5 == 0
+        let inner = isMajor ? radius - 10 : radius - 5
+        let outer = radius - 2
+        let angle = Angle.degrees(Double(tick) * 6 - 90)
+        let p1 = polar(center: center, radius: inner, angle: angle)
+        let p2 = polar(center: center, radius: outer, angle: angle)
+
+        return Path { path in
+            path.move(to: p1)
+            path.addLine(to: p2)
+        }
+        .stroke(
+            GenUIStyle.primaryText(isDarkMode).opacity(isMajor ? 0.7 : 0.25),
+            style: StrokeStyle(lineWidth: isMajor ? 2 : 1, lineCap: .round)
+        )
+    }
+
+    private func hand(center: CGPoint, length: CGFloat, angle: Angle, width: CGFloat, color: Color) -> some View {
+        let end = polar(center: center, radius: length, angle: angle)
+        return Path { path in
+            path.move(to: center)
+            path.addLine(to: end)
+        }
+        .stroke(color, style: StrokeStyle(lineWidth: width, lineCap: .round))
+    }
+
+    private func polar(center: CGPoint, radius: CGFloat, angle: Angle) -> CGPoint {
+        CGPoint(
+            x: center.x + radius * CGFloat(cos(angle.radians)),
+            y: center.y + radius * CGFloat(sin(angle.radians))
+        )
+    }
+
+    private func timeParts(for date: Date) -> (hour: Int, minute: Double, second: Double) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let components = calendar.dateComponents([.hour, .minute, .second, .nanosecond], from: date)
+        let hour = components.hour ?? 0
+        let minute = Double(components.minute ?? 0)
+        let nano = Double(components.nanosecond ?? 0) / 1_000_000_000
+        let second = Double(components.second ?? 0) + nano
+        return (hour, minute, second)
+    }
+}
+
+// MARK: - Countdown timer
+
+/// Repeats a synthesized sine-tone beep + haptic at a fixed cadence until
+/// stopped. The webapp uses WebAudio to synthesize a short tone every
+/// ~850ms; on iOS we synthesize the same tone in-process and play it via
+/// `AVAudioPlayer` over a `.playback` audio session so the alarm remains
+/// audible even when the silent switch is on. Haptic feedback fires in
+/// lockstep so the alarm is felt and heard.
+@MainActor
+private final class TimerAlarmController: ObservableObject {
+    private static let beepIntervalSeconds: TimeInterval = 0.85
+    private static let beepFrequencyHz: Double = 880
+    private static let beepDurationSeconds: Double = 0.18
+    private static let beepSampleRate: Double = 44_100
+
+    private var timer: Timer?
+    private var audioPlayer: AVAudioPlayer?
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+    private let impactGenerator = UIImpactFeedbackGenerator(style: .heavy)
+
+    func start(mode: TimerAlarmMode) {
+        stop()
+        notificationGenerator.prepare()
+        impactGenerator.prepare()
+        // `.playback` category lets the alarm play even when the silent
+        // switch is on. Mix politely with any audio the user has playing.
+        try? AVAudioSession.sharedInstance().setCategory(
+            .playback,
+            mode: .default,
+            options: [.mixWithOthers, .duckOthers]
+        )
+        try? AVAudioSession.sharedInstance().setActive(true, options: [])
+
+        if mode == .sound {
+            audioPlayer = Self.makeBeepPlayer()
+            audioPlayer?.prepareToPlay()
+        }
+
+        // Fire one immediately so the user gets feedback right when the
+        // timer hits zero, then continue at a steady cadence.
+        fire(mode: mode)
+        timer = Timer.scheduledTimer(
+            withTimeInterval: Self.beepIntervalSeconds,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.fire(mode: mode)
+            }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        audioPlayer?.stop()
+        audioPlayer = nil
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    }
+
+    private func fire(mode: TimerAlarmMode) {
+        // Strong haptic feedback for both modes; only the beep is muted
+        // when the model asks for a silent flash alarm.
+        notificationGenerator.notificationOccurred(.warning)
+        impactGenerator.impactOccurred()
+        if mode == .sound, let player = audioPlayer {
+            player.currentTime = 0
+            player.play()
+        }
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    private static func makeBeepPlayer() -> AVAudioPlayer? {
+        let sampleCount = Int(beepDurationSeconds * beepSampleRate)
+        let fadeSamples = max(1, Int(0.01 * beepSampleRate))
+        var samples = [Int16](repeating: 0, count: sampleCount)
+        for i in 0..<sampleCount {
+            let envelope: Double
+            if i < fadeSamples {
+                envelope = Double(i) / Double(fadeSamples)
+            } else if i > sampleCount - fadeSamples {
+                envelope = Double(sampleCount - i) / Double(fadeSamples)
+            } else {
+                envelope = 1
+            }
+            let phase = 2.0 * .pi * beepFrequencyHz * Double(i) / beepSampleRate
+            let value = sin(phase) * envelope * 0.6
+            samples[i] = Int16(max(-1.0, min(1.0, value)) * Double(Int16.max))
+        }
+        var data = Data()
+        data.append(contentsOf: Array("RIFF".utf8))
+        let dataByteCount = UInt32(samples.count * MemoryLayout<Int16>.size)
+        data.append(contentsOf: uint32LE(36 + dataByteCount))
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        data.append(contentsOf: uint32LE(16))
+        data.append(contentsOf: uint16LE(1))
+        data.append(contentsOf: uint16LE(1))
+        data.append(contentsOf: uint32LE(UInt32(beepSampleRate)))
+        data.append(contentsOf: uint32LE(UInt32(beepSampleRate) * 2))
+        data.append(contentsOf: uint16LE(2))
+        data.append(contentsOf: uint16LE(16))
+        data.append(contentsOf: Array("data".utf8))
+        data.append(contentsOf: uint32LE(dataByteCount))
+        samples.withUnsafeBufferPointer { buffer in
+            if let base = buffer.baseAddress {
+                data.append(
+                    Data(
+                        bytes: base,
+                        count: buffer.count * MemoryLayout<Int16>.size
+                    )
+                )
+            }
+        }
+        return try? AVAudioPlayer(data: data)
+    }
+
+    private static func uint32LE(_ value: UInt32) -> [UInt8] {
+        [
+            UInt8(value & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 24) & 0xFF),
+        ]
+    }
+
+    private static func uint16LE(_ value: UInt16) -> [UInt8] {
+        [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)]
+    }
+}
+
+private enum TimerAlarmMode: String {
+    case sound
+    case flash
+
+    init(rawArg: String?) {
+        switch rawArg?.lowercased() {
+        case "flash": self = .flash
+        default: self = .sound
+        }
+    }
+}
+
+private struct CountdownView: View {
+    let args: ClockWidget.Args
+    let isDarkMode: Bool
+
+    @State private var endDate: Date = Date()
+    @State private var totalDuration: TimeInterval = 0
+    @State private var isPaused: Bool = true
+    @State private var pausedRemaining: TimeInterval = 0
+    @State private var hasStarted: Bool = false
+    @State private var dismissed: Bool = false
+    @State private var alarmActive: Bool = false
+    @State private var flashOn: Bool = false
+    @State private var hasConfigured: Bool = false
+    @StateObject private var alarm = TimerAlarmController()
+
+    private static let accent: Color = Color(red: 0.96, green: 0.70, blue: 0.29)
+
+    private var alarmMode: TimerAlarmMode {
+        TimerAlarmMode(rawArg: args.alarmMode)
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let title = args.title ?? args.label, !title.isEmpty {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+            } else {
+                Text("Timer")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+            }
+            if let description = args.description, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    .multilineTextAlignment(.center)
+            }
+
+            TimelineView(.periodic(from: .now, by: 0.25)) { context in
+                let remaining = currentRemaining(at: context.date)
+                let progress = max(0, min(1, remaining / max(totalDuration, 1)))
+                let finishedNow = remaining <= 0 && hasStarted && !dismissed
+                let triggerAlarm = finishedNow && !alarmActive
+
+                ZStack {
+                    Circle()
+                        .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 8)
+                    Circle()
+                        .trim(from: 0, to: CGFloat(progress))
+                        .stroke(Self.accent, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                        .rotationEffect(.degrees(-90))
+                        .animation(.linear(duration: 0.25), value: progress)
+                    Text(formatRemaining(max(0, remaining)))
+                        .font(.system(size: 36, weight: .light, design: .monospaced))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                }
+                .frame(width: 200, height: 200)
+                .opacity(finishedNow && alarmMode == .flash && !flashOn ? 0.4 : 1.0)
+                .onChange(of: triggerAlarm) { _, shouldStart in
+                    if shouldStart { startAlarm() }
+                }
+            }
+
+            if isFinished() && hasStarted {
+                Text(finishedLabel())
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Self.accent)
+                    .multilineTextAlignment(.center)
+            }
+
+            if isFinished() && hasStarted {
+                Button(action: handlePrimary) {
+                    Text(primaryLabel())
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .foregroundColor(.black)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Self.accent)
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 4)
+            } else {
+                HStack(spacing: 12) {
+                    Button(action: handleSecondary) {
+                        Text(secondaryLabel())
+                            .font(.subheadline.weight(.semibold))
+                            .frame(width: 80, height: 80)
+                            .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                            .background(
+                                Circle().fill(GenUIStyle.subtleBackground(isDarkMode))
+                            )
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: handlePrimary) {
+                        Text(primaryLabel())
+                            .font(.subheadline.weight(.semibold))
+                            .frame(width: 80, height: 80)
+                            .foregroundColor(.black)
+                            .background(Circle().fill(Self.accent))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity)
+        .genUICard(isDarkMode: isDarkMode, padding: 0)
+        .onAppear(perform: configure)
+        .onDisappear { alarm.stop() }
+    }
+
+    private func configure() {
+        // `onAppear` fires every time the cell scrolls back into view in
+        // a lazy container; preserve any running countdown state by only
+        // initializing once per view lifetime.
+        guard !hasConfigured else { return }
+        hasConfigured = true
+        if let duration = args.durationSeconds, duration > 0 {
+            totalDuration = duration
+            pausedRemaining = duration
+            endDate = Date().addingTimeInterval(duration)
+            isPaused = true
+            hasStarted = false
+        } else if let targetString = args.target,
+                  let target = ISO8601DateFormatter().date(from: targetString) {
+            let interval = target.timeIntervalSinceNow
+            totalDuration = max(1, interval)
+            pausedRemaining = max(0, interval)
+            endDate = target
+            isPaused = false
+            hasStarted = true
+        }
+    }
+
+    private func currentRemaining(at date: Date) -> TimeInterval {
+        if isPaused { return pausedRemaining }
+        return max(0, endDate.timeIntervalSince(date))
+    }
+
+    private func isFinished() -> Bool {
+        currentRemaining(at: Date()) <= 0
+    }
+
+    private func formatRemaining(_ value: TimeInterval) -> String {
+        let total = Int(ceil(value))
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if hours > 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    private func finishedLabel() -> String {
+        args.completedMessage ?? "Time's up"
+    }
+
+    private func handlePrimary() {
+        // While the alarm is sounding the primary button silences it and
+        // marks the run as dismissed, so the user has a single obvious tap
+        // target to make the noise stop without losing the timer.
+        if alarmActive {
+            stopAlarm()
+            dismissed = true
+            return
+        }
+        if isFinished() {
+            // Past the deadline with no alarm running (e.g. tabbed away);
+            // tapping primary just resets the timer so it can run again.
+            resetTimer()
+            return
+        }
+        if isPaused {
+            endDate = Date().addingTimeInterval(pausedRemaining)
+            isPaused = false
+            hasStarted = true
+        } else {
+            pausedRemaining = max(0, endDate.timeIntervalSinceNow)
+            isPaused = true
+        }
+    }
+
+    private func handleSecondary() {
+        // The secondary button is always a "back to the start" action so a
+        // finished timer can be restarted instead of getting stuck on a
+        // dead "Done" button.
+        if alarmActive { stopAlarm() }
+        resetTimer()
+    }
+
+    private func resetTimer() {
+        if let duration = args.durationSeconds, duration > 0 {
+            totalDuration = duration
+            pausedRemaining = duration
+            endDate = Date().addingTimeInterval(duration)
+            isPaused = true
+            hasStarted = false
+            dismissed = false
+        } else if let targetString = args.target,
+                  let target = ISO8601DateFormatter().date(from: targetString) {
+            let interval = target.timeIntervalSinceNow
+            totalDuration = max(1, interval)
+            pausedRemaining = max(0, interval)
+            endDate = target
+            isPaused = false
+            hasStarted = true
+            dismissed = false
+        }
+    }
+
+    private func startAlarm() {
+        alarmActive = true
+        alarm.start(mode: alarmMode)
+        if alarmMode == .flash {
+            withAnimation(.easeInOut(duration: 0.45).repeatForever(autoreverses: true)) {
+                flashOn.toggle()
+            }
+        }
+    }
+
+    private func stopAlarm() {
+        alarm.stop()
+        alarmActive = false
+        flashOn = false
+    }
+
+    private func primaryLabel() -> String {
+        if alarmActive { return "Stop" }
+        if isFinished() && hasStarted { return "Restart" }
+        if isPaused { return hasStarted ? "Resume" : "Start" }
+        return "Pause"
+    }
+
+    private func secondaryLabel() -> String {
+        if isFinished() && hasStarted { return "Restart" }
+        return hasStarted ? "Restart" : "Reset"
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/ImagePreviewView.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ImagePreviewView.swift
@@ -1,0 +1,221 @@
+//
+//  ImagePreviewView.swift
+//  TinfoilChat
+//
+//  Full-screen, swipeable, pinch-to-zoom image previewer used by the
+//  GenUI image widget. Mirrors the webapp lightbox: the user taps a
+//  thumbnail and the gallery opens over the chat with paging across
+//  the full image set, a close button, and an optional caption.
+
+import SwiftUI
+
+private let previewCloseButtonInset: CGFloat = 16
+private let previewMinScale: CGFloat = 1.0
+private let previewMaxScale: CGFloat = 4.0
+private let previewDoubleTapScale: CGFloat = 2.5
+private let previewBackgroundOpacity: Double = 0.96
+private let previewSwipeDismissThreshold: CGFloat = 120
+private let previewSwipeDismissMaxOffset: CGFloat = 600
+private let previewSwipeDirectionLockRatio: CGFloat = 1.4
+
+struct ImagePreviewView: View {
+    let images: [ImageWidget.Item]
+    @Binding var startIndex: Int
+    @Binding var isPresented: Bool
+
+    @State private var currentIndex: Int = 0
+    @State private var dismissOffset: CGFloat = 0
+
+    init(
+        images: [ImageWidget.Item],
+        startIndex: Binding<Int>,
+        isPresented: Binding<Bool>
+    ) {
+        self.images = images
+        self._startIndex = startIndex
+        self._isPresented = isPresented
+        self._currentIndex = State(initialValue: startIndex.wrappedValue)
+    }
+
+    private var backgroundOpacity: Double {
+        let progress = min(abs(dismissOffset) / previewSwipeDismissMaxOffset, 1.0)
+        return previewBackgroundOpacity * (1.0 - progress * 0.6)
+    }
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Color.black
+                .opacity(backgroundOpacity)
+                .ignoresSafeArea()
+
+            TabView(selection: $currentIndex) {
+                ForEach(Array(images.enumerated()), id: \.offset) { index, image in
+                    ZoomableImage(url: image.url, alt: image.alt, caption: image.caption)
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: images.count > 1 ? .automatic : .never))
+            .indexViewStyle(.page(backgroundDisplayMode: .always))
+            .offset(y: dismissOffset)
+            .simultaneousGesture(dismissGesture)
+
+            Button(action: { isPresented = false }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(Color.white.opacity(0.18)))
+            }
+            .padding(.top, previewCloseButtonInset)
+            .padding(.trailing, previewCloseButtonInset)
+            .accessibilityLabel("Close image viewer")
+        }
+        .onAppear { currentIndex = startIndex }
+        .onChange(of: currentIndex) { _, value in startIndex = value }
+        .statusBarHidden(true)
+    }
+
+    /// Vertical swipe-to-dismiss. Direction-locks so that horizontal
+    /// drags fall through to the underlying `TabView`'s page gesture.
+    private var dismissGesture: some Gesture {
+        DragGesture(minimumDistance: 12)
+            .onChanged { value in
+                let dx = abs(value.translation.width)
+                let dy = value.translation.height
+                guard dy > 0,
+                      dy > dx * previewSwipeDirectionLockRatio else {
+                    return
+                }
+                dismissOffset = dy
+            }
+            .onEnded { value in
+                if dismissOffset > previewSwipeDismissThreshold ||
+                   value.predictedEndTranslation.height > previewSwipeDismissMaxOffset / 2 {
+                    isPresented = false
+                } else {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                        dismissOffset = 0
+                    }
+                }
+            }
+    }
+}
+
+private struct ZoomableImage: View {
+    let url: String
+    let alt: String?
+    let caption: String?
+
+    @State private var scale: CGFloat = previewMinScale
+    @State private var lastScale: CGFloat = previewMinScale
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+
+    private var isZoomed: Bool { scale > previewMinScale }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            GeometryReader { proxy in
+                imageContent(in: proxy.size)
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+                    .contentShape(Rectangle())
+                    .gesture(magnification)
+                    // Pan only while zoomed, so an un-zoomed view never
+                    // intercepts horizontal drags from the parent
+                    // TabView's page gesture or the container's
+                    // swipe-down-to-dismiss.
+                    .gesture(isZoomed ? panWhenZoomed : nil)
+                    .onTapGesture(count: 2) { handleDoubleTap() }
+            }
+            if let caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.footnote)
+                    .foregroundColor(.white.opacity(0.85))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func imageContent(in size: CGSize) -> some View {
+        if let parsed = URL(string: url),
+           parsed.scheme?.lowercased() == "https" {
+            AsyncImage(url: parsed) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView().tint(.white)
+                case .success(let image):
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .scaleEffect(scale)
+                        .offset(offset)
+                case .failure:
+                    Image(systemName: "photo")
+                        .font(.largeTitle)
+                        .foregroundColor(.white.opacity(0.6))
+                @unknown default:
+                    Color.clear
+                }
+            }
+            .accessibilityLabel(altText)
+        } else {
+            Image(systemName: "photo")
+                .font(.largeTitle)
+                .foregroundColor(.white.opacity(0.6))
+        }
+    }
+
+    private var altText: String {
+        if let alt, !alt.isEmpty { return alt }
+        if let caption, !caption.isEmpty { return caption }
+        return "Image"
+    }
+
+    private var magnification: some Gesture {
+        MagnificationGesture()
+            .onChanged { value in
+                let proposed = lastScale * value
+                scale = min(max(proposed, previewMinScale), previewMaxScale)
+            }
+            .onEnded { _ in
+                lastScale = scale
+                if scale <= previewMinScale {
+                    resetTransform()
+                }
+            }
+    }
+
+    private var panWhenZoomed: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                offset = CGSize(
+                    width: lastOffset.width + value.translation.width,
+                    height: lastOffset.height + value.translation.height
+                )
+            }
+            .onEnded { _ in
+                lastOffset = offset
+            }
+    }
+
+    private func handleDoubleTap() {
+        withAnimation(.easeInOut(duration: 0.18)) {
+            if scale > previewMinScale {
+                resetTransform()
+            } else {
+                scale = previewDoubleTapScale
+                lastScale = previewDoubleTapScale
+            }
+        }
+    }
+
+    private func resetTransform() {
+        scale = previewMinScale
+        lastScale = previewMinScale
+        offset = .zero
+        lastOffset = .zero
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/ImageWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ImageWidget.swift
@@ -1,0 +1,271 @@
+//
+//  ImageWidget.swift
+//  TinfoilChat
+//
+//  Unified image widget. A single item renders as a large standalone
+//  image with optional caption; multiple items render as a responsive
+//  grid. Mirrors the webapp's `render_image` widget. Tapping any image
+//  opens an in-app full-screen viewer (paging + pinch-to-zoom) unless
+//  the model supplied a `link`, in which case the link wins.
+
+import OpenAI
+import SwiftUI
+
+struct ImageWidget: GenUIWidget {
+    struct Item: Decodable {
+        let url: String
+        let alt: String?
+        let caption: String?
+        let link: String?
+    }
+
+    struct Args: Decodable {
+        let images: [Item]
+        let title: String?
+        let aspectRatio: String?
+    }
+
+    let name = "render_image"
+    let description = "Display one or more images. Pass a single item for a large standalone image; pass multiple items to render a responsive grid (galleries, comparisons, multi-visual references)."
+    let promptHint = "one or more images — pass a single item for a large standalone image, or multiple items for a responsive grid"
+
+    var schema: JSONSchema {
+        let item = GenUISchema.object(
+            properties: [
+                "url": GenUISchema.string(description: "Image URL"),
+                "alt": GenUISchema.string(description: "Accessible alt text"),
+                "caption": GenUISchema.string(),
+                "link": GenUISchema.string(description: "Optional destination when tapped"),
+            ],
+            required: ["url"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "images": GenUISchema.array(
+                    items: item,
+                    description: "One or more images. A single image renders large with an optional caption; multiple images render in a responsive grid.",
+                    minItems: 1
+                ),
+                "title": GenUISchema.string(),
+                "aspectRatio": GenUISchema.string(
+                    description: "Single-image only. Container shape: square (1:1), video (16:9), or auto. Ignored when multiple images are provided.",
+                    enumValues: ["square", "video", "auto"]
+                ),
+            ],
+            required: ["images"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        if args.images.count == 1, let only = args.images.first {
+            return AnyView(SingleImageView(
+                images: args.images,
+                image: only,
+                aspectRatio: args.aspectRatio,
+                isDarkMode: context.isDarkMode
+            ))
+        }
+        return AnyView(ImageGridView(
+            images: args.images,
+            title: args.title,
+            isDarkMode: context.isDarkMode
+        ))
+    }
+}
+
+private struct SingleImageView: View {
+    let images: [ImageWidget.Item]
+    let image: ImageWidget.Item
+    let aspectRatio: String?
+    let isDarkMode: Bool
+
+    @State private var previewIndex: Int = 0
+    @State private var isPreviewPresented: Bool = false
+
+    private var ratio: CGFloat? {
+        switch aspectRatio {
+        case "square": return 1.0
+        case "video": return 16.0 / 9.0
+        default: return nil
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Group {
+                if let ratio {
+                    GenUIRemoteImage(url: image.url, isDarkMode: isDarkMode, contentMode: .fill)
+                        .aspectRatio(ratio, contentMode: .fit)
+                } else {
+                    GenUIRemoteImage(url: image.url, isDarkMode: isDarkMode, contentMode: .fit)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                    .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+            .accessibilityLabel(accessibilityText(for: image))
+            .onTapGesture { handleTap() }
+
+            if let caption = image.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.caption)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+        }
+        .fullScreenCover(isPresented: $isPreviewPresented) {
+            ImagePreviewView(
+                images: images,
+                startIndex: $previewIndex,
+                isPresented: $isPreviewPresented
+            )
+        }
+    }
+
+    private func handleTap() {
+        if let link = image.link, !link.isEmpty {
+            GenUIURLOpener.open(link)
+            return
+        }
+        previewIndex = 0
+        isPreviewPresented = true
+    }
+}
+
+private struct ImageGridView: View {
+    let images: [ImageWidget.Item]
+    let title: String?
+    let isDarkMode: Bool
+
+    @State private var previewIndex: Int = 0
+    @State private var isPreviewPresented: Bool = false
+
+    private enum Layout {
+        static let columnCount = 2
+        static let columnSpacing: CGFloat = 8
+        static let rowSpacing: CGFloat = 8
+        static let captionSpacing: CGFloat = 4
+        static let fallbackHorizontalInset: CGFloat = 32
+    }
+
+    @State private var availableWidth: CGFloat = max(
+        0,
+        UIScreen.main.bounds.width - Layout.fallbackHorizontalInset
+    )
+
+    private var measuredWidth: some View {
+        Color.clear
+            .frame(height: 0)
+            .frame(maxWidth: .infinity)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(key: ImageGridWidthPreferenceKey.self, value: proxy.size.width)
+                }
+            )
+    }
+
+    private var rowCount: Int {
+        (images.count + Layout.columnCount - 1) / Layout.columnCount
+    }
+
+    private var cellWidth: CGFloat {
+        let totalSpacing = CGFloat(Layout.columnCount - 1) * Layout.columnSpacing
+        return max(0, floor((availableWidth - totalSpacing) / CGFloat(Layout.columnCount)))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let title, !title.isEmpty {
+                GenUITitle(text: title, isDarkMode: isDarkMode)
+            }
+
+            measuredWidth
+
+            VStack(alignment: .leading, spacing: Layout.rowSpacing) {
+                ForEach(0..<rowCount, id: \.self) { rowIndex in
+                    HStack(alignment: .top, spacing: Layout.columnSpacing) {
+                        ForEach(0..<Layout.columnCount, id: \.self) { columnIndex in
+                            let imageIndex = rowIndex * Layout.columnCount + columnIndex
+                            if imageIndex < images.count {
+                                gridCell(index: imageIndex, image: images[imageIndex])
+                                    .frame(width: cellWidth, alignment: .leading)
+                            } else {
+                                Spacer(minLength: 0)
+                                    .frame(width: cellWidth)
+                            }
+                        }
+                    }
+                    .frame(width: availableWidth, alignment: .leading)
+                }
+            }
+            .frame(width: availableWidth, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(ImageGridWidthPreferenceKey.self) { width in
+            if width > 0 {
+                availableWidth = width
+            }
+        }
+        .fullScreenCover(isPresented: $isPreviewPresented) {
+            ImagePreviewView(
+                images: images,
+                startIndex: $previewIndex,
+                isPresented: $isPreviewPresented
+            )
+        }
+    }
+
+    private func gridCell(index: Int, image: ImageWidget.Item) -> some View {
+        VStack(alignment: .leading, spacing: Layout.captionSpacing) {
+            GenUIRemoteImage(url: image.url, isDarkMode: isDarkMode, contentMode: .fill)
+                .frame(width: cellWidth, height: cellWidth)
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius)
+                        .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                )
+                .contentShape(Rectangle())
+                .accessibilityLabel(accessibilityText(for: image))
+                .onTapGesture { handleTap(index: index, image: image) }
+
+            if let caption = image.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.caption2)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .frame(width: cellWidth, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(width: cellWidth, alignment: .leading)
+        .clipped()
+    }
+
+    private func handleTap(index: Int, image: ImageWidget.Item) {
+        if let link = image.link, !link.isEmpty {
+            GenUIURLOpener.open(link)
+            return
+        }
+        previewIndex = index
+        isPreviewPresented = true
+    }
+}
+
+private func accessibilityText(for image: ImageWidget.Item) -> String {
+    if let alt = image.alt, !alt.isEmpty { return alt }
+    if let caption = image.caption, !caption.isEmpty { return caption }
+    return "Image"
+}
+
+private struct ImageGridWidthPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
@@ -1,0 +1,122 @@
+//
+//  LinkPreviewWidget.swift
+//  TinfoilChat
+//
+
+import OpenAI
+import SwiftUI
+
+private let linkPreviewImageSize: CGFloat = 112
+private let linkPreviewCornerRadius: CGFloat = 12
+private let linkPreviewCardPadding: CGFloat = 12
+private let linkPreviewFaviconSize: CGFloat = 16
+
+struct LinkPreviewWidget: GenUIWidget {
+    struct Args: Decodable {
+        let url: String
+        let title: String
+    }
+
+    let name = "render_link_preview"
+    let description = "Display a rich preview card for a single web link. Use when linking to an article, page, or resource and you want to surface title and favicon."
+    let promptHint = "rich preview card for a single web link"
+
+    var schema: JSONSchema {
+        GenUISchema.object(
+            properties: [
+                "url": GenUISchema.string(description: "Full URL of the resource"),
+                "title": GenUISchema.string(description: "Best guess at the page title"),
+            ],
+            required: ["url", "title"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(LinkPreviewView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct LinkPreviewView: View {
+    let args: LinkPreviewWidget.Args
+    let isDarkMode: Bool
+
+    @State private var metadata: LinkMetadata?
+
+    private var domain: String {
+        guard let url = URL(string: args.url), let host = url.host else { return args.url }
+        return host.replacingOccurrences(of: "^www\\.", with: "", options: .regularExpression)
+    }
+
+    private var displayTitle: String {
+        if let title = metadata?.title, !title.isEmpty { return title }
+        return args.title
+    }
+
+    private var displaySiteName: String {
+        if let siteName = metadata?.siteName, !siteName.isEmpty { return siteName }
+        return domain
+    }
+
+    var body: some View {
+        Button(action: { GenUIURLOpener.open(args.url) }) {
+            HStack(alignment: .top, spacing: 0) {
+                if let image = metadata?.image, !image.isEmpty {
+                    GenUIRemoteImage(url: image, isDarkMode: isDarkMode, contentMode: .fill)
+                        .frame(width: linkPreviewImageSize, height: linkPreviewImageSize)
+                        .clipped()
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        FaviconView(url: args.url, isDarkMode: isDarkMode)
+                            .frame(width: linkPreviewFaviconSize, height: linkPreviewFaviconSize)
+                        Text(displaySiteName)
+                            .font(.caption)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                            .lineLimit(1)
+                    }
+                    Text(displayTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+                    if let description = metadata?.description, !description.isEmpty {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(2)
+                    }
+                    HStack(spacing: 4) {
+                        Text(domain)
+                            .font(.caption)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                            .lineLimit(1)
+                        Image(systemName: "arrow.up.right")
+                            .font(.caption2)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    }
+                }
+                .padding(linkPreviewCardPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(GenUIStyle.cardBackground(isDarkMode))
+            .clipShape(RoundedRectangle(cornerRadius: linkPreviewCornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: linkPreviewCornerRadius)
+                    .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .task(id: args.url) {
+            await MainActor.run { metadata = nil }
+            do {
+                let result = try await LinkMetadataService.shared.metadata(for: args.url)
+                await MainActor.run { metadata = result }
+            } catch {
+                // Keep model-provided title; render the leaner card.
+            }
+        }
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/MapWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/MapWidget.swift
@@ -1,0 +1,498 @@
+//
+//  MapWidget.swift
+//  TinfoilChat
+//
+//  Native MapKit-backed map widget. Mirrors the webapp's `render_map`
+//  but uses iOS's first-party MapKit so no consent gate or external
+//  loader is required. Renders one or more pinned locations with a
+//  button to open the place (or directions, when there are multiple
+//  stops) in the Maps app.
+
+import CoreLocation
+import MapKit
+import OpenAI
+import SwiftUI
+import UIKit
+
+struct MapWidget: GenUIWidget {
+    struct Location: Decodable, Equatable {
+        let name: String
+        let address: String?
+        let latitude: Double?
+        let longitude: Double?
+        let description: String?
+    }
+
+    struct Args: Decodable {
+        let title: String?
+        let mode: String?
+        let query: String?
+        let locations: [Location]
+        let travelMode: String?
+        let mapType: String?
+    }
+
+    let name = "render_map"
+    let description = """
+        Display an interactive Apple Map with one or more pinned locations and \
+        a button to open the place (or directions, when multiple stops are \
+        provided) in the Maps app. Use when the user asks about places, \
+        addresses, routes, or wants to see somewhere on a map. Provide \
+        latitude/longitude when known; otherwise an address string is \
+        geocoded automatically.
+        """
+    let promptHint = "an interactive Apple Map with one or more locations and a button to open Apple Maps"
+
+    var schema: JSONSchema {
+        let location = GenUISchema.object(
+            properties: [
+                "name": GenUISchema.string(description: "Display name shown on the pin"),
+                "address": GenUISchema.string(description: "Full address or place query (e.g. \"1 Apple Park Way, Cupertino, CA\" or \"Eiffel Tower, Paris\"). Used for geocoding when coordinates are not provided."),
+                "latitude": GenUISchema.number(description: "Latitude in degrees. Always provide when known to avoid geocoding ambiguity."),
+                "longitude": GenUISchema.number(description: "Longitude in degrees. Always provide when known to avoid geocoding ambiguity."),
+                "description": GenUISchema.string(description: "One-line subtitle"),
+            ],
+            required: ["name"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "title": GenUISchema.string(),
+                "mode": GenUISchema.string(
+                    description: "`place` (default) for a single location, `search` for a POI query, `directions` for a routed list",
+                    enumValues: ["place", "search", "directions"]
+                ),
+                "query": GenUISchema.string(description: "Used when `mode === \"search\"`, e.g. \"coffee\""),
+                "locations": GenUISchema.array(items: location, minItems: 1),
+                "travelMode": GenUISchema.string(enumValues: ["driving", "walking", "transit", "cycling"]),
+                "mapType": GenUISchema.string(
+                    description: "Visual style of the map tiles",
+                    enumValues: ["standard", "hybrid", "satellite", "muted"]
+                ),
+            ],
+            required: ["locations"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(MapWidgetView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+// MARK: - Pin annotation
+
+private struct MapPinItem: Identifiable {
+    let id: Int
+    let coordinate: CLLocationCoordinate2D
+    let name: String
+    let subtitle: String?
+}
+
+// MARK: - Open-in-Maps URL builders
+
+private func encodeAddressOrCoord(_ loc: MapWidget.Location) -> String? {
+    if let lat = loc.latitude, let lon = loc.longitude, isValidCoordinate(latitude: lat, longitude: lon) {
+        return "\(lat),\(lon)"
+    }
+    if let address = loc.address, !address.isEmpty { return address }
+    if !loc.name.isEmpty { return loc.name }
+    return nil
+}
+
+private let appleMapsQueryAllowedCharacters: CharacterSet = {
+    var allowed = CharacterSet.urlQueryAllowed
+    allowed.remove(charactersIn: "&=+")
+    return allowed
+}()
+
+private func encode(_ value: String) -> String {
+    value.addingPercentEncoding(withAllowedCharacters: appleMapsQueryAllowedCharacters) ?? value
+}
+
+private func isValidCoordinate(latitude: Double, longitude: Double) -> Bool {
+    latitude.isFinite
+        && longitude.isFinite
+        && (-90.0...90.0).contains(latitude)
+        && (-180.0...180.0).contains(longitude)
+}
+
+private func placeURL(for loc: MapWidget.Location) -> URL? {
+    var params: [String] = []
+    if let lat = loc.latitude, let lon = loc.longitude, isValidCoordinate(latitude: lat, longitude: lon) {
+        params.append("ll=\(lat),\(lon)")
+        if !loc.name.isEmpty { params.append("q=\(encode(loc.name))") }
+    } else if let address = loc.address, !address.isEmpty {
+        params.append("address=\(encode(address))")
+    } else if !loc.name.isEmpty {
+        params.append("q=\(encode(loc.name))")
+    }
+    let query = params.isEmpty ? "" : "?\(params.joined(separator: "&"))"
+    return URL(string: "https://maps.apple.com/\(query)")
+}
+
+private func searchURL(query: String, center: MapWidget.Location?) -> URL? {
+    var params: [String] = ["q=\(encode(query))"]
+    if let center, let lat = center.latitude, let lon = center.longitude, isValidCoordinate(latitude: lat, longitude: lon) {
+        params.append("sll=\(lat),\(lon)")
+    }
+    return URL(string: "https://maps.apple.com/?\(params.joined(separator: "&"))")
+}
+
+private func directionsURL(locations: [MapWidget.Location], travelMode: String?) -> URL? {
+    let points = locations.compactMap(encodeAddressOrCoord)
+    guard !points.isEmpty else { return URL(string: "https://maps.apple.com/?dirflg=d") }
+    var params: [String] = []
+    if points.count == 1 {
+        params.append("daddr=\(encode(points[0]))")
+    } else {
+        params.append("saddr=\(encode(points.first!))")
+        let waypoints = points.dropFirst().joined(separator: " to ")
+        params.append("daddr=\(encode(waypoints))")
+    }
+    if let mode = travelMode {
+        let flag: String?
+        switch mode {
+        case "driving": flag = "d"
+        case "walking": flag = "w"
+        case "transit": flag = "r"
+        case "cycling": flag = "d" // Apple Maps doesn't expose cycling via URL — fall back to driving
+        default: flag = nil
+        }
+        if let flag { params.append("dirflg=\(flag)") }
+    }
+    return URL(string: "https://maps.apple.com/?\(params.joined(separator: "&"))")
+}
+
+private func primaryAppleMapsURL(args: MapWidget.Args) -> URL? {
+    if args.mode == "directions" || args.locations.count > 1 {
+        return directionsURL(locations: args.locations, travelMode: args.travelMode)
+    }
+    if args.mode == "search", let query = args.query, !query.isEmpty {
+        return searchURL(query: query, center: args.locations.first)
+    }
+    if let first = args.locations.first {
+        return placeURL(for: first)
+    }
+    return URL(string: "https://maps.apple.com/")
+}
+
+private func modeBadge(_ args: MapWidget.Args) -> String? {
+    if args.mode == "directions" || (args.mode == nil && args.locations.count > 1) {
+        return "Directions"
+    }
+    if args.mode == "search" { return "Search results" }
+    return nil
+}
+
+// MARK: - Native Map view
+
+private struct MapWidgetView: View {
+    let args: MapWidget.Args
+    let isDarkMode: Bool
+
+    @State private var pins: [MapPinItem] = []
+    @State private var region: MKCoordinateRegion = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+        span: MKCoordinateSpan(latitudeDelta: 60, longitudeDelta: 60)
+    )
+    @State private var copyConfirmation: Bool = false
+
+    private var primary: MapWidget.Location? { args.locations.first }
+    private var isDirections: Bool {
+        args.mode == "directions" || args.locations.count > 1
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            mapView
+                .frame(height: 220)
+                .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                        .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                )
+
+            if args.locations.count > 1 {
+                locationList
+            }
+
+            actionsRow
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                .fill(GenUIStyle.cardBackground(isDarkMode))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+        )
+        .task(id: locationsKey) {
+            await resolvePins()
+        }
+    }
+
+    private var locationsKey: String {
+        var parts: [String] = []
+        for loc in args.locations {
+            let lat = loc.latitude.map { String($0) } ?? ""
+            let lon = loc.longitude.map { String($0) } ?? ""
+            let address = loc.address ?? ""
+            let description = loc.description ?? ""
+            let fields: [String] = [loc.name, address, lat, lon, description]
+            parts.append(fields.joined(separator: "|"))
+        }
+        return parts.joined(separator: "~")
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        if args.title != nil || modeBadge(args) != nil {
+            VStack(alignment: .leading, spacing: 2) {
+                if let badge = modeBadge(args) {
+                    Text(badgeText(badge: badge))
+                        .font(.caption2.weight(.semibold))
+                        .tracking(1.0)
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                }
+                if let title = args.title, !title.isEmpty {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                }
+            }
+        }
+    }
+
+    private func badgeText(badge: String) -> String {
+        if args.mode == "search", let query = args.query, !query.isEmpty {
+            return "\(badge.uppercased()) · \(query)"
+        }
+        return badge.uppercased()
+    }
+
+    private var mapType: MKMapType {
+        switch args.mapType {
+        case "hybrid": return .hybrid
+        case "satellite": return .satellite
+        case "muted": return .mutedStandard
+        default: return .standard
+        }
+    }
+
+    private var mapView: some View {
+        MapViewRepresentable(region: region, pins: pins, mapType: mapType)
+    }
+
+    private var locationList: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(Array(args.locations.enumerated()), id: \.offset) { index, loc in
+                HStack(alignment: .top, spacing: 8) {
+                    Text("\(index + 1)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        .frame(width: 20, height: 20)
+                        .background(
+                            Circle().fill(GenUIStyle.subtleBackground(isDarkMode))
+                        )
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(loc.name)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                            .lineLimit(1)
+                        if let secondary = loc.description ?? loc.address, !secondary.isEmpty {
+                            Text(secondary)
+                                .font(.caption)
+                                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer(minLength: 4)
+                    Button {
+                        if let url = placeURL(for: loc) { UIApplication.shared.open(url) }
+                    } label: {
+                        Text("Open")
+                            .font(.caption2.weight(.medium))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius)
+                        .fill(GenUIStyle.subtleBackground(isDarkMode))
+                )
+            }
+        }
+    }
+
+    private var actionsRow: some View {
+        HStack(spacing: 8) {
+            Spacer()
+            if args.locations.count == 1, let primary, primary.address != nil {
+                Button(action: copyAddress) {
+                    HStack(spacing: 6) {
+                        Image(systemName: copyConfirmation ? "checkmark" : "doc.on.doc")
+                        Text(copyConfirmation ? "Copied" : "Copy address")
+                    }
+                    .font(.caption.weight(.medium))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+            }
+            Button(action: openInMaps) {
+                HStack(spacing: 6) {
+                    Image(systemName: isDirections ? "arrow.triangle.turn.up.right.circle" : "mappin.and.ellipse")
+                    Text(isDirections ? "Open directions" : "Open in Apple Maps")
+                }
+                .font(.caption.weight(.semibold))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .foregroundColor(isDarkMode ? .black : .white)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(GenUIStyle.primaryText(isDarkMode))
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func openInMaps() {
+        if let url = primaryAppleMapsURL(args: args) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func copyAddress() {
+        guard let primary else { return }
+        let text: String
+        if let address = primary.address, !address.isEmpty {
+            text = address
+        } else if let lat = primary.latitude, let lon = primary.longitude {
+            text = "\(lat), \(lon)"
+        } else {
+            text = primary.name
+        }
+        UIPasteboard.general.string = text
+        copyConfirmation = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            copyConfirmation = false
+        }
+    }
+
+    private func resolvePins() async {
+        let geocoder = CLGeocoder()
+        var resolved: [MapPinItem] = []
+        for (index, loc) in args.locations.enumerated() {
+            if let lat = loc.latitude, let lon = loc.longitude, isValidCoordinate(latitude: lat, longitude: lon) {
+                resolved.append(MapPinItem(
+                    id: index,
+                    coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+                    name: loc.name,
+                    subtitle: loc.description ?? loc.address
+                ))
+                continue
+            }
+            let query = loc.address ?? loc.name
+            guard !query.isEmpty else { continue }
+            do {
+                let placemarks = try await geocoder.geocodeAddressString(query)
+                if let coord = placemarks.first?.location?.coordinate {
+                    resolved.append(MapPinItem(
+                        id: index,
+                        coordinate: coord,
+                        name: loc.name,
+                        subtitle: loc.description ?? loc.address
+                    ))
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                // Geocoding can fail for ambiguous queries; skip silently —
+                // the "Open in Apple Maps" button still works because Apple
+                // Maps resolves the string itself.
+                continue
+            }
+        }
+        if Task.isCancelled { return }
+        await MainActor.run {
+            self.pins = resolved
+            if !resolved.isEmpty {
+                self.region = computeRegion(for: resolved)
+            }
+        }
+    }
+
+    private func computeRegion(for pins: [MapPinItem]) -> MKCoordinateRegion {
+        guard !pins.isEmpty else { return region }
+        if pins.count == 1 {
+            return MKCoordinateRegion(
+                center: pins[0].coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+            )
+        }
+        let lats = pins.map(\.coordinate.latitude)
+        let lons = pins.map(\.coordinate.longitude)
+        guard let minLat = lats.min(), let maxLat = lats.max(),
+              let minLon = lons.min(), let maxLon = lons.max() else { return region }
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLon + maxLon) / 2
+        )
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLat - minLat) * 1.5, 0.02),
+            longitudeDelta: max((maxLon - minLon) * 1.5, 0.02)
+        )
+        return MKCoordinateRegion(center: center, span: span)
+    }
+}
+
+// MARK: - UIKit map bridge
+
+private struct MapViewRepresentable: UIViewRepresentable {
+    let region: MKCoordinateRegion
+    let pins: [MapPinItem]
+    let mapType: MKMapType
+
+    func makeUIView(context: Context) -> MKMapView {
+        let view = MKMapView()
+        view.showsCompass = true
+        view.isRotateEnabled = true
+        view.isPitchEnabled = false
+        view.mapType = mapType
+        view.setRegion(region, animated: false)
+        return view
+    }
+
+    func updateUIView(_ uiView: MKMapView, context: Context) {
+        uiView.mapType = mapType
+        uiView.removeAnnotations(uiView.annotations)
+        for pin in pins {
+            let annotation = MKPointAnnotation()
+            annotation.coordinate = pin.coordinate
+            annotation.title = pin.name
+            annotation.subtitle = pin.subtitle
+            uiView.addAnnotation(annotation)
+        }
+        if !pins.isEmpty {
+            uiView.setRegion(region, animated: false)
+        }
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/MessageComposeWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/MessageComposeWidget.swift
@@ -1,0 +1,266 @@
+//
+//  MessageComposeWidget.swift
+//  TinfoilChat
+//
+
+import OpenAI
+import SwiftUI
+
+struct MessageComposeWidget: GenUIWidget {
+    struct Variant: Decodable {
+        let label: String
+        let subject: String?
+        let body: String
+    }
+
+    struct Args: Decodable {
+        let channel: String?
+        let to: String?
+        let title: String?
+        let variants: [Variant]
+    }
+
+    let name = "render_message_compose"
+    let description = "Draft a message or email with one or more tone variants. Includes Copy and (for email) Open in Mail."
+    let promptHint = "a draft message or email with optional tone variants and Copy / Open in Mail"
+
+    var schema: JSONSchema {
+        let variant = GenUISchema.object(
+            properties: [
+                "label": GenUISchema.string(description: "Short variant label, e.g. \"Formal\""),
+                "subject": GenUISchema.string(),
+                "body": GenUISchema.string(),
+            ],
+            required: ["label", "body"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "channel": GenUISchema.string(enumValues: ["email", "message"]),
+                "to": GenUISchema.string(description: "Recipient — used for mailto:"),
+                "title": GenUISchema.string(),
+                "variants": GenUISchema.array(items: variant, minItems: 1),
+            ],
+            required: ["variants"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(MessageComposeView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct MessageComposeView: View {
+    let args: MessageComposeWidget.Args
+    let isDarkMode: Bool
+
+    @State private var selected: Int = 0
+    @State private var copied: Bool = false
+
+    private var isEmail: Bool {
+        (args.channel ?? "email") == "email"
+    }
+
+    private var variant: MessageComposeWidget.Variant? {
+        args.variants[safe: selected] ?? args.variants.first
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if isEmail { emailHeader }
+            if args.variants.count > 1 { variantTabs }
+            if isEmail { emailHeaderFields }
+
+            if let body = variant?.body {
+                Text(body)
+                    .font(.subheadline)
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+            }
+
+            if isEmail {
+                emailFooter
+            } else {
+                HStack {
+                    Spacer()
+                    copyButton
+                }
+                .padding([.horizontal, .bottom], 12)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                .fill(GenUIStyle.cardBackground(isDarkMode))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
+                .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius))
+    }
+
+    @ViewBuilder
+    private var emailHeader: some View {
+        HStack(spacing: 6) {
+            HStack(spacing: 4) {
+                Circle().fill(Color(red: 1.0, green: 0.37, blue: 0.34)).frame(width: 10, height: 10)
+                Circle().fill(Color(red: 1.0, green: 0.74, blue: 0.18)).frame(width: 10, height: 10)
+                Circle().fill(Color(red: 0.16, green: 0.78, blue: 0.25)).frame(width: 10, height: 10)
+            }
+            Spacer()
+            Text(args.title ?? "New Message")
+                .font(.caption.weight(.medium))
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+            Spacer()
+            // Invisible spacer matching the traffic-light dots so the
+            // title stays optically centered in the header row.
+            HStack(spacing: 4) {
+                Circle().fill(Color.clear).frame(width: 10, height: 10)
+                Circle().fill(Color.clear).frame(width: 10, height: 10)
+                Circle().fill(Color.clear).frame(width: 10, height: 10)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(GenUIStyle.subtleBackground(isDarkMode))
+        .overlay(Rectangle().frame(height: 1).foregroundColor(GenUIStyle.borderColor(isDarkMode)), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private var emailFooter: some View {
+        HStack(spacing: 8) {
+            Spacer()
+            copyButton
+            if let variant {
+                Button(action: { openMail(variant: variant) }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "paperplane.fill").font(.caption2)
+                        Text("Open in mail").font(.caption2.weight(.semibold))
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(GenUIStyle.primaryText(isDarkMode))
+                    .foregroundColor(isDarkMode ? .black : .white)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(GenUIStyle.subtleBackground(isDarkMode))
+        .overlay(Rectangle().frame(height: 1).foregroundColor(GenUIStyle.borderColor(isDarkMode)), alignment: .top)
+    }
+
+    @ViewBuilder
+    private var variantTabs: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(Array(args.variants.enumerated()), id: \.offset) { index, variant in
+                    Button(action: { selected = index }) {
+                        Text(variant.label)
+                            .font(.caption.weight(.medium))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(
+                                Capsule().fill(
+                                    selected == index
+                                    ? GenUIStyle.primaryText(isDarkMode)
+                                    : Color.clear
+                                )
+                            )
+                            .overlay(
+                                Capsule().stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+                            )
+                            .foregroundColor(
+                                selected == index
+                                ? (isDarkMode ? .black : .white)
+                                : GenUIStyle.primaryText(isDarkMode)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .background(GenUIStyle.subtleBackground(isDarkMode))
+        .overlay(Rectangle().frame(height: 1).foregroundColor(GenUIStyle.borderColor(isDarkMode)), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private var emailHeaderFields: some View {
+        VStack(spacing: 0) {
+            headerRow(label: "TO", value: args.to ?? "", placeholder: "recipient@example.com")
+            Rectangle().frame(height: 1).foregroundColor(GenUIStyle.borderColor(isDarkMode))
+            headerRow(label: "SUBJECT", value: variant?.subject ?? "", placeholder: "(no subject)")
+            Rectangle().frame(height: 1).foregroundColor(GenUIStyle.borderColor(isDarkMode))
+        }
+    }
+
+    @ViewBuilder
+    private func headerRow(label: String, value: String, placeholder: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(label)
+                .font(.caption2.weight(.medium))
+                .tracking(0.5)
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                .frame(width: 64, alignment: .leading)
+            Text(value.isEmpty ? placeholder : value)
+                .font(.subheadline)
+                .foregroundColor(value.isEmpty ? GenUIStyle.mutedText(isDarkMode) : GenUIStyle.primaryText(isDarkMode))
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var copyButton: some View {
+        Button(action: copy) {
+            HStack(spacing: 4) {
+                Image(systemName: "doc.on.doc").font(.caption2)
+                Text(copied ? "Copied" : "Copy").font(.caption2.weight(.medium))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func copy() {
+        guard let body = variant?.body else { return }
+        UIPasteboard.general.string = body
+        copied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { copied = false }
+    }
+
+    private func openMail(variant: MessageComposeWidget.Variant) {
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = args.to ?? ""
+        var queryItems: [URLQueryItem] = []
+        if let subject = variant.subject, !subject.isEmpty {
+            queryItems.append(URLQueryItem(name: "subject", value: subject))
+        }
+        queryItems.append(URLQueryItem(name: "body", value: variant.body))
+        components.queryItems = queryItems
+        if let url = components.url {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard index >= 0 && index < count else { return nil }
+        return self[index]
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
@@ -1,0 +1,574 @@
+//
+//  RecipeCardWidget.swift
+//  TinfoilChat
+//
+
+import OpenAI
+import SwiftUI
+
+private let recipeScaleOptions: [Double] = [1, 2, 3]
+private let defaultRecipeScale: Double = 1
+private let recipeAccent = Color.orange
+private let scaledRecipeQuantityColor = recipeAccent
+private let fractionMatchTolerance = 0.02
+private let quantityPattern = #"\d+\s+\d+/\d+|\d+/\d+|\d+[⅛¼⅓⅜½⅝⅔¾⅞]|\d*\.?\d+|[⅛¼⅓⅜½⅝⅔¾⅞]"#
+
+private let unicodeFractions: [String: Double] = [
+    "⅛": 1.0 / 8.0,
+    "¼": 1.0 / 4.0,
+    "⅓": 1.0 / 3.0,
+    "⅜": 3.0 / 8.0,
+    "½": 1.0 / 2.0,
+    "⅝": 5.0 / 8.0,
+    "⅔": 2.0 / 3.0,
+    "¾": 3.0 / 4.0,
+    "⅞": 7.0 / 8.0,
+]
+
+private let fractionLabels: [(value: Double, label: String)] = [
+    (1.0 / 8.0, "⅛"),
+    (1.0 / 4.0, "¼"),
+    (1.0 / 3.0, "⅓"),
+    (3.0 / 8.0, "⅜"),
+    (1.0 / 2.0, "½"),
+    (5.0 / 8.0, "⅝"),
+    (2.0 / 3.0, "⅔"),
+    (3.0 / 4.0, "¾"),
+    (7.0 / 8.0, "⅞"),
+]
+
+struct RecipeCardWidget: GenUIWidget {
+    struct Ingredient: Decodable {
+        let quantity: String?
+        let item: String
+        let note: String?
+    }
+
+    struct Step: Decodable {
+        let title: String?
+        let content: String
+    }
+
+    struct Args: Decodable {
+        let title: String
+        let description: String?
+        let image: String?
+        let cuisine: String?
+        let difficulty: String?
+        let servings: StringOrNumber?
+        let prepTime: String?
+        let cookTime: String?
+        let totalTime: String?
+        let ingredients: [Ingredient]?
+        let steps: [Step]?
+        let sourceUrl: String?
+        let source: String?
+    }
+
+    let name = "render_recipe_card"
+    let description = "Display a cookable recipe card with ingredients and step-by-step instructions."
+    let promptHint = "a cookable recipe card with ingredients and steps"
+
+    var schema: JSONSchema {
+        let ingredient = GenUISchema.object(
+            properties: [
+                "quantity": GenUISchema.string(),
+                "item": GenUISchema.string(),
+                "note": GenUISchema.string(),
+            ],
+            required: ["item"]
+        )
+        let step = GenUISchema.object(
+            properties: [
+                "title": GenUISchema.string(),
+                "content": GenUISchema.string(),
+            ],
+            required: ["content"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "title": GenUISchema.string(),
+                "description": GenUISchema.string(),
+                "image": GenUISchema.string(),
+                "cuisine": GenUISchema.string(),
+                "difficulty": GenUISchema.string(enumValues: ["easy", "medium", "hard"]),
+                "servings": GenUISchema.stringOrNumber(),
+                "prepTime": GenUISchema.string(),
+                "cookTime": GenUISchema.string(),
+                "totalTime": GenUISchema.string(),
+                "ingredients": GenUISchema.array(items: ingredient),
+                "steps": GenUISchema.array(items: step),
+                "sourceUrl": GenUISchema.string(),
+                "source": GenUISchema.string(),
+            ],
+            required: ["title"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(RecipeCardView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct RecipeCardView: View {
+    let args: RecipeCardWidget.Args
+    let isDarkMode: Bool
+
+    @State private var checkedIngredients: Set<Int> = []
+    @State private var completedSteps: Set<Int> = []
+    @State private var recipeScale: Double = defaultRecipeScale
+
+    private var difficultyText: String? {
+        guard let value = args.difficulty, !value.isEmpty else { return nil }
+        return value.prefix(1).uppercased() + value.dropFirst()
+    }
+
+    private var cuisineText: String? {
+        guard let cuisine = args.cuisine?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !cuisine.isEmpty else { return nil }
+        return cuisine
+    }
+
+    private var hasSource: Bool {
+        if let source = args.source?.trimmingCharacters(in: .whitespacesAndNewlines), !source.isEmpty {
+            return true
+        }
+        if let sourceUrl = args.sourceUrl?.trimmingCharacters(in: .whitespacesAndNewlines), !sourceUrl.isEmpty {
+            return true
+        }
+        return false
+    }
+
+    private struct MetaItem: Identifiable {
+        let id = UUID()
+        let icon: String
+        let label: String
+        let value: String
+        let scaled: Bool
+    }
+
+    private var metaItems: [MetaItem] {
+        var items: [MetaItem] = []
+        if let prep = args.prepTime, !prep.isEmpty {
+            items.append(.init(icon: "clock", label: "PREP", value: prep, scaled: false))
+        }
+        if let cook = args.cookTime, !cook.isEmpty {
+            items.append(.init(icon: "flame", label: "COOK", value: cook, scaled: false))
+        }
+        if items.isEmpty, let total = args.totalTime, !total.isEmpty {
+            items.append(.init(icon: "clock", label: "TOTAL", value: total, scaled: false))
+        }
+        if let servings = args.servings?.stringValue, !servings.isEmpty {
+            let scaledServings = scaleQuantityText(servings, scale: recipeScale)
+            items.append(.init(
+                icon: "person.2",
+                label: "SERVES",
+                value: scaledServings,
+                scaled: recipeScale != defaultRecipeScale && scaledServings != servings
+            ))
+        }
+        return items
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let image = args.image, !image.isEmpty {
+                GenUIRemoteImage(url: image, isDarkMode: isDarkMode, contentMode: .fill)
+                    .aspectRatio(16.0/9.0, contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius))
+            }
+
+            VStack(alignment: .center, spacing: 6) {
+                if cuisineText != nil || difficultyText != nil {
+                    HStack(spacing: 4) {
+                        if let cuisine = cuisineText {
+                            Text(cuisine.uppercased()).tracking(1.5)
+                        }
+                        if cuisineText != nil && difficultyText != nil {
+                            Text("\u{00B7}")
+                        }
+                        if let diff = difficultyText {
+                            Text(diff)
+                        }
+                    }
+                    .font(.caption2.weight(.semibold))
+                    .foregroundColor(recipeAccent)
+                }
+                Text(args.title)
+                    .font(.title3.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                if let description = args.description, !description.isEmpty {
+                    Text(description)
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                }
+            }
+            .frame(maxWidth: .infinity)
+
+            if !metaItems.isEmpty {
+                metaRow
+            }
+
+            if let ingredients = args.ingredients, !ingredients.isEmpty {
+                scaleControl
+            }
+
+            if let ingredients = args.ingredients, !ingredients.isEmpty {
+                sectionHeader("INGREDIENTS")
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(ingredients.enumerated()), id: \.offset) { index, ingredient in
+                        ingredientRow(index: index, ingredient: ingredient)
+                    }
+                }
+            }
+
+            if let steps = args.steps, !steps.isEmpty {
+                sectionHeader("STEPS")
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                        stepRow(index: index, step: step)
+                    }
+                }
+            }
+
+            if hasSource {
+                sourceRow
+            }
+        }
+        .genUICard(isDarkMode: isDarkMode, padding: 16)
+    }
+
+    @ViewBuilder
+    private var metaRow: some View {
+        RecipeTagFlowLayout(spacing: 8) {
+            ForEach(metaItems) { item in
+                HStack(spacing: 8) {
+                    Image(systemName: item.icon)
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(item.label.uppercased())
+                            .font(.system(size: 10, weight: .semibold))
+                            .tracking(0.6)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                        Text(item.value)
+                            .font(.system(.subheadline, design: .rounded).weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundColor(item.scaled ? scaledRecipeQuantityColor : GenUIStyle.primaryText(isDarkMode))
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(GenUIStyle.subtleBackground(isDarkMode))
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder
+    private var scaleControl: some View {
+        HStack(spacing: 10) {
+            Text("SCALE")
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.6)
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                .padding(.leading, 10)
+                .padding(.trailing, 2)
+            ForEach(recipeScaleOptions, id: \.self) { scale in
+                Button(action: { recipeScale = scale }) {
+                    Text(scaleLabel(scale))
+                        .font(.system(.caption, design: .rounded).weight(.semibold))
+                        .foregroundColor(scaleButtonForeground(scale))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(
+                            Capsule()
+                                .fill(scaleButtonBackground(scale))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(
+            Capsule()
+                .fill(GenUIStyle.subtleBackground(isDarkMode))
+        )
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.caption2.weight(.bold))
+            .tracking(1.4)
+            .foregroundColor(recipeAccent)
+    }
+
+    @ViewBuilder
+    private func ingredientRow(index: Int, ingredient: RecipeCardWidget.Ingredient) -> some View {
+        let checked = checkedIngredients.contains(index)
+        Button(action: {
+            if checked { checkedIngredients.remove(index) } else { checkedIngredients.insert(index) }
+        }) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: checked ? "checkmark.square.fill" : "square")
+                    .foregroundColor(checked ? recipeAccent : GenUIStyle.mutedText(isDarkMode))
+                    .font(.subheadline)
+                ingredientText(ingredient, checked: checked)
+                .font(.subheadline)
+                .strikethrough(checked)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                if let note = ingredient.note, !note.isEmpty {
+                    Text("(\(note))")
+                        .font(.caption)
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func ingredientText(_ ingredient: RecipeCardWidget.Ingredient, checked: Bool) -> Text {
+        let primaryColor = checked ? GenUIStyle.mutedText(isDarkMode) : GenUIStyle.primaryText(isDarkMode)
+        guard let quantity = ingredient.quantity, !quantity.isEmpty else {
+            return Text(ingredient.item).foregroundColor(primaryColor)
+        }
+
+        let quantityColor = checked || recipeScale == defaultRecipeScale ? primaryColor : scaledRecipeQuantityColor
+        return Text(scaleQuantityText(quantity, scale: recipeScale) + " ")
+            .bold()
+            .foregroundColor(quantityColor) +
+            Text(ingredient.item)
+            .foregroundColor(primaryColor)
+    }
+
+    private func scaleLabel(_ scale: Double) -> String {
+        "\(Int(scale))x"
+    }
+
+    private func scaleButtonForeground(_ scale: Double) -> Color {
+        if scale == recipeScale {
+            return .white
+        }
+        return GenUIStyle.mutedText(isDarkMode)
+    }
+
+    private func scaleButtonBackground(_ scale: Double) -> Color {
+        guard scale == recipeScale else { return Color.clear }
+        return recipeAccent
+    }
+
+    @ViewBuilder
+    private func stepRow(index: Int, step: RecipeCardWidget.Step) -> some View {
+        let done = completedSteps.contains(index)
+        Button(action: {
+            if done { completedSteps.remove(index) } else { completedSteps.insert(index) }
+        }) {
+            HStack(alignment: .top, spacing: 10) {
+                ZStack {
+                    if done {
+                        Circle().fill(recipeAccent)
+                            .frame(width: 24, height: 24)
+                        Image(systemName: "checkmark")
+                            .font(.caption.weight(.bold))
+                            .foregroundColor(.white)
+                    } else {
+                        Circle().fill(recipeAccent.opacity(0.14))
+                            .frame(width: 24, height: 24)
+                        Text("\(index + 1)")
+                            .font(.caption.weight(.bold))
+                            .foregroundColor(recipeAccent)
+                    }
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    if let title = step.title, !title.isEmpty {
+                        Text(title)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundColor(done ? GenUIStyle.mutedText(isDarkMode) : GenUIStyle.primaryText(isDarkMode))
+                            .strikethrough(done)
+                    }
+                    Text(step.content)
+                        .font(.subheadline)
+                        .foregroundColor(done ? GenUIStyle.mutedText(isDarkMode) : GenUIStyle.primaryText(isDarkMode))
+                        .strikethrough(done)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius)
+                    .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var sourceRow: some View {
+        HStack {
+            Text("Source: ")
+                .font(.caption)
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            if let url = args.sourceUrl?.trimmingCharacters(in: .whitespacesAndNewlines), !url.isEmpty {
+                Button(action: { GenUIURLOpener.open(url) }) {
+                    Text(sourceLabel(fallback: url))
+                        .underline()
+                        .font(.caption)
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                }
+                .buttonStyle(.plain)
+            } else if let source = args.source?.trimmingCharacters(in: .whitespacesAndNewlines), !source.isEmpty {
+                Text(source)
+                    .font(.caption)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+            Spacer()
+        }
+        .padding(.top, 6)
+        .overlay(
+            Rectangle()
+                .frame(height: 1)
+                .foregroundColor(GenUIStyle.borderColor(isDarkMode))
+                .padding(.top, 0),
+            alignment: .top
+        )
+    }
+
+    private func sourceLabel(fallback: String) -> String {
+        guard let source = args.source?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !source.isEmpty else { return fallback }
+        return source
+    }
+}
+
+private func scaleQuantityText(_ value: String, scale: Double) -> String {
+    guard scale != defaultRecipeScale,
+          let regex = try? NSRegularExpression(pattern: quantityPattern) else {
+        return value
+    }
+
+    var result = value
+    let range = NSRange(value.startIndex..<value.endIndex, in: value)
+    let matches = regex.matches(in: value, range: range).reversed()
+    for match in matches {
+        guard let tokenRange = Range(match.range, in: result) else { continue }
+        let token = String(result[tokenRange])
+        guard let amount = parseQuantityToken(token) else { continue }
+        result.replaceSubrange(tokenRange, with: formatScaledQuantity(amount * scale))
+    }
+    return result
+}
+
+private func parseQuantityToken(_ token: String) -> Double? {
+    let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let fraction = unicodeFractions[trimmed] {
+        return fraction
+    }
+
+    // Compact mixed unicode fractions like `1½` or `2¾`: a run of digits
+    // followed by a single unicode fraction character with no separator.
+    if let lastScalar = trimmed.unicodeScalars.last,
+       let fraction = unicodeFractions[String(lastScalar)],
+       trimmed.unicodeScalars.count > 1 {
+        let wholePart = String(trimmed.unicodeScalars.dropLast())
+        if let whole = Double(wholePart) {
+            return whole + fraction
+        }
+    }
+
+    let parts = trimmed.split(separator: " ")
+    if parts.count == 2,
+       let whole = Double(parts[0]),
+       let fraction = parseSlashFraction(String(parts[1])) {
+        return whole + fraction
+    }
+
+    if let fraction = parseSlashFraction(trimmed) {
+        return fraction
+    }
+
+    return Double(trimmed)
+}
+
+private func parseSlashFraction(_ value: String) -> Double? {
+    let parts = value.split(separator: "/")
+    guard parts.count == 2,
+          let numerator = Double(parts[0]),
+          let denominator = Double(parts[1]),
+          denominator != 0 else {
+        return nil
+    }
+    return numerator / denominator
+}
+
+private func formatScaledQuantity(_ value: Double) -> String {
+    if value.rounded() == value {
+        return String(Int(value))
+    }
+
+    let whole = floor(value)
+    let fraction = value - whole
+    if let match = fractionLabels.first(where: { abs($0.value - fraction) < fractionMatchTolerance }) {
+        return whole > 0 ? "\(Int(whole)) \(match.label)" : match.label
+    }
+
+    let formatted = String(format: "%.2f", value)
+    return formatted
+        .replacingOccurrences(of: #"\.?0+$"#, with: "", options: .regularExpression)
+}
+
+/// Minimal flow layout for tag rows (works on iOS 16+).
+private struct RecipeTagFlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var width: CGFloat = 0
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            // Only wrap when the row already has content; an item wider
+            // than the container still goes on the current row (and gets
+            // clipped) instead of forcing an empty leading row.
+            if x > 0, x + size.width > maxWidth {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+            width = max(width, x)
+        }
+        return CGSize(width: width, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x: CGFloat = bounds.minX
+        var y: CGFloat = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
@@ -1,0 +1,407 @@
+//
+//  SportsDataWidget.swift
+//  TinfoilChat
+//
+
+import OpenAI
+import SwiftUI
+
+private let sportsLiveAccent = Color.red
+private let sportsLiveBackgroundOpacity: Double = 0.12
+private let sportsRowAltBackgroundOpacity: Double = 0.04
+private let sportsLeaderHighlightOpacity: Double = 0.08
+
+private func sportsIsLive(_ status: String?) -> Bool {
+    guard let status, !status.isEmpty else { return false }
+    let lowered = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return lowered.contains("live")
+        || lowered.contains("in progress")
+        || lowered.contains("halftime")
+        || lowered.contains("half time")
+        || lowered == "ot"
+        || lowered.contains("overtime")
+        || lowered.contains(" ot")
+}
+
+struct SportsDataWidget: GenUIWidget {
+    struct Team: Decodable {
+        let name: String
+        let score: StringOrNumber?
+        let logo: String?
+        let rank: String?
+    }
+
+    struct Standing: Decodable {
+        let team: String
+        let wins: Double?
+        let losses: Double?
+        let ties: Double?
+        let points: StringOrNumber?
+        let gamesBack: String?
+    }
+
+    struct Args: Decodable {
+        let sport: String?
+        let kind: String
+        let title: String?
+        let status: String?
+        let venue: String?
+        let startTime: String?
+        let home: Team?
+        let away: Team?
+        let standings: [Standing]?
+    }
+
+    let name = "render_sports_data"
+    let description = "Display a sports fixture (game scoreline) or a league standings table."
+    let promptHint = "a sports fixture scoreline or a league standings table"
+
+    var schema: JSONSchema {
+        let team = GenUISchema.object(
+            properties: [
+                "name": GenUISchema.string(),
+                "score": GenUISchema.stringOrNumber(),
+                "logo": GenUISchema.string(),
+                "rank": GenUISchema.string(),
+            ],
+            required: ["name"]
+        )
+        let standing = GenUISchema.object(
+            properties: [
+                "team": GenUISchema.string(),
+                "wins": GenUISchema.number(),
+                "losses": GenUISchema.number(),
+                "ties": GenUISchema.number(),
+                "points": GenUISchema.stringOrNumber(),
+                "gamesBack": GenUISchema.string(),
+            ],
+            required: ["team"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "sport": GenUISchema.string(description: "e.g. \"NBA\", \"Premier League\""),
+                "kind": GenUISchema.string(
+                    description: "`fixture` for a single game (scoreline), `standings` for a league table",
+                    enumValues: ["fixture", "standings"]
+                ),
+                "title": GenUISchema.string(),
+                "status": GenUISchema.string(),
+                "venue": GenUISchema.string(),
+                "startTime": GenUISchema.string(),
+                "home": team,
+                "away": team,
+                "standings": GenUISchema.array(items: standing),
+            ],
+            required: ["kind"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(SportsDataView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct SportsDataView: View {
+    let args: SportsDataWidget.Args
+    let isDarkMode: Bool
+
+    private var isLive: Bool { sportsIsLive(args.status) }
+
+    private var leadingScore: Double? {
+        guard let home = args.home?.score?.numericValue,
+              let away = args.away?.score?.numericValue else { return nil }
+        return max(home, away)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            if args.kind == "fixture" {
+                fixtureView
+            } else if args.kind == "standings", let standings = args.standings, !standings.isEmpty {
+                standingsView(standings: standings)
+            }
+
+            footer
+        }
+        .genUICard(isDarkMode: isDarkMode)
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 8) {
+            if let sport = args.sport, !sport.isEmpty {
+                Text(sport.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .tracking(0.8)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+            if let status = args.status, !status.isEmpty {
+                statusPill(text: status)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func statusPill(text: String) -> some View {
+        if isLive {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(sportsLiveAccent)
+                    .frame(width: 6, height: 6)
+                Text(text)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundColor(sportsLiveAccent)
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(
+                Capsule().fill(sportsLiveAccent.opacity(sportsLiveBackgroundOpacity))
+            )
+        } else {
+            Text(text)
+                .font(.caption2.weight(.medium))
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+        }
+    }
+
+    private var titleText: String? {
+        guard let title = args.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !title.isEmpty else { return nil }
+        return title
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if titleText != nil || venueText != nil || startTimeText != nil {
+            VStack(alignment: .leading, spacing: 2) {
+                if let title = titleText {
+                    Text(title)
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                }
+                if venueText != nil || startTimeText != nil {
+                    HStack(spacing: 6) {
+                        if let venue = venueText { Text(venue) }
+                        if venueText != nil && startTimeText != nil { Text("\u{00B7}") }
+                        if let startTime = startTimeText { Text(startTime) }
+                    }
+                    .font(.caption2)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                }
+            }
+        }
+    }
+
+    private var venueText: String? {
+        guard let venue = args.venue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !venue.isEmpty else { return nil }
+        return venue
+    }
+
+    private var startTimeText: String? {
+        guard let startTime = args.startTime?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !startTime.isEmpty else { return nil }
+        return startTime
+    }
+
+    @ViewBuilder
+    private var fixtureView: some View {
+        HStack(alignment: .center, spacing: 16) {
+            if let home = args.home {
+                teamBlock(team: home, alignment: .leading)
+            }
+            if let home = args.home, let away = args.away {
+                connector(home: home, away: away)
+            } else {
+                Text("VS")
+                    .font(.caption2.weight(.semibold))
+                    .tracking(0.5)
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+            if let away = args.away {
+                teamBlock(team: away, alignment: .trailing)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func connector(home: SportsDataWidget.Team, away: SportsDataWidget.Team) -> some View {
+        if home.score?.numericValue == nil && away.score?.numericValue == nil,
+           let startTime = args.startTime, !startTime.isEmpty {
+            Text(startTime)
+                .font(.caption2.weight(.semibold))
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+        } else {
+            Text("–")
+                .font(.system(size: 22, weight: .light, design: .rounded))
+                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+        }
+    }
+
+    private func teamBlock(team: SportsDataWidget.Team, alignment: HorizontalAlignment) -> some View {
+        let isWinner = isWinningTeam(team)
+        let isLoser = isLosingTeam(team)
+        let scoreColor: Color = {
+            if isLive { return .red }
+            if isWinner { return GenUIStyle.accent }
+            if isLoser { return GenUIStyle.mutedText(isDarkMode) }
+            return GenUIStyle.primaryText(isDarkMode)
+        }()
+        let scoreWeight: Font.Weight = isWinner ? .bold : .semibold
+
+        return VStack(alignment: alignment, spacing: 6) {
+            HStack(spacing: 8) {
+                if alignment == .trailing { Spacer(minLength: 0) }
+                if let logo = team.logo, !logo.isEmpty {
+                    GenUIRemoteImage(url: logo, isDarkMode: isDarkMode)
+                        .frame(width: 28, height: 28)
+                        .clipShape(Circle())
+                }
+                VStack(alignment: alignment, spacing: 1) {
+                    Text(team.name)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        .lineLimit(1)
+                    if let rank = team.rank, !rank.isEmpty {
+                        Text(rank)
+                            .font(.caption2)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                            .lineLimit(1)
+                    }
+                }
+                if alignment == .leading { Spacer(minLength: 0) }
+            }
+            Text(team.score?.stringValue ?? "—")
+                .font(.system(size: 34, weight: scoreWeight, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(scoreColor)
+                .frame(maxWidth: .infinity, alignment: alignment == .leading ? .leading : .trailing)
+        }
+        .frame(maxWidth: .infinity, alignment: alignment == .leading ? .leading : .trailing)
+    }
+
+    private func isWinningTeam(_ team: SportsDataWidget.Team) -> Bool {
+        guard !isLive,
+              let home = args.home?.score?.numericValue,
+              let away = args.away?.score?.numericValue,
+              home != away else { return false }
+        if let value = team.score?.numericValue {
+            return value == max(home, away)
+        }
+        return false
+    }
+
+    private func isLosingTeam(_ team: SportsDataWidget.Team) -> Bool {
+        guard !isLive,
+              let home = args.home?.score?.numericValue,
+              let away = args.away?.score?.numericValue,
+              home != away else { return false }
+        if let value = team.score?.numericValue {
+            return value == min(home, away)
+        }
+        return false
+    }
+
+    @ViewBuilder
+    private func standingsView(standings: [SportsDataWidget.Standing]) -> some View {
+        let hasGamesBack = standings.contains { ($0.gamesBack ?? "").isEmpty == false }
+
+        VStack(spacing: 0) {
+            ForEach(Array(standings.enumerated()), id: \.offset) { index, row in
+                if index > 0 {
+                    Divider()
+                        .background(GenUIStyle.borderColor(isDarkMode).opacity(0.6))
+                }
+                standingsRow(index: index, row: row, showGamesBack: hasGamesBack)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: GenUIStyle.smallCornerRadius)
+                .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func standingsRow(
+        index: Int,
+        row: SportsDataWidget.Standing,
+        showGamesBack: Bool
+    ) -> some View {
+        let isLeader = index == 0
+
+        HStack(spacing: 12) {
+            rankChip(index: index, isLeader: isLeader)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.team)
+                    .font(.subheadline.weight(isLeader ? .semibold : .medium))
+                    .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                    .lineLimit(1)
+                Text(recordLabel(row))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if showGamesBack, let gb = row.gamesBack, !gb.isEmpty {
+                Text(gb)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+            }
+
+            if let points = row.points?.stringValue, !points.isEmpty {
+                Text(points)
+                    .font(.system(.subheadline, design: .rounded).weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundColor(isLeader ? GenUIStyle.accent : GenUIStyle.primaryText(isDarkMode))
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            isLeader
+                ? GenUIStyle.accent.opacity(0.10)
+                : Color.clear
+        )
+    }
+
+    @ViewBuilder
+    private func rankChip(index: Int, isLeader: Bool) -> some View {
+        Text("\(index + 1)")
+            .font(.caption2.monospacedDigit().weight(.semibold))
+            .foregroundColor(isLeader ? .white : GenUIStyle.mutedText(isDarkMode))
+            .frame(width: 22, height: 22)
+            .background(
+                Circle()
+                    .fill(isLeader ? GenUIStyle.accent : GenUIStyle.primaryText(isDarkMode).opacity(sportsRowAltBackgroundOpacity * 2))
+            )
+    }
+
+    private func recordLabel(_ row: SportsDataWidget.Standing) -> String {
+        var parts: [String] = []
+        if row.wins != nil { parts.append(numberLabel(row.wins)) }
+        if row.losses != nil { parts.append(numberLabel(row.losses)) }
+        if let ties = row.ties, ties > 0 { parts.append(numberLabel(ties)) }
+        if parts.isEmpty { return "" }
+        return parts.joined(separator: "–")
+    }
+
+    private func numberLabel(_ value: Double?) -> String {
+        guard let value else { return "" }
+        if value.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(Int(value))
+        }
+        return String(value)
+    }
+}
+
+private extension StringOrNumber {
+    var numericValue: Double? {
+        Double(stringValue.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
@@ -1,0 +1,88 @@
+//
+//  StatCardsWidget.swift
+//  TinfoilChat
+//
+
+import OpenAI
+import SwiftUI
+
+struct StatCardsWidget: GenUIWidget {
+    struct Stat: Decodable {
+        let label: String
+        let value: StringOrNumber
+        let trend: String?
+    }
+
+    struct Args: Decodable {
+        let stats: [Stat]
+    }
+
+    let name = "render_stat_cards"
+    let description = "Display a grid of metrics or KPIs. Use when presenting multiple numeric summaries."
+    let promptHint = "grid of numeric KPIs or metrics"
+
+    var schema: JSONSchema {
+        let statSchema = GenUISchema.object(
+            properties: [
+                "label": GenUISchema.string(),
+                "value": GenUISchema.stringOrNumber(),
+                "trend": GenUISchema.string(enumValues: ["up", "down"]),
+            ],
+            required: ["label", "value"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "stats": GenUISchema.array(
+                    items: statSchema,
+                    description: "Metrics or KPIs to display in a responsive grid",
+                    minItems: 1
+                ),
+            ],
+            required: ["stats"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(StatCardsView(stats: args.stats, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct StatCardsView: View {
+    let stats: [StatCardsWidget.Stat]
+    let isDarkMode: Bool
+
+    private var columns: [GridItem] {
+        [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)]
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(Array(stats.enumerated()), id: \.offset) { _, stat in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(stat.label)
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                        .lineLimit(2)
+
+                    HStack(spacing: 6) {
+                        Text(stat.value.stringValue)
+                            .font(.title3.weight(.semibold))
+                            .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        if stat.trend == "up" {
+                            Image(systemName: "arrow.up.right")
+                                .font(.caption.weight(.semibold))
+                                .foregroundColor(.green)
+                        } else if stat.trend == "down" {
+                            Image(systemName: "arrow.down.right")
+                                .font(.caption.weight(.semibold))
+                                .foregroundColor(.red)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .genUICard(isDarkMode: isDarkMode, padding: 12)
+            }
+        }
+    }
+}

--- a/TinfoilChat/Views/GenUI/Widgets/TimelineWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/TimelineWidget.swift
@@ -1,0 +1,103 @@
+//
+//  TimelineWidget.swift
+//  TinfoilChat
+//
+
+import OpenAI
+import SwiftUI
+
+struct TimelineWidget: GenUIWidget {
+    struct Event: Decodable {
+        let date: String
+        let title: String
+        let description: String?
+    }
+
+    struct Args: Decodable {
+        let events: [Event]
+        let title: String?
+    }
+
+    let name = "render_timeline"
+    let description = "Display a chronological timeline of events. Use for history, news recaps, or project milestones."
+    let promptHint = "chronological events, history, news recaps, or milestones"
+
+    var schema: JSONSchema {
+        let eventSchema = GenUISchema.object(
+            properties: [
+                "date": GenUISchema.string(),
+                "title": GenUISchema.string(),
+                "description": GenUISchema.string(),
+            ],
+            required: ["date", "title"]
+        )
+        return GenUISchema.object(
+            properties: [
+                "events": GenUISchema.array(
+                    items: eventSchema,
+                    description: "Chronological events",
+                    minItems: 1
+                ),
+                "title": GenUISchema.string(),
+            ],
+            required: ["events"]
+        )
+    }
+
+    @MainActor
+    func renderInline(args: Args, context: GenUIRenderContext) -> AnyView? {
+        AnyView(TimelineEventsView(args: args, isDarkMode: context.isDarkMode))
+    }
+}
+
+private struct TimelineEventsView: View {
+    let args: TimelineWidget.Args
+    let isDarkMode: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let title = args.title, !title.isEmpty {
+                GenUITitle(text: title, isDarkMode: isDarkMode)
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(Array(args.events.enumerated()), id: \.offset) { index, event in
+                    HStack(alignment: .top, spacing: 12) {
+                        ZStack(alignment: .top) {
+                            // Connector line
+                            Rectangle()
+                                .fill(GenUIStyle.borderColor(isDarkMode))
+                                .frame(width: 1)
+                                .padding(.top, 18)
+                                .opacity(index == args.events.count - 1 ? 0 : 1)
+
+                            Circle()
+                                .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 2)
+                                .background(Circle().fill(GenUIStyle.cardBackground(isDarkMode)))
+                                .frame(width: 12, height: 12)
+                                .padding(.top, 4)
+                        }
+                        .frame(width: 14)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(event.date.uppercased())
+                                .font(.caption2.weight(.semibold))
+                                .tracking(0.5)
+                                .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                            Text(event.title)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                            if let description = event.description, !description.isEmpty {
+                                Text(description)
+                                    .font(.caption)
+                                    .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -185,8 +185,57 @@ struct MessageInputView: View {
         }
     }
 
+    /// When the latest assistant message ends in an input-surface
+    /// GenUI tool call, the chat input is replaced by the widget.
+    private var pendingInputToolCall: PendingInputToolCall? {
+        viewModel.currentChat?.pendingInputToolCall()
+    }
+
     @ViewBuilder
     private var inputContent: some View {
+        if let pending = pendingInputToolCall {
+            genUIInputContainer(pending: pending)
+        } else {
+            standardInputContent
+        }
+    }
+
+    @ViewBuilder
+    private func genUIInputContainer(pending: PendingInputToolCall) -> some View {
+        VStack(spacing: 8) {
+            rateLimitLabel
+
+            GenUIInputAreaView(
+                pending: pending,
+                isDarkMode: isDarkMode,
+                onResolve: { toolCallId, resultText, resultData in
+                    viewModel.resolveGenUIToolCall(
+                        toolCallId: toolCallId,
+                        resultText: resultText,
+                        resultData: resultData
+                    )
+                },
+                onCancel: nil
+            )
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.top, 10)
+        .padding(.bottom, max(inputBottomPadding, 12))
+        .frame(maxWidth: .infinity)
+        .background {
+            UnevenRoundedRectangle(topLeadingRadius: 28, topTrailingRadius: 28)
+                .fill(.thickMaterial)
+                .ignoresSafeArea(edges: .bottom)
+        }
+        .overlay(alignment: .top) {
+            Rectangle()
+                .frame(height: 1)
+                .foregroundColor(GenUIStyle.borderColor(isDarkMode))
+        }
+    }
+
+    @ViewBuilder
+    private var standardInputContent: some View {
         if #available(iOS 26, *) {
             // iOS 26+ with liquid glass effect
             VStack(spacing: 4) {

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -55,14 +55,33 @@ struct MessageView: View {
     /// don't stack N full-height pills in the chat.
     private enum InlineSegmentRun {
         case text(String, isTrailing: Bool)
+        case thinking(content: String, isThinking: Bool, duration: Double?)
         case webSearches([WebSearchInstance])
         case urlFetches([URLFetchState])
+        case toolCall(GenUIToolCall, isTrailing: Bool)
     }
 
     private func inlineSegmentRuns(from segments: [MessageSegment]) -> [InlineSegmentRun] {
         let lastTextIndex: Int? = {
             for i in segments.indices.reversed() {
                 if case .text = segments[i] { return i }
+            }
+            return nil
+        }()
+
+        // Index of the last tool-call segment whose widget hasn't yet
+        // produced fully-parseable arguments. Used to drive the streaming
+        // "Generating component" placeholder on exactly that one widget.
+        let lastStreamingToolCallIndex: Int? = {
+            for i in segments.indices.reversed() {
+                guard case .toolCall(let toolCallId) = segments[i],
+                      let toolCall = message.toolCalls.first(where: { $0.id == toolCallId }) else { continue }
+                if !toolCall.arguments.isEmpty,
+                   let data = toolCall.arguments.data(using: .utf8),
+                   (try? JSONSerialization.jsonObject(with: data)) != nil {
+                    return nil
+                }
+                return i
             }
             return nil
         }()
@@ -92,6 +111,10 @@ struct MessageView: View {
                 if !text.isEmpty {
                     runs.append(.text(text, isTrailing: index == lastTextIndex))
                 }
+            case .thinking(let content, let isThinking, let duration):
+                flushSearches()
+                flushFetches()
+                runs.append(.thinking(content: content, isThinking: isThinking, duration: duration))
             case .webSearch(let searchId):
                 flushFetches()
                 if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
@@ -101,6 +124,12 @@ struct MessageView: View {
                 flushSearches()
                 if let fetch = message.urlFetches.first(where: { $0.id == fetchId }) {
                     fetchBuffer.append(fetch)
+                }
+            case .toolCall(let toolCallId):
+                flushSearches()
+                flushFetches()
+                if let toolCall = message.toolCalls.first(where: { $0.id == toolCallId }) {
+                    runs.append(.toolCall(toolCall, isTrailing: index == lastStreamingToolCallIndex))
                 }
             }
         }
@@ -165,6 +194,15 @@ struct MessageView: View {
                         .transaction { transaction in
                             transaction.animation = nil
                         }
+                case .thinking(let content, let isThinking, let duration):
+                    CollapsibleThinkingBox(
+                        thinkingText: content,
+                        isDarkMode: isDarkMode,
+                        isStreaming: isThinking && isLoading && isLastMessage,
+                        generationTimeSeconds: duration,
+                        thinkingSummary: isLastMessage && isThinking ? viewModel.thinkingSummary : nil,
+                        onTap: { showThoughtsSheet = true }
+                    )
                 case .webSearches(let group):
                     let aggregate = aggregatedState(for: group)
                     let isSearchInFlight = aggregate.status == .searching
@@ -192,9 +230,43 @@ struct MessageView: View {
                             activeURLFetchGroup = IdentifiedGroup(items: group)
                         }
                     )
+                case .toolCall(let toolCall, let isTrailing):
+                    GenUIToolCallView(
+                        toolCall: toolCall,
+                        isStreaming: isTrailing && isLoading && isLastMessage,
+                        isDarkMode: isDarkMode,
+                        resolution: message.genUIResolution(for: toolCall.id),
+                        onRetry: nil
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
+    }
+
+    private func segmentsCoverEntireAssistantMessage(_ segments: [MessageSegment]) -> Bool {
+        if message.thoughts != nil || message.isThinking {
+            let hasThinkingSegment = segments.contains { segment in
+                if case .thinking = segment { return true }
+                return false
+            }
+            if !hasThinkingSegment { return false }
+        }
+        if !message.content.isEmpty {
+            let hasTextSegment = segments.contains { segment in
+                if case .text(let text) = segment, !text.isEmpty { return true }
+                return false
+            }
+            if !hasTextSegment { return false }
+        }
+        for toolCall in message.toolCalls {
+            let hasToolCallSegment = segments.contains { segment in
+                if case .toolCall(let id) = segment, id == toolCall.id { return true }
+                return false
+            }
+            if !hasToolCallSegment { return false }
+        }
+        return true
     }
 
     /// URLs the router annotated as web-search citations on this message.
@@ -237,6 +309,7 @@ struct MessageView: View {
                     message.content.isEmpty &&
                     message.thoughts == nil &&
                     !message.isThinking &&
+                    (message.segments?.isEmpty ?? true) &&
                     isLoading &&
                     isLastMessage {
                     VStack(alignment: .leading, spacing: 4) {
@@ -261,6 +334,17 @@ struct MessageView: View {
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                // Assistant messages whose timeline-derived segments cover
+                // the entire message (thinking, web search, content, tool
+                // calls) render through the unified inline-segments
+                // pipeline so chronological order matches the webapp.
+                else if message.role == .assistant,
+                        let segments = message.segments,
+                        !segments.isEmpty,
+                        segmentsCoverEntireAssistantMessage(segments) {
+                    inlineSegmentsView(segments: segments)
                 }
 
                 // If the message is thinking or has thoughts, display them in a thinking box
@@ -373,7 +457,7 @@ struct MessageView: View {
                     }
                 }
 
-                else if !message.content.isEmpty {
+                else if !message.content.isEmpty || !message.toolCalls.isEmpty {
                     if message.role == .user {
                         if isEditMode {
                             UserMessageEditView(
@@ -430,6 +514,21 @@ struct MessageView: View {
                                 )
                                     .equatable()
                                     .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+
+                            // Render any GenUI tool calls that came from a
+                            // session that didn't persist segments (e.g.
+                            // older saved messages or messages synced from
+                            // a client that doesn't emit segments).
+                            ForEach(message.toolCalls) { toolCall in
+                                GenUIToolCallView(
+                                    toolCall: toolCall,
+                                    isStreaming: false,
+                                    isDarkMode: isDarkMode,
+                                    resolution: message.genUIResolution(for: toolCall.id),
+                                    onRetry: nil
+                                )
+                                .frame(maxWidth: .infinity, alignment: .leading)
                             }
                         }
                     }
@@ -1467,11 +1566,11 @@ struct UnsupportedGenUINoticeView: View {
                 .foregroundColor(.orange)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("Interactive component unavailable")
+                Text("Component unavailable")
                     .font(.subheadline.weight(.medium))
                     .foregroundColor(isDarkMode ? .white : .black)
 
-                Text("This message includes a GenUI component. Tinfoil for iOS doesn't support GenUI yet; open this chat on web to view it.")
+                Text("This message includes a component that isn't available in this version of the app.")
                     .font(.caption)
                     .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)

--- a/TinfoilChatTests/MessageSegmentDecodeTests.swift
+++ b/TinfoilChatTests/MessageSegmentDecodeTests.swift
@@ -73,7 +73,8 @@ struct MessageSegmentDecodeTests {
         #expect(message.segments?.isEmpty == true)
     }
 
-    @Test func decodesAndPreservesGenUIToolCalls() throws {
+    @Test @MainActor
+    func decodesAndPreservesGenUIToolCalls() throws {
         let json = """
         {
           "id": "m1",
@@ -111,7 +112,8 @@ struct MessageSegmentDecodeTests {
         #expect(roundTripped.timeline == message.timeline)
     }
 
-    @Test func detectsGenUIFromTimelineWhenToolCallsAreMissing() throws {
+    @Test @MainActor
+    func detectsUnsupportedGenUIFromTimelineWhenToolCallsAreMissing() throws {
         let json = """
         {
           "id": "m1",
@@ -124,15 +126,132 @@ struct MessageSegmentDecodeTests {
               "type": "tool_call",
               "id": "tool-call-1",
               "toolCallId": "call_1",
+              "name": "render_future_widget",
+              "arguments": "{\\"foo\\":\\"bar\\"}"
+            }
+          ]
+        }
+        """
+
+        // Webapp-synced messages omit the flat `toolCalls` array but still
+        // carry tool calls on the timeline. iOS derives `toolCalls` from
+        // the timeline so the unsupported-widget notice fires regardless
+        // of which client wrote the message.
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        #expect(message.toolCalls.count == 1)
+        #expect(message.toolCalls[0].name == "render_future_widget")
+        #expect(message.hasUnsupportedGenUI)
+    }
+
+    @Test @MainActor
+    func registeredGenUIToolCallIsNotMarkedUnsupported() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "toolCalls": [
+            {
+              "id": "call_1",
               "name": "render_link_preview",
-              "arguments": "{\\"url\\":\\"https://example.com\\"}"
+              "arguments": "{\\"url\\":\\"https://example.com\\",\\"title\\":\\"Example\\"}"
             }
           ]
         }
         """
 
         let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
-        #expect(message.toolCalls.isEmpty)
-        #expect(message.hasUnsupportedGenUI)
+        #expect(message.toolCalls.count == 1)
+        #expect(!message.hasUnsupportedGenUI)
+    }
+
+    @Test @MainActor
+    func derivesSegmentsAndWebSearchesFromTimeline() throws {
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "Done.",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "timeline": [
+            { "type": "thinking", "id": "t-0", "content": "Reasoning...", "isThinking": false, "duration": 1.5 },
+            {
+              "type": "web_search",
+              "id": "ws-0",
+              "state": {
+                "query": "weather",
+                "status": "completed",
+                "sources": [{ "title": "Example", "url": "https://example.com" }]
+              }
+            },
+            { "type": "content", "id": "c-0", "content": "Looking up weather." },
+            {
+              "type": "tool_call",
+              "id": "tc-0",
+              "toolCallId": "call_1",
+              "name": "render_clock",
+              "arguments": "{\\"label\\":\\"NYC\\"}"
+            },
+            { "type": "content", "id": "c-1", "content": "Done." }
+          ]
+        }
+        """
+
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        let segments = try #require(message.segments)
+        #expect(segments.count == 5)
+        if case .thinking(let content, _, let duration) = segments[0] {
+            #expect(content == "Reasoning...")
+            #expect(duration == 1.5)
+        } else {
+            Issue.record("Expected first segment to be thinking, got \(segments[0])")
+        }
+        #expect(segments[1] == .webSearch(searchId: "ws-0"))
+        #expect(segments[2] == .text("Looking up weather."))
+        #expect(segments[3] == .toolCall(toolCallId: "call_1"))
+        #expect(segments[4] == .text("Done."))
+
+        let webSearches = try #require(message.webSearches)
+        #expect(webSearches.count == 1)
+        #expect(webSearches[0].id == "ws-0")
+        #expect(webSearches[0].query == "weather")
+        #expect(webSearches[0].sources?.first?.url == "https://example.com")
+
+        #expect(message.toolCalls.count == 1)
+        #expect(message.toolCalls[0].name == "render_clock")
+    }
+
+    @Test @MainActor
+    func readsResolutionFromTimelineToolCallBlock() throws {
+        let resolvedAtMillis: Int = 1_714_060_800_000
+        let json = """
+        {
+          "id": "m1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-04-21T12:00:00.000Z",
+          "toolCalls": [
+            { "id": "call_1", "name": "ask_user_input", "arguments": "{}" }
+          ],
+          "timeline": [
+            {
+              "type": "tool_call",
+              "id": "tool-call-0",
+              "toolCallId": "call_1",
+              "name": "ask_user_input",
+              "arguments": "{}",
+              "resolvedAt": \(resolvedAtMillis),
+              "resolution": { "text": "Yes", "data": { "choice": "yes" } }
+            }
+          ]
+        }
+        """
+
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        let resolution = try #require(message.genUIResolution(for: "call_1"))
+        #expect(resolution.text == "Yes")
+        let expectedDate = Date(timeIntervalSince1970: TimeInterval(resolvedAtMillis) / 1000)
+        #expect(abs(resolution.resolvedAt.timeIntervalSince(expectedDate)) < 0.001)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds generative UI to chat with a SwiftUI widget system that renders tool-called components inline and in the input area. Streams args, resolves input widgets, and persists `tool_call` blocks so chats round‑trip across platforms; also adds link preview metadata.

- **New Features**
  - Widget framework: `GenUIWidget` protocol, `GenUIRegistry`, shared `GenUIStyle`, and timeline helpers for `tool_call` blocks.
  - Rendering: `GenUIToolCallView` (inline) with streaming placeholders; `GenUIInputAreaView` inside `MessageInputView`; `ChatViewModel.resolveGenUIToolCall` writes the resolution and submits a user reply.
  - Widgets: charts, images (full-screen viewer with paging/swipe), link preview, map, message compose, stat cards, timeline, clock/timer, sports, recipe card, and artifact preview.
  - Link previews: `LinkMetadataService` fetches OpenGraph and deduplicates in-flight requests.
  - Pipeline and models: `MessageSegment` adds `thinking`/`toolCall`; `ChatQueryBuilder` adds GenUI prompt hints and `genUIEnabled` (now `@MainActor`). Tests cover decoding, timeline resolution, and registered/unknown widget detection.

- **Migration**
  - No required changes. To disable generative UI, call `ChatQueryBuilder.buildQuery(..., genUIEnabled: false)`.

<sup>Written for commit fb04b5099648821f9876c91e02e105e28962d58b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

