### PR TITLE
Fix various performance bugs

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -65,6 +65,17 @@ enum Constants {
         static let maxCellHeight: CGFloat = 200_000
     }
 
+    enum Streaming {
+        /// Minimum interval between SwiftUI invalidations during a streaming
+        /// response. Updating any faster forces SwiftUI to walk a long
+        /// environment property list and rebuild the markdown view tree on
+        /// every token, which has been observed to either burn the main
+        /// thread or grow the AttributeGraph until it aborts on a 256 MB
+        /// realloc. 100 ms is fast enough that a reader does not perceive
+        /// the throttle while keeping per-second renders bounded.
+        static let uiUpdateInterval: TimeInterval = 0.1
+    }
+
     enum API {
         static let chatCompletionsEndpoint = "/v1/chat/completions"
         static let baseURL = "https://api.tinfoil.sh"

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1622,7 +1622,7 @@ class ChatViewModel: ObservableObject {
                 var hapticChunkCount = 0
                 var hasStartedResponse = false
                 var lastUIUpdateTime = Date.distantPast
-                let uiUpdateInterval: TimeInterval = 0.033
+                let uiUpdateInterval: TimeInterval = Constants.Streaming.uiUpdateInterval
 
                 await MainActor.run {
                     if let chat = self.currentChat,

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -43,13 +43,11 @@ private struct SegmentView: View {
                     citationUrls: citationUrls
                 )
             StructuredText(markdown: strippedText)
-                .textual.structuredTextStyle(.gitHub)
                 .textual.highlighterTheme(isStreaming ? .plain : .default)
                 .if(textSelectionEnabled) { view in
                     view.textual.textSelection(.enabled)
                 }
                 .fixedSize(horizontal: false, vertical: true)
-                .environment(\.colorScheme, isDarkMode ? .dark : .light)
         case .latex(let latex, let isDisplay):
             LaTeXView(
                 latex: latex,
@@ -180,7 +178,6 @@ struct LaTeXMarkdownView: View, Equatable {
                 markdownFallback(content: content)
             }
         }
-        .environment(\.colorScheme, isDarkMode ? .dark : .light)
         .padding(.horizontal, horizontalPadding)
         .frame(maxWidth: horizontalPadding > 0 ? .infinity : nil, alignment: maxWidthAlignment)
         .transaction { transaction in
@@ -208,13 +205,11 @@ struct LaTeXMarkdownView: View, Equatable {
                 citationUrls: citationUrls
             )
         return StructuredText(markdown: strippedText)
-            .textual.structuredTextStyle(.gitHub)
             .textual.highlighterTheme(isStreaming ? .plain : .default)
             .if(textSelectionEnabled) { view in
                 view.textual.textSelection(.enabled)
             }
             .fixedSize(horizontal: false, vertical: true)
-            .environment(\.colorScheme, isDarkMode ? .dark : .light)
     }
 
     /// Rewrite standard markdown links whose URL matches an annotated web-search

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Textual
+import ObjectiveC
 
 struct MessageTableView: UIViewRepresentable {
     let archivedMessagesStartIndex: Int
@@ -326,26 +327,24 @@ struct MessageTableView: UIViewRepresentable {
             cell.backgroundColor = .clear
 
             if parent.messages.isEmpty {
-                if cell.boundContentToken != "welcome" {
-                    cell.contentConfiguration = UIHostingConfiguration {
-                        if let authManager = parent.viewModel.authManager {
-                            WelcomeView(
-                                isDarkMode: parent.isDarkMode,
-                                authManager: authManager,
-                                onRequestSignIn: parent.onRequestSignIn
-                            )
-                            .padding(.vertical, 16)
-                            .padding(.horizontal, UIDevice.current.userInterfaceIdiom == .pad ? 100 : 0)
-                            .frame(maxWidth: 900)
-                            .frame(maxWidth: .infinity)
-                            .markdownStyleHost(isDarkMode: parent.isDarkMode)
-                        }
+                cell.contentConfiguration = UIHostingConfiguration {
+                    if let authManager = parent.viewModel.authManager {
+                        WelcomeView(
+                            isDarkMode: parent.isDarkMode,
+                            authManager: authManager,
+                            onRequestSignIn: parent.onRequestSignIn
+                        )
+                        .padding(.vertical, 16)
+                        .padding(.horizontal, UIDevice.current.userInterfaceIdiom == .pad ? 100 : 0)
+                        .frame(maxWidth: 900)
+                        .frame(maxWidth: .infinity)
+                        .markdownStyleHost(isDarkMode: parent.isDarkMode)
                     }
-                    .minSize(width: 0, height: 0)
-                    .margins(.all, 0)
-                    .background(.clear)
-                    cell.boundContentToken = "welcome"
                 }
+                .minSize(width: 0, height: 0)
+                .margins(.all, 0)
+                .background(.clear)
+                cell.boundContentToken = "welcome"
             } else {
                 let message = parent.messages[indexPath.row]
                 let isLastMessage = indexPath.row == parent.messages.count - 1
@@ -372,7 +371,6 @@ struct MessageTableView: UIViewRepresentable {
                 if cell.boundContentToken != message.id {
                     cell.contentConfiguration = UIHostingConfiguration {
                         ObservableMessageCell(wrapper: wrapper, viewModel: parent.viewModel, coordinator: self)
-                            .markdownStyleHost(isDarkMode: parent.isDarkMode)
                     }
                     .minSize(width: 0, height: 0)
                     .margins(.all, 0)
@@ -721,6 +719,7 @@ struct ObservableMessageCell: View {
                     messageIndex: wrapper.messageIndex
                 )
                 .environmentObject(viewModel)
+                .markdownStyleHost(isDarkMode: wrapper.isDarkMode)
                 .opacity(wrapper.isArchived ? 0.6 : 1.0)
                 .padding(.vertical, 8)
                 .padding(.horizontal, UIDevice.current.userInterfaceIdiom == .pad ? 100 : 8)

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -87,7 +87,8 @@ struct MessageTableView: UIViewRepresentable {
             }
             context.coordinator.lastMessageIds = currentMessageIds
         } else if currentMessageIds != context.coordinator.lastMessageIds {
-            // Message IDs changed without chat ID changing (e.g., regenerate)
+            // Message IDs changed without chat ID changing (e.g., regenerate,
+            // edit, archive cleanup).
             let idsWereReplaced = !currentMessageIds.isEmpty &&
                                   !context.coordinator.lastMessageIds.isEmpty &&
                                   currentMessageIds.isDisjoint(with: context.coordinator.lastMessageIds)
@@ -97,6 +98,23 @@ struct MessageTableView: UIViewRepresentable {
                 context.coordinator.messageWrappers.removeAll()
                 context.coordinator.shownMessageIds.removeAll()
                 context.coordinator.heightCache.removeAll()
+                context.coordinator.messageHeightCache.removeAll()
+            } else {
+                // Drop any wrappers and cached heights that belong to messages
+                // that no longer exist. Without this, long sessions accumulate
+                // ObservableMessageWrapper instances - each holding seven
+                // @Published values - which inflates SwiftUI's environment
+                // property list and shows up as long compareLists / env-diff
+                // hangs in production.
+                let removedIds = context.coordinator.lastMessageIds.subtracting(currentMessageIds)
+                if !removedIds.isEmpty {
+                    for messageId in removedIds {
+                        context.coordinator.messageWrappers.removeValue(forKey: messageId)
+                        context.coordinator.shownMessageIds.remove(messageId)
+                        context.coordinator.messageHeightCache.removeValue(forKey: messageId)
+                    }
+                    context.coordinator.heightCache.removeAll()
+                }
             }
             context.coordinator.lastMessageIds = currentMessageIds
             tableView.reloadData()

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Textual
 
 struct MessageTableView: UIViewRepresentable {
     let archivedMessagesStartIndex: Int
@@ -336,6 +337,7 @@ struct MessageTableView: UIViewRepresentable {
                         .padding(.horizontal, UIDevice.current.userInterfaceIdiom == .pad ? 100 : 0)
                         .frame(maxWidth: 900)
                         .frame(maxWidth: .infinity)
+                        .markdownStyleHost(isDarkMode: parent.isDarkMode)
                     }
                 }
                 .minSize(width: 0, height: 0)
@@ -360,6 +362,7 @@ struct MessageTableView: UIViewRepresentable {
                 // Always recreate the content configuration to ensure correct wrapper is used
                 cell.contentConfiguration = UIHostingConfiguration {
                     ObservableMessageCell(wrapper: wrapper, viewModel: parent.viewModel, coordinator: self)
+                        .markdownStyleHost(isDarkMode: parent.isDarkMode)
                 }
                 .minSize(width: 0, height: 0)
                 .margins(.all, 0)
@@ -735,6 +738,28 @@ struct ObservableMessageCell: View {
                 hasAppeared = true
             }
         }
+    }
+}
+
+/// Applies the Textual styles every markdown view in a message cell needs,
+/// once at the cell host. Doing this here means the eleven environment
+/// writes that `structuredTextStyle(.gitHub)` expands into are paid one
+/// time per cell instead of once per `LaTeXMarkdownView` / `SegmentView`
+/// inside the cell, which is what was driving the long `compareLists` /
+/// `EnvironmentBox.update` hangs in production.
+private struct MarkdownStyleHost: ViewModifier {
+    let isDarkMode: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .textual.structuredTextStyle(.gitHub)
+            .environment(\.colorScheme, isDarkMode ? .dark : .light)
+    }
+}
+
+extension View {
+    fileprivate func markdownStyleHost(isDarkMode: Bool) -> some View {
+        modifier(MarkdownStyleHost(isDarkMode: isDarkMode))
     }
 }
 

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -326,23 +326,26 @@ struct MessageTableView: UIViewRepresentable {
             cell.backgroundColor = .clear
 
             if parent.messages.isEmpty {
-                cell.contentConfiguration = UIHostingConfiguration {
-                    if let authManager = parent.viewModel.authManager {
-                        WelcomeView(
-                            isDarkMode: parent.isDarkMode,
-                            authManager: authManager,
-                            onRequestSignIn: parent.onRequestSignIn
-                        )
-                        .padding(.vertical, 16)
-                        .padding(.horizontal, UIDevice.current.userInterfaceIdiom == .pad ? 100 : 0)
-                        .frame(maxWidth: 900)
-                        .frame(maxWidth: .infinity)
-                        .markdownStyleHost(isDarkMode: parent.isDarkMode)
+                if cell.boundContentToken != "welcome" {
+                    cell.contentConfiguration = UIHostingConfiguration {
+                        if let authManager = parent.viewModel.authManager {
+                            WelcomeView(
+                                isDarkMode: parent.isDarkMode,
+                                authManager: authManager,
+                                onRequestSignIn: parent.onRequestSignIn
+                            )
+                            .padding(.vertical, 16)
+                            .padding(.horizontal, UIDevice.current.userInterfaceIdiom == .pad ? 100 : 0)
+                            .frame(maxWidth: 900)
+                            .frame(maxWidth: .infinity)
+                            .markdownStyleHost(isDarkMode: parent.isDarkMode)
+                        }
                     }
+                    .minSize(width: 0, height: 0)
+                    .margins(.all, 0)
+                    .background(.clear)
+                    cell.boundContentToken = "welcome"
                 }
-                .minSize(width: 0, height: 0)
-                .margins(.all, 0)
-                .background(.clear)
             } else {
                 let message = parent.messages[indexPath.row]
                 let isLastMessage = indexPath.row == parent.messages.count - 1
@@ -359,14 +362,23 @@ struct MessageTableView: UIViewRepresentable {
                     messageIndex: indexPath.row
                 )
 
-                // Always recreate the content configuration to ensure correct wrapper is used
-                cell.contentConfiguration = UIHostingConfiguration {
-                    ObservableMessageCell(wrapper: wrapper, viewModel: parent.viewModel, coordinator: self)
-                        .markdownStyleHost(isDarkMode: parent.isDarkMode)
+                // Only rebuild the hosting configuration when the cell is now
+                // bound to a different message. Reassigning the configuration
+                // for the same wrapper tears down the SwiftUI subgraph and
+                // can deallocate AG attributes that an in-flight context
+                // menu animation is still tracking - the cause of the
+                // ContextMenuResponder.startTrackingUpdates EXC_BAD_ACCESS
+                // we see when the table reloads during streaming.
+                if cell.boundContentToken != message.id {
+                    cell.contentConfiguration = UIHostingConfiguration {
+                        ObservableMessageCell(wrapper: wrapper, viewModel: parent.viewModel, coordinator: self)
+                            .markdownStyleHost(isDarkMode: parent.isDarkMode)
+                    }
+                    .minSize(width: 0, height: 0)
+                    .margins(.all, 0)
+                    .background(.clear)
+                    cell.boundContentToken = message.id
                 }
-                .minSize(width: 0, height: 0)
-                .margins(.all, 0)
-                .background(.clear)
             }
 
             return cell
@@ -760,6 +772,28 @@ private struct MarkdownStyleHost: ViewModifier {
 extension View {
     fileprivate func markdownStyleHost(isDarkMode: Bool) -> some View {
         modifier(MarkdownStyleHost(isDarkMode: isDarkMode))
+    }
+}
+
+extension UITableViewCell {
+    private static var boundContentTokenKey: UInt8 = 0
+
+    /// Identifier of the content currently hosted by this cell ("welcome" or
+    /// a message id). Used to skip a `contentConfiguration` reassignment when
+    /// the cell is being dequeued for the same logical content it already
+    /// hosts.
+    fileprivate var boundContentToken: String? {
+        get {
+            objc_getAssociatedObject(self, &Self.boundContentTokenKey) as? String
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &Self.boundContentTokenKey,
+                newValue,
+                .OBJC_ASSOCIATION_COPY_NONATOMIC
+            )
+        }
     }
 }
 

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1205,12 +1205,10 @@ struct MarkdownText: View {
 
     var body: some View {
         StructuredText(markdown: content)
-            .textual.structuredTextStyle(.gitHub)
             .textual.highlighterTheme(.default)
             .textual.textSelection(.enabled)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, horizontalPadding)
-            .environment(\.colorScheme, isDarkMode ? .dark : .light)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -1229,12 +1227,10 @@ struct AdaptiveMarkdownText: View {
 
     var body: some View {
         StructuredText(markdown: content)
-            .textual.structuredTextStyle(.gitHub)
             .textual.highlighterTheme(.default)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.bottom, -16)
             .padding(.horizontal, horizontalPadding)
-            .environment(\.colorScheme, isDarkMode ? .dark : .light)
     }
 }
 

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -679,14 +679,19 @@ struct MessageView: View {
                 }
                 .cornerRadius(16)
                 .modifier(MessageBubbleModifier(isUserMessage: message.role == .user))
-                .contextMenu {
-                    if message.role == .user && !message.content.isEmpty {
+                // While a stream is in flight the table reloads its rows
+                // every UI tick, which can deallocate the SwiftUI subgraph
+                // that backs an in-flight context menu and trip a deref of
+                // a freed AG attribute (ContextMenuResponder.startTrackingUpdates
+                // EXC_BAD_ACCESS). Withhold the menu entirely until streaming
+                // finishes; long-press still works between turns.
+                .if(message.role == .user && !message.content.isEmpty && !viewModel.isLoading) { view in
+                    view.contextMenu {
                         Button {
                             viewModel.regenerateMessage(at: messageIndex)
                         } label: {
                             Label("Resend", systemImage: "arrow.clockwise")
                         }
-                        .disabled(viewModel.isLoading)
 
                         Button {
                             UIPasteboard.general.string = message.content

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -61,7 +61,12 @@ struct MessageView: View {
         case toolCall(GenUIToolCall, isTrailing: Bool)
     }
 
-    private func inlineSegmentRuns(from segments: [MessageSegment]) -> [InlineSegmentRun] {
+    private struct IdentifiedInlineSegmentRun: Identifiable {
+        let id: String
+        let run: InlineSegmentRun
+    }
+
+    private func inlineSegmentRuns(from segments: [MessageSegment]) -> [IdentifiedInlineSegmentRun] {
         let lastTextIndex: Int? = {
             for i in segments.indices.reversed() {
                 if case .text = segments[i] { return i }
@@ -86,20 +91,32 @@ struct MessageView: View {
             return nil
         }()
 
-        var runs: [InlineSegmentRun] = []
+        var runs: [IdentifiedInlineSegmentRun] = []
         var searchBuffer: [WebSearchInstance] = []
+        var searchBufferStartIndex: Int?
         var fetchBuffer: [URLFetchState] = []
+        var fetchBufferStartIndex: Int?
 
         func flushSearches() {
-            if !searchBuffer.isEmpty {
-                runs.append(.webSearches(searchBuffer))
+            if let firstId = searchBuffer.first?.id,
+               let startIndex = searchBufferStartIndex {
+                runs.append(IdentifiedInlineSegmentRun(
+                    id: "websearches:\(startIndex):\(firstId)",
+                    run: .webSearches(searchBuffer)
+                ))
                 searchBuffer.removeAll()
+                searchBufferStartIndex = nil
             }
         }
         func flushFetches() {
-            if !fetchBuffer.isEmpty {
-                runs.append(.urlFetches(fetchBuffer))
+            if let firstId = fetchBuffer.first?.id,
+               let startIndex = fetchBufferStartIndex {
+                runs.append(IdentifiedInlineSegmentRun(
+                    id: "urlfetches:\(startIndex):\(firstId)",
+                    run: .urlFetches(fetchBuffer)
+                ))
                 fetchBuffer.removeAll()
+                fetchBufferStartIndex = nil
             }
         }
 
@@ -109,27 +126,42 @@ struct MessageView: View {
                 flushSearches()
                 flushFetches()
                 if !text.isEmpty {
-                    runs.append(.text(text, isTrailing: index == lastTextIndex))
+                    runs.append(IdentifiedInlineSegmentRun(
+                        id: "text:\(index)",
+                        run: .text(text, isTrailing: index == lastTextIndex)
+                    ))
                 }
             case .thinking(let content, let isThinking, let duration):
                 flushSearches()
                 flushFetches()
-                runs.append(.thinking(content: content, isThinking: isThinking, duration: duration))
+                runs.append(IdentifiedInlineSegmentRun(
+                    id: "thinking:\(index)",
+                    run: .thinking(content: content, isThinking: isThinking, duration: duration)
+                ))
             case .webSearch(let searchId):
                 flushFetches()
                 if let instance = message.webSearches?.first(where: { $0.id == searchId }) {
+                    if searchBuffer.isEmpty {
+                        searchBufferStartIndex = index
+                    }
                     searchBuffer.append(instance)
                 }
             case .urlFetch(let fetchId):
                 flushSearches()
                 if let fetch = message.urlFetches.first(where: { $0.id == fetchId }) {
+                    if fetchBuffer.isEmpty {
+                        fetchBufferStartIndex = index
+                    }
                     fetchBuffer.append(fetch)
                 }
             case .toolCall(let toolCallId):
                 flushSearches()
                 flushFetches()
                 if let toolCall = message.toolCalls.first(where: { $0.id == toolCallId }) {
-                    runs.append(.toolCall(toolCall, isTrailing: index == lastStreamingToolCallIndex))
+                    runs.append(IdentifiedInlineSegmentRun(
+                        id: "toolcall:\(index):\(toolCall.id)",
+                        run: .toolCall(toolCall, isTrailing: index == lastStreamingToolCallIndex)
+                    ))
                 }
             }
         }
@@ -178,8 +210,8 @@ struct MessageView: View {
     private func inlineSegmentsView(segments: [MessageSegment]) -> some View {
         let runs = inlineSegmentRuns(from: segments)
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(runs.enumerated()), id: \.offset) { _, run in
-                switch run {
+            ForEach(runs) { identifiedRun in
+                switch identifiedRun.run {
                 case .text(let text, let isTrailing):
                     let isStreamingText = isTrailing && isLoading && isLastMessage
                     LaTeXMarkdownView(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves streaming performance and message list stability by throttling UI updates, hoisting markdown styles to the cell host, cleaning stale state, and guarding context menus during streams.

- **Performance**
  - Throttle streaming UI invalidations to 10 Hz via `Constants.Streaming.uiUpdateInterval`.
  - Hoist `Textual` markdown styles and color scheme to the cell host (`.markdownStyleHost`) to cut environment writes.
  - Keep cells bound to their current message (`boundContentToken`) to avoid unnecessary `UIHostingConfiguration` rebuilds.
  - Drop stale wrappers and height caches (`heightCache`, per-message `messageHeightCache`) when messages are removed, edited, or archived to reduce memory and env diff work.

- **Bug Fixes**
  - Stabilize identity of streamed inline segment runs to prevent SwiftUI diff churn.
  - Hide the message context menu while streaming to avoid menu-related crashes.
  - Ensure markdown styling stays in sync with theme changes.

<sup>Written for commit 86ac93cd187b3a6acdad848c78d018ea46caa4a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

