### PR TITLE
Make GenUI components consistent across ecosystem

### DIFF
--- a/TinfoilChat/Views/GenUI/GenUIWidget.swift
+++ b/TinfoilChat/Views/GenUI/GenUIWidget.swift
@@ -14,9 +14,12 @@ import SwiftUI
 ///
 /// - `inline`: inside the assistant message body in the chat scroll.
 /// - `input`: replaces the `MessageInputView` until the user resolves it.
+/// - `artifact`: compact inline summary plus a dedicated artifact surface
+///   (reserved for future widgets; currently treated like `inline`).
 enum GenUIWidgetSurface {
     case inline
     case input
+    case artifact
 }
 
 /// Read-only context passed to inline-surface widgets.

--- a/TinfoilChat/Views/GenUI/GenUIWidget.swift
+++ b/TinfoilChat/Views/GenUI/GenUIWidget.swift
@@ -165,11 +165,17 @@ enum GenUISchema {
         return JSONSchema(fields: fields)
     }
 
-    static func number(description: String? = nil, minimum: Double? = nil, maximum: Double? = nil) -> JSONSchema {
+    static func number(
+        description: String? = nil,
+        minimum: Double? = nil,
+        maximum: Double? = nil,
+        exclusiveMinimum: Double? = nil
+    ) -> JSONSchema {
         var fields: [JSONSchemaField] = [.type(.number)]
         if let description { fields.append(.description(description)) }
         if let minimum { fields.append(.minimum(minimum)) }
         if let maximum { fields.append(.maximum(maximum)) }
+        if let exclusiveMinimum { fields.append(.exclusiveMinimum(exclusiveMinimum)) }
         return JSONSchema(fields: fields)
     }
 

--- a/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
@@ -29,7 +29,7 @@ struct ArtifactPreviewWidget: GenUIWidget {
     }
 
     let name = "render_artifact_preview"
-    let description = "Display a visual artifact in a side panel: a hosted URL, a self-contained HTML snippet, or Markdown. Use for content worth inspecting at full size."
+    let description = "Display a visual artifact in a side panel: a hosted URL, a self-contained HTML snippet, or Markdown. Use for content worth inspecting at full size — interactive demos, long-form documents, or rich HTML mockups. For SVG illustrations and Mermaid diagrams, emit a fenced `svg` or `mermaid` code block in the regular assistant message instead. The chat shows a compact summary card; clicking it opens the full artifact in the right sidebar."
     let promptHint = "large artifacts (markdown/html/url) opened in a side panel"
 
     var schema: JSONSchema {

--- a/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
@@ -11,7 +11,6 @@ import OpenAI
 import SwiftUI
 import UIKit
 
-private let minTimerSeconds: Double = 1
 private let maxTimerSeconds: Double = 604_800
 
 struct ClockWidget: GenUIWidget {
@@ -57,11 +56,11 @@ struct ClockWidget: GenUIWidget {
                 "showSeconds": GenUISchema.boolean(description: "Clock mode: include the second hand (default true)."),
                 "showDate": GenUISchema.boolean(description: "Clock mode: include date line (default true)."),
                 "durationSeconds": GenUISchema.number(
-                    description: "Timer mode. Duration in seconds. Prefer for requests like \"set a 5 minute timer\".",
-                    minimum: minTimerSeconds,
-                    maximum: maxTimerSeconds
+                    description: "Timer mode. Duration in seconds. Prefer this for requests like \"set a 5 minute timer\".",
+                    maximum: maxTimerSeconds,
+                    exclusiveMinimum: 0
                 ),
-                "target": GenUISchema.string(description: "Timer mode. ISO date-time when the timer should end."),
+                "target": GenUISchema.string(description: "Timer mode. ISO date-time when the timer should end, e.g. \"2026-12-31T23:59:59Z\". Use when an exact end time is known."),
                 "completedMessage": GenUISchema.string(description: "Timer mode. Message shown when the timer finishes."),
                 "alarmMode": GenUISchema.string(
                     description: "Timer mode. Alarm behavior when done. \"sound\" beeps; \"flash\" stays silent and flashes visually. Defaults to sound.",

--- a/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
@@ -18,14 +18,14 @@ struct LinkPreviewWidget: GenUIWidget {
     }
 
     let name = "render_link_preview"
-    let description = "Display a rich preview card for a single web link. Use when linking to an article, page, or resource and you want to surface title and favicon."
+    let description = "Display a rich preview card for a single web link. Use when linking to an article, page, or resource and you want to surface title, description, and favicon. The card fetches metadata (title, description, site name, image, favicon) from the opengraph-metadata.tinfoil.sh enclave. Provide only the URL and a fallback title — every other field is resolved server-side."
     let promptHint = "rich preview card for a single web link"
 
     var schema: JSONSchema {
         GenUISchema.object(
             properties: [
                 "url": GenUISchema.string(description: "Full URL of the resource"),
-                "title": GenUISchema.string(description: "Best guess at the page title"),
+                "title": GenUISchema.string(description: "Best guess at the page or resource title. Used as a fallback if the metadata fetch fails."),
             ],
             required: ["url", "title"]
         )

--- a/TinfoilChat/Views/GenUI/Widgets/MessageComposeWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/MessageComposeWidget.swift
@@ -21,13 +21,13 @@ struct MessageComposeWidget: GenUIWidget {
     }
 
     let name = "render_message_compose"
-    let description = "Draft a message or email with one or more tone variants. Includes Copy and (for email) Open in Mail."
+    let description = "Draft a message or email with one or more tone variants. Includes Copy and (for email) Open in Mail. Use when proposing a reply, message, or email draft to send."
     let promptHint = "a draft message or email with optional tone variants and Copy / Open in Mail"
 
     var schema: JSONSchema {
         let variant = GenUISchema.object(
             properties: [
-                "label": GenUISchema.string(description: "Short variant label, e.g. \"Formal\""),
+                "label": GenUISchema.string(description: "Short variant label, e.g. \"Formal\", \"Concise\", \"Apologetic\""),
                 "subject": GenUISchema.string(),
                 "body": GenUISchema.string(),
             ],
@@ -35,10 +35,17 @@ struct MessageComposeWidget: GenUIWidget {
         )
         return GenUISchema.object(
             properties: [
-                "channel": GenUISchema.string(enumValues: ["email", "message"]),
+                "channel": GenUISchema.string(
+                    description: "email (shows subject + \"Open in Mail\") or message (body only)",
+                    enumValues: ["email", "message"]
+                ),
                 "to": GenUISchema.string(description: "Recipient — used for mailto:"),
-                "title": GenUISchema.string(),
-                "variants": GenUISchema.array(items: variant, minItems: 1),
+                "title": GenUISchema.string(description: "Card title, e.g. \"Draft reply to Alice\""),
+                "variants": GenUISchema.array(
+                    items: variant,
+                    description: "One or more message drafts to offer. First variant is selected by default.",
+                    minItems: 1
+                ),
             ],
             required: ["variants"]
         )

--- a/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
@@ -66,7 +66,7 @@ struct RecipeCardWidget: GenUIWidget {
     }
 
     let name = "render_recipe_card"
-    let description = "Display a cookable recipe card with ingredients and step-by-step instructions."
+    let description = "Display a cookable recipe card with ingredients and step-by-step instructions. Use when presenting a recipe, cooking procedure, or multi-step preparation with ingredients."
     let promptHint = "a cookable recipe card with ingredients and steps"
 
     var schema: JSONSchema {

--- a/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
@@ -53,7 +53,7 @@ struct SportsDataWidget: GenUIWidget {
     }
 
     let name = "render_sports_data"
-    let description = "Display a sports fixture (game scoreline) or a league standings table."
+    let description = "Display a sports fixture (game scoreline) or a league standings table. Use when the user asks about a game score, match result, or league table."
     let promptHint = "a sports fixture scoreline or a league standings table"
 
     var schema: JSONSchema {
@@ -85,7 +85,7 @@ struct SportsDataWidget: GenUIWidget {
                     enumValues: ["fixture", "standings"]
                 ),
                 "title": GenUISchema.string(),
-                "status": GenUISchema.string(),
+                "status": GenUISchema.string(description: "e.g. \"Final\", \"Live — 3rd quarter\", \"Scheduled\""),
                 "venue": GenUISchema.string(),
                 "startTime": GenUISchema.string(),
                 "home": team,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns GenUI widgets with the web app for cross‑platform consistency and adds an `artifact` surface for future artifact UIs. Also tightens timer validation to require a strictly positive duration.

- **New Features**
  - Added `artifact` surface to `GenUIWidget` (currently behaves like `inline`); updated `ArtifactPreviewWidget` copy to describe compact summary and sidebar, and to prefer fenced `svg`/`mermaid` blocks for diagrams.
  - Added `exclusiveMinimum` to `GenUISchema.number` for strict greater-than constraints.
  - Synced copy and field docs for `LinkPreviewWidget`, `MessageComposeWidget`, `RecipeCardWidget`, and `SportsDataWidget` to match the web app; `LinkPreviewWidget` now documents server-side OpenGraph metadata (only provide `url` and fallback `title`).

- **Bug Fixes**
  - `ClockWidget`: enforce `durationSeconds` > 0 using `exclusiveMinimum: 0`; improved timer/target field descriptions with an ISO timestamp example.

<sup>Written for commit 96160f3ff26a85d3f6e8d6ede81a93ebadd43852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

