### PR TITLE
Add support for projects

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -95,6 +95,7 @@ enum Constants {
 
     enum Pagination {
         static let chatsPerPage = 20
+        static let projectsPerPage = 20
         static let recentChatThresholdSeconds: TimeInterval = 120  // 2 minutes
         static let cleanupThresholdSeconds: TimeInterval = 90     // 1.5 minutes
     }
@@ -131,6 +132,13 @@ enum Constants {
     enum Summarizer {
         static let enclaveURL = "https://summarizer.tinfoil.sh"
         static let configRepo = "tinfoilsh/confidential-summarizer"
+    }
+
+    enum DocumentProcessing {
+        static let enclaveURL = "https://doc-upload.inf9.tinfoil.sh"
+        static let configRepo = "tinfoilsh/confidential-doc-upload"
+        static let convertPath = "/v1/convert/file"
+        static let defaultMode = "text"
     }
 
     enum ThinkingSummary {
@@ -271,7 +279,7 @@ enum Constants {
         static let previewMaxWidth: CGFloat = 200
         static let messageThumbnailSize: CGFloat = 80
         static let messageThumbnailColumns: Int = 3
-        static let supportedDocumentExtensions: Set<String> = ["pdf", "txt", "md", "csv", "html"]
+        static let supportedDocumentExtensions: Set<String> = ["pdf", "docx", "pptx", "xlsx", "txt", "md", "csv", "html", "json", "xml"]
         static let supportedImageExtensions: Set<String> = ["jpg", "jpeg", "png", "gif", "webp", "heic"]
         static let defaultImageMimeType = "image/jpeg"
     }

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -228,6 +228,9 @@ enum Constants {
             static let chatStatus = "tinfoil-sync-chat-status"
             static let allChatsStatus = "tinfoil-sync-all-chats-status"
 
+            static func projectChatStatus(projectId: String) -> String {
+                "tinfoil-sync-project-chat-status-\(projectId)"
+            }
             static func lastSyncDate(userId: String) -> String {
                 "tinfoil-sync-last-sync-date-\(userId)"
             }

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -143,7 +143,8 @@ struct Chat: Identifiable, Codable {
         syncedAt: Date? = nil,
         locallyModified: Bool = true,
         updatedAt: Date? = nil,
-        isLocalOnly: Bool = false
+        isLocalOnly: Bool = false,
+        projectId: String? = nil
     ) -> Chat {
         // Try to use the provided model, fall back to current model, then first available
         guard let model = modelType ?? AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first else {
@@ -162,7 +163,8 @@ struct Chat: Identifiable, Codable {
             syncedAt: syncedAt,
             locallyModified: locallyModified,
             updatedAt: updatedAt,
-            isLocalOnly: isLocalOnly
+            isLocalOnly: isLocalOnly,
+            projectId: projectId
         )
     }
     

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -304,7 +304,7 @@ struct DeletedChatsResponse: Codable {
 /// Remote chat metadata from API
 struct RemoteChat: Codable {
     let id: String
-    let key: String
+    let key: String?
     let createdAt: String
     let updatedAt: String
     let title: String?  // Optional - encrypted chats don't have readable titles
@@ -340,6 +340,10 @@ struct UploadConversationRequest: Codable {
 struct UpdateMetadataRequest: Codable {
     let conversationId: String
     let metadata: [String: String]
+}
+
+struct UpdateChatProjectRequest: Codable {
+    let projectId: String?
 }
 
 // MARK: - Profile Sync Models

--- a/TinfoilChat/Models/ProjectModels.swift
+++ b/TinfoilChat/Models/ProjectModels.swift
@@ -1,0 +1,134 @@
+//
+//  ProjectModels.swift
+//  TinfoilChat
+//
+//  Models for webapp-compatible Projects.
+//
+
+import Foundation
+
+struct MemoryFact: Codable, Identifiable, Equatable {
+    let id: String
+    var fact: String
+    var date: String
+    var category: String
+    var confidence: Double
+}
+
+struct Project: Codable, Identifiable, Equatable {
+    let id: String
+    var name: String
+    var description: String
+    var systemInstructions: String
+    var memory: [MemoryFact]
+    var createdAt: String
+    var updatedAt: String
+    var syncVersion: Int
+    var decryptionFailed: Bool?
+}
+
+struct ProjectData: Codable, Equatable {
+    var name: String
+    var description: String
+    var systemInstructions: String
+    var memory: [MemoryFact]
+}
+
+struct CreateProjectData: Codable, Equatable {
+    var name: String
+    var description: String = ""
+    var systemInstructions: String = ""
+}
+
+struct UpdateProjectData: Codable, Equatable {
+    var name: String?
+    var description: String?
+    var systemInstructions: String?
+    var memory: [MemoryFact]?
+}
+
+struct ProjectDocument: Codable, Identifiable, Equatable {
+    let id: String
+    let projectId: String
+    var filename: String
+    var contentType: String
+    var sizeBytes: Int
+    var syncVersion: Int
+    var createdAt: String
+    var updatedAt: String
+    var content: String?
+}
+
+struct ProjectDocumentPayload: Codable, Equatable {
+    var content: String
+    var filename: String
+    var contentType: String
+}
+
+struct ProjectChat: Codable, Identifiable, Equatable {
+    let id: String
+    let projectId: String
+    let messageCount: Int?
+    let syncVersion: Int?
+    let size: Int?
+    let formatVersion: Int?
+    let createdAt: String
+    let updatedAt: String
+    let content: String?
+}
+
+struct GenerateProjectIdResponse: Codable {
+    let projectId: String
+    let timestamp: String
+    let reverseTimestamp: Int
+}
+
+struct GenerateDocumentIdResponse: Codable {
+    let documentId: String
+    let timestamp: String
+    let reverseTimestamp: Int
+}
+
+struct ProjectListResponse: Codable {
+    let projects: [ProjectListItem]
+    let nextContinuationToken: String?
+    let hasMore: Bool
+}
+
+struct ProjectListItem: Codable, Identifiable {
+    let id: String
+    let key: String?
+    let createdAt: String
+    let updatedAt: String
+    let syncVersion: Int
+    let size: Int?
+    let content: String?
+}
+
+struct ProjectDocumentListResponse: Codable {
+    let documents: [ProjectDocumentListItem]
+}
+
+struct ProjectDocumentListItem: Codable, Identifiable {
+    let id: String
+    let projectId: String
+    let sizeBytes: Int?
+    let syncVersion: Int
+    let createdAt: String
+    let updatedAt: String
+    let content: String?
+}
+
+struct ProjectChatListResponse: Codable {
+    let chats: [RemoteChat]
+    let hasMore: Bool?
+    let nextContinuationToken: String?
+}
+
+struct ProjectSyncStatus: Codable, Equatable {
+    let count: Int
+    let lastUpdated: String?
+}
+
+typealias ProjectChatSyncStatus = ProjectSyncStatus
+typealias ProjectDocumentSyncStatus = ProjectSyncStatus

--- a/TinfoilChat/Models/ProjectModels.swift
+++ b/TinfoilChat/Models/ProjectModels.swift
@@ -132,3 +132,29 @@ struct ProjectSyncStatus: Codable, Equatable {
 
 typealias ProjectChatSyncStatus = ProjectSyncStatus
 typealias ProjectDocumentSyncStatus = ProjectSyncStatus
+
+struct EncryptedProjectContent: Codable {
+    let encryptedData: EncryptedData
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let encryptedData = try? container.decode(EncryptedData.self) {
+            self.encryptedData = encryptedData
+            return
+        }
+
+        let encryptedString = try container.decode(String.self)
+        guard let data = encryptedString.data(using: .utf8) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Encrypted content is not valid UTF-8"
+            )
+        }
+        self.encryptedData = try JSONDecoder().decode(EncryptedData.self, from: data)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(encryptedData)
+    }
+}

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -475,6 +475,97 @@ class CloudStorageService: ObservableObject {
         return try JSONDecoder().decode(ChatListResponse.self, from: data)
     }
 
+    // MARK: - Project Chat Operations
+
+    func updateChatProject(chatId: String, projectId: String?) async throws {
+        let url = URL(string: "\(apiBaseURL)/api/storage/conversation/\(chatId)/project")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.allHTTPHeaderFields = try await getHeaders()
+        request.httpBody = try JSONEncoder().encode(UpdateChatProjectRequest(projectId: projectId))
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw CloudStorageError.metadataUpdateFailed
+        }
+    }
+
+    func listProjectChats(projectId: String, includeContent: Bool = false, continuationToken: String? = nil) async throws -> ProjectChatListResponse {
+        var components = URLComponents(string: "\(apiBaseURL)/api/projects/\(projectId)/chats")!
+        var queryItems: [URLQueryItem] = []
+
+        if includeContent {
+            queryItems.append(URLQueryItem(name: "includeContent", value: "true"))
+        }
+        if let continuationToken {
+            queryItems.append(URLQueryItem(name: "continuationToken", value: continuationToken))
+        }
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.allHTTPHeaderFields = try await getHeaders()
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw CloudStorageError.listFailed
+        }
+
+        return try JSONDecoder().decode(ProjectChatListResponse.self, from: data)
+    }
+
+    func getProjectChatsSyncStatus(projectId: String) async throws -> ChatSyncStatus {
+        var components = URLComponents(string: "\(apiBaseURL)/api/projects/\(projectId)/chats/sync-status")!
+        components.queryItems = [URLQueryItem(name: "_t", value: String(Int(Date().timeIntervalSince1970 * 1000)))]
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.allHTTPHeaderFields = try await getHeaders()
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw CloudStorageError.listFailed
+        }
+
+        return try JSONDecoder().decode(ChatSyncStatus.self, from: data)
+    }
+
+    func getProjectChatsUpdatedSince(projectId: String, since: String, continuationToken: String? = nil) async throws -> ProjectChatListResponse {
+        var components = URLComponents(string: "\(apiBaseURL)/api/projects/\(projectId)/chats/updated-since")!
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "since", value: since),
+            URLQueryItem(name: "_t", value: String(Int(Date().timeIntervalSince1970 * 1000)))
+        ]
+        if let continuationToken {
+            queryItems.append(URLQueryItem(name: "continuationToken", value: continuationToken))
+        }
+        components.queryItems = queryItems
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.allHTTPHeaderFields = try await getHeaders()
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw CloudStorageError.listFailed
+        }
+
+        return try JSONDecoder().decode(ProjectChatListResponse.self, from: data)
+    }
+
     /// Get chats updated since a specific timestamp
     func getChatsUpdatedSince(since: String, includeContent: Bool = false, continuationToken: String? = nil) async throws -> ChatListResponse {
         var components = URLComponents(string: "\(apiBaseURL)/api/chats/updated-since")!

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -199,6 +199,7 @@ class CloudSyncService: ObservableObject {
         // Set token getter for both R2 storage and ProfileSync
         cloudStorage.setTokenGetter(tokenGetter)
         ProfileSyncService.shared.setTokenGetter(tokenGetter)
+        ProjectStorageService.shared.setTokenGetter(tokenGetter)
         
     }
     
@@ -478,6 +479,9 @@ class CloudSyncService: ObservableObject {
 
             var decryptedChat = decryptionResult.value
             decryptedChat.formatVersion = formatVersion
+            if let remoteProjectId = remoteChat.projectId {
+                decryptedChat.projectId = remoteProjectId
+            }
 
             // Prefer blob's createdAt (matches React's `decrypted.createdAt ?? remote.createdAt`).
             // StoredChat decoder falls back to Date() on parse failure — detect that
@@ -516,9 +520,12 @@ class CloudSyncService: ObservableObject {
     
     /// Download a remote chat by ID, apply metadata dates, and save locally.
     /// Returns `true` if the chat was downloaded and saved, `false` on failure.
-    private func downloadAndSaveRemoteChat(_ remoteChat: RemoteChat) async throws {
+    private func downloadAndSaveRemoteChat(_ remoteChat: RemoteChat, projectId: String? = nil) async throws {
         guard var downloadedChat = try await cloudStorage.downloadChat(remoteChat.id) else {
             return
+        }
+        if let projectId = projectId ?? remoteChat.projectId {
+            downloadedChat.projectId = projectId
         }
 
         // If decryption failed, don't overwrite a valid local copy.
@@ -974,6 +981,323 @@ class CloudSyncService: ObservableObject {
         return result
     }
 
+    func smartSync(projectId: String?) async -> SyncResult {
+        guard let projectId else {
+            return await smartSync()
+        }
+        return await smartSyncProjectChats(projectId)
+    }
+
+    func updateChatProject(_ chatId: String, projectId: String?) async throws {
+        guard canWriteToCloud() else { return }
+        try await cloudStorage.updateChatProject(chatId: chatId, projectId: projectId)
+    }
+
+    func syncProjectChats(_ projectId: String) async -> SyncResult {
+        guard !isSyncing else {
+            return SyncResult()
+        }
+
+        guard await cloudStorage.isAuthenticated() else {
+            return SyncResult()
+        }
+
+        isSyncing = true
+        syncStatus = "Syncing project..."
+        defer {
+            isSyncing = false
+            syncStatus = ""
+            lastSyncDate = Date()
+        }
+
+        let result = await doSyncProjectChats(projectId)
+        syncErrors = result.errors
+        return result
+    }
+
+    private func smartSyncProjectChats(_ projectId: String) async -> SyncResult {
+        guard !isSyncing else {
+            return SyncResult()
+        }
+
+        guard await cloudStorage.isAuthenticated() else {
+            return SyncResult()
+        }
+
+        let unsyncedChats = await getUnsyncedChats()
+        let localProjectChanges = unsyncedChats.contains {
+            $0.projectId == projectId && !$0.isBlankChat && !$0.messages.isEmpty
+        }
+
+        do {
+            let remoteStatus = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
+            let cachedStatus = getCachedProjectChatSyncStatus(projectId)
+
+            if !localProjectChanges,
+               let cachedStatus,
+               remoteStatus.count == cachedStatus.count,
+               remoteStatus.lastUpdated == cachedStatus.lastUpdated {
+                return SyncResult()
+            }
+
+            isSyncing = true
+            syncStatus = "Syncing project..."
+            defer {
+                isSyncing = false
+                syncStatus = ""
+                lastSyncDate = Date()
+            }
+
+            if !localProjectChanges,
+               let cachedLastUpdated = cachedStatus?.lastUpdated,
+               remoteStatus.count == cachedStatus?.count {
+                let result = await syncProjectChatsChanged(projectId, since: cachedLastUpdated)
+                if result.errors.isEmpty {
+                    saveProjectChatSyncStatus(projectId, remoteStatus)
+                    return result
+                }
+            }
+
+            let result = await doSyncProjectChats(projectId)
+            syncErrors = result.errors
+            return result
+        } catch {
+            return await syncProjectChats(projectId)
+        }
+    }
+
+    private func doSyncProjectChats(_ projectId: String) async -> SyncResult {
+        var result = SyncResult()
+
+        let backupResult = await backupUnsyncedProjectChats(projectId)
+        result = SyncResult(
+            uploaded: backupResult.uploaded,
+            downloaded: 0,
+            deleted: 0,
+            errors: backupResult.errors
+        )
+
+        do {
+            _ = try? await encryptionService.initialize()
+
+            let localChats = await getAllChatsFromStorage()
+            let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
+            var continuationToken: String? = nil
+
+            repeat {
+                let remoteList = try await cloudStorage.listProjectChats(
+                    projectId: projectId,
+                    includeContent: true,
+                    continuationToken: continuationToken
+                )
+
+                for remoteChat in remoteList.chats {
+                    if deletedChatsTracker.isDeleted(remoteChat.id) {
+                        continue
+                    }
+
+                    if !(await shouldProcessRemoteChat(remoteChat)) {
+                        continue
+                    }
+
+                    if let localChat = localChatMap[remoteChat.id],
+                       localChat.locallyModified || localChat.hasActiveStream || streamingTracker.isStreaming(localChat.id) {
+                        continue
+                    }
+
+                    if let content = remoteChat.content {
+                        if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
+                            decrypted.chat.projectId = projectId
+                            await saveChatToStorage(decrypted.chat)
+                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                            result = SyncResult(
+                                uploaded: result.uploaded,
+                                downloaded: result.downloaded + 1,
+                                deleted: result.deleted,
+                                errors: result.errors
+                            )
+                        } else {
+                            let localChat = localChatMap[remoteChat.id]
+                            let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
+                            if !hasValidLocal {
+                                var placeholder = createEncryptedPlaceholder(
+                                    remoteChat: remoteChat,
+                                    encryptedContent: content
+                                )
+                                placeholder.projectId = projectId
+                                await saveChatToStorage(placeholder)
+                                result = SyncResult(
+                                    uploaded: result.uploaded,
+                                    downloaded: result.downloaded + 1,
+                                    deleted: result.deleted,
+                                    errors: result.errors
+                                )
+                            }
+                        }
+                    } else {
+                        try await downloadAndSaveRemoteChat(remoteChat, projectId: projectId)
+                        result = SyncResult(
+                            uploaded: result.uploaded,
+                            downloaded: result.downloaded + 1,
+                            deleted: result.deleted,
+                            errors: result.errors
+                        )
+                    }
+                }
+
+                let nextToken = remoteList.nextContinuationToken?.isEmpty == false ? remoteList.nextContinuationToken : nil
+                continuationToken = remoteList.hasMore == true ? nextToken : nil
+            } while continuationToken != nil
+
+            let status = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
+            saveProjectChatSyncStatus(projectId, status)
+            await syncCrossScope()
+        } catch {
+            result = SyncResult(
+                uploaded: result.uploaded,
+                downloaded: result.downloaded,
+                deleted: result.deleted,
+                errors: result.errors + ["Project sync failed: \(error.localizedDescription)"]
+            )
+        }
+
+        return result
+    }
+
+    private func syncProjectChatsChanged(_ projectId: String, since: String) async -> SyncResult {
+        var result = SyncResult()
+
+        let backupResult = await backupUnsyncedProjectChats(projectId)
+        result = SyncResult(
+            uploaded: backupResult.uploaded,
+            downloaded: 0,
+            deleted: 0,
+            errors: backupResult.errors
+        )
+
+        do {
+            _ = try? await encryptionService.initialize()
+
+            let localChats = await getAllChatsFromStorage()
+            let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
+            var continuationToken: String? = nil
+
+            repeat {
+                let changed = try await cloudStorage.getProjectChatsUpdatedSince(
+                    projectId: projectId,
+                    since: since,
+                    continuationToken: continuationToken
+                )
+
+                for remoteChat in changed.chats {
+                    if deletedChatsTracker.isDeleted(remoteChat.id) {
+                        continue
+                    }
+
+                    if let localChat = localChatMap[remoteChat.id],
+                       localChat.locallyModified || localChat.hasActiveStream || streamingTracker.isStreaming(localChat.id) {
+                        continue
+                    }
+
+                    if let content = remoteChat.content {
+                        if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
+                            decrypted.chat.projectId = projectId
+                            await saveChatToStorage(decrypted.chat)
+                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                            result = SyncResult(
+                                uploaded: result.uploaded,
+                                downloaded: result.downloaded + 1,
+                                deleted: result.deleted,
+                                errors: result.errors
+                            )
+                        } else {
+                            let localChat = localChatMap[remoteChat.id]
+                            let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
+                            if !hasValidLocal {
+                                var placeholder = createEncryptedPlaceholder(
+                                    remoteChat: remoteChat,
+                                    encryptedContent: content
+                                )
+                                placeholder.projectId = projectId
+                                await saveChatToStorage(placeholder)
+                                result = SyncResult(
+                                    uploaded: result.uploaded,
+                                    downloaded: result.downloaded + 1,
+                                    deleted: result.deleted,
+                                    errors: result.errors
+                                )
+                            }
+                        }
+                    } else {
+                        try await downloadAndSaveRemoteChat(remoteChat, projectId: projectId)
+                        result = SyncResult(
+                            uploaded: result.uploaded,
+                            downloaded: result.downloaded + 1,
+                            deleted: result.deleted,
+                            errors: result.errors
+                        )
+                    }
+                }
+
+                let nextToken = changed.nextContinuationToken?.isEmpty == false ? changed.nextContinuationToken : nil
+                continuationToken = changed.hasMore == true ? nextToken : nil
+            } while continuationToken != nil
+
+            let status = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
+            saveProjectChatSyncStatus(projectId, status)
+            await syncCrossScope()
+        } catch {
+            result = SyncResult(
+                uploaded: result.uploaded,
+                downloaded: result.downloaded,
+                deleted: result.deleted,
+                errors: result.errors + ["Project delta sync failed: \(error.localizedDescription)"]
+            )
+        }
+
+        return result
+    }
+
+    private func backupUnsyncedProjectChats(_ projectId: String) async -> SyncResult {
+        var result = SyncResult()
+
+        guard canWriteToCloud() else {
+            return result
+        }
+
+        let unsyncedChats = await getUnsyncedChats()
+        let unsyncedProjectChats = unsyncedChats.filter { $0.projectId == projectId }
+
+        for chat in unsyncedProjectChats {
+            guard !chat.isBlankChat,
+                  !chat.messages.isEmpty,
+                  !chat.decryptionFailed,
+                  chat.encryptedData == nil,
+                  !streamingTracker.isStreaming(chat.id) else {
+                continue
+            }
+
+            do {
+                try await uploadAndMarkSynced(chat)
+                result = SyncResult(
+                    uploaded: result.uploaded + 1,
+                    downloaded: result.downloaded,
+                    deleted: result.deleted,
+                    errors: result.errors
+                )
+            } catch {
+                result = SyncResult(
+                    uploaded: result.uploaded,
+                    downloaded: result.downloaded,
+                    deleted: result.deleted,
+                    errors: result.errors + ["Failed to backup project chat \(chat.id): \(error.localizedDescription)"]
+                )
+            }
+        }
+
+        return result
+    }
+
     /// Clear cached sync status (call on logout)
     func clearSyncStatus() {
         UserDefaults.standard.removeObject(forKey: syncStatusKey)
@@ -993,6 +1317,21 @@ class CloudSyncService: ObservableObject {
         let status = ChatSyncStatus(count: count, lastUpdated: lastUpdated)
         if let data = try? JSONEncoder().encode(status) {
             UserDefaults.standard.set(data, forKey: syncStatusKey)
+        }
+    }
+
+    private func getCachedProjectChatSyncStatus(_ projectId: String) -> ChatSyncStatus? {
+        let key = Constants.StorageKeys.Sync.projectChatStatus(projectId: projectId)
+        guard let data = UserDefaults.standard.data(forKey: key) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(ChatSyncStatus.self, from: data)
+    }
+
+    private func saveProjectChatSyncStatus(_ projectId: String, _ status: ChatSyncStatus) {
+        let key = Constants.StorageKeys.Sync.projectChatStatus(projectId: projectId)
+        if let data = try? JSONEncoder().encode(status) {
+            UserDefaults.standard.set(data, forKey: key)
         }
     }
 

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1067,6 +1067,43 @@ class CloudSyncService: ObservableObject {
     }
 
     private func doSyncProjectChats(_ projectId: String) async -> SyncResult {
+        await syncProjectChatsRemote(
+            projectId: projectId,
+            errorPrefix: "Project sync failed",
+            applyShouldProcessFilter: true,
+            fetchPage: { [cloudStorage] continuationToken in
+                let page = try await cloudStorage.listProjectChats(
+                    projectId: projectId,
+                    includeContent: true,
+                    continuationToken: continuationToken
+                )
+                return (page.chats, page.nextContinuationToken, page.hasMore == true)
+            }
+        )
+    }
+
+    private func syncProjectChatsChanged(_ projectId: String, since: String) async -> SyncResult {
+        await syncProjectChatsRemote(
+            projectId: projectId,
+            errorPrefix: "Project delta sync failed",
+            applyShouldProcessFilter: false,
+            fetchPage: { [cloudStorage] continuationToken in
+                let page = try await cloudStorage.getProjectChatsUpdatedSince(
+                    projectId: projectId,
+                    since: since,
+                    continuationToken: continuationToken
+                )
+                return (page.chats, page.nextContinuationToken, page.hasMore == true)
+            }
+        )
+    }
+
+    private func syncProjectChatsRemote(
+        projectId: String,
+        errorPrefix: String,
+        applyShouldProcessFilter: Bool,
+        fetchPage: (String?) async throws -> (chats: [RemoteChat], nextToken: String?, hasMore: Bool)
+    ) async -> SyncResult {
         var result = SyncResult()
 
         let backupResult = await backupUnsyncedProjectChats(projectId)
@@ -1085,18 +1122,14 @@ class CloudSyncService: ObservableObject {
             var continuationToken: String? = nil
 
             repeat {
-                let remoteList = try await cloudStorage.listProjectChats(
-                    projectId: projectId,
-                    includeContent: true,
-                    continuationToken: continuationToken
-                )
+                let page = try await fetchPage(continuationToken)
 
-                for remoteChat in remoteList.chats {
+                for remoteChat in page.chats {
                     if deletedChatsTracker.isDeleted(remoteChat.id) {
                         continue
                     }
 
-                    if !(await shouldProcessRemoteChat(remoteChat)) {
+                    if applyShouldProcessFilter, !(await shouldProcessRemoteChat(remoteChat)) {
                         continue
                     }
 
@@ -1105,48 +1138,22 @@ class CloudSyncService: ObservableObject {
                         continue
                     }
 
-                    if let content = remoteChat.content {
-                        if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
-                            decrypted.chat.projectId = projectId
-                            await saveChatToStorage(decrypted.chat)
-                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
-                            result = SyncResult(
-                                uploaded: result.uploaded,
-                                downloaded: result.downloaded + 1,
-                                deleted: result.deleted,
-                                errors: result.errors
-                            )
-                        } else {
-                            let localChat = localChatMap[remoteChat.id]
-                            let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
-                            if !hasValidLocal {
-                                var placeholder = createEncryptedPlaceholder(
-                                    remoteChat: remoteChat,
-                                    encryptedContent: content
-                                )
-                                placeholder.projectId = projectId
-                                await saveChatToStorage(placeholder)
-                                result = SyncResult(
-                                    uploaded: result.uploaded,
-                                    downloaded: result.downloaded + 1,
-                                    deleted: result.deleted,
-                                    errors: result.errors
-                                )
-                            }
-                        }
-                    } else {
-                        try await downloadAndSaveRemoteChat(remoteChat, projectId: projectId)
-                        result = SyncResult(
-                            uploaded: result.uploaded,
-                            downloaded: result.downloaded + 1,
-                            deleted: result.deleted,
-                            errors: result.errors
-                        )
-                    }
+                    let processed = await processRemoteProjectChat(
+                        remoteChat,
+                        projectId: projectId,
+                        localChatMap: localChatMap,
+                        errorPrefix: errorPrefix
+                    )
+                    result = SyncResult(
+                        uploaded: result.uploaded,
+                        downloaded: result.downloaded + processed.downloaded,
+                        deleted: result.deleted,
+                        errors: result.errors + processed.errors
+                    )
                 }
 
-                let nextToken = remoteList.nextContinuationToken?.isEmpty == false ? remoteList.nextContinuationToken : nil
-                continuationToken = remoteList.hasMore == true ? nextToken : nil
+                let nextToken = page.nextToken?.isEmpty == false ? page.nextToken : nil
+                continuationToken = page.hasMore ? nextToken : nil
             } while continuationToken != nil
 
             let status = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
@@ -1157,105 +1164,47 @@ class CloudSyncService: ObservableObject {
                 uploaded: result.uploaded,
                 downloaded: result.downloaded,
                 deleted: result.deleted,
-                errors: result.errors + ["Project sync failed: \(error.localizedDescription)"]
+                errors: result.errors + ["\(errorPrefix): \(error.localizedDescription)"]
             )
         }
 
         return result
     }
 
-    private func syncProjectChatsChanged(_ projectId: String, since: String) async -> SyncResult {
-        var result = SyncResult()
-
-        let backupResult = await backupUnsyncedProjectChats(projectId)
-        result = SyncResult(
-            uploaded: backupResult.uploaded,
-            downloaded: 0,
-            deleted: 0,
-            errors: backupResult.errors
-        )
-
-        do {
-            _ = try? await encryptionService.initialize()
-
-            let localChats = await getAllChatsFromStorage()
-            let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
-            var continuationToken: String? = nil
-
-            repeat {
-                let changed = try await cloudStorage.getProjectChatsUpdatedSince(
-                    projectId: projectId,
-                    since: since,
-                    continuationToken: continuationToken
-                )
-
-                for remoteChat in changed.chats {
-                    if deletedChatsTracker.isDeleted(remoteChat.id) {
-                        continue
-                    }
-
-                    if let localChat = localChatMap[remoteChat.id],
-                       localChat.locallyModified || localChat.hasActiveStream || streamingTracker.isStreaming(localChat.id) {
-                        continue
-                    }
-
-                    if let content = remoteChat.content {
-                        if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
-                            decrypted.chat.projectId = projectId
-                            await saveChatToStorage(decrypted.chat)
-                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
-                            result = SyncResult(
-                                uploaded: result.uploaded,
-                                downloaded: result.downloaded + 1,
-                                deleted: result.deleted,
-                                errors: result.errors
-                            )
-                        } else {
-                            let localChat = localChatMap[remoteChat.id]
-                            let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
-                            if !hasValidLocal {
-                                var placeholder = createEncryptedPlaceholder(
-                                    remoteChat: remoteChat,
-                                    encryptedContent: content
-                                )
-                                placeholder.projectId = projectId
-                                await saveChatToStorage(placeholder)
-                                result = SyncResult(
-                                    uploaded: result.uploaded,
-                                    downloaded: result.downloaded + 1,
-                                    deleted: result.deleted,
-                                    errors: result.errors
-                                )
-                            }
-                        }
-                    } else {
-                        try await downloadAndSaveRemoteChat(remoteChat, projectId: projectId)
-                        result = SyncResult(
-                            uploaded: result.uploaded,
-                            downloaded: result.downloaded + 1,
-                            deleted: result.deleted,
-                            errors: result.errors
-                        )
-                    }
+    private func processRemoteProjectChat(
+        _ remoteChat: RemoteChat,
+        projectId: String,
+        localChatMap: [String: Chat],
+        errorPrefix: String
+    ) async -> (downloaded: Int, errors: [String]) {
+        if let content = remoteChat.content {
+            if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
+                decrypted.chat.projectId = projectId
+                await saveChatToStorage(decrypted.chat)
+                await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                return (1, [])
+            } else {
+                let localChat = localChatMap[remoteChat.id]
+                let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
+                if !hasValidLocal {
+                    var placeholder = createEncryptedPlaceholder(
+                        remoteChat: remoteChat,
+                        encryptedContent: content
+                    )
+                    placeholder.projectId = projectId
+                    await saveChatToStorage(placeholder)
+                    return (1, [])
                 }
-
-                let nextToken = changed.nextContinuationToken?.isEmpty == false ? changed.nextContinuationToken : nil
-                continuationToken = changed.hasMore == true ? nextToken : nil
-            } while continuationToken != nil
-
-            let status = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
-            saveProjectChatSyncStatus(projectId, status)
-            await syncCrossScope()
-        } catch {
-            result = SyncResult(
-                uploaded: result.uploaded,
-                downloaded: result.downloaded,
-                deleted: result.deleted,
-                errors: result.errors + ["Project delta sync failed: \(error.localizedDescription)"]
-            )
+                return (0, [])
+            }
         }
 
-        return result
+        do {
+            try await downloadAndSaveRemoteChat(remoteChat, projectId: projectId)
+            return (1, [])
+        } catch {
+            return (0, ["\(errorPrefix) (\(remoteChat.id)): \(error.localizedDescription)"])
+        }
     }
 
     private func backupUnsyncedProjectChats(_ projectId: String) async -> SyncResult {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -45,6 +45,7 @@ private actor UploadCoalescer {
         var workerRunning: Bool = false
         var failureCount: Int = 0
         var waiters: [CheckedContinuation<Void, Never>] = []
+        var throwingWaiters: [CheckedContinuation<Void, Error>] = []
     }
 
     private var states: [String: ChatUploadState] = [:]
@@ -74,11 +75,25 @@ private actor UploadCoalescer {
         }
     }
 
+    func enqueueAndWait(_ chatId: String) async throws {
+        enqueue(chatId)
+
+        guard let state = states[chatId], state.workerRunning || state.dirty else {
+            return
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            states[chatId]?.throwingWaiters.append(continuation)
+        }
+    }
+
     private func runWorker(_ chatId: String) async {
+        var terminalError: Error?
+
         while states[chatId]?.dirty == true {
             states[chatId]?.dirty = false
 
-            await uploadWithRetry(chatId)
+            terminalError = await uploadWithRetry(chatId)
         }
 
         // Notify waiters and clean up in a single access
@@ -87,22 +102,35 @@ private actor UploadCoalescer {
             waiter.resume()
         }
 
+        let throwingWaiters = states[chatId]?.throwingWaiters ?? []
+        for waiter in throwingWaiters {
+            if let terminalError {
+                waiter.resume(throwing: terminalError)
+            } else {
+                waiter.resume()
+            }
+        }
+
         let failureCount = states[chatId]?.failureCount ?? 0
         if failureCount == 0 {
             states.removeValue(forKey: chatId)
         } else {
             states[chatId]?.workerRunning = false
             states[chatId]?.waiters = []
+            states[chatId]?.throwingWaiters = []
         }
     }
 
-    private func uploadWithRetry(_ chatId: String) async {
+    private func uploadWithRetry(_ chatId: String) async -> Error? {
+        var lastError: Error?
+
         for attempt in 0...Constants.Sync.uploadMaxRetries {
             do {
                 try await uploadFn(chatId)
                 states[chatId]?.failureCount = 0
-                return
+                return nil
             } catch {
+                lastError = error
                 let currentCount = states[chatId]?.failureCount ?? 0
                 states[chatId]?.failureCount = currentCount + 1
 
@@ -119,10 +147,12 @@ private actor UploadCoalescer {
                 // If dirty was set during backoff, return early to upload fresh data
                 let isDirty = states[chatId]?.dirty ?? false
                 if isDirty {
-                    return
+                    return nil
                 }
             }
         }
+
+        return lastError
     }
 }
 
@@ -305,7 +335,7 @@ class CloudSyncService: ObservableObject {
             }
 
             do {
-                try await uploadAndMarkSynced(chat)
+                try await uploadCoalescer.enqueueAndWait(chat.id)
                 result = SyncResult(
                     uploaded: result.uploaded + 1,
                     downloaded: result.downloaded,
@@ -1227,7 +1257,7 @@ class CloudSyncService: ObservableObject {
             }
 
             do {
-                try await uploadAndMarkSynced(chat)
+                try await uploadCoalescer.enqueueAndWait(chat.id)
                 result = SyncResult(
                     uploaded: result.uploaded + 1,
                     downloaded: result.downloaded,
@@ -1464,6 +1494,8 @@ class CloudSyncService: ObservableObject {
     /// Upload a chat to cloud and mark it as synced with an incremented version.
     /// Encapsulates the two-step "upload current version, increment after success" protocol.
     private func uploadAndMarkSynced(_ chat: Chat) async throws {
+        guard !streamingTracker.isStreaming(chat.id) else { return }
+
         let storedChat = StoredChat(from: chat, syncVersion: chat.syncVersion)
         try await cloudStorage.uploadChat(storedChat)
         await markChatAsSynced(chat.id, version: chat.syncVersion + 1)
@@ -1663,7 +1695,7 @@ class CloudSyncService: ObservableObject {
                 
                 // Save locally then upload (will be encrypted with new key)
                 await saveChatToStorage(StoredChat(from: chatToReencrypt))
-                try await uploadAndMarkSynced(chatToReencrypt)
+                try await uploadCoalescer.enqueueAndWait(chatToReencrypt.id)
                 
                 result.uploaded += 1
                 result.reencrypted += 1

--- a/TinfoilChat/Services/DocumentConversionService.swift
+++ b/TinfoilChat/Services/DocumentConversionService.swift
@@ -1,0 +1,163 @@
+//
+//  DocumentConversionService.swift
+//  TinfoilChat
+//
+//  Attested document conversion for project context uploads.
+//
+
+import Foundation
+import TinfoilAI
+import UniformTypeIdentifiers
+
+actor DocumentConversionService {
+    static let shared = DocumentConversionService()
+
+    private var client: SecureClient?
+    private var verificationTask: Task<SecureClient, Error>?
+    private let decoder = JSONDecoder()
+
+    private init() {}
+
+    private func getClient() async throws -> SecureClient {
+        if let client {
+            return client
+        }
+
+        if let verificationTask {
+            return try await verificationTask.value
+        }
+
+        let task = Task<SecureClient, Error> {
+            let newClient = SecureClient(
+                githubRepo: Constants.DocumentProcessing.configRepo,
+                enclaveURL: Constants.DocumentProcessing.enclaveURL
+            )
+            _ = try await newClient.verify()
+            return newClient
+        }
+        verificationTask = task
+
+        do {
+            let verifiedClient = try await task.value
+            client = verifiedClient
+            verificationTask = nil
+            return verifiedClient
+        } catch {
+            verificationTask = nil
+            throw error
+        }
+    }
+
+    func convertToMarkdown(url: URL, filename: String, contentType: String? = nil, mode: String = Constants.DocumentProcessing.defaultMode) async throws -> String {
+        let fileData = try Data(contentsOf: url)
+        let boundary = "Boundary-\(UUID().uuidString)"
+        let mimeType = contentType ?? Self.mimeType(for: filename)
+        let body = Self.multipartBody(
+            boundary: boundary,
+            fileData: fileData,
+            filename: filename,
+            contentType: mimeType
+        )
+
+        guard var components = URLComponents(string: "\(Constants.DocumentProcessing.enclaveURL)\(Constants.DocumentProcessing.convertPath)") else {
+            throw DocumentConversionError.invalidResponse
+        }
+        components.queryItems = [URLQueryItem(name: "mode", value: mode)]
+
+        let apiKey = await SessionTokenManager.shared.getSessionToken()
+        guard !apiKey.isEmpty else {
+            throw DocumentConversionError.missingAPIKey
+        }
+
+        let client = try await getClient()
+        let response = try await client.post(
+            url: components.url?.absoluteString ?? "\(Constants.DocumentProcessing.enclaveURL)\(Constants.DocumentProcessing.convertPath)",
+            headers: [
+                "Authorization": "Bearer \(apiKey)",
+                "Content-Type": "multipart/form-data; boundary=\(boundary)"
+            ],
+            body: body
+        )
+
+        guard response.statusCode == 200 else {
+            throw DocumentConversionError.requestFailed(statusCode: response.statusCode)
+        }
+
+        let decoded = try decoder.decode(DocumentConversionResponse.self, from: response.body)
+        if let mdContent = decoded.document?.mdContent {
+            return mdContent
+        }
+        if let mdContent = decoded.documents?.first?.mdContent {
+            return mdContent
+        }
+        throw DocumentConversionError.invalidResponse
+    }
+
+    static func mimeType(for filename: String) -> String {
+        let ext = (filename as NSString).pathExtension
+        if let type = UTType(filenameExtension: ext),
+           let mimeType = type.preferredMIMEType {
+            return mimeType
+        }
+        switch ext.lowercased() {
+        case "md": return "text/markdown"
+        case "csv": return "text/csv"
+        case "json": return "application/json"
+        case "xml": return "application/xml"
+        default: return "application/octet-stream"
+        }
+    }
+
+    private static func multipartBody(boundary: String, fileData: Data, filename: String, contentType: String) -> Data {
+        var body = Data()
+        body.appendString("--\(boundary)\r\n")
+        body.appendString("Content-Disposition: form-data; name=\"files\"; filename=\"\(filename)\"\r\n")
+        body.appendString("Content-Type: \(contentType)\r\n\r\n")
+        body.append(fileData)
+        body.appendString("\r\n--\(boundary)--\r\n")
+        return body
+    }
+}
+
+private struct DocumentConversionResponse: Codable {
+    let document: ConvertedDocument?
+    let documents: [ConvertedDocument]?
+    let status: String?
+    let processingTime: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case document, documents, status
+        case processingTime = "processing_time"
+    }
+}
+
+private struct ConvertedDocument: Codable {
+    let mdContent: String?
+
+    enum CodingKeys: String, CodingKey {
+        case mdContent = "md_content"
+    }
+}
+
+enum DocumentConversionError: LocalizedError {
+    case missingAPIKey
+    case invalidResponse
+    case requestFailed(statusCode: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "Could not get a Tinfoil session key."
+        case .invalidResponse:
+            return "Document conversion returned an invalid response."
+        case .requestFailed(let statusCode):
+            return "Document conversion failed with status \(statusCode)."
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendString(_ string: String) {
+        append(Data(string.utf8))
+    }
+}

--- a/TinfoilChat/Services/DocumentConversionService.swift
+++ b/TinfoilChat/Services/DocumentConversionService.swift
@@ -110,12 +110,22 @@ actor DocumentConversionService {
 
     private static func multipartBody(boundary: String, fileData: Data, filename: String, contentType: String) -> Data {
         var body = Data()
+        let safeFilename = sanitizeMultipartHeaderValue(filename)
+        let safeContentType = sanitizeMultipartHeaderValue(contentType)
         body.appendString("--\(boundary)\r\n")
-        body.appendString("Content-Disposition: form-data; name=\"files\"; filename=\"\(filename)\"\r\n")
-        body.appendString("Content-Type: \(contentType)\r\n\r\n")
+        body.appendString("Content-Disposition: form-data; name=\"files\"; filename=\"\(safeFilename)\"\r\n")
+        body.appendString("Content-Type: \(safeContentType)\r\n\r\n")
         body.append(fileData)
         body.appendString("\r\n--\(boundary)--\r\n")
         return body
+    }
+
+    private static func sanitizeMultipartHeaderValue(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\r", with: "")
+            .replacingOccurrences(of: "\n", with: "")
     }
 }
 

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -44,16 +44,18 @@ final class DocumentProcessingService {
             throw ProcessingError.fileTooLarge(fileSize)
         }
 
-        return try await Task.detached(priority: .userInitiated) {
-            switch fileExtension {
-            case "pdf":
-                return try self.extractTextFromPDF(at: url)
-            case "txt", "md", "csv", "html":
-                return try self.readPlainText(at: url)
-            default:
-                throw ProcessingError.unsupportedFormat(fileExtension)
-            }
-        }.value
+        switch fileExtension {
+        case "pdf":
+            return try await Task.detached(priority: .userInitiated) {
+                try self.extractTextFromPDF(at: url)
+            }.value
+        case "txt", "md", "csv", "html", "json", "xml":
+            return try await Task.detached(priority: .userInitiated) {
+                try self.readPlainText(at: url)
+            }.value
+        default:
+            return try await DocumentConversionService.shared.convertToMarkdown(url: url, filename: url.lastPathComponent)
+        }
     }
 
     private func extractTextFromPDF(at url: URL) throws -> String {

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -133,13 +133,13 @@ class ProfileManager: ObservableObject {
             isDarkMode: isDarkMode,
             maxPromptMessages: maxPromptMessages,
             language: language,
-            nickname: nickname.isEmpty ? nil : nickname,
-            profession: profession.isEmpty ? nil : profession,
-            traits: traits.isEmpty ? nil : traits,
-            additionalContext: additionalContext.isEmpty ? nil : additionalContext,
+            nickname: nickname,
+            profession: profession,
+            traits: traits,
+            additionalContext: additionalContext,
             isUsingPersonalization: isUsingPersonalization,
             isUsingCustomPrompt: isUsingCustomPrompt,
-            customSystemPrompt: customSystemPrompt.isEmpty ? nil : customSystemPrompt,
+            customSystemPrompt: customSystemPrompt,
             version: lastSyncedVersion,  // Will be incremented by ProfileSyncService
             updatedAt: ISO8601DateFormatter().string(from: Date())
         )
@@ -158,14 +158,27 @@ class ProfileManager: ObservableObject {
         if let language = profile.language {
             self.language = language
         }
-        // For personalization fields, treat nil as cleared/empty to ensure cross-device erasure propagates
-        self.nickname = profile.nickname ?? ""
-        self.profession = profile.profession ?? ""
-        self.traits = profile.traits ?? []
-        self.additionalContext = profile.additionalContext ?? ""
-        self.isUsingPersonalization = profile.isUsingPersonalization ?? false
-        self.isUsingCustomPrompt = profile.isUsingCustomPrompt ?? false
-        self.customSystemPrompt = profile.customSystemPrompt ?? ""
+        if let nickname = profile.nickname {
+            self.nickname = nickname
+        }
+        if let profession = profile.profession {
+            self.profession = profession
+        }
+        if let traits = profile.traits {
+            self.traits = traits
+        }
+        if let additionalContext = profile.additionalContext {
+            self.additionalContext = additionalContext
+        }
+        if let isUsingPersonalization = profile.isUsingPersonalization {
+            self.isUsingPersonalization = isUsingPersonalization
+        }
+        if let isUsingCustomPrompt = profile.isUsingCustomPrompt {
+            self.isUsingCustomPrompt = isUsingCustomPrompt
+        }
+        if let customSystemPrompt = profile.customSystemPrompt {
+            self.customSystemPrompt = customSystemPrompt
+        }
         if let version = profile.version {
             self.lastSyncedVersion = version
         }

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -51,6 +51,7 @@ class ProfileManager: ObservableObject {
     // Keychain keys
     private let keychainKey = "userProfile"
     private let keychainService = "com.tinfoil.chat.profile"
+    private let profileDirtyKey = "com.tinfoil.chat.profile.dirty"
     
     private init() {
         loadFromKeychain()
@@ -79,13 +80,41 @@ class ProfileManager: ObservableObject {
             lastSyncedVersion = version
         }
         // Treat the loaded profile as the last synced baseline
-        lastSyncedProfile = profile
+        if !hasPendingLocalProfileChanges {
+            lastSyncedProfile = profile
+        }
     }
     
     /// Save profile to Keychain
     private func saveToKeychain() {
         let profile = createProfileData()
-        
+
+        persistProfileToKeychain(profile)
+
+        // For user-initiated changes, schedule a debounced cloud sync
+        if !isApplyingProfile {
+            markLocalProfileChanged()
+            if !isSyncing {
+                debounceCloudSync()
+            } else {
+                // If a sync is running, we'll re-check after it finishes
+            }
+        }
+    }
+
+    private var hasPendingLocalProfileChanges: Bool {
+        UserDefaults.standard.bool(forKey: profileDirtyKey)
+    }
+
+    private func markLocalProfileChanged() {
+        UserDefaults.standard.set(true, forKey: profileDirtyKey)
+    }
+
+    private func clearLocalProfileChanged() {
+        UserDefaults.standard.removeObject(forKey: profileDirtyKey)
+    }
+
+    private func persistProfileToKeychain(_ profile: ProfileData) {
         guard let data = try? JSONEncoder().encode(profile) else {
             return
         }
@@ -95,15 +124,6 @@ class ProfileManager: ObservableObject {
         let service = keychainService
         keychainQueue.async {
             helper.save(data, for: key, service: service)
-        }
-
-        // For user-initiated changes, schedule a debounced cloud sync
-        if !isApplyingProfile {
-            if !isSyncing {
-                debounceCloudSync()
-            } else {
-                // If a sync is running, we'll re-check after it finishes
-            }
         }
     }
     
@@ -288,6 +308,10 @@ class ProfileManager: ObservableObject {
             return
         }
 
+        guard !hasPendingLocalProfileChanges else {
+            return
+        }
+
         // Prevent overlapping pulls
         guard !isPulling else { return }
         isPulling = true
@@ -302,18 +326,11 @@ class ProfileManager: ObservableObject {
                     applyProfile(cloudProfile)
                     
                     // Save to keychain without triggering local change observers
-                    let data = try? JSONEncoder().encode(cloudProfile)
-                    if let data = data {
-                        let helper = self.keychainHelper
-                        let key = self.keychainKey
-                        let service = self.keychainService
-                        self.keychainQueue.async {
-                            helper.save(data, for: key, service: service)
-                        }
-                    }
+                    persistProfileToKeychain(cloudProfile)
                     
                     lastSyncedVersion = cloudVersion
                     lastSyncedProfile = cloudProfile
+                    clearLocalProfileChanged()
                     lastSyncDate = Date()
                     syncError = nil
                 }
@@ -371,7 +388,11 @@ class ProfileManager: ObservableObject {
                     // Fallback: ensure we at least bump our local version
                     lastSyncedVersion = (profile.version ?? lastSyncedVersion) + 1
                 }
-                lastSyncedProfile = profile
+                var syncedProfile = profile
+                syncedProfile.version = lastSyncedVersion
+                lastSyncedProfile = syncedProfile
+                persistProfileToKeychain(syncedProfile)
+                clearLocalProfileChanged()
                 lastSyncDate = Date()
                 syncError = nil
                 
@@ -404,11 +425,12 @@ class ProfileManager: ObservableObject {
         do {
             if let decryptedProfile = try await profileSync.retryDecryptionWithNewKey() {
                 applyProfile(decryptedProfile)
-                saveToKeychain()
+                persistProfileToKeychain(decryptedProfile)
                 if let version = decryptedProfile.version {
                     lastSyncedVersion = version
                 }
                 lastSyncedProfile = decryptedProfile
+                clearLocalProfileChanged()
                 syncError = nil
             }
         } catch {
@@ -512,6 +534,7 @@ class ProfileManager: ObservableObject {
         lastSyncedVersion = 0
         lastSyncedProfile = nil
         syncError = nil
+        clearLocalProfileChanged()
         
         // Clear cloud cache
         profileSync.clearCache()

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -202,8 +202,8 @@ final class ProjectStorageService: ObservableObject {
         repeat {
             let response = try await listProjects(
                 limit: limit,
-                includeContent: true,
-                continuationToken: continuationToken
+                continuationToken: continuationToken,
+                includeContent: true
             )
             allItems.append(contentsOf: response.projects)
             let nextToken = response.nextContinuationToken?.isEmpty == false ? response.nextContinuationToken : nil

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -153,7 +153,7 @@ final class ProjectStorageService: ObservableObject {
         }
 
         let item = try decoder.decode(ProjectStorageItem.self, from: data)
-        let encrypted = try decodeEncryptedData(from: item.content)
+        let encrypted = item.content.encryptedData
         let decryptionResult = try await EncryptionService.shared.decrypt(encrypted, as: ProjectData.self)
         let projectData = decryptionResult.value
 
@@ -372,7 +372,7 @@ private struct ProjectStorageItem: Codable {
     let createdAt: String
     let updatedAt: String
     let syncVersion: Int
-    let content: String
+    let content: EncryptedProjectContent
 }
 
 private extension Sequence {

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -196,8 +196,21 @@ final class ProjectStorageService: ObservableObject {
     }
 
     func loadProjects(limit: Int = Constants.Pagination.projectsPerPage) async throws -> [Project] {
-        let response = try await listProjects(limit: limit, includeContent: true)
-        return try await response.projects.asyncMap { item in
+        var allItems: [ProjectListItem] = []
+        var continuationToken: String? = nil
+
+        repeat {
+            let response = try await listProjects(
+                limit: limit,
+                includeContent: true,
+                continuationToken: continuationToken
+            )
+            allItems.append(contentsOf: response.projects)
+            let nextToken = response.nextContinuationToken?.isEmpty == false ? response.nextContinuationToken : nil
+            continuationToken = response.hasMore ? nextToken : nil
+        } while continuationToken != nil
+
+        return try await allItems.asyncMap { item in
             guard let content = item.content else {
                 return Project(
                     id: item.id,

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -1,0 +1,387 @@
+//
+//  ProjectStorageService.swift
+//  TinfoilChat
+//
+//  Cloud storage API for webapp-compatible Projects.
+//
+
+import Foundation
+import ClerkKit
+
+final class ProjectStorageService: ObservableObject {
+    static let shared = ProjectStorageService()
+
+    private let apiBaseURL = Constants.API.baseURL
+    private var getToken: (() async -> String?)?
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    private init() {}
+
+    func setTokenGetter(_ tokenGetter: @escaping () async -> String?) {
+        self.getToken = tokenGetter
+    }
+
+    func isAuthenticated() async -> Bool {
+        let token = await (getToken ?? defaultTokenGetter)()
+        return token?.isEmpty == false
+    }
+
+    private func defaultTokenGetter() async -> String? {
+        do {
+            guard await !Clerk.shared.publishableKey.isEmpty else {
+                return nil
+            }
+
+            if await !Clerk.shared.isLoaded {
+                try await Clerk.shared.refreshClient()
+            }
+
+            if let session = await Clerk.shared.session {
+                if let token = try? await session.getToken() {
+                    return token
+                }
+                return session.lastActiveToken?.jwt
+            }
+
+            return nil
+        } catch {
+            return nil
+        }
+    }
+
+    private func getHeaders(contentType: String = "application/json") async throws -> [String: String] {
+        guard let token = await (getToken ?? defaultTokenGetter)(), !token.isEmpty else {
+            throw CloudStorageError.authenticationRequired
+        }
+
+        return [
+            "Authorization": "Bearer \(token)",
+            "Content-Type": contentType
+        ]
+    }
+
+    private func performJSONRequest<T: Decodable>(_ request: URLRequest, as type: T.Type) async throws -> T {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw CloudStorageError.invalidResponse
+        }
+        return try decoder.decode(T.self, from: data)
+    }
+
+    private func performEmptyRequest(_ request: URLRequest, acceptedStatusCodes: Set<Int> = [200]) async throws {
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              acceptedStatusCodes.contains(httpResponse.statusCode) else {
+            throw CloudStorageError.invalidResponse
+        }
+    }
+
+    func generateProjectId() async throws -> GenerateProjectIdResponse {
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/projects/generate-id")!)
+        request.httpMethod = "POST"
+        request.allHTTPHeaderFields = try await getHeaders()
+        return try await performJSONRequest(request, as: GenerateProjectIdResponse.self)
+    }
+
+    func createProject(_ data: CreateProjectData) async throws -> Project {
+        let idResponse = try await generateProjectId()
+        let payload = ProjectData(
+            name: data.name,
+            description: data.description,
+            systemInstructions: data.systemInstructions,
+            memory: []
+        )
+        let encrypted = try await EncryptionService.shared.encrypt(payload)
+        let encryptedString = String(data: try encoder.encode(encrypted), encoding: .utf8) ?? "{}"
+
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/storage/project")!)
+        request.httpMethod = "PUT"
+        request.allHTTPHeaderFields = try await getHeaders()
+        request.httpBody = try encoder.encode(ProjectUpsertRequest(projectId: idResponse.projectId, data: encryptedString))
+
+        let response = try await performJSONRequest(request, as: ProjectUpsertResponse.self)
+        return Project(
+            id: idResponse.projectId,
+            name: payload.name,
+            description: payload.description,
+            systemInstructions: payload.systemInstructions,
+            memory: payload.memory,
+            createdAt: response.createdAt,
+            updatedAt: response.updatedAt,
+            syncVersion: response.syncVersion
+        )
+    }
+
+    func updateProject(_ projectId: String, data: UpdateProjectData) async throws {
+        guard let existing = try await getProject(projectId) else {
+            throw CloudStorageError.invalidResponse
+        }
+
+        let payload = ProjectData(
+            name: data.name ?? existing.name,
+            description: data.description ?? existing.description,
+            systemInstructions: data.systemInstructions ?? existing.systemInstructions,
+            memory: data.memory ?? existing.memory
+        )
+        let encrypted = try await EncryptionService.shared.encrypt(payload)
+        let encryptedString = String(data: try encoder.encode(encrypted), encoding: .utf8) ?? "{}"
+
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/storage/project")!)
+        request.httpMethod = "PUT"
+        request.allHTTPHeaderFields = try await getHeaders()
+        request.httpBody = try encoder.encode(ProjectUpsertRequest(projectId: projectId, data: encryptedString))
+
+        try await performEmptyRequest(request)
+    }
+
+    func getProject(_ projectId: String) async throws -> Project? {
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/storage/project/\(projectId)")!)
+        request.httpMethod = "GET"
+        request.allHTTPHeaderFields = try await getHeaders()
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CloudStorageError.invalidResponse
+        }
+        if httpResponse.statusCode == 404 {
+            return nil
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw CloudStorageError.downloadFailed
+        }
+
+        let item = try decoder.decode(ProjectStorageItem.self, from: data)
+        let encrypted = try decodeEncryptedData(from: item.content)
+        let decryptionResult = try await EncryptionService.shared.decrypt(encrypted, as: ProjectData.self)
+        let projectData = decryptionResult.value
+
+        return Project(
+            id: projectId,
+            name: projectData.name,
+            description: projectData.description,
+            systemInstructions: projectData.systemInstructions,
+            memory: projectData.memory,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
+            syncVersion: item.syncVersion
+        )
+    }
+
+    func deleteProject(_ projectId: String) async throws {
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/storage/project/\(projectId)")!)
+        request.httpMethod = "DELETE"
+        request.allHTTPHeaderFields = try await getHeaders()
+        try await performEmptyRequest(request, acceptedStatusCodes: [200, 404])
+    }
+
+    func listProjects(limit: Int = Constants.Pagination.projectsPerPage, continuationToken: String? = nil, includeContent: Bool = true) async throws -> ProjectListResponse {
+        var components = URLComponents(string: "\(apiBaseURL)/api/projects")!
+        var queryItems = [
+            URLQueryItem(name: "limit", value: String(limit))
+        ]
+        if includeContent {
+            queryItems.append(URLQueryItem(name: "includeContent", value: "true"))
+        }
+        if let continuationToken {
+            queryItems.append(URLQueryItem(name: "continuationToken", value: continuationToken))
+        }
+        components.queryItems = queryItems
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.allHTTPHeaderFields = try await getHeaders()
+        return try await performJSONRequest(request, as: ProjectListResponse.self)
+    }
+
+    func loadProjects(limit: Int = Constants.Pagination.projectsPerPage) async throws -> [Project] {
+        let response = try await listProjects(limit: limit, includeContent: true)
+        return try await response.projects.asyncMap { item in
+            guard let content = item.content else {
+                return Project(
+                    id: item.id,
+                    name: "Encrypted",
+                    description: "",
+                    systemInstructions: "",
+                    memory: [],
+                    createdAt: item.createdAt,
+                    updatedAt: item.updatedAt,
+                    syncVersion: item.syncVersion,
+                    decryptionFailed: true
+                )
+            }
+
+            do {
+                let encrypted = try decodeEncryptedData(from: content)
+                let decryptionResult = try await EncryptionService.shared.decrypt(encrypted, as: ProjectData.self)
+                let projectData = decryptionResult.value
+                return Project(
+                    id: item.id,
+                    name: projectData.name,
+                    description: projectData.description,
+                    systemInstructions: projectData.systemInstructions,
+                    memory: projectData.memory,
+                    createdAt: item.createdAt,
+                    updatedAt: item.updatedAt,
+                    syncVersion: item.syncVersion
+                )
+            } catch {
+                return Project(
+                    id: item.id,
+                    name: "Encrypted",
+                    description: "",
+                    systemInstructions: "",
+                    memory: [],
+                    createdAt: item.createdAt,
+                    updatedAt: item.updatedAt,
+                    syncVersion: item.syncVersion,
+                    decryptionFailed: true
+                )
+            }
+        }
+    }
+
+    func generateDocumentId(projectId: String) async throws -> GenerateDocumentIdResponse {
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/projects/\(projectId)/documents/generate-id")!)
+        request.httpMethod = "POST"
+        request.allHTTPHeaderFields = try await getHeaders()
+        return try await performJSONRequest(request, as: GenerateDocumentIdResponse.self)
+    }
+
+    func uploadDocument(projectId: String, filename: String, contentType: String, content: String) async throws -> ProjectDocument {
+        let idResponse = try await generateDocumentId(projectId: projectId)
+        let payload = ProjectDocumentPayload(content: content, filename: filename, contentType: contentType)
+        let encrypted = try await EncryptionService.shared.encrypt(payload)
+        let encryptedString = String(data: try encoder.encode(encrypted), encoding: .utf8) ?? "{}"
+
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/projects/\(projectId)/documents")!)
+        request.httpMethod = "PUT"
+        request.allHTTPHeaderFields = try await getHeaders()
+        request.httpBody = try encoder.encode(ProjectDocumentUpsertRequest(documentId: idResponse.documentId, data: encryptedString))
+
+        let response = try await performJSONRequest(request, as: ProjectDocumentUpsertResponse.self)
+        return ProjectDocument(
+            id: idResponse.documentId,
+            projectId: projectId,
+            filename: filename,
+            contentType: contentType,
+            sizeBytes: content.data(using: .utf8)?.count ?? content.count,
+            syncVersion: response.syncVersion,
+            createdAt: response.createdAt,
+            updatedAt: response.updatedAt,
+            content: content
+        )
+    }
+
+    func listDocuments(projectId: String, includeContent: Bool = true) async throws -> [ProjectDocument] {
+        var components = URLComponents(string: "\(apiBaseURL)/api/projects/\(projectId)/documents")!
+        if includeContent {
+            components.queryItems = [URLQueryItem(name: "includeContent", value: "true")]
+        }
+
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.allHTTPHeaderFields = try await getHeaders()
+        let response = try await performJSONRequest(request, as: ProjectDocumentListResponse.self)
+
+        return try await response.documents.asyncMap { item in
+            if includeContent, let content = item.content {
+                do {
+                    let encrypted = try decodeEncryptedData(from: content)
+                    let decryptionResult = try await EncryptionService.shared.decrypt(encrypted, as: ProjectDocumentPayload.self)
+                    let payload = decryptionResult.value
+                    return ProjectDocument(
+                        id: item.id,
+                        projectId: item.projectId,
+                        filename: payload.filename,
+                        contentType: payload.contentType,
+                        sizeBytes: item.sizeBytes ?? (payload.content.data(using: .utf8)?.count ?? payload.content.count),
+                        syncVersion: item.syncVersion,
+                        createdAt: item.createdAt,
+                        updatedAt: item.updatedAt,
+                        content: payload.content
+                    )
+                } catch {
+                    return ProjectDocument(
+                        id: item.id,
+                        projectId: item.projectId,
+                        filename: "Encrypted",
+                        contentType: "",
+                        sizeBytes: item.sizeBytes ?? 0,
+                        syncVersion: item.syncVersion,
+                        createdAt: item.createdAt,
+                        updatedAt: item.updatedAt,
+                        content: nil
+                    )
+                }
+            }
+
+            return ProjectDocument(
+                id: item.id,
+                projectId: item.projectId,
+                filename: "",
+                contentType: "",
+                sizeBytes: item.sizeBytes ?? 0,
+                syncVersion: item.syncVersion,
+                createdAt: item.createdAt,
+                updatedAt: item.updatedAt,
+                content: nil
+            )
+        }
+    }
+
+    func deleteDocument(projectId: String, documentId: String) async throws {
+        var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/projects/\(projectId)/documents/\(documentId)")!)
+        request.httpMethod = "DELETE"
+        request.allHTTPHeaderFields = try await getHeaders()
+        try await performEmptyRequest(request, acceptedStatusCodes: [200, 404])
+    }
+
+    private func decodeEncryptedData(from string: String) throws -> EncryptedData {
+        guard let data = string.data(using: .utf8) else {
+            throw CloudStorageError.decryptionFailed
+        }
+        return try decoder.decode(EncryptedData.self, from: data)
+    }
+}
+
+private struct ProjectUpsertRequest: Codable {
+    let projectId: String
+    let data: String
+}
+
+private struct ProjectDocumentUpsertRequest: Codable {
+    let documentId: String
+    let data: String
+}
+
+private struct ProjectUpsertResponse: Codable {
+    let createdAt: String
+    let updatedAt: String
+    let syncVersion: Int
+}
+
+private struct ProjectDocumentUpsertResponse: Codable {
+    let createdAt: String
+    let updatedAt: String
+    let syncVersion: Int
+}
+
+private struct ProjectStorageItem: Codable {
+    let createdAt: String
+    let updatedAt: String
+    let syncVersion: Int
+    let content: String
+}
+
+private extension Sequence {
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async throws -> [T] {
+        var values: [T] = []
+        for element in self {
+            let value = try await transform(element)
+            values.append(value)
+        }
+        return values
+    }
+}

--- a/TinfoilChat/Utilities/ProjectContextBuilder.swift
+++ b/TinfoilChat/Utilities/ProjectContextBuilder.swift
@@ -1,0 +1,46 @@
+//
+//  ProjectContextBuilder.swift
+//  TinfoilChat
+//
+//  Builds project context using the webapp-compatible prompt format.
+//
+
+import Foundation
+
+enum ProjectContextBuilder {
+    static func estimateTokenCount(_ text: String?) -> Int {
+        guard let text, !text.isEmpty else { return 0 }
+        return Int(ceil(Double(text.count) / 4.0))
+    }
+
+    static func build(project: Project, documents: [ProjectDocument]) -> String {
+        var context = "## Project: \(project.name)\n"
+
+        if !project.description.isEmpty {
+            context += "\n\(project.description)\n"
+        }
+
+        if !project.systemInstructions.isEmpty {
+            context += "\n### Instructions\n\(project.systemInstructions)\n"
+        }
+
+        let documentsWithContent = documents.filter { ($0.content?.isEmpty == false) }
+        if !documentsWithContent.isEmpty {
+            context += "\n### Documents\n"
+            for document in documentsWithContent {
+                context += "--- \(document.filename) ---\n\(document.content ?? "")\n\n"
+            }
+        }
+
+        return context
+    }
+
+    static func applyProjectContext(to baseSystemPrompt: String, project: Project?, documents: [ProjectDocument]) -> String {
+        guard let project else { return baseSystemPrompt }
+
+        let projectContext = build(project: project, documents: documents)
+        guard !projectContext.isEmpty else { return baseSystemPrompt }
+
+        return "\(baseSystemPrompt)\n\n<project_context>\n\(projectContext)\n</project_context>"
+    }
+}

--- a/TinfoilChat/Utilities/ProjectContextBuilder.swift
+++ b/TinfoilChat/Utilities/ProjectContextBuilder.swift
@@ -14,21 +14,23 @@ enum ProjectContextBuilder {
     }
 
     static func build(project: Project, documents: [ProjectDocument]) -> String {
-        var context = "## Project: \(project.name)\n"
+        var context = "## Project: \(neutralizeSentinels(project.name))\n"
 
         if !project.description.isEmpty {
-            context += "\n\(project.description)\n"
+            context += "\n\(neutralizeSentinels(project.description))\n"
         }
 
         if !project.systemInstructions.isEmpty {
-            context += "\n### Instructions\n\(project.systemInstructions)\n"
+            context += "\n### Instructions\n\(neutralizeSentinels(project.systemInstructions))\n"
         }
 
         let documentsWithContent = documents.filter { ($0.content?.isEmpty == false) }
         if !documentsWithContent.isEmpty {
             context += "\n### Documents\n"
             for document in documentsWithContent {
-                context += "--- \(document.filename) ---\n\(document.content ?? "")\n\n"
+                let safeFilename = neutralizeSentinels(document.filename)
+                let safeContent = neutralizeSentinels(document.content ?? "")
+                context += "--- \(safeFilename) ---\n\(safeContent)\n\n"
             }
         }
 
@@ -42,5 +44,11 @@ enum ProjectContextBuilder {
         guard !projectContext.isEmpty else { return baseSystemPrompt }
 
         return "\(baseSystemPrompt)\n\n<project_context>\n\(projectContext)\n</project_context>"
+    }
+
+    private static func neutralizeSentinels(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "<project_context>", with: "<project_context\u{200B}>")
+            .replacingOccurrences(of: "</project_context>", with: "</project_context\u{200B}>")
     }
 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -845,6 +845,11 @@ class ChatViewModel: ObservableObject {
         createNewChat(isLocalOnly: false, focusInput: false)
     }
 
+    func returnToProjectLanding() {
+        guard let projectId = activeProject?.id else { return }
+        createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
+    }
+
     func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
         guard let project = activeProject else { return }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -108,6 +108,7 @@ class ChatViewModel: ObservableObject {
     private let passkeyManager = PasskeyManager.shared
     private let cloudSync = CloudSyncService.shared
     private let streamingTracker = StreamingTracker.shared
+    private let projectStorage = ProjectStorageService.shared
     private var isSignInInProgress: Bool = false  // Prevent duplicate sign-in flows
     private var hasPerformedInitialSync: Bool = false  // Track if initial sync has been done
     private var hasAnonymousChatsToSync: Bool = false  // Track if we have anonymous chats to sync
@@ -178,6 +179,16 @@ class ChatViewModel: ObservableObject {
     @Published var isProcessingAttachment: Bool = false
     @Published var attachmentError: String? = nil
     @Published var pendingImageThumbnails: [String: String] = [:]
+
+    // Project properties
+    @Published var projects: [Project] = []
+    @Published var activeProject: Project?
+    @Published var projectDocuments: [ProjectDocument] = []
+    @Published var isLoadingProjects: Bool = false
+    @Published var isLoadingProject: Bool = false
+    @Published var isUploadingProjectDocument: Bool = false
+    @Published var projectError: String?
+
     // Private properties
     private var client: TinfoilAI?
     private var currentTask: Task<Void, Error>?
@@ -217,12 +228,28 @@ class ChatViewModel: ObservableObject {
                     currentChat = localChat
                     activeStorageTab = .local
                 }
+            } else {
+                projects = []
+                activeProject = nil
+                projectDocuments = []
+                projectError = nil
             }
         }
     }
     
     var messages: [Message] {
         currentChat?.messages ?? []
+    }
+
+    var isProjectMode: Bool {
+        activeProject != nil
+    }
+
+    var activeProjectChats: [Chat] {
+        guard let projectId = activeProject?.id else { return [] }
+        return chats
+            .filter { $0.projectId == projectId && !$0.isTemporary && !$0.isBlankChat }
+            .sorted { $0.createdAt > $1.createdAt }
     }
     
     // Computed property to check if user has premium access
@@ -678,7 +705,7 @@ class ChatViewModel: ObservableObject {
     }
 
     /// Creates a new chat and sets it as the current chat
-    func createNewChat(language: String? = nil, modelType: ModelType? = nil, isLocalOnly: Bool? = nil, focusInput: Bool = true) {
+    func createNewChat(language: String? = nil, modelType: ModelType? = nil, isLocalOnly: Bool? = nil, projectId: String? = nil, focusInput: Bool = true) {
         // Allow creating new chats for all authenticated users
         guard hasChatAccess else { return }
         
@@ -700,8 +727,11 @@ class ChatViewModel: ObservableObject {
             previousChatIdBeforeTemporary = nil
         }
 
+        let targetProjectId = projectId ?? activeProject?.id
         let shouldBeLocal: Bool
-        if let explicit = isLocalOnly {
+        if targetProjectId != nil {
+            shouldBeLocal = false
+        } else if let explicit = isLocalOnly {
             shouldBeLocal = explicit
         } else if !SettingsManager.shared.isCloudSyncEnabled {
             shouldBeLocal = true
@@ -713,13 +743,13 @@ class ChatViewModel: ObservableObject {
 
         // Check if we already have a blank chat in the target list
         if shouldBeLocal {
-            if let existing = localChats.first(where: { $0.isBlankChat }) {
+            if let existing = localChats.first(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
                 selectChat(existing)
                 shouldFocusInput = focusInput
                 return
             }
         } else {
-            if let existing = chats.first(where: { $0.isBlankChat }) {
+            if let existing = chats.first(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
                 selectChat(existing)
                 shouldFocusInput = focusInput
                 return
@@ -731,7 +761,8 @@ class ChatViewModel: ObservableObject {
             modelType: modelType ?? currentModel,
             language: language,
             userId: currentUserId,
-            isLocalOnly: shouldBeLocal
+            isLocalOnly: shouldBeLocal,
+            projectId: targetProjectId
         )
 
         if shouldBeLocal {
@@ -741,6 +772,250 @@ class ChatViewModel: ObservableObject {
         }
         selectChat(newChat)
         shouldFocusInput = focusInput
+    }
+
+    func loadProjects() async {
+        guard hasChatAccess, SettingsManager.shared.isCloudSyncEnabled else {
+            projects = []
+            return
+        }
+
+        isLoadingProjects = true
+        projectError = nil
+        do {
+            projects = try await projectStorage.loadProjects()
+        } catch {
+            projectError = error.localizedDescription
+        }
+        isLoadingProjects = false
+    }
+
+    @discardableResult
+    func createProject(name: String? = nil) async -> Project? {
+        guard hasChatAccess else { return nil }
+
+        isLoadingProject = true
+        projectError = nil
+        do {
+            let project = try await projectStorage.createProject(
+                CreateProjectData(name: name ?? Self.generateProjectName())
+            )
+            projects.insert(project, at: 0)
+            await enterProject(projectId: project.id)
+            isLoadingProject = false
+            return project
+        } catch {
+            projectError = error.localizedDescription
+            isLoadingProject = false
+            return nil
+        }
+    }
+
+    func enterProject(projectId: String) async {
+        guard hasChatAccess else { return }
+
+        isLoadingProject = true
+        projectError = nil
+        do {
+            let project = try await projectStorage.getProject(projectId)
+            guard let project else {
+                throw CloudStorageError.downloadFailed
+            }
+
+            let documents = try await projectStorage.listDocuments(projectId: projectId, includeContent: true)
+            activeProject = project
+            projectDocuments = documents
+
+            let syncResult = await cloudSync.smartSync(projectId: projectId)
+            if syncResult.downloaded > 0 || syncResult.uploaded > 0 || activeProjectChats.isEmpty {
+                await loadProjectChatsIntoMemory(projectId: projectId)
+            }
+
+            createNewChat(isLocalOnly: false, projectId: projectId)
+        } catch {
+            projectError = error.localizedDescription
+        }
+        isLoadingProject = false
+    }
+
+    func exitProject() {
+        activeProject = nil
+        projectDocuments = []
+        projectError = nil
+        createNewChat(isLocalOnly: false)
+    }
+
+    func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
+        guard let project = activeProject else { return }
+
+        projectError = nil
+        do {
+            let update = UpdateProjectData(
+                name: name,
+                description: description,
+                systemInstructions: systemInstructions,
+                memory: memory
+            )
+            try await projectStorage.updateProject(project.id, data: update)
+            var updated = project
+            updated.name = name ?? updated.name
+            updated.description = description ?? updated.description
+            updated.systemInstructions = systemInstructions ?? updated.systemInstructions
+            updated.memory = memory ?? updated.memory
+            updated.updatedAt = ISO8601DateFormatter().string(from: Date())
+            activeProject = updated
+            if let index = projects.firstIndex(where: { $0.id == updated.id }) {
+                projects[index] = updated
+            }
+        } catch {
+            projectError = error.localizedDescription
+        }
+    }
+
+    func deleteActiveProject() async {
+        guard let project = activeProject else { return }
+
+        projectError = nil
+        do {
+            try await projectStorage.deleteProject(project.id)
+            projects.removeAll { $0.id == project.id }
+            exitProject()
+        } catch {
+            projectError = error.localizedDescription
+        }
+    }
+
+    func uploadProjectDocument(url: URL, filename: String) async {
+        guard let project = activeProject else { return }
+
+        isUploadingProjectDocument = true
+        projectError = nil
+        do {
+            let markdown = try await DocumentConversionService.shared.convertToMarkdown(
+                url: url,
+                filename: filename
+            )
+            let contentType = DocumentConversionService.mimeType(for: filename)
+            let document = try await projectStorage.uploadDocument(
+                projectId: project.id,
+                filename: filename,
+                contentType: contentType,
+                content: markdown
+            )
+            projectDocuments.append(document)
+        } catch {
+            projectError = error.localizedDescription
+        }
+        isUploadingProjectDocument = false
+    }
+
+    func deleteProjectDocument(_ documentId: String) async {
+        guard let project = activeProject else { return }
+
+        let existing = projectDocuments
+        projectDocuments.removeAll { $0.id == documentId }
+        do {
+            try await projectStorage.deleteDocument(projectId: project.id, documentId: documentId)
+        } catch {
+            projectDocuments = existing
+            projectError = error.localizedDescription
+        }
+    }
+
+    func moveChatToProject(chatId: String, projectId: String) async {
+        await updateChatProject(chatId: chatId, projectId: projectId)
+    }
+
+    func removeChatFromProject(chatId: String) async {
+        await updateChatProject(chatId: chatId, projectId: nil)
+    }
+
+    private func updateChatProject(chatId: String, projectId: String?) async {
+        guard hasChatAccess else { return }
+
+        let wasCurrent = currentChat?.id == chatId
+        guard var chat = chatForProjectMove(chatId) else { return }
+        let wasLocal = chat.isLocalOnly
+        let oldProjectId = chat.projectId
+
+        chat.projectId = projectId
+        chat.isLocalOnly = false
+        chat.locallyModified = true
+        chat.updatedAt = Date()
+
+        if wasLocal {
+            localChats.removeAll { $0.id == chatId }
+            chats.insert(chat, at: min(1, chats.count))
+            if let userId = currentUserId {
+                try? await EncryptedFileStorage.local.deleteChat(chatId: chatId, userId: userId)
+            }
+        } else {
+            replaceChat(chat)
+        }
+
+        if wasCurrent {
+            currentChat = chat
+        }
+
+        saveChat(chat)
+
+        do {
+            try await cloudSync.updateChatProject(chatId, projectId: projectId)
+            await cloudSync.backupChat(chatId, ensureLatestUpload: true)
+            if let projectId {
+                await loadProjectChatsIntoMemory(projectId: projectId)
+            }
+        } catch {
+            projectError = error.localizedDescription
+            chat.projectId = oldProjectId
+            chat.isLocalOnly = wasLocal
+            replaceChat(chat)
+            saveChat(chat)
+            return
+        }
+
+        if wasCurrent, activeProject?.id != projectId {
+            createNewChat(isLocalOnly: false, projectId: activeProject?.id)
+        }
+    }
+
+    private func chatForProjectMove(_ chatId: String) -> Chat? {
+        if let location = findChatLocation(chatId) {
+            return chat(at: location)
+        }
+        return nil
+    }
+
+    private func loadProjectChatsIntoMemory(projectId: String) async {
+        let projectChats = await loadProjectChatsFromStorage(projectId: projectId)
+        for projectChat in projectChats {
+            if let index = chats.firstIndex(where: { $0.id == projectChat.id }) {
+                chats[index] = projectChat
+            } else {
+                chats.append(projectChat)
+            }
+        }
+        chats.sort { $0.createdAt > $1.createdAt }
+    }
+
+    private func loadProjectChatsFromStorage(projectId: String) async -> [Chat] {
+        guard let userId = currentUserId else { return [] }
+        let index = await Chat.loadChatIndex(userId: userId)
+        let ids = index
+            .filter {
+                $0.projectId == projectId &&
+                ($0.messageCount > 0 || $0.decryptionFailed || $0.titleState != .placeholder)
+            }
+            .sorted { $0.createdAt > $1.createdAt }
+            .map(\.id)
+        return await Chat.loadChats(chatIds: ids, userId: userId)
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    private static func generateProjectName() -> String {
+        let adjectives = ["Private", "Secret", "Encrypted", "Anonymous", "Stealth", "Incognito", "Covert", "Hidden"]
+        let animals = ["Orangutan", "Penguin", "Platypus", "Armadillo", "Chameleon", "Pangolin", "Narwhal", "Capybara"]
+        return "\(adjectives.randomElement() ?? "Private") \(animals.randomElement() ?? "Project")"
     }
 
     /// Toggles temporary (incognito) chat mode. When enabled, the current chat
@@ -1345,6 +1620,11 @@ class ChatViewModel: ObservableObject {
                 
                 systemPrompt = systemPrompt.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTime)
                 systemPrompt = systemPrompt.replacingOccurrences(of: "{TIMEZONE}", with: timezone)
+                systemPrompt = ProjectContextBuilder.applyProjectContext(
+                    to: systemPrompt,
+                    project: self.activeProject,
+                    documents: self.projectDocuments
+                )
                 
                 // Process rules with same replacements
                 var processedRules = AppConfig.shared.rules

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -48,6 +48,7 @@ class ChatViewModel: ObservableObject {
     @Published var showCloudSyncOnboarding: Bool = false
     @Published var cloudSyncOnboardingMode: CloudSyncOnboardingMode = .setup
     @Published var shouldOpenCloudSync: Bool = false
+    @Published var shouldExpandProjectsInSidebar: Bool = false
     @Published var scrollTargetMessageId: String? = nil 
     @Published var scrollTargetOffset: CGFloat = 0 
     /// When set to true, the input field should become first responder (focus keyboard)
@@ -842,6 +843,7 @@ class ChatViewModel: ObservableObject {
         activeProject = nil
         projectDocuments = []
         projectError = nil
+        shouldExpandProjectsInSidebar = true
         createNewChat(isLocalOnly: false, focusInput: false)
     }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -49,6 +49,7 @@ class ChatViewModel: ObservableObject {
     @Published var cloudSyncOnboardingMode: CloudSyncOnboardingMode = .setup
     @Published var shouldOpenCloudSync: Bool = false
     @Published var shouldExpandProjectsInSidebar: Bool = false
+    @Published var isViewingProjectChat: Bool = false
     @Published var scrollTargetMessageId: String? = nil 
     @Published var scrollTargetOffset: CGFloat = 0 
     /// When set to true, the input field should become first responder (focus keyboard)
@@ -817,6 +818,7 @@ class ChatViewModel: ObservableObject {
 
         isLoadingProject = true
         projectError = nil
+        isViewingProjectChat = false
         do {
             let project = try await projectStorage.getProject(projectId)
             guard let project else {
@@ -843,13 +845,26 @@ class ChatViewModel: ObservableObject {
         activeProject = nil
         projectDocuments = []
         projectError = nil
+        isViewingProjectChat = false
         shouldExpandProjectsInSidebar = true
         createNewChat(isLocalOnly: false, focusInput: false)
     }
 
     func returnToProjectLanding() {
         guard let projectId = activeProject?.id else { return }
+        isViewingProjectChat = false
         createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
+    }
+
+    func openProjectChat(_ chat: Chat) {
+        selectChat(chat)
+        isViewingProjectChat = true
+    }
+
+    func startNewProjectChat() {
+        guard let projectId = activeProject?.id else { return }
+        createNewChat(isLocalOnly: false, projectId: projectId)
+        isViewingProjectChat = true
     }
 
     func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -969,7 +969,19 @@ class ChatViewModel: ObservableObject {
             projectError = error.localizedDescription
             chat.projectId = oldProjectId
             chat.isLocalOnly = wasLocal
-            replaceChat(chat)
+            if wasLocal {
+                chats.removeAll { $0.id == chatId }
+                if let index = localChats.firstIndex(where: { $0.id == chatId }) {
+                    localChats[index] = chat
+                } else {
+                    localChats.insert(chat, at: min(1, localChats.count))
+                }
+            } else {
+                replaceChat(chat)
+            }
+            if wasCurrent {
+                currentChat = chat
+            }
             saveChat(chat)
             return
         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -831,7 +831,7 @@ class ChatViewModel: ObservableObject {
                 await loadProjectChatsIntoMemory(projectId: projectId)
             }
 
-            createNewChat(isLocalOnly: false, projectId: projectId)
+            createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
         } catch {
             projectError = error.localizedDescription
         }
@@ -842,7 +842,7 @@ class ChatViewModel: ObservableObject {
         activeProject = nil
         projectDocuments = []
         projectError = nil
-        createNewChat(isLocalOnly: false)
+        createNewChat(isLocalOnly: false, focusInput: false)
     }
 
     func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -142,45 +142,10 @@ struct ChatSidebar: View {
     private var sidebarContent: some View {
         VStack(spacing: 0) {
 
-            // Chat History Header
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Chat History")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(.secondary)
-
-                if !authManager.isAuthenticated {
-                    Text("Log in to save chat history.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                } else if !settings.isCloudSyncEnabled {
-                    Text("Chats are only stored locally on this device.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                } else if activeTab == .local {
-                    Text("Local chats are stored only on this device and won't sync across devices.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                } else {
-                    Text("Your chats are encrypted and synced to the cloud. The encryption key is only stored on this device and never sent to Tinfoil.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 16)
-            .overlay(
-                Divider()
-                    .background(Color.gray.opacity(0.3)),
-                alignment: .bottom
-            )
-
             if authManager.isAuthenticated && settings.isCloudSyncEnabled {
                 projectsSection
                     .padding(.horizontal, 16)
-                    .padding(.top, 8)
+                    .padding(.top, 16)
             }
 
             chatsSectionHeader
@@ -194,6 +159,10 @@ struct ChatSidebar: View {
                     .progressViewStyle(CircularProgressViewStyle())
                 Spacer()
             } else if isChatsExpanded {
+                chatsDescription
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+
                 if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
                     cloudLocalTabSwitcher
                         .padding(.horizontal, 16)
@@ -433,6 +402,25 @@ struct ChatSidebar: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private var chatsDescription: some View {
+        Group {
+            if !authManager.isAuthenticated {
+                Text("Log in to save chat history.")
+            } else if !settings.isCloudSyncEnabled {
+                Text("Chats are only stored locally on this device.")
+            } else if activeTab == .local {
+                Text("Local chats are stored only on this device and won't sync across devices.")
+            } else {
+                Text("Your chats are encrypted and synced to the cloud. The encryption key is only stored on this device and never sent to Tinfoil.")
+            }
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var chatsSectionHeader: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -177,13 +177,6 @@ struct ChatSidebar: View {
                 alignment: .bottom
             )
 
-            // Cloud / Local tab switcher
-            if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
-                cloudLocalTabSwitcher
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-            }
-
             if authManager.isAuthenticated && settings.isCloudSyncEnabled {
                 projectsSection
                     .padding(.horizontal, 16)
@@ -201,6 +194,12 @@ struct ChatSidebar: View {
                     .progressViewStyle(CircularProgressViewStyle())
                 Spacer()
             } else if isChatsExpanded {
+                if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
+                    cloudLocalTabSwitcher
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                }
+
             ScrollView {
                 LazyVStack(spacing: 12) {
                     ForEach(Array(filteredChats.enumerated()), id: \.element.id) { index, chat in

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -24,7 +24,7 @@ struct ChatSidebar: View {
     @State private var selectedEncryptedChat: Chat? = nil
 
     @State private var isTabSwitching: Bool = false
-    @State private var isProjectsExpanded: Bool = true
+    @State private var isProjectsExpanded: Bool = false
     @State private var isChatsExpanded: Bool = true
     @ObservedObject private var settings = SettingsManager.shared
 

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -375,6 +375,9 @@ struct ChatSidebar: View {
                         .rotationEffect(.degrees(isProjectsExpanded ? 0 : -90))
                         .foregroundColor(.secondary)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
@@ -437,6 +440,9 @@ struct ChatSidebar: View {
                     .rotationEffect(.degrees(isChatsExpanded ? 0 : -90))
                     .foregroundColor(.secondary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -159,15 +159,15 @@ struct ChatSidebar: View {
                     .progressViewStyle(CircularProgressViewStyle())
                 Spacer()
             } else if isChatsExpanded {
-                chatsDescription
-                    .padding(.horizontal, 16)
-                    .padding(.top, 8)
-
                 if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
                     cloudLocalTabSwitcher
                         .padding(.horizontal, 16)
                         .padding(.top, 8)
                 }
+
+                chatsDescription
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
 
             ScrollView {
                 LazyVStack(spacing: 12) {
@@ -406,21 +406,19 @@ struct ChatSidebar: View {
 
     @ViewBuilder
     private var chatsDescription: some View {
-        Group {
-            if !authManager.isAuthenticated {
-                Text("Log in to save chat history.")
-            } else if !settings.isCloudSyncEnabled {
-                Text("Chats are only stored locally on this device.")
-            } else if activeTab == .local {
-                Text("Local chats are stored only on this device and won't sync across devices.")
-            } else {
-                Text("Your chats are encrypted and synced to the cloud. The encryption key is only stored on this device and never sent to Tinfoil.")
+        if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
+            Group {
+                if activeTab == .local {
+                    Text("Local chats are stored only on this device and won't sync across devices.")
+                } else {
+                    Text("Your chats are encrypted and synced to the cloud. The encryption key is only stored on this device and never sent to Tinfoil.")
+                }
             }
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var chatsSectionHeader: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -167,6 +167,7 @@ struct ChatSidebar: View {
                         .foregroundColor(.secondary)
                 }
             }
+            .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16)
             .padding(.vertical, 16)
@@ -363,7 +364,7 @@ struct ChatSidebar: View {
     }
 
     private var projectsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     isProjectsExpanded.toggle()
@@ -398,9 +399,10 @@ struct ChatSidebar: View {
                     Label("New project", systemImage: "folder.badge.plus")
                         .font(.subheadline)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(10)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 14)
                         .background(Color(UIColor.secondarySystemBackground).opacity(0.3))
-                        .cornerRadius(8)
+                        .cornerRadius(10)
                 }
                 .buttonStyle(.plain)
 
@@ -413,7 +415,7 @@ struct ChatSidebar: View {
                             }
                         }
                     } label: {
-                        HStack {
+                        HStack(spacing: 12) {
                             Image(systemName: project.decryptionFailed == true ? "lock.fill" : "folder")
                                 .foregroundColor(project.decryptionFailed == true ? .orange : .accentColor)
                             Text(project.name)
@@ -421,9 +423,11 @@ struct ChatSidebar: View {
                             Spacer()
                         }
                         .font(.subheadline)
-                        .padding(10)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 14)
                         .background(Color(UIColor.secondarySystemBackground).opacity(0.3))
-                        .cornerRadius(8)
+                        .cornerRadius(10)
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .disabled(project.decryptionFailed == true)

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -400,6 +400,9 @@ struct ChatSidebar: View {
                     Button {
                         Task {
                             await viewModel.enterProject(projectId: project.id)
+                            withAnimation {
+                                isOpen = false
+                            }
                         }
                     } label: {
                         HStack {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -24,6 +24,8 @@ struct ChatSidebar: View {
     @State private var selectedEncryptedChat: Chat? = nil
 
     @State private var isTabSwitching: Bool = false
+    @State private var isProjectsExpanded: Bool = true
+    @State private var isChatsExpanded: Bool = true
     @ObservedObject private var settings = SettingsManager.shared
 
     private var activeTab: ChatStorageTab {
@@ -43,8 +45,8 @@ struct ChatSidebar: View {
             // When cloud sync is off, all chats are local
             source = viewModel.localChats
         }
-        // Temporary (incognito) chats are never listed in the sidebar
-        return source.filter { !$0.isTemporary }
+        // Temporary and project chats are never listed in the root chat sidebar
+        return source.filter { !$0.isTemporary && $0.projectId == nil }
     }
 
     // Timer to update relative time strings
@@ -124,6 +126,9 @@ struct ChatSidebar: View {
                 isOpen = false
             }
         }
+        .task {
+            await viewModel.loadProjects()
+        }
     }
     
     private var sidebarContent: some View {
@@ -170,13 +175,23 @@ struct ChatSidebar: View {
                     .padding(.vertical, 8)
             }
 
+            if authManager.isAuthenticated && settings.isCloudSyncEnabled {
+                projectsSection
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+            }
+
+            chatsSectionHeader
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
             // Chat List - shows multiple chats for all authenticated users
             if isTabSwitching {
                 Spacer()
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle())
                 Spacer()
-            } else {
+            } else if isChatsExpanded {
             ScrollView {
                 LazyVStack(spacing: 12) {
                     ForEach(Array(filteredChats.enumerated()), id: \.element.id) { index, chat in
@@ -208,6 +223,19 @@ struct ChatSidebar: View {
                             onDelete: { confirmDelete(chat) },
                             showEditDelete: authManager.isAuthenticated
                         )
+                        .contextMenu {
+                            if authManager.isAuthenticated && !chat.isBlankChat && !chat.decryptionFailed {
+                                ForEach(viewModel.projects.filter { $0.decryptionFailed != true }) { project in
+                                    Button {
+                                        Task {
+                                            await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
+                                        }
+                                    } label: {
+                                        Label("Add to \(project.name)", systemImage: "folder")
+                                    }
+                                }
+                            }
+                        }
                     }
                     
                     // Load More button or loading indicator (cloud tab only — local chats are never paginated)
@@ -275,6 +303,8 @@ struct ChatSidebar: View {
                 await viewModel.performFullSync()
             }
             .frame(maxHeight: .infinity)
+            } else {
+                Spacer()
             } // end tab switching else
 
             Divider()
@@ -322,6 +352,93 @@ struct ChatSidebar: View {
             .safeAreaPadding(.bottom)
         }
         .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    private var projectsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isProjectsExpanded.toggle()
+                }
+            } label: {
+                HStack {
+                    Label("Projects", systemImage: "folder")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Spacer()
+                    if viewModel.isLoadingProjects {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                    }
+                    Image(systemName: "chevron.down")
+                        .font(.caption)
+                        .rotationEffect(.degrees(isProjectsExpanded ? 0 : -90))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isProjectsExpanded {
+                Button {
+                    Task {
+                        await viewModel.createProject()
+                    }
+                } label: {
+                    Label("New project", systemImage: "folder.badge.plus")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .background(Color(UIColor.secondarySystemBackground).opacity(0.3))
+                        .cornerRadius(8)
+                }
+                .buttonStyle(.plain)
+
+                ForEach(viewModel.projects) { project in
+                    Button {
+                        Task {
+                            await viewModel.enterProject(projectId: project.id)
+                            withAnimation {
+                                isOpen = false
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: project.decryptionFailed == true ? "lock.fill" : "folder")
+                                .foregroundColor(project.decryptionFailed == true ? .orange : .accentColor)
+                            Text(project.name)
+                                .lineLimit(1)
+                            Spacer()
+                        }
+                        .font(.subheadline)
+                        .padding(10)
+                        .background(Color(UIColor.secondarySystemBackground).opacity(0.3))
+                        .cornerRadius(8)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(project.decryptionFailed == true)
+                }
+            }
+        }
+    }
+
+    private var chatsSectionHeader: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isChatsExpanded.toggle()
+            }
+        } label: {
+            HStack {
+                Label("Chats", systemImage: "bubble.left.and.bubble.right")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+                    .rotationEffect(.degrees(isChatsExpanded ? 0 : -90))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
     }
     
     private var cloudLocalTabSwitcher: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -141,194 +141,192 @@ struct ChatSidebar: View {
     
     private var sidebarContent: some View {
         VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if authManager.isAuthenticated && settings.isCloudSyncEnabled {
+                        projectsSection
+                            .padding(.horizontal, 16)
+                            .padding(.top, 16)
+                    }
 
-            if authManager.isAuthenticated && settings.isCloudSyncEnabled {
-                projectsSection
-                    .padding(.horizontal, 16)
-                    .padding(.top, 16)
-            }
-
-            chatsSectionHeader
-                .padding(.horizontal, 16)
-                .padding(.top, 8)
-
-            // Chat List - shows multiple chats for all authenticated users
-            if isTabSwitching {
-                Spacer()
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle())
-                Spacer()
-            } else if isChatsExpanded {
-                if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
-                    cloudLocalTabSwitcher
+                    chatsSectionHeader
                         .padding(.horizontal, 16)
                         .padding(.top, 8)
-                }
 
-                chatsDescription
-                    .padding(.horizontal, 16)
-                    .padding(.top, 8)
-
-            ScrollView {
-                LazyVStack(spacing: 12) {
-                    ForEach(Array(filteredChats.enumerated()), id: \.element.id) { index, chat in
-                        ChatListItem(
-                            chat: chat,
-                            isSelected: viewModel.currentChat?.id == chat.id,
-                            isEditing: editingChatId == chat.id,
-                            editingTitle: $editingTitle,
-                            timeString: chat.isBlankChat ? "" : relativeTimeString(from: chat.createdAt),
-                            onSelect: {
-                                if chat.decryptionFailed {
-                                    // Show alert for encrypted chats
-                                    selectedEncryptedChat = chat
-                                    showEncryptedChatAlert = true
-                                } else {
-                                    viewModel.selectChat(chat)
-                                }
-                            },
-                            onEdit: { 
-                                if editingChatId == chat.id {
-                                    // Save the edit
-                                    viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
-                                    editingChatId = nil
-                                } else {
-                                    // Start editing
-                                    startEditing(chat)
-                                }
-                            },
-                            onDelete: { confirmDelete(chat) },
-                            showEditDelete: authManager.isAuthenticated
-                        )
-                        .contextMenu {
-                            if authManager.isAuthenticated && !chat.isBlankChat && !chat.decryptionFailed {
-                                ForEach(viewModel.projects.filter { $0.decryptionFailed != true }) { project in
-                                    Button {
-                                        Task {
-                                            await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
-                                        }
-                                    } label: {
-                                        Label("Add to \(project.name)", systemImage: "folder")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    
-                    // Load More button or loading indicator (cloud tab only — local chats are never paginated)
-                    if viewModel.hasMoreChats && activeTab != .local {
-                        if viewModel.isLoadingMore {
-                            HStack {
-                                ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle())
-                                    .scaleEffect(0.8)
-                                Text("Loading...")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
+                    if isTabSwitching {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                        } else {
-                            Group {
-                                if #available(iOS 26, *) {
-                                    Button(action: {
-                                        Task {
-                                            await viewModel.loadMoreChats()
-                                        }
-                                    }) {
-                                        Text("Load More")
-                                            .font(.system(size: 16, weight: .regular))
-                                            .frame(maxWidth: .infinity)
-                                            .padding(.vertical, 12)
-                                    }
-                                    .buttonStyle(.glass)
-                                    .clipShape(RoundedRectangle(cornerRadius: 20))
-                                } else {
-                                    Button(action: {
-                                        Task {
-                                            await viewModel.loadMoreChats()
-                                        }
-                                    }) {
-                                        Text("Load More")
-                                            .foregroundColor(.primary)
-                                            .font(.system(size: 16, weight: .regular))
-                                            .frame(maxWidth: .infinity)
-                                            .padding(.vertical, 12)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 20)
-                                                    .fill(Color(UIColor.secondarySystemBackground).opacity(0.3))
-                                            )
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: 20)
-                                                    .strokeBorder(Color.gray.opacity(0.1), lineWidth: 1)
-                                            )
-                                    }
-                                    .buttonStyle(PlainButtonStyle())
-                                }
-                            }
+                            .padding(.vertical, 24)
+                    } else if isChatsExpanded {
+                        if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
+                            cloudLocalTabSwitcher
+                                .padding(.horizontal, 16)
+                                .padding(.top, 8)
                         }
+
+                        chatsDescription
+                            .padding(.horizontal, 16)
+                            .padding(.top, 8)
+
+                        chatList
+                            .padding(.horizontal, 16)
+                            .padding(.top, 8)
+                            .padding(.bottom, 8)
                     }
                 }
-                .padding(.horizontal, 16)
-                .padding(.top, 8)
-                .padding(.bottom, 8)
             }
             .applyAlwaysBounceIfAvailable()
             .refreshable {
-                // Ensure auth state is up-to-date, then attempt a full sync.
                 await authManager.initializeAuthState()
                 await viewModel.performFullSync()
             }
             .frame(maxHeight: .infinity)
-            } else {
-                Spacer()
-            } // end tab switching else
 
             Divider()
                 .background(Color.gray.opacity(0.3))
 
-            // Settings Button
-            Group {
-                if #available(iOS 26, *) {
-                    Button(action: {
-                        viewModel.showSidebarSettings = true
-                    }) {
-                        HStack {
-                            Image(systemName: "gear")
-                            Text("Settings")
+            settingsButton
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .padding(.bottom, 8)
+                .safeAreaPadding(.bottom)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    private var chatList: some View {
+        VStack(spacing: 12) {
+            ForEach(Array(filteredChats.enumerated()), id: \.element.id) { _, chat in
+                ChatListItem(
+                    chat: chat,
+                    isSelected: viewModel.currentChat?.id == chat.id,
+                    isEditing: editingChatId == chat.id,
+                    editingTitle: $editingTitle,
+                    timeString: chat.isBlankChat ? "" : relativeTimeString(from: chat.createdAt),
+                    onSelect: {
+                        if chat.decryptionFailed {
+                            selectedEncryptedChat = chat
+                            showEncryptedChatAlert = true
+                        } else {
+                            viewModel.selectChat(chat)
                         }
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 16)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                    }
-                    .buttonStyle(.glass)
-                } else {
-                    Button(action: {
-                        viewModel.showSidebarSettings = true
-                    }) {
-                        HStack {
-                            Image(systemName: "gear")
-                            Text("Settings")
+                    },
+                    onEdit: {
+                        if editingChatId == chat.id {
+                            viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
+                            editingChatId = nil
+                        } else {
+                            startEditing(chat)
                         }
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 16)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .background(Color.sidebarButtonBackground(for: colorScheme))
-                        .foregroundColor(colorScheme == .dark ? .white : .black)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .strokeBorder(colorScheme == .dark ? Color.clear : Color.gray.opacity(0.2), lineWidth: 1)
-                        )
-                        .cornerRadius(8)
+                    },
+                    onDelete: { confirmDelete(chat) },
+                    showEditDelete: authManager.isAuthenticated
+                )
+                .contextMenu {
+                    if authManager.isAuthenticated && !chat.isBlankChat && !chat.decryptionFailed {
+                        ForEach(viewModel.projects.filter { $0.decryptionFailed != true }) { project in
+                            Button {
+                                Task {
+                                    await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
+                                }
+                            } label: {
+                                Label("Add to \(project.name)", systemImage: "folder")
+                            }
+                        }
                     }
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 8)
-            .padding(.bottom, 8)
-            .safeAreaPadding(.bottom)
+
+            if viewModel.hasMoreChats && activeTab != .local {
+                if viewModel.isLoadingMore {
+                    HStack {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                            .scaleEffect(0.8)
+                        Text("Loading...")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                } else {
+                    loadMoreButton
+                }
+            }
         }
-        .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    @ViewBuilder
+    private var loadMoreButton: some View {
+        if #available(iOS 26, *) {
+            Button {
+                Task { await viewModel.loadMoreChats() }
+            } label: {
+                Text("Load More")
+                    .font(.system(size: 16, weight: .regular))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+            .buttonStyle(.glass)
+            .clipShape(RoundedRectangle(cornerRadius: 20))
+        } else {
+            Button {
+                Task { await viewModel.loadMoreChats() }
+            } label: {
+                Text("Load More")
+                    .foregroundColor(.primary)
+                    .font(.system(size: 16, weight: .regular))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color(UIColor.secondarySystemBackground).opacity(0.3))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                            .strokeBorder(Color.gray.opacity(0.1), lineWidth: 1)
+                    )
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+    }
+
+    @ViewBuilder
+    private var settingsButton: some View {
+        if #available(iOS 26, *) {
+            Button {
+                viewModel.showSidebarSettings = true
+            } label: {
+                HStack {
+                    Image(systemName: "gear")
+                    Text("Settings")
+                }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .buttonStyle(.glass)
+        } else {
+            Button {
+                viewModel.showSidebarSettings = true
+            } label: {
+                HStack {
+                    Image(systemName: "gear")
+                    Text("Settings")
+                }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .background(Color.sidebarButtonBackground(for: colorScheme))
+                .foregroundColor(colorScheme == .dark ? .white : .black)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(colorScheme == .dark ? Color.clear : Color.gray.opacity(0.2), lineWidth: 1)
+                )
+                .cornerRadius(8)
+            }
+        }
     }
 
     private var projectsSection: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -129,6 +129,14 @@ struct ChatSidebar: View {
         .task {
             await viewModel.loadProjects()
         }
+        .onChange(of: viewModel.shouldExpandProjectsInSidebar) { _, shouldExpand in
+            if shouldExpand {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isProjectsExpanded = true
+                }
+                viewModel.shouldExpandProjectsInSidebar = false
+            }
+        }
     }
     
     private var sidebarContent: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -400,9 +400,6 @@ struct ChatSidebar: View {
                     Button {
                         Task {
                             await viewModel.enterProject(projectId: project.id)
-                            withAnimation {
-                                isOpen = false
-                            }
                         }
                     } label: {
                         HStack {

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -244,7 +244,7 @@ struct ChatContainer: View {
                         .resizable()
                         .scaledToFit()
                         .frame(height: 22)
-                        .opacity(isSidebarOpen ? 1 : 0)
+                        .opacity(isSidebarOpen && viewModel.activeProject == nil ? 1 : 0)
 
                     if !viewModel.isTemporaryMode && viewModel.activeProject == nil && authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled && viewModel.activeStorageTab == .local {
                         chatStorageLabel
@@ -262,7 +262,7 @@ struct ChatContainer: View {
                                 .lineLimit(1)
                                 .foregroundColor(.accentColor)
                         }
-                        .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
+                        .opacity(isVerificationBadgeExpanded ? 0 : 1)
                     }
 
                     if viewModel.isTemporaryMode && viewModel.activeProject == nil {

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -445,7 +445,6 @@ struct ChatContainer: View {
         if isShowingProjectLanding {
             ProjectPage(viewModel: viewModel)
                 .background(Color.settingsBackground(for: colorScheme))
-                .ignoresSafeArea(edges: .top)
         } else {
             chatArea
         }

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -232,9 +232,13 @@ struct ChatContainer: View {
         .applyTransparentToolbarIfAvailable()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                if isInProjectChat && !isSidebarOpen {
+                if viewModel.activeProject != nil && !isSidebarOpen {
                     Button {
-                        viewModel.returnToProjectLanding()
+                        if isInProjectChat {
+                            viewModel.returnToProjectLanding()
+                        } else {
+                            viewModel.exitProject()
+                        }
                     } label: {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 18, weight: .semibold))

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -238,6 +238,9 @@ struct ChatContainer: View {
                             viewModel.returnToProjectLanding()
                         } else {
                             viewModel.exitProject()
+                            withAnimation {
+                                isSidebarOpen = true
+                            }
                         }
                     } label: {
                         Image(systemName: "chevron.left")

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -433,11 +433,11 @@ struct ChatContainer: View {
     }
 
     private var isShowingProjectLanding: Bool {
-        viewModel.activeProject != nil && (viewModel.currentChat?.isBlankChat ?? true)
+        viewModel.activeProject != nil && !viewModel.isViewingProjectChat
     }
 
     private var isInProjectChat: Bool {
-        viewModel.activeProject != nil && (viewModel.currentChat?.isBlankChat == false)
+        viewModel.activeProject != nil && viewModel.isViewingProjectChat
     }
 
     @ViewBuilder

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -205,7 +205,7 @@ struct ChatContainer: View {
                 GeometryReader { geometry in
                     HStack(spacing: 0) {
                         if isSidebarOpen {
-                            ChatSidebar(isOpen: $isSidebarOpen, viewModel: viewModel, authManager: authManager)
+                            activeSidebar
                                 .frame(width: sidebarWidth)
                                 .overlay(alignment: .trailing) {
                                     Rectangle()
@@ -246,12 +246,26 @@ struct ChatContainer: View {
                         .frame(height: 22)
                         .opacity(isSidebarOpen ? 1 : 0)
 
-                    if !viewModel.isTemporaryMode && authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled && viewModel.activeStorageTab == .local {
+                    if !viewModel.isTemporaryMode && viewModel.activeProject == nil && authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled && viewModel.activeStorageTab == .local {
                         chatStorageLabel
                             .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
                     }
 
-                    if viewModel.isTemporaryMode {
+                    if let activeProject = viewModel.activeProject {
+                        HStack(spacing: 6) {
+                            Image(systemName: "folder")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundColor(.accentColor)
+                            Text(activeProject.name)
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .lineLimit(1)
+                                .foregroundColor(.accentColor)
+                        }
+                        .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
+                    }
+
+                    if viewModel.isTemporaryMode && viewModel.activeProject == nil {
                         HStack(spacing: 6) {
                             GhostIcon(size: 14, color: .accentColor, style: .filled)
                             Text("Temporary")
@@ -377,7 +391,7 @@ struct ChatContainer: View {
             
             // Sidebar with slide transition
             HStack(spacing: 0) {
-                ChatSidebar(isOpen: $isSidebarOpen, viewModel: viewModel, authManager: authManager)
+                activeSidebar
                     .frame(width: sidebarWidth)
                     .overlay(alignment: .trailing) {
                         Rectangle()
@@ -391,6 +405,15 @@ struct ChatContainer: View {
             }
         }
         .animation(.easeInOut, value: isSidebarOpen)
+    }
+
+    @ViewBuilder
+    private var activeSidebar: some View {
+        if viewModel.isProjectMode || viewModel.isLoadingProject {
+            ProjectSidebar(isOpen: $isSidebarOpen, viewModel: viewModel)
+        } else {
+            ChatSidebar(isOpen: $isSidebarOpen, viewModel: viewModel, authManager: authManager)
+        }
     }
     
     // MARK: - Helper Methods

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -298,14 +298,16 @@ struct ChatContainer: View {
                 .animation(.easeInOut(duration: 0.2), value: isSidebarOpen)
                 .animation(.easeInOut(duration: 0.35), value: isVerificationBadgeExpanded)
             }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                VerificationStatusIndicator(viewModel: viewModel, isBadgeExpanded: $isVerificationBadgeExpanded)
+            if viewModel.activeProject == nil {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    VerificationStatusIndicator(viewModel: viewModel, isBadgeExpanded: $isVerificationBadgeExpanded)
+                }
             }
             // Temporary (incognito) chat toggle. Only shown when no chat is in
             // progress (i.e. when the new-chat "+" button is hidden). Once a
             // chat has started, the temporary state is indicated by a label
             // in the navbar's principal slot instead.
-            if authManager.isAuthenticated && (viewModel.currentChat?.isBlankChat ?? true) {
+            if authManager.isAuthenticated && viewModel.activeProject == nil && (viewModel.currentChat?.isBlankChat ?? true) {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: toggleTemporaryMode) {
                         GhostIcon(
@@ -318,7 +320,7 @@ struct ChatContainer: View {
                 }
             }
             // Only show new chat button when chat has messages (not a new/blank chat)
-            if authManager.isAuthenticated && !(viewModel.currentChat?.isBlankChat ?? true) {
+            if authManager.isAuthenticated && viewModel.activeProject == nil && !(viewModel.currentChat?.isBlankChat ?? true) {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: createNewChat) {
                         Image(systemName: "plus")

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -215,7 +215,7 @@ struct ChatContainer: View {
                                 .transition(.move(edge: .leading))
                         }
                         
-                        chatArea
+                        mainSurface
                             .frame(width: isSidebarOpen ? geometry.size.width - sidebarWidth : geometry.size.width)
                     }
                 }
@@ -223,7 +223,7 @@ struct ChatContainer: View {
             } else {
                 // iPhone: Overlay layout
                 ZStack {
-                    chatArea
+                    mainSurface
                     sidebarLayer
                 }
             }
@@ -232,10 +232,21 @@ struct ChatContainer: View {
         .applyTransparentToolbarIfAvailable()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: toggleSidebar) {
-                    MenuToXButton(isX: isSidebarOpen)
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(toolbarContentColor)
+                if isInProjectChat && !isSidebarOpen {
+                    Button {
+                        viewModel.returnToProjectLanding()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 18, weight: .semibold))
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(toolbarContentColor)
+                    }
+                } else {
+                    Button(action: toggleSidebar) {
+                        MenuToXButton(isX: isSidebarOpen)
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(toolbarContentColor)
+                    }
                 }
             }
             ToolbarItem(placement: .principal) {
@@ -409,10 +420,25 @@ struct ChatContainer: View {
 
     @ViewBuilder
     private var activeSidebar: some View {
-        if viewModel.isProjectMode || viewModel.isLoadingProject {
-            ProjectSidebar(isOpen: $isSidebarOpen, viewModel: viewModel)
+        ChatSidebar(isOpen: $isSidebarOpen, viewModel: viewModel, authManager: authManager)
+    }
+
+    private var isShowingProjectLanding: Bool {
+        viewModel.activeProject != nil && (viewModel.currentChat?.isBlankChat ?? true)
+    }
+
+    private var isInProjectChat: Bool {
+        viewModel.activeProject != nil && (viewModel.currentChat?.isBlankChat == false)
+    }
+
+    @ViewBuilder
+    private var mainSurface: some View {
+        if isShowingProjectLanding {
+            ProjectPage(viewModel: viewModel)
+                .background(Color.settingsBackground(for: colorScheme))
+                .ignoresSafeArea(edges: .top)
         } else {
-            ChatSidebar(isOpen: $isSidebarOpen, viewModel: viewModel, authManager: authManager)
+            chatArea
         }
     }
     

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -15,7 +15,13 @@ struct DocumentPickerView: UIViewControllerRepresentable {
         .plainText,
         .html,
         .commaSeparatedText,
-        UTType(filenameExtension: "md") ?? .plainText
+        .json,
+        .xml,
+        .image,
+        UTType(filenameExtension: "md") ?? .plainText,
+        UTType(filenameExtension: "docx") ?? .data,
+        UTType(filenameExtension: "pptx") ?? .data,
+        UTType(filenameExtension: "xlsx") ?? .data
     ]
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -14,6 +14,8 @@ struct ProjectPage: View {
 
     @State private var deletingChatId: String?
     @State private var showDeleteChatAlert = false
+    @State private var editingName: String = ""
+    @FocusState private var isNameFieldFocused: Bool
 
     private var project: Project? {
         viewModel.activeProject
@@ -29,9 +31,15 @@ struct ProjectPage: View {
                                 .font(.title3)
                                 .foregroundColor(.accentColor)
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(project.name)
+                                TextField("Project name", text: $editingName)
                                     .font(.headline)
-                                    .lineLimit(1)
+                                    .textFieldStyle(.plain)
+                                    .submitLabel(.done)
+                                    .focused($isNameFieldFocused)
+                                    .onSubmit { commitName() }
+                                    .onChange(of: isNameFieldFocused) { _, focused in
+                                        if !focused { commitName() }
+                                    }
                                 if !project.description.isEmpty {
                                     Text(project.description)
                                         .font(.subheadline)
@@ -102,6 +110,11 @@ struct ProjectPage: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar(.hidden, for: .navigationBar)
         }
+        .onAppear { syncEditingName() }
+        .onChange(of: project?.id) { _, _ in syncEditingName() }
+        .onChange(of: project?.name) { _, _ in
+            if !isNameFieldFocused { syncEditingName() }
+        }
         .alert("Delete Chat", isPresented: $showDeleteChatAlert) {
             Button("Cancel", role: .cancel) {
                 deletingChatId = nil
@@ -112,6 +125,22 @@ struct ProjectPage: View {
                 }
                 deletingChatId = nil
             }
+        }
+    }
+
+    private func syncEditingName() {
+        editingName = project?.name ?? ""
+    }
+
+    private func commitName() {
+        guard let project else { return }
+        let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != project.name else {
+            editingName = project.name
+            return
+        }
+        Task {
+            await viewModel.updateActiveProject(name: trimmed)
         }
     }
 
@@ -196,7 +225,6 @@ struct ProjectDetailsView: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
 
-    @State private var editingName = ""
     @State private var editingDescription = ""
     @State private var editingInstructions = ""
     @State private var editingMemory = ""
@@ -209,13 +237,6 @@ struct ProjectDetailsView: View {
 
     var body: some View {
         Form {
-            Section("Name") {
-                TextField("Project name", text: $editingName)
-                    .submitLabel(.done)
-                    .onChange(of: editingName) { _, _ in hasPendingChanges = true }
-            }
-            .listRowBackground(Color.cardSurface(for: colorScheme))
-
             Section("Description") {
                 TextField("What is this project about?", text: $editingDescription, axis: .vertical)
                     .lineLimit(3...8)
@@ -269,7 +290,6 @@ struct ProjectDetailsView: View {
             isSaving = true
             viewModel.projectError = nil
             await viewModel.updateActiveProject(
-                name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
                 description: editingDescription,
                 systemInstructions: editingInstructions,
                 memory: memoryFactsFromEditor()
@@ -283,7 +303,6 @@ struct ProjectDetailsView: View {
 
     private func syncEditingState() {
         guard let project else { return }
-        editingName = project.name
         editingDescription = project.description
         editingInstructions = project.systemInstructions
         editingMemory = project.memory.map(\.fact).joined(separator: "\n")

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -83,7 +83,7 @@ struct ProjectPage: View {
 
                 Section {
                     Button {
-                        viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
+                        viewModel.startNewProjectChat()
                     } label: {
                         Label("New project chat", systemImage: "square.and.pencil")
                     }
@@ -141,7 +141,7 @@ struct ProjectPage: View {
 
     private func chatRow(_ chat: Chat) -> some View {
         Button {
-            viewModel.selectChat(chat)
+            viewModel.openProjectChat(chat)
         } label: {
             HStack(spacing: 8) {
                 VStack(alignment: .leading, spacing: 2) {

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -22,8 +22,7 @@ struct ProjectPage: View {
     }
 
     var body: some View {
-        NavigationStack {
-            Form {
+        Form {
                 if let project {
                     Section {
                         HStack(spacing: 12) {
@@ -104,12 +103,8 @@ struct ProjectPage: View {
                 }
                 .listRowBackground(Color.cardSurface(for: colorScheme))
             }
-            .scrollContentBackground(.hidden)
-            .background(Color.settingsBackground(for: colorScheme))
-            .navigationTitle(project?.name ?? "Project")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar(.hidden, for: .navigationBar)
-        }
+        .scrollContentBackground(.hidden)
+        .background(Color.settingsBackground(for: colorScheme))
         .onAppear { syncEditingName() }
         .onChange(of: project?.id) { _, _ in syncEditingName() }
         .onChange(of: project?.name) { _, _ in

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -1,19 +1,17 @@
 //
-//  ProjectSidebar.swift
+//  ProjectPage.swift
 //  TinfoilChat
 //
-//  Sidebar shown while a project is active.
+//  Full-screen project landing page shown when a project is active and no
+//  project chat is currently selected.
 //
 
 import SwiftUI
 
-struct ProjectSidebar: View {
-    @Environment(\.colorScheme) var colorScheme
-    @Binding var isOpen: Bool
+struct ProjectPage: View {
+    @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
 
-    @State private var editingChatId: String?
-    @State private var editingTitle = ""
     @State private var deletingChatId: String?
     @State private var showDeleteChatAlert = false
 
@@ -23,88 +21,87 @@ struct ProjectSidebar: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                exitButton
-                    .padding(.horizontal, 16)
-                    .padding(.top, 12)
-                    .padding(.bottom, 8)
-
-                header
-
-                if let error = viewModel.projectError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundColor(.red)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                }
-
-                List {
+            Form {
+                if let project {
                     Section {
-                        NavigationLink {
-                            ProjectDetailsView(viewModel: viewModel)
-                        } label: {
-                            Label("Details", systemImage: "slider.horizontal.3")
-                        }
-
-                        NavigationLink {
-                            ProjectDocumentsView(viewModel: viewModel)
-                        } label: {
-                            HStack {
-                                Label("Documents", systemImage: "doc.text")
-                                Spacer()
-                                if !viewModel.projectDocuments.isEmpty {
-                                    Text("\(viewModel.projectDocuments.count)")
+                        HStack(spacing: 12) {
+                            Image(systemName: "folder.fill")
+                                .font(.title3)
+                                .foregroundColor(.accentColor)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(project.name)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                if !project.description.isEmpty {
+                                    Text(project.description)
                                         .font(.subheadline)
                                         .foregroundColor(.secondary)
+                                        .lineLimit(3)
                                 }
                             }
                         }
-
-                        NavigationLink {
-                            ProjectSettingsView(viewModel: viewModel, isOpen: $isOpen)
-                        } label: {
-                            Label("Settings", systemImage: "gearshape")
-                        }
-                    }
-                    .listRowBackground(Color.cardSurface(for: colorScheme))
-
-                    Section {
-                        Button {
-                            viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
-                            withAnimation {
-                                isOpen = false
-                            }
-                        } label: {
-                            Label("New project chat", systemImage: "square.and.pencil")
-                        }
-
-                        if viewModel.activeProjectChats.isEmpty {
-                            Text("No project chats yet")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        } else {
-                            ForEach(viewModel.activeProjectChats) { chat in
-                                chatRow(chat)
-                            }
-                        }
-                    } header: {
-                        Text("Project chats")
+                        .padding(.vertical, 4)
                     }
                     .listRowBackground(Color.cardSurface(for: colorScheme))
                 }
-                .listStyle(.insetGrouped)
-                .scrollContentBackground(.hidden)
-                .background(Color.settingsBackground(for: colorScheme))
+
+                Section {
+                    NavigationLink {
+                        ProjectDetailsView(viewModel: viewModel)
+                    } label: {
+                        Label("Details", systemImage: "slider.horizontal.3")
+                    }
+
+                    NavigationLink {
+                        ProjectDocumentsView(viewModel: viewModel)
+                    } label: {
+                        HStack {
+                            Label("Documents", systemImage: "doc.text")
+                            Spacer()
+                            if !viewModel.projectDocuments.isEmpty {
+                                Text("\(viewModel.projectDocuments.count)")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+
+                    NavigationLink {
+                        ProjectSettingsView(viewModel: viewModel)
+                    } label: {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+                }
+                .listRowBackground(Color.cardSurface(for: colorScheme))
+
+                Section {
+                    Button {
+                        viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
+                    } label: {
+                        Label("New project chat", systemImage: "square.and.pencil")
+                    }
+                    .disabled(project == nil)
+
+                    if viewModel.activeProjectChats.isEmpty {
+                        Text("No project chats yet")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(viewModel.activeProjectChats) { chat in
+                            chatRow(chat)
+                        }
+                    }
+                } header: {
+                    Text("Project chats")
+                }
+                .listRowBackground(Color.cardSurface(for: colorScheme))
             }
-            .frame(width: 300)
+            .scrollContentBackground(.hidden)
             .background(Color.settingsBackground(for: colorScheme))
-            .navigationBarHidden(true)
+            .navigationTitle(project?.name ?? "Project")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden, for: .navigationBar)
         }
-        .frame(width: 300)
-        .ignoresSafeArea(edges: .bottom)
-        .ignoresSafeArea(.keyboard)
         .alert("Delete Chat", isPresented: $showDeleteChatAlert) {
             Button("Cancel", role: .cancel) {
                 deletingChatId = nil
@@ -118,55 +115,9 @@ struct ProjectSidebar: View {
         }
     }
 
-    private var exitButton: some View {
-        Button {
-            viewModel.exitProject()
-            withAnimation {
-                isOpen = false
-            }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "arrow.left")
-                    .font(.subheadline.weight(.semibold))
-                Text("Exit Project")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                Spacer()
-            }
-            .foregroundColor(.accentColor)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
-                Image(systemName: "folder.fill")
-                    .font(.subheadline)
-                    .foregroundColor(.accentColor)
-                Text(project?.name ?? "Project")
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                    .lineLimit(1)
-                Spacer()
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 16)
-        .padding(.bottom, 12)
-        .overlay(
-            Divider().background(Color.gray.opacity(0.3)),
-            alignment: .bottom
-        )
-    }
-
     private func chatRow(_ chat: Chat) -> some View {
         Button {
             viewModel.selectChat(chat)
-            withAnimation {
-                isOpen = false
-            }
         } label: {
             HStack(spacing: 8) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -181,11 +132,9 @@ struct ProjectSidebar: View {
                     }
                 }
                 Spacer()
-                if viewModel.currentChat?.id == chat.id {
-                    Image(systemName: "checkmark")
-                        .font(.footnote.weight(.semibold))
-                        .foregroundColor(.accentColor)
-                }
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
             }
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
@@ -243,7 +192,7 @@ struct ProjectSidebar: View {
 
 // MARK: - Project Details Page
 
-private struct ProjectDetailsView: View {
+struct ProjectDetailsView: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
 
@@ -361,7 +310,7 @@ private struct ProjectDetailsView: View {
 
 // MARK: - Project Documents Page
 
-private struct ProjectDocumentsView: View {
+struct ProjectDocumentsView: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
     @State private var showDocumentPicker = false
@@ -454,11 +403,9 @@ private struct ProjectDocumentsView: View {
 
 // MARK: - Project Settings Page
 
-private struct ProjectSettingsView: View {
+struct ProjectSettingsView: View {
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.dismiss) private var dismiss
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
-    @Binding var isOpen: Bool
     @State private var showDeleteAlert = false
 
     private var project: Project? {
@@ -498,9 +445,6 @@ private struct ProjectSettingsView: View {
             Button("Delete", role: .destructive) {
                 Task {
                     await viewModel.deleteActiveProject()
-                    withAnimation {
-                        isOpen = false
-                    }
                 }
             }
         } message: {

--- a/TinfoilChat/Views/ProjectSidebar.swift
+++ b/TinfoilChat/Views/ProjectSidebar.swift
@@ -12,72 +12,99 @@ struct ProjectSidebar: View {
     @Binding var isOpen: Bool
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
 
-    @State private var detailsExpanded = false
-    @State private var documentsExpanded = true
-    @State private var chatsExpanded = true
-    @State private var showDocumentPicker = false
-    @State private var editingName = ""
-    @State private var editingDescription = ""
-    @State private var editingInstructions = ""
-    @State private var editingMemory = ""
     @State private var editingChatId: String?
     @State private var editingTitle = ""
     @State private var deletingChatId: String?
     @State private var showDeleteChatAlert = false
-    @State private var showDeleteProjectAlert = false
-    @State private var hasPendingChanges = false
 
     private var project: Project? {
         viewModel.activeProject
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-
-            if let error = viewModel.projectError {
-                Text(error)
-                    .font(.caption)
-                    .foregroundColor(.red)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        NavigationStack {
+            VStack(spacing: 0) {
+                exitButton
                     .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-            }
+                    .padding(.top, 12)
+                    .padding(.bottom, 8)
 
-            List {
-                detailsSection
-                documentsSection
-                chatsSection
-                deleteSection
+                header
+
+                if let error = viewModel.projectError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                }
+
+                List {
+                    Section {
+                        NavigationLink {
+                            ProjectDetailsView(viewModel: viewModel)
+                        } label: {
+                            Label("Details", systemImage: "slider.horizontal.3")
+                        }
+
+                        NavigationLink {
+                            ProjectDocumentsView(viewModel: viewModel)
+                        } label: {
+                            HStack {
+                                Label("Documents", systemImage: "doc.text")
+                                Spacer()
+                                if !viewModel.projectDocuments.isEmpty {
+                                    Text("\(viewModel.projectDocuments.count)")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+
+                        NavigationLink {
+                            ProjectSettingsView(viewModel: viewModel, isOpen: $isOpen)
+                        } label: {
+                            Label("Settings", systemImage: "gearshape")
+                        }
+                    }
+                    .listRowBackground(Color.cardSurface(for: colorScheme))
+
+                    Section {
+                        Button {
+                            viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
+                            withAnimation {
+                                isOpen = false
+                            }
+                        } label: {
+                            Label("New project chat", systemImage: "square.and.pencil")
+                        }
+
+                        if viewModel.activeProjectChats.isEmpty {
+                            Text("No project chats yet")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(viewModel.activeProjectChats) { chat in
+                                chatRow(chat)
+                            }
+                        }
+                    } header: {
+                        Text("Project chats")
+                    }
+                    .listRowBackground(Color.cardSurface(for: colorScheme))
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+                .background(Color.settingsBackground(for: colorScheme))
             }
-            .listStyle(.insetGrouped)
-            .scrollContentBackground(.hidden)
+            .frame(width: 300)
             .background(Color.settingsBackground(for: colorScheme))
-            .scrollDismissesKeyboardIfAvailable()
-
-            Divider()
-                .background(Color.gray.opacity(0.3))
-
-            exitButton
-                .padding(.horizontal, 16)
-                .padding(.top, 8)
-                .padding(.bottom, 8)
-                .safeAreaPadding(.bottom)
+            .navigationBarHidden(true)
         }
         .frame(width: 300)
-        .background(Color.settingsBackground(for: colorScheme))
         .ignoresSafeArea(edges: .bottom)
         .ignoresSafeArea(.keyboard)
-        .onAppear(perform: syncEditingState)
-        .onChange(of: project?.id) { _, _ in syncEditingState() }
-        .onChange(of: project?.name) { _, _ in syncEditingState() }
-        .sheet(isPresented: $showDocumentPicker) {
-            DocumentPickerView { url, fileName in
-                Task {
-                    await viewModel.uploadProjectDocument(url: url, filename: fileName)
-                }
-            }
-        }
         .alert("Delete Chat", isPresented: $showDeleteChatAlert) {
             Button("Cancel", role: .cancel) {
                 deletingChatId = nil
@@ -89,16 +116,27 @@ struct ProjectSidebar: View {
                 deletingChatId = nil
             }
         }
-        .alert("Delete Project", isPresented: $showDeleteProjectAlert) {
-            Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
-                Task {
-                    await viewModel.deleteActiveProject()
-                }
+    }
+
+    private var exitButton: some View {
+        Button {
+            viewModel.exitProject()
+            withAnimation {
+                isOpen = false
             }
-        } message: {
-            Text("This deletes the project and its project context documents.")
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.left")
+                    .font(.subheadline.weight(.semibold))
+                Text("Exit Project")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+            }
+            .foregroundColor(.accentColor)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
     }
 
     private var header: some View {
@@ -108,185 +146,19 @@ struct ProjectSidebar: View {
                     .font(.subheadline)
                     .foregroundColor(.accentColor)
                 Text(project?.name ?? "Project")
-                    .font(.headline)
+                    .font(.title3)
+                    .fontWeight(.semibold)
                     .lineLimit(1)
                 Spacer()
             }
-
-            Text("Context, documents, and chats")
-                .font(.caption)
-                .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
-        .padding(.vertical, 16)
+        .padding(.bottom, 12)
         .overlay(
             Divider().background(Color.gray.opacity(0.3)),
             alignment: .bottom
         )
-    }
-
-    private var detailsSection: some View {
-        Section {
-            DisclosureGroup(isExpanded: $detailsExpanded) {
-                fieldRow(label: "Name") {
-                    TextField("Project name", text: $editingName)
-                        .submitLabel(.done)
-                        .multilineTextAlignment(.trailing)
-                        .onChange(of: editingName) { _, _ in hasPendingChanges = true }
-                }
-
-                multilineFieldRow(label: "Description", placeholder: "What is this project about?", text: $editingDescription, lineLimit: 2...4)
-
-                multilineFieldRow(label: "Instructions", placeholder: "How should Tin behave in this project?", text: $editingInstructions, lineLimit: 3...8)
-
-                multilineFieldRow(label: "Memory", placeholder: "One fact per line", text: $editingMemory, lineLimit: 3...8)
-
-                Button {
-                    Task {
-                        viewModel.projectError = nil
-                        await viewModel.updateActiveProject(
-                            name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
-                            description: editingDescription,
-                            systemInstructions: editingInstructions,
-                            memory: memoryFactsFromEditor()
-                        )
-                        if viewModel.projectError == nil {
-                            hasPendingChanges = false
-                        }
-                    }
-                } label: {
-                    Label("Save changes", systemImage: "checkmark.circle.fill")
-                }
-                .disabled(!hasPendingChanges || project == nil)
-            } label: {
-                Label("Details", systemImage: "slider.horizontal.3")
-            }
-        }
-        .listRowBackground(Color.cardSurface(for: colorScheme))
-    }
-
-    private func fieldRow<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
-        HStack {
-            Text(label)
-                .font(.subheadline)
-            Spacer()
-            content()
-                .font(.subheadline)
-        }
-    }
-
-    private func multilineFieldRow(label: String, placeholder: String, text: Binding<String>, lineLimit: ClosedRange<Int>) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(label.uppercased())
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .foregroundColor(.secondary)
-                .tracking(0.5)
-
-            TextField(placeholder, text: text, axis: .vertical)
-                .font(.subheadline)
-                .lineLimit(lineLimit)
-                .padding(10)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.settingsBackground(for: colorScheme))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(Color.gray.opacity(0.25), lineWidth: 1)
-                )
-                .onChange(of: text.wrappedValue) { _, _ in hasPendingChanges = true }
-        }
-        .padding(.vertical, 4)
-    }
-
-    private var documentsSection: some View {
-        Section {
-            DisclosureGroup(isExpanded: $documentsExpanded) {
-                if viewModel.projectDocuments.isEmpty && !viewModel.isUploadingProjectDocument {
-                    Text("No documents yet")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-
-                ForEach(viewModel.projectDocuments) { document in
-                    documentRow(document)
-                }
-
-                if viewModel.isUploadingProjectDocument {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .scaleEffect(0.8)
-                        Text("Uploading…")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                Button {
-                    showDocumentPicker = true
-                } label: {
-                    Label("Add document", systemImage: "plus.circle.fill")
-                }
-                .disabled(viewModel.isUploadingProjectDocument)
-            } label: {
-                Label("Documents", systemImage: "doc.text")
-            }
-        }
-        .listRowBackground(Color.cardSurface(for: colorScheme))
-    }
-
-    private func documentRow(_ document: ProjectDocument) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: "doc")
-                .foregroundColor(.secondary)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(document.filename.isEmpty ? "Encrypted" : document.filename)
-                    .font(.subheadline)
-                    .lineLimit(1)
-                Text(formatFileSize(document.sizeBytes))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-        }
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            Button(role: .destructive) {
-                Task {
-                    await viewModel.deleteProjectDocument(document.id)
-                }
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-        }
-    }
-
-    private var chatsSection: some View {
-        Section {
-            DisclosureGroup(isExpanded: $chatsExpanded) {
-                Button {
-                    viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
-                    withAnimation {
-                        isOpen = false
-                    }
-                } label: {
-                    Label("New project chat", systemImage: "square.and.pencil")
-                }
-
-                if viewModel.activeProjectChats.isEmpty {
-                    Text("No project chats yet")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(viewModel.activeProjectChats) { chat in
-                        chatRow(chat)
-                    }
-                }
-            } label: {
-                Label("Chats", systemImage: "bubble.left.and.bubble.right")
-            }
-        }
-        .listRowBackground(Color.cardSurface(for: colorScheme))
     }
 
     private func chatRow(_ chat: Chat) -> some View {
@@ -353,42 +225,111 @@ struct ProjectSidebar: View {
         }
     }
 
-    private var deleteSection: some View {
-        Section {
-            Button(role: .destructive) {
-                showDeleteProjectAlert = true
-            } label: {
-                Label("Delete project", systemImage: "trash")
-            }
-            .disabled(project == nil)
+    private func relativeTimeString(from date: Date) -> String {
+        let difference = Date().timeIntervalSince(date)
+        if difference < 60 {
+            return "Just now"
+        } else if difference < 3600 {
+            return "\(Int(difference / 60))m ago"
+        } else if difference < 86400 {
+            return "\(Int(difference / 3600))h ago"
+        } else if difference < 604800 {
+            return "\(Int(difference / 86400))d ago"
+        } else {
+            return "\(Int(difference / 604800))w ago"
         }
-        .listRowBackground(Color.cardSurface(for: colorScheme))
+    }
+}
+
+// MARK: - Project Details Page
+
+private struct ProjectDetailsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @ObservedObject var viewModel: TinfoilChat.ChatViewModel
+
+    @State private var editingName = ""
+    @State private var editingDescription = ""
+    @State private var editingInstructions = ""
+    @State private var editingMemory = ""
+    @State private var hasPendingChanges = false
+    @State private var isSaving = false
+
+    private var project: Project? {
+        viewModel.activeProject
     }
 
-    private var exitButton: some View {
-        Button {
-            viewModel.exitProject()
-            withAnimation {
-                isOpen = false
+    var body: some View {
+        Form {
+            Section("Name") {
+                TextField("Project name", text: $editingName)
+                    .submitLabel(.done)
+                    .onChange(of: editingName) { _, _ in hasPendingChanges = true }
             }
-        } label: {
-            HStack {
-                Image(systemName: "arrow.left")
-                Text("Exit Project")
-                    .fontWeight(.medium)
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
+            Section("Description") {
+                TextField("What is this project about?", text: $editingDescription, axis: .vertical)
+                    .lineLimit(3...8)
+                    .onChange(of: editingDescription) { _, _ in hasPendingChanges = true }
             }
-            .padding(.vertical, 12)
-            .padding(.horizontal, 16)
-            .frame(maxWidth: .infinity)
-            .background(Color.sidebarButtonBackground(for: colorScheme))
-            .foregroundColor(colorScheme == .dark ? .white : .black)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(colorScheme == .dark ? Color.white.opacity(0.08) : Color.gray.opacity(0.2), lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
+            Section("Instructions") {
+                TextField("How should Tin behave in this project?", text: $editingInstructions, axis: .vertical)
+                    .lineLimit(5...15)
+                    .onChange(of: editingInstructions) { _, _ in hasPendingChanges = true }
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
+            Section {
+                TextField("One fact per line", text: $editingMemory, axis: .vertical)
+                    .lineLimit(5...15)
+                    .onChange(of: editingMemory) { _, _ in hasPendingChanges = true }
+            } header: {
+                Text("Memory")
+            } footer: {
+                Text("Each line becomes a memory fact stored with the project.")
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
         }
-        .buttonStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Color.settingsBackground(for: colorScheme))
+        .navigationTitle("Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    saveChanges()
+                } label: {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Text("Save")
+                            .fontWeight(.semibold)
+                    }
+                }
+                .disabled(!hasPendingChanges || project == nil || isSaving)
+            }
+        }
+        .onAppear(perform: syncEditingState)
+        .onChange(of: project?.id) { _, _ in syncEditingState() }
+    }
+
+    private func saveChanges() {
+        Task {
+            isSaving = true
+            viewModel.projectError = nil
+            await viewModel.updateActiveProject(
+                name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
+                description: editingDescription,
+                systemInstructions: editingInstructions,
+                memory: memoryFactsFromEditor()
+            )
+            if viewModel.projectError == nil {
+                hasPendingChanges = false
+            }
+            isSaving = false
+        }
     }
 
     private func syncEditingState() {
@@ -396,7 +337,7 @@ struct ProjectSidebar: View {
         editingName = project.name
         editingDescription = project.description
         editingInstructions = project.systemInstructions
-        editingMemory = project.memory.map(\.fact).joined(separator: "\n\n")
+        editingMemory = project.memory.map(\.fact).joined(separator: "\n")
         hasPendingChanges = false
     }
 
@@ -416,6 +357,89 @@ struct ProjectSidebar: View {
                 )
             }
     }
+}
+
+// MARK: - Project Documents Page
+
+private struct ProjectDocumentsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @ObservedObject var viewModel: TinfoilChat.ChatViewModel
+    @State private var showDocumentPicker = false
+
+    var body: some View {
+        Form {
+            if viewModel.projectDocuments.isEmpty && !viewModel.isUploadingProjectDocument {
+                Section {
+                    Text("No documents yet. Add files to use as context for this project.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .listRowBackground(Color.cardSurface(for: colorScheme))
+            } else {
+                Section {
+                    ForEach(viewModel.projectDocuments) { document in
+                        documentRow(document)
+                    }
+
+                    if viewModel.isUploadingProjectDocument {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                            Text("Uploading…")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .listRowBackground(Color.cardSurface(for: colorScheme))
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.settingsBackground(for: colorScheme))
+        .navigationTitle("Documents")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showDocumentPicker = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .disabled(viewModel.isUploadingProjectDocument)
+            }
+        }
+        .sheet(isPresented: $showDocumentPicker) {
+            DocumentPickerView { url, fileName in
+                Task {
+                    await viewModel.uploadProjectDocument(url: url, filename: fileName)
+                }
+            }
+        }
+    }
+
+    private func documentRow(_ document: ProjectDocument) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc")
+                .foregroundColor(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(document.filename.isEmpty ? "Encrypted" : document.filename)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                Text(formatFileSize(document.sizeBytes))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                Task {
+                    await viewModel.deleteProjectDocument(document.id)
+                }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
 
     private func formatFileSize(_ bytes: Int) -> String {
         if bytes < 1024 {
@@ -426,30 +450,70 @@ struct ProjectSidebar: View {
         }
         return String(format: "%.1f MB", Double(bytes) / (1024.0 * 1024.0))
     }
-
-    private func relativeTimeString(from date: Date) -> String {
-        let difference = Date().timeIntervalSince(date)
-        if difference < 60 {
-            return "Just now"
-        } else if difference < 3600 {
-            return "\(Int(difference / 60))m ago"
-        } else if difference < 86400 {
-            return "\(Int(difference / 3600))h ago"
-        } else if difference < 604800 {
-            return "\(Int(difference / 86400))d ago"
-        } else {
-            return "\(Int(difference / 604800))w ago"
-        }
-    }
 }
 
-private extension View {
-    @ViewBuilder
-    func scrollDismissesKeyboardIfAvailable() -> some View {
-        if #available(iOS 16.0, *) {
-            self.scrollDismissesKeyboard(.interactively)
-        } else {
-            self
+// MARK: - Project Settings Page
+
+private struct ProjectSettingsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var viewModel: TinfoilChat.ChatViewModel
+    @Binding var isOpen: Bool
+    @State private var showDeleteAlert = false
+
+    private var project: Project? {
+        viewModel.activeProject
+    }
+
+    var body: some View {
+        Form {
+            if let project {
+                Section("Project info") {
+                    LabeledContent("Created", value: relativeDate(project.createdAt))
+                    LabeledContent("Updated", value: relativeDate(project.updatedAt))
+                    LabeledContent("Documents", value: "\(viewModel.projectDocuments.count)")
+                    LabeledContent("Chats", value: "\(viewModel.activeProjectChats.count)")
+                }
+                .listRowBackground(Color.cardSurface(for: colorScheme))
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    showDeleteAlert = true
+                } label: {
+                    Label("Delete project", systemImage: "trash")
+                }
+                .disabled(project == nil)
+            } footer: {
+                Text("Deletes the project, its context documents, and removes this project from all associated chats.")
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
         }
+        .scrollContentBackground(.hidden)
+        .background(Color.settingsBackground(for: colorScheme))
+        .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Delete Project", isPresented: $showDeleteAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                Task {
+                    await viewModel.deleteActiveProject()
+                    withAnimation {
+                        isOpen = false
+                    }
+                }
+            }
+        } message: {
+            Text("This deletes the project and its project context documents.")
+        }
+    }
+
+    private func relativeDate(_ iso: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: iso) ?? ISO8601DateFormatter().date(from: iso) ?? Date()
+        let style = RelativeDateTimeFormatter()
+        style.unitsStyle = .abbreviated
+        return style.localizedString(for: date, relativeTo: Date())
     }
 }

--- a/TinfoilChat/Views/ProjectSidebar.swift
+++ b/TinfoilChat/Views/ProjectSidebar.swift
@@ -1,0 +1,410 @@
+//
+//  ProjectSidebar.swift
+//  TinfoilChat
+//
+//  Sidebar shown while a project is active.
+//
+
+import SwiftUI
+
+struct ProjectSidebar: View {
+    @Environment(\.colorScheme) var colorScheme
+    @Binding var isOpen: Bool
+    @ObservedObject var viewModel: TinfoilChat.ChatViewModel
+
+    @State private var settingsExpanded = false
+    @State private var documentsExpanded = true
+    @State private var chatsExpanded = true
+    @State private var showDocumentPicker = false
+    @State private var editingName = ""
+    @State private var editingDescription = ""
+    @State private var editingInstructions = ""
+    @State private var editingMemory = ""
+    @State private var editingChatId: String?
+    @State private var editingTitle = ""
+    @State private var deletingChatId: String?
+    @State private var showDeleteChatAlert = false
+    @State private var showDeleteProjectAlert = false
+
+    private var project: Project? {
+        viewModel.activeProject
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            if let error = viewModel.projectError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+            }
+
+            ScrollView {
+                VStack(spacing: 12) {
+                    settingsSection
+                    documentsSection
+                    chatsSection
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+            .applyAlwaysBounceIfAvailable()
+
+            Divider()
+                .background(Color.gray.opacity(0.3))
+
+            Button {
+                viewModel.exitProject()
+                withAnimation {
+                    isOpen = false
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "arrow.left")
+                    Text("Exit Project")
+                }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.plain)
+            .background(Color.sidebarButtonBackground(for: colorScheme))
+            .cornerRadius(8)
+            .padding(16)
+            .safeAreaPadding(.bottom)
+        }
+        .frame(width: 300)
+        .background(colorScheme == .dark ? Color.sidebarBackground(for: colorScheme) : Color.white)
+        .ignoresSafeArea(edges: .bottom)
+        .onAppear(perform: syncEditingState)
+        .onChange(of: project?.id) { _, _ in syncEditingState() }
+        .onChange(of: project?.name) { _, _ in syncEditingState() }
+        .sheet(isPresented: $showDocumentPicker) {
+            DocumentPickerView { url, fileName in
+                Task {
+                    await viewModel.uploadProjectDocument(url: url, filename: fileName)
+                }
+            }
+        }
+        .alert("Delete Chat", isPresented: $showDeleteChatAlert) {
+            Button("Cancel", role: .cancel) {
+                deletingChatId = nil
+            }
+            Button("Delete", role: .destructive) {
+                if let deletingChatId {
+                    viewModel.deleteChat(deletingChatId)
+                }
+                deletingChatId = nil
+            }
+        }
+        .alert("Delete Project", isPresented: $showDeleteProjectAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                Task {
+                    await viewModel.deleteActiveProject()
+                }
+            }
+        } message: {
+            Text("This deletes the project and its project context documents.")
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "folder")
+                    .foregroundColor(.accentColor)
+                Text(project?.name ?? "Loading...")
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                Button {
+                    withAnimation {
+                        isOpen = false
+                    }
+                } label: {
+                    Image(systemName: "sidebar.left")
+                }
+                .buttonStyle(.plain)
+            }
+
+            Text("Project context, documents, and chats")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+        .overlay(
+            Divider().background(Color.gray.opacity(0.3)),
+            alignment: .bottom
+        )
+    }
+
+    private var settingsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(title: "Project Params", systemImage: "slider.horizontal.3", isExpanded: $settingsExpanded)
+
+            if settingsExpanded {
+                VStack(alignment: .leading, spacing: 10) {
+                    TextField("Project name", text: $editingName)
+                        .textFieldStyle(.roundedBorder)
+
+                    TextField("Description", text: $editingDescription, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(2...4)
+
+                    TextField("Instructions", text: $editingInstructions, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(3...8)
+
+                    TextField("Memory", text: $editingMemory, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(3...8)
+
+                    HStack {
+                        Button("Save") {
+                            Task {
+                                await viewModel.updateActiveProject(
+                                    name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
+                                    description: editingDescription,
+                                    systemInstructions: editingInstructions,
+                                    memory: memoryFactsFromEditor()
+                                )
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Delete", role: .destructive) {
+                            showDeleteProjectAlert = true
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+        }
+        .sectionCard()
+    }
+
+    private var documentsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(title: "Project Documents", systemImage: "doc.text", isExpanded: $documentsExpanded)
+
+            if documentsExpanded {
+                if viewModel.projectDocuments.isEmpty && !viewModel.isUploadingProjectDocument {
+                    Text("No documents yet.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                ForEach(viewModel.projectDocuments) { document in
+                    HStack(spacing: 8) {
+                        Image(systemName: "doc")
+                            .foregroundColor(.secondary)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(document.filename.isEmpty ? "Encrypted" : document.filename)
+                                .font(.subheadline)
+                                .lineLimit(1)
+                            Text(formatFileSize(document.sizeBytes))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Button(role: .destructive) {
+                            Task {
+                                await viewModel.deleteProjectDocument(document.id)
+                            }
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(8)
+                    .background(Color(UIColor.secondarySystemBackground).opacity(0.35))
+                    .cornerRadius(8)
+                }
+
+                if viewModel.isUploadingProjectDocument {
+                    HStack {
+                        ProgressView()
+                        Text("Uploading...")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Button {
+                    showDocumentPicker = true
+                } label: {
+                    Label("Add document", systemImage: "doc.badge.plus")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.isUploadingProjectDocument)
+            }
+        }
+        .sectionCard()
+    }
+
+    private var chatsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(title: "Project Chats", systemImage: "bubble.left.and.bubble.right", isExpanded: $chatsExpanded)
+
+            if chatsExpanded {
+                Button {
+                    viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
+                    withAnimation {
+                        isOpen = false
+                    }
+                } label: {
+                    Label("New project chat", systemImage: "square.and.pencil")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+
+                ForEach(viewModel.activeProjectChats) { chat in
+                    ChatListItem(
+                        chat: chat,
+                        isSelected: viewModel.currentChat?.id == chat.id,
+                        isEditing: editingChatId == chat.id,
+                        editingTitle: $editingTitle,
+                        timeString: relativeTimeString(from: chat.createdAt),
+                        onSelect: {
+                            viewModel.selectChat(chat)
+                            withAnimation {
+                                isOpen = false
+                            }
+                        },
+                        onEdit: {
+                            if editingChatId == chat.id {
+                                viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
+                                editingChatId = nil
+                            } else {
+                                editingChatId = chat.id
+                                editingTitle = chat.title
+                            }
+                        },
+                        onDelete: {
+                            deletingChatId = chat.id
+                            showDeleteChatAlert = true
+                        },
+                        showEditDelete: true
+                    )
+                    .contextMenu {
+                        Button {
+                            Task {
+                                await viewModel.removeChatFromProject(chatId: chat.id)
+                            }
+                        } label: {
+                            Label("Remove from Project", systemImage: "arrow.uturn.left")
+                        }
+
+                        ForEach(viewModel.projects.filter { $0.id != project?.id }) { destination in
+                            Button {
+                                Task {
+                                    await viewModel.moveChatToProject(chatId: chat.id, projectId: destination.id)
+                                }
+                            } label: {
+                                Label("Move to \(destination.name)", systemImage: "folder")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .sectionCard()
+    }
+
+    private func sectionHeader(title: String, systemImage: String, isExpanded: Binding<Bool>) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.wrappedValue.toggle()
+            }
+        } label: {
+            HStack {
+                Label(title, systemImage: systemImage)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+                    .rotationEffect(.degrees(isExpanded.wrappedValue ? 0 : -90))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func syncEditingState() {
+        guard let project else { return }
+        editingName = project.name
+        editingDescription = project.description
+        editingInstructions = project.systemInstructions
+        editingMemory = project.memory.map(\.fact).joined(separator: "\n\n")
+    }
+
+    private func memoryFactsFromEditor() -> [MemoryFact] {
+        let existing = Dictionary(uniqueKeysWithValues: (project?.memory ?? []).map { ($0.fact, $0) })
+        return editingMemory
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { line in
+                existing[line] ?? MemoryFact(
+                    id: UUID().uuidString.lowercased(),
+                    fact: line,
+                    date: ISO8601DateFormatter().string(from: Date()),
+                    category: "other",
+                    confidence: 1
+                )
+            }
+    }
+
+    private func formatFileSize(_ bytes: Int) -> String {
+        if bytes < 1024 {
+            return "\(bytes) B"
+        }
+        if bytes < 1024 * 1024 {
+            return String(format: "%.1f KB", Double(bytes) / 1024.0)
+        }
+        return String(format: "%.1f MB", Double(bytes) / (1024.0 * 1024.0))
+    }
+
+    private func relativeTimeString(from date: Date) -> String {
+        let difference = Date().timeIntervalSince(date)
+        if difference < 60 {
+            return "Just now"
+        } else if difference < 3600 {
+            return "\(Int(difference / 60))m ago"
+        } else if difference < 86400 {
+            return "\(Int(difference / 3600))h ago"
+        } else if difference < 604800 {
+            return "\(Int(difference / 86400))d ago"
+        } else {
+            return "\(Int(difference / 604800))w ago"
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func applyAlwaysBounceIfAvailable() -> some View {
+        if #available(iOS 16.0, *) {
+            self.scrollBounceBehavior(.always)
+        } else {
+            self
+        }
+    }
+
+    func sectionCard() -> some View {
+        self
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(UIColor.secondarySystemBackground).opacity(0.3))
+            .cornerRadius(12)
+    }
+}

--- a/TinfoilChat/Views/ProjectSidebar.swift
+++ b/TinfoilChat/Views/ProjectSidebar.swift
@@ -67,6 +67,7 @@ struct ProjectSidebar: View {
         .frame(width: 300)
         .background(Color.settingsBackground(for: colorScheme))
         .ignoresSafeArea(edges: .bottom)
+        .ignoresSafeArea(.keyboard)
         .onAppear(perform: syncEditingState)
         .onChange(of: project?.id) { _, _ in syncEditingState() }
         .onChange(of: project?.name) { _, _ in syncEditingState() }

--- a/TinfoilChat/Views/ProjectSidebar.swift
+++ b/TinfoilChat/Views/ProjectSidebar.swift
@@ -143,13 +143,16 @@ struct ProjectSidebar: View {
 
                 Button {
                     Task {
+                        viewModel.projectError = nil
                         await viewModel.updateActiveProject(
                             name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
                             description: editingDescription,
                             systemInstructions: editingInstructions,
                             memory: memoryFactsFromEditor()
                         )
-                        hasPendingChanges = false
+                        if viewModel.projectError == nil {
+                            hasPendingChanges = false
+                        }
                     }
                 } label: {
                     Label("Save changes", systemImage: "checkmark.circle.fill")
@@ -397,7 +400,7 @@ struct ProjectSidebar: View {
     }
 
     private func memoryFactsFromEditor() -> [MemoryFact] {
-        let existing = Dictionary(uniqueKeysWithValues: (project?.memory ?? []).map { ($0.fact, $0) })
+        let existing = Dictionary((project?.memory ?? []).map { ($0.fact, $0) }, uniquingKeysWith: { first, _ in first })
         return editingMemory
             .split(separator: "\n")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }

--- a/TinfoilChat/Views/ProjectSidebar.swift
+++ b/TinfoilChat/Views/ProjectSidebar.swift
@@ -12,7 +12,6 @@ struct ProjectSidebar: View {
     @Binding var isOpen: Bool
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
 
-    @State private var settingsExpanded = false
     @State private var documentsExpanded = true
     @State private var chatsExpanded = true
     @State private var showDocumentPicker = false
@@ -25,6 +24,7 @@ struct ProjectSidebar: View {
     @State private var deletingChatId: String?
     @State private var showDeleteChatAlert = false
     @State private var showDeleteProjectAlert = false
+    @State private var hasPendingChanges = false
 
     private var project: Project? {
         viewModel.activeProject
@@ -43,42 +43,28 @@ struct ProjectSidebar: View {
                     .padding(.vertical, 8)
             }
 
-            ScrollView {
-                VStack(spacing: 12) {
-                    settingsSection
-                    documentsSection
-                    chatsSection
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
+            List {
+                detailsSection
+                documentsSection
+                chatsSection
+                deleteSection
             }
-            .applyAlwaysBounceIfAvailable()
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Color.settingsBackground(for: colorScheme))
+            .scrollDismissesKeyboardIfAvailable()
 
             Divider()
                 .background(Color.gray.opacity(0.3))
 
-            Button {
-                viewModel.exitProject()
-                withAnimation {
-                    isOpen = false
-                }
-            } label: {
-                HStack {
-                    Image(systemName: "arrow.left")
-                    Text("Exit Project")
-                }
-                .padding(.vertical, 12)
+            exitButton
                 .padding(.horizontal, 16)
-                .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.plain)
-            .background(Color.sidebarButtonBackground(for: colorScheme))
-            .cornerRadius(8)
-            .padding(16)
-            .safeAreaPadding(.bottom)
+                .padding(.top, 8)
+                .padding(.bottom, 8)
+                .safeAreaPadding(.bottom)
         }
         .frame(width: 300)
-        .background(colorScheme == .dark ? Color.sidebarBackground(for: colorScheme) : Color.white)
+        .background(Color.settingsBackground(for: colorScheme))
         .ignoresSafeArea(edges: .bottom)
         .onAppear(perform: syncEditingState)
         .onChange(of: project?.id) { _, _ in syncEditingState() }
@@ -114,25 +100,18 @@ struct ProjectSidebar: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "folder")
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: "folder.fill")
+                    .font(.subheadline)
                     .foregroundColor(.accentColor)
-                Text(project?.name ?? "Loading...")
+                Text(project?.name ?? "Project")
                     .font(.headline)
                     .lineLimit(1)
                 Spacer()
-                Button {
-                    withAnimation {
-                        isOpen = false
-                    }
-                } label: {
-                    Image(systemName: "sidebar.left")
-                }
-                .buttonStyle(.plain)
             }
 
-            Text("Project context, documents, and chats")
+            Text("Context, documents, and chats")
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
@@ -145,94 +124,65 @@ struct ProjectSidebar: View {
         )
     }
 
-    private var settingsSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionHeader(title: "Project Params", systemImage: "slider.horizontal.3", isExpanded: $settingsExpanded)
+    private var detailsSection: some View {
+        Section("Details") {
+            TextField("Name", text: $editingName)
+                .submitLabel(.done)
+                .onChange(of: editingName) { _, _ in hasPendingChanges = true }
 
-            if settingsExpanded {
-                VStack(alignment: .leading, spacing: 10) {
-                    TextField("Project name", text: $editingName)
-                        .textFieldStyle(.roundedBorder)
+            TextField("Description", text: $editingDescription, axis: .vertical)
+                .lineLimit(2...4)
+                .onChange(of: editingDescription) { _, _ in hasPendingChanges = true }
 
-                    TextField("Description", text: $editingDescription, axis: .vertical)
-                        .textFieldStyle(.roundedBorder)
-                        .lineLimit(2...4)
+            TextField("Instructions", text: $editingInstructions, axis: .vertical)
+                .lineLimit(3...8)
+                .onChange(of: editingInstructions) { _, _ in hasPendingChanges = true }
 
-                    TextField("Instructions", text: $editingInstructions, axis: .vertical)
-                        .textFieldStyle(.roundedBorder)
-                        .lineLimit(3...8)
+            TextField("Memory (one fact per line)", text: $editingMemory, axis: .vertical)
+                .lineLimit(3...8)
+                .onChange(of: editingMemory) { _, _ in hasPendingChanges = true }
 
-                    TextField("Memory", text: $editingMemory, axis: .vertical)
-                        .textFieldStyle(.roundedBorder)
-                        .lineLimit(3...8)
-
-                    HStack {
-                        Button("Save") {
-                            Task {
-                                await viewModel.updateActiveProject(
-                                    name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
-                                    description: editingDescription,
-                                    systemInstructions: editingInstructions,
-                                    memory: memoryFactsFromEditor()
-                                )
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-
-                        Button("Delete", role: .destructive) {
-                            showDeleteProjectAlert = true
-                        }
-                        .buttonStyle(.bordered)
-                    }
+            Button {
+                Task {
+                    await viewModel.updateActiveProject(
+                        name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
+                        description: editingDescription,
+                        systemInstructions: editingInstructions,
+                        memory: memoryFactsFromEditor()
+                    )
+                    hasPendingChanges = false
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                    Text("Save changes")
+                    Spacer()
                 }
             }
+            .disabled(!hasPendingChanges || project == nil)
         }
-        .sectionCard()
+        .listRowBackground(Color.cardSurface(for: colorScheme))
     }
 
     private var documentsSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionHeader(title: "Project Documents", systemImage: "doc.text", isExpanded: $documentsExpanded)
-
-            if documentsExpanded {
+        Section {
+            DisclosureGroup(isExpanded: $documentsExpanded) {
                 if viewModel.projectDocuments.isEmpty && !viewModel.isUploadingProjectDocument {
-                    Text("No documents yet.")
-                        .font(.caption)
+                    Text("No documents yet")
+                        .font(.subheadline)
                         .foregroundColor(.secondary)
                 }
 
                 ForEach(viewModel.projectDocuments) { document in
-                    HStack(spacing: 8) {
-                        Image(systemName: "doc")
-                            .foregroundColor(.secondary)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(document.filename.isEmpty ? "Encrypted" : document.filename)
-                                .font(.subheadline)
-                                .lineLimit(1)
-                            Text(formatFileSize(document.sizeBytes))
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        Spacer()
-                        Button(role: .destructive) {
-                            Task {
-                                await viewModel.deleteProjectDocument(document.id)
-                            }
-                        } label: {
-                            Image(systemName: "trash")
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    .padding(8)
-                    .background(Color(UIColor.secondarySystemBackground).opacity(0.35))
-                    .cornerRadius(8)
+                    documentRow(document)
                 }
 
                 if viewModel.isUploadingProjectDocument {
-                    HStack {
+                    HStack(spacing: 8) {
                         ProgressView()
-                        Text("Uploading...")
-                            .font(.caption)
+                            .scaleEffect(0.8)
+                        Text("Uploading…")
+                            .font(.subheadline)
                             .foregroundColor(.secondary)
                     }
                 }
@@ -240,21 +190,43 @@ struct ProjectSidebar: View {
                 Button {
                     showDocumentPicker = true
                 } label: {
-                    Label("Add document", systemImage: "doc.badge.plus")
-                        .frame(maxWidth: .infinity)
+                    Label("Add document", systemImage: "plus.circle.fill")
                 }
-                .buttonStyle(.bordered)
                 .disabled(viewModel.isUploadingProjectDocument)
+            } label: {
+                Label("Documents", systemImage: "doc.text")
             }
         }
-        .sectionCard()
+        .listRowBackground(Color.cardSurface(for: colorScheme))
+    }
+
+    private func documentRow(_ document: ProjectDocument) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc")
+                .foregroundColor(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(document.filename.isEmpty ? "Encrypted" : document.filename)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                Text(formatFileSize(document.sizeBytes))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                Task {
+                    await viewModel.deleteProjectDocument(document.id)
+                }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
     }
 
     private var chatsSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionHeader(title: "Project Chats", systemImage: "bubble.left.and.bubble.right", isExpanded: $chatsExpanded)
-
-            if chatsExpanded {
+        Section {
+            DisclosureGroup(isExpanded: $chatsExpanded) {
                 Button {
                     viewModel.createNewChat(isLocalOnly: false, projectId: project?.id)
                     withAnimation {
@@ -262,79 +234,122 @@ struct ProjectSidebar: View {
                     }
                 } label: {
                     Label("New project chat", systemImage: "square.and.pencil")
-                        .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.bordered)
 
-                ForEach(viewModel.activeProjectChats) { chat in
-                    ChatListItem(
-                        chat: chat,
-                        isSelected: viewModel.currentChat?.id == chat.id,
-                        isEditing: editingChatId == chat.id,
-                        editingTitle: $editingTitle,
-                        timeString: relativeTimeString(from: chat.createdAt),
-                        onSelect: {
-                            viewModel.selectChat(chat)
-                            withAnimation {
-                                isOpen = false
-                            }
-                        },
-                        onEdit: {
-                            if editingChatId == chat.id {
-                                viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
-                                editingChatId = nil
-                            } else {
-                                editingChatId = chat.id
-                                editingTitle = chat.title
-                            }
-                        },
-                        onDelete: {
-                            deletingChatId = chat.id
-                            showDeleteChatAlert = true
-                        },
-                        showEditDelete: true
-                    )
-                    .contextMenu {
-                        Button {
-                            Task {
-                                await viewModel.removeChatFromProject(chatId: chat.id)
-                            }
-                        } label: {
-                            Label("Remove from Project", systemImage: "arrow.uturn.left")
-                        }
-
-                        ForEach(viewModel.projects.filter { $0.id != project?.id }) { destination in
-                            Button {
-                                Task {
-                                    await viewModel.moveChatToProject(chatId: chat.id, projectId: destination.id)
-                                }
-                            } label: {
-                                Label("Move to \(destination.name)", systemImage: "folder")
-                            }
-                        }
+                if viewModel.activeProjectChats.isEmpty {
+                    Text("No project chats yet")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(viewModel.activeProjectChats) { chat in
+                        chatRow(chat)
                     }
+                }
+            } label: {
+                Label("Chats", systemImage: "bubble.left.and.bubble.right")
+            }
+        }
+        .listRowBackground(Color.cardSurface(for: colorScheme))
+    }
+
+    private func chatRow(_ chat: Chat) -> some View {
+        Button {
+            viewModel.selectChat(chat)
+            withAnimation {
+                isOpen = false
+            }
+        } label: {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(chat.title)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    if !chat.isBlankChat {
+                        Text(relativeTimeString(from: chat.createdAt))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Spacer()
+                if viewModel.currentChat?.id == chat.id {
+                    Image(systemName: "checkmark")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.accentColor)
                 }
             }
         }
-        .sectionCard()
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                deletingChatId = chat.id
+                showDeleteChatAlert = true
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            Button {
+                Task {
+                    await viewModel.removeChatFromProject(chatId: chat.id)
+                }
+            } label: {
+                Label("Remove", systemImage: "arrow.uturn.left")
+            }
+            .tint(.orange)
+        }
+        .contextMenu {
+            Button {
+                Task {
+                    await viewModel.removeChatFromProject(chatId: chat.id)
+                }
+            } label: {
+                Label("Remove from Project", systemImage: "arrow.uturn.left")
+            }
+
+            ForEach(viewModel.projects.filter { $0.id != project?.id }) { destination in
+                Button {
+                    Task {
+                        await viewModel.moveChatToProject(chatId: chat.id, projectId: destination.id)
+                    }
+                } label: {
+                    Label("Move to \(destination.name)", systemImage: "folder")
+                }
+            }
+        }
     }
 
-    private func sectionHeader(title: String, systemImage: String, isExpanded: Binding<Bool>) -> some View {
+    private var deleteSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showDeleteProjectAlert = true
+            } label: {
+                Label("Delete project", systemImage: "trash")
+            }
+            .disabled(project == nil)
+        }
+        .listRowBackground(Color.cardSurface(for: colorScheme))
+    }
+
+    private var exitButton: some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded.wrappedValue.toggle()
+            viewModel.exitProject()
+            withAnimation {
+                isOpen = false
             }
         } label: {
             HStack {
-                Label(title, systemImage: systemImage)
-                    .font(.subheadline)
+                Image(systemName: "arrow.left")
+                Text("Exit Project")
                     .fontWeight(.medium)
-                Spacer()
-                Image(systemName: "chevron.down")
-                    .font(.caption)
-                    .rotationEffect(.degrees(isExpanded.wrappedValue ? 0 : -90))
-                    .foregroundColor(.secondary)
             }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity)
+            .background(Color.sidebarButtonBackground(for: colorScheme))
+            .foregroundColor(colorScheme == .dark ? .white : .black)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(colorScheme == .dark ? Color.white.opacity(0.08) : Color.gray.opacity(0.2), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
         }
         .buttonStyle(.plain)
     }
@@ -345,6 +360,7 @@ struct ProjectSidebar: View {
         editingDescription = project.description
         editingInstructions = project.systemInstructions
         editingMemory = project.memory.map(\.fact).joined(separator: "\n\n")
+        hasPendingChanges = false
     }
 
     private func memoryFactsFromEditor() -> [MemoryFact] {
@@ -392,19 +408,11 @@ struct ProjectSidebar: View {
 
 private extension View {
     @ViewBuilder
-    func applyAlwaysBounceIfAvailable() -> some View {
+    func scrollDismissesKeyboardIfAvailable() -> some View {
         if #available(iOS 16.0, *) {
-            self.scrollBounceBehavior(.always)
+            self.scrollDismissesKeyboard(.interactively)
         } else {
             self
         }
-    }
-
-    func sectionCard() -> some View {
-        self
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(UIColor.secondarySystemBackground).opacity(0.3))
-            .cornerRadius(12)
     }
 }

--- a/TinfoilChat/Views/ProjectSidebar.swift
+++ b/TinfoilChat/Views/ProjectSidebar.swift
@@ -12,6 +12,7 @@ struct ProjectSidebar: View {
     @Binding var isOpen: Bool
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
 
+    @State private var detailsExpanded = false
     @State private var documentsExpanded = true
     @State private var chatsExpanded = true
     @State private var showDocumentPicker = false
@@ -125,43 +126,75 @@ struct ProjectSidebar: View {
     }
 
     private var detailsSection: some View {
-        Section("Details") {
-            TextField("Name", text: $editingName)
-                .submitLabel(.done)
-                .onChange(of: editingName) { _, _ in hasPendingChanges = true }
-
-            TextField("Description", text: $editingDescription, axis: .vertical)
-                .lineLimit(2...4)
-                .onChange(of: editingDescription) { _, _ in hasPendingChanges = true }
-
-            TextField("Instructions", text: $editingInstructions, axis: .vertical)
-                .lineLimit(3...8)
-                .onChange(of: editingInstructions) { _, _ in hasPendingChanges = true }
-
-            TextField("Memory (one fact per line)", text: $editingMemory, axis: .vertical)
-                .lineLimit(3...8)
-                .onChange(of: editingMemory) { _, _ in hasPendingChanges = true }
-
-            Button {
-                Task {
-                    await viewModel.updateActiveProject(
-                        name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
-                        description: editingDescription,
-                        systemInstructions: editingInstructions,
-                        memory: memoryFactsFromEditor()
-                    )
-                    hasPendingChanges = false
+        Section {
+            DisclosureGroup(isExpanded: $detailsExpanded) {
+                fieldRow(label: "Name") {
+                    TextField("Project name", text: $editingName)
+                        .submitLabel(.done)
+                        .multilineTextAlignment(.trailing)
+                        .onChange(of: editingName) { _, _ in hasPendingChanges = true }
                 }
+
+                multilineFieldRow(label: "Description", placeholder: "What is this project about?", text: $editingDescription, lineLimit: 2...4)
+
+                multilineFieldRow(label: "Instructions", placeholder: "How should Tin behave in this project?", text: $editingInstructions, lineLimit: 3...8)
+
+                multilineFieldRow(label: "Memory", placeholder: "One fact per line", text: $editingMemory, lineLimit: 3...8)
+
+                Button {
+                    Task {
+                        await viewModel.updateActiveProject(
+                            name: editingName.trimmingCharacters(in: .whitespacesAndNewlines),
+                            description: editingDescription,
+                            systemInstructions: editingInstructions,
+                            memory: memoryFactsFromEditor()
+                        )
+                        hasPendingChanges = false
+                    }
+                } label: {
+                    Label("Save changes", systemImage: "checkmark.circle.fill")
+                }
+                .disabled(!hasPendingChanges || project == nil)
             } label: {
-                HStack {
-                    Image(systemName: "checkmark.circle.fill")
-                    Text("Save changes")
-                    Spacer()
-                }
+                Label("Details", systemImage: "slider.horizontal.3")
             }
-            .disabled(!hasPendingChanges || project == nil)
         }
         .listRowBackground(Color.cardSurface(for: colorScheme))
+    }
+
+    private func fieldRow<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+            Spacer()
+            content()
+                .font(.subheadline)
+        }
+    }
+
+    private func multilineFieldRow(label: String, placeholder: String, text: Binding<String>, lineLimit: ClosedRange<Int>) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label.uppercased())
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+                .tracking(0.5)
+
+            TextField(placeholder, text: text, axis: .vertical)
+                .font(.subheadline)
+                .lineLimit(lineLimit)
+                .padding(10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.settingsBackground(for: colorScheme))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Color.gray.opacity(0.25), lineWidth: 1)
+                )
+                .onChange(of: text.wrappedValue) { _, _ in hasPendingChanges = true }
+        }
+        .padding(.vertical, 4)
     }
 
     private var documentsSection: some View {

--- a/TinfoilChatTests/ProjectChatEncodingTests.swift
+++ b/TinfoilChatTests/ProjectChatEncodingTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ProjectChatEncodingTests {
+    @Test @MainActor
+    func chatCreatePreservesProjectId() {
+        let chat = Chat.create(
+            id: "chat-1",
+            modelType: Self.testModel,
+            projectId: "project-1"
+        )
+
+        #expect(chat.projectId == "project-1")
+        #expect(chat.isLocalOnly == false)
+    }
+
+    @Test @MainActor
+    func storedChatRoundTripsProjectId() throws {
+        let chat = Chat.create(
+            id: "chat-1",
+            modelType: Self.testModel,
+            projectId: "project-1"
+        )
+        let stored = StoredChat(from: chat)
+        let data = try JSONEncoder().encode(stored)
+        let decoded = try JSONDecoder().decode(StoredChat.self, from: data)
+
+        #expect(decoded.projectId == "project-1")
+    }
+
+    private static let testModel = ModelType(
+        from: AppModelConfig(
+            modelName: "gpt-oss-120b",
+            image: "openai.png",
+            name: "GPT OSS 120B",
+            nameShort: "GPT OSS",
+            description: "",
+            details: "",
+            parameters: "",
+            contextWindow: "64k tokens",
+            type: "chat",
+            chat: true,
+            paid: false,
+            multimodal: false,
+            reasoningConfig: nil
+        )
+    )
+}

--- a/TinfoilChatTests/ProjectContextBuilderTests.swift
+++ b/TinfoilChatTests/ProjectContextBuilderTests.swift
@@ -3,6 +3,18 @@ import Testing
 @testable import TinfoilChat
 
 struct ProjectContextBuilderTests {
+    @Test func decodesEncryptedContentObjectOrString() throws {
+        let envelope = EncryptedData(iv: "iv", data: "data")
+        let objectData = try JSONEncoder().encode(envelope)
+        let stringData = try JSONEncoder().encode(String(data: objectData, encoding: .utf8) ?? "")
+
+        let objectDecoded = try JSONDecoder().decode(EncryptedProjectContent.self, from: objectData)
+        let stringDecoded = try JSONDecoder().decode(EncryptedProjectContent.self, from: stringData)
+
+        #expect(objectDecoded.encryptedData.iv == "iv")
+        #expect(stringDecoded.encryptedData.data == "data")
+    }
+
     @Test func buildsWebappCompatibleProjectContext() {
         let project = Project(
             id: "project-1",

--- a/TinfoilChatTests/ProjectContextBuilderTests.swift
+++ b/TinfoilChatTests/ProjectContextBuilderTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ProjectContextBuilderTests {
+    @Test func buildsWebappCompatibleProjectContext() {
+        let project = Project(
+            id: "project-1",
+            name: "Private Penguin",
+            description: "Launch notes",
+            systemInstructions: "Prefer concise answers.",
+            memory: [
+                MemoryFact(
+                    id: "fact-1",
+                    fact: "User likes short updates.",
+                    date: "2026-05-07T00:00:00.000Z",
+                    category: "preference",
+                    confidence: 1
+                )
+            ],
+            createdAt: "2026-05-07T00:00:00.000Z",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+            syncVersion: 1
+        )
+        let documents = [
+            ProjectDocument(
+                id: "doc-1",
+                projectId: "project-1",
+                filename: "brief.md",
+                contentType: "text/markdown",
+                sizeBytes: 12,
+                syncVersion: 1,
+                createdAt: "2026-05-07T00:00:00.000Z",
+                updatedAt: "2026-05-07T00:00:00.000Z",
+                content: "Important context"
+            )
+        ]
+
+        let context = ProjectContextBuilder.build(project: project, documents: documents)
+
+        #expect(context.contains("## Project: Private Penguin"))
+        #expect(context.contains("Launch notes"))
+        #expect(context.contains("### Instructions\nPrefer concise answers."))
+        #expect(context.contains("--- brief.md ---\nImportant context"))
+        #expect(!context.contains("User likes short updates."))
+    }
+
+    @Test func wrapsSystemPromptWithProjectContext() {
+        let project = Project(
+            id: "project-1",
+            name: "Private Penguin",
+            description: "",
+            systemInstructions: "",
+            memory: [],
+            createdAt: "2026-05-07T00:00:00.000Z",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+            syncVersion: 1
+        )
+
+        let prompt = ProjectContextBuilder.applyProjectContext(
+            to: "Base prompt",
+            project: project,
+            documents: []
+        )
+
+        #expect(prompt == "Base prompt\n\n<project_context>\n## Project: Private Penguin\n\n</project_context>")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add full project support with project-scoped chats, documents, and prompt context. Replaces the old Project Sidebar with a full-screen Project Page and smoother navigation.

- **New Features**
  - Storage and sync: project models and `ProjectStorageService`; `CloudStorageService` adds project chat APIs; `CloudSyncService` syncs project chats (delta) with cached per‑project status.
  - Chat and UI: `Chat.projectId`; root sidebar hides project chats; ChatSidebar gets a Projects section; new full‑screen Project Page with inline name editing, document management, and project chat navigation; back button while inside a project; on project exit, the sidebar opens and Projects are collapsed by default.
  - Documents: broader picker (docx, pptx, xlsx, json, xml, images); private conversion via `DocumentConversionService` using `TinfoilAI`.
  - Prompting: `ProjectContextBuilder` builds project context and wraps the system prompt.
  - Tests: coverage for project chat encoding and project context.

- **Bug Fixes**
  - Reliability: load all project pages and fix listProjects argument order; keep project mode after entering; restore local chat placement if a move fails; share project chat sync logic and isolate per‑chat failures; serialize chat uploads through a queue to avoid races; protect profile edits and details during sync.
  - Navigation and layout: unify project navigation under the root nav bar, prevent keyboard inset issues, stop the Project Page from extending under the nav bar, make the sidebar fully scrollable when sections expand, and navigate directly to a chat when opening or creating a project chat.
  - Security: neutralize `<project_context>` markers in user content; sanitize multipart header values to prevent injection.

<sup>Written for commit ccfdae15361445b70e5cbca612bf569f3db84966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

