### PR TITLE
Add temporary chats and fix minor UX problems

### DIFF
--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -50,6 +50,10 @@ struct Chat: Identifiable, Codable {
     // Project association (used by React, preserved by iOS)
     var projectId: String?
 
+    // Transient flag for ephemeral "temporary" chats. Never persisted to disk
+    // or cloud. Used to power the toolbar incognito toggle.
+    var isTemporary: Bool = false
+
     // Computed properties for sync filtering
     var isBlankChat: Bool {
         // Don't treat failed-to-decrypt chats as blank
@@ -236,7 +240,9 @@ struct Chat: Identifiable, Codable {
     // MARK: - Per-Chat File Storage Methods
 
     /// Routes to `.local` or `.cloud` storage based on `chat.isLocalOnly`.
+    /// Temporary chats are never persisted.
     static func saveChat(_ chat: Chat, userId: String?) async {
+        guard !chat.isTemporary else { return }
         guard let userId = userId else { return }
         let storage: EncryptedFileStorage = chat.isLocalOnly ? .local : .cloud
         do {

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -18,7 +18,7 @@ struct Chat: Identifiable, Codable {
         case manual
     }
 
-    static let placeholderTitle = "Untitled"
+    static let placeholderTitle = "New Chat"
 
     let id: String
     var title: String

--- a/TinfoilChat/Services/AudioRecordingService.swift
+++ b/TinfoilChat/Services/AudioRecordingService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AVFoundation
+import UIKit
 import TinfoilAI
 import OpenAI
 
@@ -21,6 +22,7 @@ class AudioRecordingService: NSObject, ObservableObject {
     private var audioRecorder: AVAudioRecorder?
     private var timeoutTimer: Timer?
     private var recordingURL: URL?
+    private var didDisableIdleTimer: Bool = false
 
     private override init() {
         super.init()
@@ -65,6 +67,7 @@ class AudioRecordingService: NSObject, ObservableObject {
         audioRecorder = try AVAudioRecorder(url: url, settings: settings)
         audioRecorder?.record()
         isRecording = true
+        disableIdleTimer()
 
         // Auto-stop after timeout
         timeoutTimer = Timer.scheduledTimer(withTimeInterval: Constants.Audio.recordingTimeoutSeconds, repeats: false) { [weak self] _ in
@@ -85,6 +88,7 @@ class AudioRecordingService: NSObject, ObservableObject {
         audioRecorder?.stop()
         audioRecorder = nil
         isRecording = false
+        restoreIdleTimer()
 
         return recordingURL
     }
@@ -143,6 +147,24 @@ class AudioRecordingService: NSObject, ObservableObject {
         guard let url = recordingURL else { return }
         try? FileManager.default.removeItem(at: url)
         recordingURL = nil
+    }
+
+    private func disableIdleTimer() {
+        guard !didDisableIdleTimer else { return }
+        didDisableIdleTimer = true
+        Task { @MainActor in
+            if !UIApplication.shared.isIdleTimerDisabled {
+                UIApplication.shared.isIdleTimerDisabled = true
+            }
+        }
+    }
+
+    private func restoreIdleTimer() {
+        guard didDisableIdleTimer else { return }
+        didDisableIdleTimer = false
+        Task { @MainActor in
+            UIApplication.shared.isIdleTimerDisabled = false
+        }
     }
 }
 

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -436,34 +436,53 @@ class ProfileManager: ObservableObject {
                p1.customSystemPrompt != p2.customSystemPrompt
     }
     
-    /// Generate personalization prompt for chat
+    /// Generate personalization prompt for chat as a `<user_preferences>` XML block.
+    ///
+    /// Mirrors the webapp's `useCustomSystemPrompt` so the same prompt structure
+    /// reaches the model regardless of platform. The `isUsingPersonalization`
+    /// flag is treated as a soft preference — if the user has filled in fields
+    /// we still inject them, since the most common cause of "the model doesn't
+    /// know my name" is the flag not having flipped to true (e.g. cross-device
+    /// sync, restore from cloud, edit-without-save). "Reset All" clears the
+    /// fields outright, which makes this method return `nil` naturally.
     func getPersonalizationPrompt() -> String? {
-        guard isUsingPersonalization else { return nil }
-        
-        var components: [String] = []
-        
-        if !nickname.isEmpty {
-            components.append("The user's name is \(nickname).")
+        let trimmedNickname = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedProfession = profession.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nonEmptyTraits = traits.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        let trimmedContext = additionalContext.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let hasAnyField = !trimmedNickname.isEmpty
+            || !trimmedProfession.isEmpty
+            || !nonEmptyTraits.isEmpty
+            || !trimmedContext.isEmpty
+
+        guard hasAnyField else { return nil }
+
+        var xml = "The user has provided personal preferences for this conversation. Adapt your responses according to these settings while maintaining accuracy and helpfulness.\n\n<user_preferences>"
+
+        if !trimmedNickname.isEmpty {
+            xml += "\n  <nickname>\(trimmedNickname)</nickname>"
         }
-        
-        if !profession.isEmpty {
-            components.append("They work as a \(profession).")
+
+        if !trimmedProfession.isEmpty {
+            xml += "\n  <profession>\(trimmedProfession)</profession>"
         }
-        
-        if !traits.isEmpty {
-            let traitsText = traits.joined(separator: ", ")
-            components.append("Their interests/traits include: \(traitsText).")
+
+        if !nonEmptyTraits.isEmpty {
+            xml += "\n  <traits>"
+            for trait in nonEmptyTraits {
+                xml += "\n    <trait>\(trait)</trait>"
+            }
+            xml += "\n  </traits>"
         }
-        
-        if !additionalContext.isEmpty {
-            components.append(additionalContext)
+
+        if !trimmedContext.isEmpty {
+            xml += "\n  <additional_context>\n    \(trimmedContext)\n  </additional_context>"
         }
-        
-        if !language.isEmpty && language != "English" {
-            components.append("Please respond in \(language).")
-        }
-        
-        return components.isEmpty ? nil : components.joined(separator: " ")
+
+        xml += "\n</user_preferences>"
+
+        return xml
     }
     
     /// Get custom system prompt if enabled

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -168,6 +168,11 @@ class ChatViewModel: ObservableObject {
     @Published var audioError: String? = nil
     @Published var showMicrophonePermissionAlert: Bool = false
 
+    // Temporary (incognito) chat mode. When active, the current chat is an
+    // ephemeral in-memory chat that is never persisted or synced.
+    @Published var isTemporaryMode: Bool = false
+    private var previousChatIdBeforeTemporary: String?
+
     // Attachment properties
     @Published var pendingAttachments: [Attachment] = []
     @Published var isProcessingAttachment: Bool = false
@@ -682,6 +687,19 @@ class ChatViewModel: ObservableObject {
             cancelGeneration()
         }
 
+        // Exit temporary mode when the user explicitly creates a fresh chat.
+        if isTemporaryMode {
+            if let temp = currentChat, temp.isTemporary {
+                if temp.isLocalOnly {
+                    localChats.removeAll { $0.id == temp.id }
+                } else {
+                    chats.removeAll { $0.id == temp.id }
+                }
+            }
+            isTemporaryMode = false
+            previousChatIdBeforeTemporary = nil
+        }
+
         let shouldBeLocal: Bool
         if let explicit = isLocalOnly {
             shouldBeLocal = explicit
@@ -724,12 +742,88 @@ class ChatViewModel: ObservableObject {
         selectChat(newChat)
         shouldFocusInput = focusInput
     }
-    
+
+    /// Toggles temporary (incognito) chat mode. When enabled, the current chat
+    /// is replaced with an ephemeral in-memory chat that is never persisted to
+    /// disk or synced to the cloud. Disabling restores the previously active
+    /// chat (or creates a new one if none was tracked).
+    func toggleTemporaryMode() {
+        guard hasChatAccess else { return }
+
+        if isLoading {
+            cancelGeneration()
+        }
+
+        if isTemporaryMode {
+            // Exit temporary mode: drop the ephemeral chat and restore previous.
+            if let current = currentChat, current.isTemporary {
+                if current.isLocalOnly {
+                    localChats.removeAll { $0.id == current.id }
+                } else {
+                    chats.removeAll { $0.id == current.id }
+                }
+            }
+
+            isTemporaryMode = false
+            let previousId = previousChatIdBeforeTemporary
+            previousChatIdBeforeTemporary = nil
+
+            if let previousId,
+               let restored = chats.first(where: { $0.id == previousId })
+                                ?? localChats.first(where: { $0.id == previousId }) {
+                selectChat(restored)
+            } else {
+                createNewChat()
+            }
+        } else {
+            // Enter temporary mode: snapshot the current chat ID and swap in a
+            // brand-new ephemeral chat.
+            previousChatIdBeforeTemporary = currentChat?.id
+
+            guard let model = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first else {
+                return
+            }
+
+            var temp = Chat(
+                id: "temp-\(UUID().uuidString.lowercased())",
+                title: "Temporary Chat",
+                modelType: model,
+                userId: currentUserId,
+                isLocalOnly: true
+            )
+            temp.isTemporary = true
+
+            // Track in localChats so existing flows (selection, message rendering)
+            // see it. It is filtered out of the sidebar via `isBlankChat`/sort
+            // logic and never persisted thanks to the `isTemporary` guards in
+            // `Chat.saveChat` / `ChatViewModel.saveChat`.
+            localChats.insert(temp, at: 0)
+            isTemporaryMode = true
+            selectChat(temp)
+            shouldFocusInput = true
+        }
+    }
+
     /// Selects a chat as the current chat
     func selectChat(_ chat: Chat) {
         // Cancel any ongoing generation first
         if isLoading {
             cancelGeneration()
+        }
+
+        // If the user picked a different chat while in temporary mode, drop
+        // the ephemeral chat and exit temporary mode. The selected chat takes
+        // over normally below.
+        if isTemporaryMode && !chat.isTemporary {
+            if let temp = currentChat, temp.isTemporary {
+                if temp.isLocalOnly {
+                    localChats.removeAll { $0.id == temp.id }
+                } else {
+                    chats.removeAll { $0.id == temp.id }
+                }
+            }
+            isTemporaryMode = false
+            previousChatIdBeforeTemporary = nil
         }
 
         // Find the most up-to-date version of the chat in both arrays
@@ -2572,6 +2666,7 @@ class ChatViewModel: ObservableObject {
     
     /// Saves a single chat to per-chat file storage and triggers cloud backup
     private func saveChat(_ chat: Chat) {
+        guard !chat.isTemporary else { return }
         guard hasChatAccess else { return }
         guard !chat.messages.isEmpty || chat.decryptionFailed else { return }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1227,10 +1227,12 @@ class ChatViewModel: ObservableObject {
                 }
                 systemPrompt = systemPrompt.replacingOccurrences(of: "{LANGUAGE}", with: languageToUse)
                 
-                // Add personalization - use ProfileManager first, then fall back to SettingsManager
+                // Add personalization - use ProfileManager first, then fall back to SettingsManager.
+                // ProfileManager returns a fully-formed `<user_preferences>` block; the
+                // SettingsManager fallback already does the same.
                 var personalizationXML = ""
                 if let profilePersonalization = profileManager.getPersonalizationPrompt() {
-                    personalizationXML = "<user_preferences>\n\(profilePersonalization)\n</user_preferences>"
+                    personalizationXML = profilePersonalization
                 } else {
                     personalizationXML = settingsManager.generateUserPreferencesXML()
                 }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -31,16 +31,20 @@ struct ChatSidebar: View {
     }
 
     private var filteredChats: [Chat] {
+        let source: [Chat]
         if authManager.isAuthenticated && settings.isCloudSyncEnabled {
             switch activeTab {
             case .cloud:
-                return viewModel.chats
+                source = viewModel.chats
             case .local:
-                return viewModel.localChats
+                source = viewModel.localChats
             }
+        } else {
+            // When cloud sync is off, all chats are local
+            source = viewModel.localChats
         }
-        // When cloud sync is off, all chats are local
-        return viewModel.localChats
+        // Temporary (incognito) chats are never listed in the sidebar
+        return source.filter { !$0.isTemporary }
     }
 
     // Timer to update relative time strings

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -258,6 +258,17 @@ struct ChatContainer: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 VerificationStatusIndicator(viewModel: viewModel, isBadgeExpanded: $isVerificationBadgeExpanded)
             }
+            // Temporary (incognito) chat toggle
+            if authManager.isAuthenticated {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: toggleTemporaryMode) {
+                        Image(systemName: viewModel.isTemporaryMode ? "theatermasks.fill" : "theatermasks")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(viewModel.isTemporaryMode ? .accentColor : toolbarContentColor)
+                    }
+                    .accessibilityLabel(viewModel.isTemporaryMode ? "Exit temporary chat" : "Start temporary chat")
+                }
+            }
             // Only show new chat button when chat has messages (not a new/blank chat)
             if authManager.isAuthenticated && !(viewModel.currentChat?.isBlankChat ?? true) {
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -317,15 +328,22 @@ struct ChatContainer: View {
     
     /// The scrollable chat message area
     private var chatArea: some View {
-        ChatListView(
-            isDarkMode: colorScheme == .dark,
-            isLoading: viewModel.isLoading,
-            onRequestSignIn: showAuthenticationView,
-            viewModel: viewModel,
-            messageText: $messageText
-        )
-        .background(Color.chatBackground(isDarkMode: colorScheme == .dark))
-        .ignoresSafeArea(edges: .top)
+        ZStack(alignment: .top) {
+            ChatListView(
+                isDarkMode: colorScheme == .dark,
+                isLoading: viewModel.isLoading,
+                onRequestSignIn: showAuthenticationView,
+                viewModel: viewModel,
+                messageText: $messageText
+            )
+            .background(Color.chatBackground(isDarkMode: colorScheme == .dark))
+            .ignoresSafeArea(edges: .top)
+
+            if viewModel.isTemporaryMode {
+                TemporaryChatBorderOverlay()
+                    .allowsHitTesting(false)
+            }
+        }
     }
     
     /// The sliding sidebar and dimming overlay
@@ -454,6 +472,12 @@ struct ChatContainer: View {
             viewModel.createNewChat(language: language)
             messageText = ""
         }
+    }
+
+    /// Toggles the temporary (incognito) chat mode.
+    private func toggleTemporaryMode() {
+        viewModel.toggleTemporaryMode()
+        messageText = ""
     }
 }
 
@@ -1051,5 +1075,39 @@ extension Animation {
         @unknown default:
             self = .easeInOut(duration: duration) // Fallback
         }
+    }
+}
+
+/// Subtle accent border + label rendered on top of the chat area while
+/// temporary (incognito) mode is active. Mirrors the webapp's tinted
+/// container / accent border treatment.
+private struct TemporaryChatBorderOverlay: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "theatermasks.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Temporary chat")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+            }
+            .foregroundColor(.accentColor)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(Color.accentColor.opacity(0.15))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(Color.accentColor.opacity(0.4), lineWidth: 1)
+                    )
+            )
+            .padding(.top, 4)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
     }
 }

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -246,9 +246,20 @@ struct ChatContainer: View {
                         .frame(height: 22)
                         .opacity(isSidebarOpen ? 1 : 0)
 
-                    if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled && viewModel.activeStorageTab == .local {
+                    if !viewModel.isTemporaryMode && authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled && viewModel.activeStorageTab == .local {
                         chatStorageLabel
                             .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
+                    }
+
+                    if viewModel.isTemporaryMode {
+                        HStack(spacing: 6) {
+                            GhostIcon(size: 14, color: .accentColor, style: .filled)
+                            Text("Temporary")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundColor(.accentColor)
+                        }
+                        .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
                     }
                 }
                 .offset(x: (isSidebarOpen && UIDevice.current.userInterfaceIdiom == .pad) ? sidebarWidth / 2 : 0)
@@ -258,13 +269,18 @@ struct ChatContainer: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 VerificationStatusIndicator(viewModel: viewModel, isBadgeExpanded: $isVerificationBadgeExpanded)
             }
-            // Temporary (incognito) chat toggle
-            if authManager.isAuthenticated {
+            // Temporary (incognito) chat toggle. Only shown when no chat is in
+            // progress (i.e. when the new-chat "+" button is hidden). Once a
+            // chat has started, the temporary state is indicated by a label
+            // in the navbar's principal slot instead.
+            if authManager.isAuthenticated && (viewModel.currentChat?.isBlankChat ?? true) {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: toggleTemporaryMode) {
-                        Image(systemName: viewModel.isTemporaryMode ? "theatermasks.fill" : "theatermasks")
-                            .font(.system(size: 18, weight: .medium))
-                            .foregroundColor(viewModel.isTemporaryMode ? .accentColor : toolbarContentColor)
+                        GhostIcon(
+                            size: 17,
+                            color: viewModel.isTemporaryMode ? .accentColor : toolbarContentColor,
+                            style: viewModel.isTemporaryMode ? .filled : .outline
+                        )
                     }
                     .accessibilityLabel(viewModel.isTemporaryMode ? "Exit temporary chat" : "Start temporary chat")
                 }
@@ -328,22 +344,15 @@ struct ChatContainer: View {
     
     /// The scrollable chat message area
     private var chatArea: some View {
-        ZStack(alignment: .top) {
-            ChatListView(
-                isDarkMode: colorScheme == .dark,
-                isLoading: viewModel.isLoading,
-                onRequestSignIn: showAuthenticationView,
-                viewModel: viewModel,
-                messageText: $messageText
-            )
-            .background(Color.chatBackground(isDarkMode: colorScheme == .dark))
-            .ignoresSafeArea(edges: .top)
-
-            if viewModel.isTemporaryMode {
-                TemporaryChatBorderOverlay()
-                    .allowsHitTesting(false)
-            }
-        }
+        ChatListView(
+            isDarkMode: colorScheme == .dark,
+            isLoading: viewModel.isLoading,
+            onRequestSignIn: showAuthenticationView,
+            viewModel: viewModel,
+            messageText: $messageText
+        )
+        .background(Color.chatBackground(isDarkMode: colorScheme == .dark))
+        .ignoresSafeArea(edges: .top)
     }
     
     /// The sliding sidebar and dimming overlay
@@ -1075,39 +1084,5 @@ extension Animation {
         @unknown default:
             self = .easeInOut(duration: duration) // Fallback
         }
-    }
-}
-
-/// Subtle accent border + label rendered on top of the chat area while
-/// temporary (incognito) mode is active. Mirrors the webapp's tinted
-/// container / accent border treatment.
-private struct TemporaryChatBorderOverlay: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 6) {
-                Image(systemName: "theatermasks.fill")
-                    .font(.system(size: 12, weight: .semibold))
-                Text("Temporary chat")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-            }
-            .foregroundColor(.accentColor)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
-            .background(
-                Capsule()
-                    .fill(Color.accentColor.opacity(0.15))
-                    .overlay(
-                        Capsule()
-                            .strokeBorder(Color.accentColor.opacity(0.4), lineWidth: 1)
-                    )
-            )
-            .padding(.top, 4)
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
     }
 }

--- a/TinfoilChat/Views/CloudSyncOnboardingView.swift
+++ b/TinfoilChat/Views/CloudSyncOnboardingView.swift
@@ -654,10 +654,24 @@ struct CloudSyncOnboardingView: View {
         isProcessing = true
         Task {
             let newKey = EncryptionService.shared.generateKey()
+            let activationMode: CloudKeyActivationMode = mode == .recovery ? .explicitStartFresh : .recoverExisting
+
+            // If the user already has an active passkey, the passkey wraps the
+            // encryption key and they don't need to manually save a recovery
+            // copy. Complete setup immediately and let them reveal a backup
+            // copy from Settings later if they want.
+            if PasskeyManager.shared.passkeyActive {
+                await MainActor.run {
+                    generatedKey = newKey
+                    generatedKeyMode = activationMode
+                }
+                await completeSetup(with: newKey, activationMode: activationMode)
+                return
+            }
 
             await MainActor.run {
                 generatedKey = newKey
-                generatedKeyMode = mode == .recovery ? .explicitStartFresh : .recoverExisting
+                generatedKeyMode = activationMode
                 keyError = nil
                 isProcessing = false
                 direction = .trailing
@@ -693,6 +707,12 @@ struct CloudSyncOnboardingView: View {
             isProcessing = false
             if let errorMessage {
                 keyError = errorMessage
+                if currentStep != .keyDisplay {
+                    direction = .trailing
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                        currentStep = .keyDisplay
+                    }
+                }
                 return
             }
 

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -20,6 +20,43 @@ struct CloudSyncSettingsView: View {
     @ObservedObject var authManager: AuthManager
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var passkeyManager = PasskeyManager.shared
+
+    private var cloudSyncBinding: Binding<Bool> {
+        Binding(
+            get: { settings.isCloudSyncEnabled },
+            set: { newValue in
+                if newValue {
+                    if EncryptionService.shared.hasEncryptionKey() {
+                        settings.isCloudSyncEnabled = true
+                        viewModel.reloadEncryptionKey()
+                        Task { await viewModel.performFullSync() }
+                    } else {
+                        Task {
+                            let result = await passkeyManager.retryPasskeySetup()
+                            switch result {
+                            case .manualSetupRequired:
+                                await MainActor.run {
+                                    viewModel.cloudSyncOnboardingMode = .setup
+                                    viewModel.showCloudSyncOnboarding = true
+                                }
+                            case .manualRecoveryRequired:
+                                await MainActor.run {
+                                    viewModel.cloudSyncOnboardingMode = .recovery
+                                    viewModel.showCloudSyncOnboarding = true
+                                }
+                            default:
+                                break
+                            }
+                        }
+                    }
+                } else {
+                    settings.isCloudSyncEnabled = false
+                    viewModel.activeStorageTab = .local
+                    Task { await viewModel.deleteNonLocalChats() }
+                }
+            }
+        )
+    }
     
     @State private var showKeyInput: Bool = false
     @State private var showReplacePrimaryOptions: Bool = false
@@ -30,7 +67,17 @@ struct CloudSyncSettingsView: View {
     
     var body: some View {
         List {
+            Section {
+                Toggle("Cloud Sync", isOn: cloudSyncBinding)
+                    .tint(Color.accentPrimary)
+            } footer: {
+                Text("Encrypt and back up your chats so they sync across devices.")
+                    .font(.caption)
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
             // Sync Status Section
+            if settings.isCloudSyncEnabled {
             Section {
                     HStack {
                         Text("Sync Status")
@@ -171,6 +218,7 @@ struct CloudSyncSettingsView: View {
                         .font(.caption)
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
+            } // end if settings.isCloudSyncEnabled
 
             // Local-Only Mode Section
             Section {

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -26,6 +26,7 @@ struct CloudSyncSettingsView: View {
     @State private var keyInputMode: KeyInputMode = .replacePrimary
     @State private var replacePrimaryMode: CloudKeyActivationMode = .recoverExisting
     @State private var copiedToClipboard: Bool = false
+    @State private var showBackupKeySheet: Bool = false
     
     var body: some View {
         List {
@@ -131,6 +132,13 @@ struct CloudSyncSettingsView: View {
                     }
                     
                     if passkeyManager.passkeyActive {
+                        Button(action: {
+                            showBackupKeySheet = true
+                        }) {
+                            Label("Reveal Backup Key", systemImage: "key.viewfinder")
+                                .foregroundColor(.primary)
+                        }
+
                         Button(action: {
                             keyInputMode = .addRecovery
                             showKeyInput = true
@@ -258,6 +266,9 @@ struct CloudSyncSettingsView: View {
                     }
                 }
             }
+            .sheet(isPresented: $showBackupKeySheet) {
+                BackupEncryptionKeySheet()
+            }
     }
     
     private func maskKey(_ key: String) -> String {
@@ -300,6 +311,120 @@ struct CloudSyncSettingsView: View {
             return replacePrimaryMode == .recoverExisting
                 ? "Recover Existing Data"
                 : "Start Fresh"
+        }
+    }
+}
+
+/// Sheet that reveals the current encryption key as a backup. Shown only when
+/// the user has an active passkey, since their passkey already wraps the key
+/// and they don't need to handle a copy day-to-day.
+private struct BackupEncryptionKeySheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isCopied: Bool = false
+    @State private var showFullKey: Bool = false
+
+    private var key: String? {
+        EncryptionService.shared.getKey()
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                ZStack {
+                    Circle()
+                        .fill(Color.accentColor.opacity(0.15))
+                        .frame(width: 64, height: 64)
+                    Image(systemName: "key.viewfinder")
+                        .font(.system(size: 28))
+                        .foregroundColor(.accentColor)
+                }
+                .padding(.top, 24)
+
+                Text("Backup Encryption Key")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text("Your passkey already secures cloud sync on this device. Save a copy of this key only if you want a paper backup or need to sign in on a device without your passkey.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                if let key {
+                    VStack(spacing: 12) {
+                        Text(showFullKey ? key : maskedKey(key))
+                            .font(.system(.footnote, design: .monospaced))
+                            .foregroundColor(.primary)
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(UIColor.secondarySystemBackground))
+                            .cornerRadius(10)
+                            .textSelection(.enabled)
+                            .animation(nil, value: showFullKey)
+
+                        HStack(spacing: 12) {
+                            Button(action: {
+                                var transaction = Transaction()
+                                transaction.disablesAnimations = true
+                                withTransaction(transaction) {
+                                    showFullKey.toggle()
+                                }
+                            }) {
+                                Label(showFullKey ? "Hide" : "Reveal", systemImage: showFullKey ? "eye.slash" : "eye")
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 12)
+                                    .background(Color(UIColor.tertiarySystemBackground))
+                                    .cornerRadius(10)
+                            }
+
+                            Button(action: { copyKey(key) }) {
+                                Label(isCopied ? "Copied" : "Copy",
+                                      systemImage: isCopied ? "checkmark" : "doc.on.doc")
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 12)
+                                    .background(isCopied ? Color.green.opacity(0.2) : Color(UIColor.tertiarySystemBackground))
+                                    .cornerRadius(10)
+                            }
+                        }
+                        .foregroundColor(.primary)
+                    }
+                    .padding(.horizontal)
+                } else {
+                    Text("No encryption key found on this device.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func maskedKey(_ key: String) -> String {
+        guard key.count > 16 else { return key }
+        let prefix = String(key.prefix(8))
+        let suffix = String(key.suffix(8))
+        return "\(prefix)…\(suffix)"
+    }
+
+    private func copyKey(_ key: String) {
+        UIPasteboard.general.setItems(
+            [[UIPasteboard.typeAutomatic: key]],
+            options: [
+                .expirationDate: Date().addingTimeInterval(Constants.CloudSync.clipboardExpirationSeconds)
+            ]
+        )
+        isCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            isCopied = false
         }
     }
 }

--- a/TinfoilChat/Views/GhostIcon.swift
+++ b/TinfoilChat/Views/GhostIcon.swift
@@ -1,0 +1,104 @@
+//
+//  GhostIcon.swift
+//  TinfoilChat
+//
+//  SwiftUI rendering of the "ghost" glyph used by the webapp's temporary
+//  chat button (`SlGhost` from simple-line-icons / react-icons). Drawn
+//  directly with `Shape` so it scales cleanly and matches the look of the
+//  web button.
+//
+
+import SwiftUI
+
+/// The ghost silhouette: rounded dome on top, three scalloped humps along
+/// the bottom edge, with two circular eyes punched out of the body.
+struct GhostIcon: View {
+    enum Style {
+        case outline
+        case filled
+    }
+
+    var size: CGFloat = 18
+    var color: Color = .primary
+    var style: Style = .outline
+
+    var body: some View {
+        Canvas { context, canvasSize in
+            let rect = CGRect(origin: .zero, size: canvasSize)
+            let body = bodyPath(in: rect)
+            let eyes = eyesPath(in: rect)
+
+            switch style {
+            case .filled:
+                let punched = body.subtracting(eyes)
+                context.fill(punched, with: .color(color))
+            case .outline:
+                let lineWidth = max(1.4, canvasSize.width * 0.085)
+                context.stroke(
+                    body,
+                    with: .color(color),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round)
+                )
+                context.fill(eyes, with: .color(color))
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+    }
+
+    private func bodyPath(in rect: CGRect) -> Path {
+        let inset = rect.insetBy(dx: rect.width * 0.06, dy: rect.height * 0.04)
+        let topRadius = inset.width / 2
+        let bottomY = inset.maxY
+        let scallopHeight = inset.height * 0.16
+        let humpCount = 3
+        let humpWidth = inset.width / CGFloat(humpCount)
+
+        var p = Path()
+        // Start at the right edge, just below the top arc.
+        p.move(to: CGPoint(x: inset.maxX, y: inset.minY + topRadius))
+        // Down the right side.
+        p.addLine(to: CGPoint(x: inset.maxX, y: bottomY))
+        // Scalloped bottom right-to-left.
+        for i in 0..<humpCount {
+            let endX = inset.maxX - CGFloat(i + 1) * humpWidth
+            let controlX = endX + humpWidth / 2
+            p.addQuadCurve(
+                to: CGPoint(x: endX, y: bottomY),
+                control: CGPoint(x: controlX, y: bottomY - scallopHeight)
+            )
+        }
+        // Up the left side.
+        p.addLine(to: CGPoint(x: inset.minX, y: inset.minY + topRadius))
+        // Top arc back to start.
+        p.addArc(
+            center: CGPoint(x: inset.midX, y: inset.minY + topRadius),
+            radius: topRadius,
+            startAngle: .degrees(180),
+            endAngle: .degrees(0),
+            clockwise: false
+        )
+        p.closeSubpath()
+        return p
+    }
+
+    private func eyesPath(in rect: CGRect) -> Path {
+        let inset = rect.insetBy(dx: rect.width * 0.06, dy: rect.height * 0.04)
+        let eyeSize = inset.width * 0.16
+        let y = inset.minY + inset.height * 0.42 - eyeSize / 2
+        let leftX = inset.minX + inset.width * 0.32 - eyeSize / 2
+        let rightX = inset.minX + inset.width * 0.68 - eyeSize / 2
+        var p = Path()
+        p.addEllipse(in: CGRect(x: leftX, y: y, width: eyeSize, height: eyeSize))
+        p.addEllipse(in: CGRect(x: rightX, y: y, width: eyeSize, height: eyeSize))
+        return p
+    }
+}
+
+#Preview {
+    HStack(spacing: 24) {
+        GhostIcon(size: 32, color: .primary, style: .outline)
+        GhostIcon(size: 32, color: .accentColor, style: .filled)
+    }
+    .padding()
+}

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -924,14 +924,15 @@ private struct LongMessageDetailView: View {
     let message: Message
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 16) {
-                SelectableTextView(text: message.content)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            ScrollView {
+                MarkdownText(content: message.content, isDarkMode: colorScheme == .dark)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(20)
             }
-            .padding(20)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .background(Color.backgroundPrimary)
             .navigationTitle("Long Message")

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1863,57 +1863,70 @@ private struct SourcesSheetView: View {
     
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(sources) { source in
-                    Button {
-                        if let url = URL(string: source.url) {
-                            UIApplication.shared.open(url)
-                        }
-                    } label: {
-                        HStack(spacing: 12) {
-                            AsyncImage(url: URL(string: faviconUrl(for: getDomain(from: source.url)))) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                case .failure, .empty:
-                                    Image(systemName: "globe")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .foregroundColor(.gray)
-                                @unknown default:
-                                    EmptyView()
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(sources) { source in
+                        Button {
+                            if let url = URL(string: source.url) {
+                                UIApplication.shared.open(url)
+                            }
+                        } label: {
+                            HStack(spacing: 12) {
+                                AsyncImage(url: URL(string: faviconUrl(for: getDomain(from: source.url)))) { phase in
+                                    switch phase {
+                                    case .success(let image):
+                                        image
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                    case .failure, .empty:
+                                        Image(systemName: "globe")
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                            .foregroundColor(.secondary)
+                                    @unknown default:
+                                        EmptyView()
+                                    }
                                 }
+                                .frame(width: 24, height: 24)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(source.title)
+                                        .font(.system(size: 15, weight: .medium))
+                                        .foregroundColor(isDarkMode ? .white : .black)
+                                        .lineLimit(2)
+                                        .multilineTextAlignment(.leading)
+
+                                    Text(getDomain(from: source.url))
+                                        .font(.system(size: 13))
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+
+                                Spacer(minLength: 8)
+
+                                Image(systemName: "arrow.up.right")
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .foregroundColor(.secondary)
                             }
-                            .frame(width: 24, height: 24)
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
-                            
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(source.title)
-                                    .font(.system(size: 15, weight: .medium))
-                                    .foregroundColor(isDarkMode ? .white : .black)
-                                    .lineLimit(2)
-                                
-                                Text(getDomain(from: source.url))
-                                    .font(.system(size: 13))
-                                    .foregroundColor(.gray)
-                            }
-                            
-                            Spacer()
-                            
-                            Image(systemName: "arrow.up.right")
-                                .font(.system(size: 12))
-                                .foregroundColor(.gray)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(isDarkMode ? Color.white.opacity(0.06) : Color.black.opacity(0.04))
+                            )
                         }
-                        .padding(.vertical, 4)
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(PlainButtonStyle())
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             }
-            .listStyle(.plain)
+            .background((isDarkMode ? Color.black : Color(UIColor.systemBackground)).ignoresSafeArea())
             .navigationTitle("Sources")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarBackground(isDarkMode ? Color.black : Color(UIColor.systemBackground), for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -440,57 +440,17 @@ struct SettingsView: View {
             }
 
             if authManager.isAuthenticated {
-                HStack {
-                    Toggle("Cloud Sync", isOn: Binding(
-                        get: { settings.isCloudSyncEnabled },
-                        set: { newValue in
-                            if newValue {
-                                if EncryptionService.shared.hasEncryptionKey() {
-                                    settings.isCloudSyncEnabled = true
-                                    chatViewModel.reloadEncryptionKey()
-                                    Task {
-                                        await chatViewModel.performFullSync()
-                                    }
-                                } else {
-                                    Task {
-                                        let result = await passkeyManager.retryPasskeySetup()
-                                        switch result {
-                                        case .manualSetupRequired:
-                                            await MainActor.run {
-                                                chatViewModel.cloudSyncOnboardingMode = .setup
-                                                chatViewModel.showCloudSyncOnboarding = true
-                                            }
-                                        case .manualRecoveryRequired:
-                                            await MainActor.run {
-                                                chatViewModel.cloudSyncOnboardingMode = .recovery
-                                                chatViewModel.showCloudSyncOnboarding = true
-                                            }
-                                        default:
-                                            break
-                                        }
-                                    }
-                                }
-                            } else {
-                                settings.isCloudSyncEnabled = false
-                                chatViewModel.activeStorageTab = .local
-                                Task {
-                                    await chatViewModel.deleteNonLocalChats()
-                                }
-                            }
-                        }
-                    ))
-                    .tint(Color.accentPrimary)
-
-                    if settings.isCloudSyncEnabled {
-                        NavigationLink {
-                            CloudSyncSettingsView(
-                                viewModel: chatViewModel,
-                                authManager: authManager
-                            )
-                        } label: {
-                            EmptyView()
-                        }
-                        .frame(width: 20)
+                NavigationLink {
+                    CloudSyncSettingsView(
+                        viewModel: chatViewModel,
+                        authManager: authManager
+                    )
+                } label: {
+                    HStack {
+                        Text("Cloud Sync")
+                        Spacer()
+                        Text(settings.isCloudSyncEnabled ? "On" : "Off")
+                            .foregroundColor(.secondary)
                     }
                 }
 

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -199,33 +199,46 @@ class SettingsManager: ObservableObject {
         isLocalOnlyModeEnabled = false
     }
 
-    // Generate user preferences XML for system prompt
+    // Generate user preferences XML for system prompt.
+    // Treats `isPersonalizationEnabled` as a soft preference: when any field is
+    // populated we still inject it so the model has the user's context. This
+    // matches `ProfileManager.getPersonalizationPrompt()`.
     func generateUserPreferencesXML() -> String {
-        guard isPersonalizationEnabled else { return "" }
-        
-        var xml = "<user_preferences>\n"
-        
-        if !nickname.isEmpty {
-            xml += "  <nickname>\(nickname)</nickname>\n"
+        let trimmedNickname = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedProfession = profession.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nonEmptyTraits = selectedTraits.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        let trimmedContext = additionalContext.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let hasAnyField = !trimmedNickname.isEmpty
+            || !trimmedProfession.isEmpty
+            || !nonEmptyTraits.isEmpty
+            || !trimmedContext.isEmpty
+
+        guard hasAnyField else { return "" }
+
+        var xml = "The user has provided personal preferences for this conversation. Adapt your responses according to these settings while maintaining accuracy and helpfulness.\n\n<user_preferences>"
+
+        if !trimmedNickname.isEmpty {
+            xml += "\n  <nickname>\(trimmedNickname)</nickname>"
         }
-        
-        if !profession.isEmpty {
-            xml += "  <profession>\(profession)</profession>\n"
+
+        if !trimmedProfession.isEmpty {
+            xml += "\n  <profession>\(trimmedProfession)</profession>"
         }
-        
-        if !selectedTraits.isEmpty {
-            xml += "  <traits>\n"
-            for trait in selectedTraits {
-                xml += "    <trait>\(trait)</trait>\n"
+
+        if !nonEmptyTraits.isEmpty {
+            xml += "\n  <traits>"
+            for trait in nonEmptyTraits {
+                xml += "\n    <trait>\(trait)</trait>"
             }
-            xml += "  </traits>\n"
+            xml += "\n  </traits>"
         }
-        
-        if !additionalContext.isEmpty {
-            xml += "  <additional_context>\(additionalContext)</additional_context>\n"
+
+        if !trimmedContext.isEmpty {
+            xml += "\n  <additional_context>\n    \(trimmedContext)\n  </additional_context>"
         }
-        
-        xml += "</user_preferences>"
+
+        xml += "\n</user_preferences>"
         return xml
     }
     

--- a/TinfoilChat/Views/VerifierViewController.swift
+++ b/TinfoilChat/Views/VerifierViewController.swift
@@ -51,8 +51,12 @@ struct VerifierView: View {
 
     private var isDarkMode: Bool { colorScheme == .dark }
 
+    private var sheetBackground: Color {
+        isDarkMode ? Color.backgroundPrimary : Color(UIColor.systemBackground)
+    }
+
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 16) {
                 if let doc = chatViewModel.verificationDocument {
                     statusBanner(for: doc)
@@ -71,8 +75,12 @@ struct VerifierView: View {
             }
             .padding(.horizontal, 16)
             .padding(.top, 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(sheetBackground.ignoresSafeArea())
             .navigationTitle("Verification Center")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarBackground(sheetBackground, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { chatViewModel.dismissVerifier() }) {
@@ -82,17 +90,7 @@ struct VerifierView: View {
                     .accessibilityLabel("Close verification screen")
                 }
             }
-            .onAppear { setupNavigationBarAppearance() }
         }
-    }
-
-    private func setupNavigationBarAppearance() {
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithDefaultBackground()
-        appearance.shadowColor = .clear
-        UINavigationBar.appearance().standardAppearance = appearance
-        UINavigationBar.appearance().compactAppearance = appearance
-        UINavigationBar.appearance().scrollEdgeAppearance = appearance
     }
 
     // MARK: - Loading State
@@ -235,7 +233,12 @@ struct VerifierView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(isSelected ? Color.tinfoilAccentLight : Color.clear, lineWidth: 1.5)
+                .stroke(
+                    isSelected
+                        ? Color.tinfoilAccentLight
+                        : Color.primary.opacity(isDarkMode ? 0.18 : 0.12),
+                    lineWidth: isSelected ? 1.5 : 1
+                )
         )
         .overlay(alignment: .topTrailing) {
             statusBadge(status)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds full project support (create/browse/edit, encrypted docs, chat association) and a private temporary chat mode. Also improves personalization flow and polishing across recording, onboarding, sources, verification, and message display.

- **New Features**
  - Projects: end-to-end support with `ProjectStorageService`, `ProjectManager`, a sidebar section, `ProjectListView`, and `ProjectDetailView`.
  - Project mode: banner in chat; new chats go to the active project; system prompt appends a `<project_context>` with project instructions and documents.
  - Move chats into a project from the chat list context menu.
  - Temporary chat mode: ghost toolbar toggle matching the web; ephemeral chats are never saved or synced and are hidden from the sidebar; shows a subtle “Temporary” label while active; cleanly returns to the previous chat when toggled off.
  - Cloud Sync settings: moved the Cloud Sync switch into `CloudSyncSettingsView`; added a “Reveal Backup Key” sheet when a passkey is active.

- **Bug Fixes**
  - Personalization always reaches the model via a single `<user_preferences>` block from `ProfileManager`/`SettingsManager` (fields are injected when present).
  - Keep the screen awake during voice recording.
  - Cloud sync onboarding skips the manual key step when a passkey exists.
  - Long message detail renders formatted Markdown; blank chat title is now “New Chat”.
  - Web search sources sheet and Verification Center: tightened layout, colors, and outlines.

<sup>Written for commit 2c0722a128c91fac88dee03b7a2702a558f7ae19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

