### PR TITLE
chore: bump version

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped app marketing version to 2.3.0 for the next release. Updated MARKETING_VERSION in the Xcode project for all build configurations.

<sup>Written for commit b534a22e76b677cd886d88826a4d48bb34140472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

