### PR TITLE
fix: surface stale passkey backup state

### DIFF
--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -611,6 +611,7 @@ enum CloudStorageError: LocalizedError {
     case metadataUpdateFailed
     case encryptionFailed
     case decryptionFailed
+    case encryptionKeyRequired
 
     var errorDescription: String? {
         switch self {
@@ -632,6 +633,8 @@ enum CloudStorageError: LocalizedError {
             return "Failed to encrypt chat data"
         case .decryptionFailed:
             return "Failed to decrypt chat data"
+        case .encryptionKeyRequired:
+            return "Cloud sync writes are paused until this device verifies the current encryption key"
         }
     }
 }

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -31,6 +31,7 @@ final class PasskeyManager: ObservableObject {
     @Published var passkeyActive: Bool = false
     @Published var passkeySetupAvailable: Bool = false
     @Published var showPasskeyRecoveryChoice: Bool = false
+    @Published var passkeyBackupNeedsAttention: Bool = false
 
     // MARK: - Callbacks
 
@@ -55,6 +56,7 @@ final class PasskeyManager: ObservableObject {
         passkeyActive = false
         passkeySetupAvailable = false
         showPasskeyRecoveryChoice = false
+        passkeyBackupNeedsAttention = false
         onRecoveryComplete = nil
         onKeyRefreshedFromBackup = nil
         syncCheckTask?.cancel()
@@ -124,6 +126,13 @@ final class PasskeyManager: ObservableObject {
     ) async -> Bool {
         guard let user = Clerk.shared.user else { return false }
 
+        if authorizationMode != .explicitStartFresh {
+            guard await CloudKeyPreflightValidator.shared.inspectRemoteState() == .empty else {
+                passkeySetupAvailable = true
+                return false
+            }
+        }
+
         let newKey = EncryptionService.shared.generateKey()
 
         do {
@@ -154,6 +163,7 @@ final class PasskeyManager: ObservableObject {
                 throw CloudKeyAuthorizationError.authorizationUnavailable
             }
             activatePasskey()
+            passkeyBackupNeedsAttention = false
             return true
 
         } catch {
@@ -273,9 +283,11 @@ final class PasskeyManager: ObservableObject {
 
             passkeyActive = true
             passkeySetupAvailable = false
+            passkeyBackupNeedsAttention = false
             startSyncCheck()
         } catch {
-            // Passkey creation failed or cancelled — leave state unchanged
+            passkeyBackupNeedsAttention = true
+            passkeySetupAvailable = true
         }
     }
 
@@ -354,8 +366,10 @@ final class PasskeyManager: ObservableObject {
             )
             setLocalSyncVersion(credentialId: result.credentialId, version: saveResult.syncVersion)
             setLocalBundleVersion(saveResult.bundleVersion)
+            passkeyBackupNeedsAttention = false
         } catch {
-            // Non-fatal — passkey backup is stale but user can re-backup from Settings
+            passkeyBackupNeedsAttention = true
+            passkeySetupAvailable = true
         }
     }
 
@@ -364,6 +378,7 @@ final class PasskeyManager: ObservableObject {
     private func activatePasskey() {
         SettingsManager.shared.isCloudSyncEnabled = true
         passkeyActive = true
+        passkeyBackupNeedsAttention = false
         startSyncCheck()
     }
 
@@ -488,8 +503,6 @@ final class PasskeyManager: ObservableObject {
     /// Uses the cached PRF to avoid biometric prompts. If no cached PRF
     /// is available, the check is skipped silently.
     private func refreshKeyFromPasskeyBackup() async {
-        var pendingRemoteVersion: (credentialId: String, syncVersion: Int, bundleVersion: Int)?
-
         do {
             guard let cached = passkeyService.getCachedPrfResult() else { return }
 
@@ -513,11 +526,6 @@ final class PasskeyManager: ObservableObject {
                 return
             }
 
-            pendingRemoteVersion = (
-                credentialId: cached.credentialId,
-                syncVersion: entry.sync_version,
-                bundleVersion: entry.bundle_version ?? 0
-            )
             let appliedMode = try await applyRecoveredKeyBundle(bundle)
 
             setLocalSyncVersion(credentialId: cached.credentialId, version: entry.sync_version)
@@ -529,14 +537,6 @@ final class PasskeyManager: ObservableObject {
 
             onKeyRefreshedFromBackup?()
         } catch {
-            if error is CloudKeyAuthorizationError,
-               let pendingRemoteVersion {
-                setLocalSyncVersion(
-                    credentialId: pendingRemoteVersion.credentialId,
-                    version: pendingRemoteVersion.syncVersion
-                )
-                setLocalBundleVersion(pendingRemoteVersion.bundleVersion)
-            }
             // Non-fatal — will retry on next interval
         }
     }

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -78,6 +78,19 @@ final class ProjectStorageService: ObservableObject {
         }
     }
 
+    @MainActor
+    private func ensureCloudWritesAuthorized() async throws {
+        if CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey() {
+            return
+        }
+
+        let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+        guard validation.canWrite,
+              CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated) else {
+            throw CloudStorageError.encryptionKeyRequired
+        }
+    }
+
     func generateProjectId() async throws -> GenerateProjectIdResponse {
         var request = URLRequest(url: URL(string: "\(apiBaseURL)/api/projects/generate-id")!)
         request.httpMethod = "POST"
@@ -86,6 +99,8 @@ final class ProjectStorageService: ObservableObject {
     }
 
     func createProject(_ data: CreateProjectData) async throws -> Project {
+        try await ensureCloudWritesAuthorized()
+
         let idResponse = try await generateProjectId()
         let payload = ProjectData(
             name: data.name,
@@ -115,6 +130,8 @@ final class ProjectStorageService: ObservableObject {
     }
 
     func updateProject(_ projectId: String, data: UpdateProjectData) async throws {
+        try await ensureCloudWritesAuthorized()
+
         guard let existing = try await getProject(projectId) else {
             throw CloudStorageError.invalidResponse
         }
@@ -263,6 +280,8 @@ final class ProjectStorageService: ObservableObject {
     }
 
     func uploadDocument(projectId: String, filename: String, contentType: String, content: String) async throws -> ProjectDocument {
+        try await ensureCloudWritesAuthorized()
+
         let idResponse = try await generateDocumentId(projectId: projectId)
         let payload = ProjectDocumentPayload(content: content, filename: filename, contentType: contentType)
         let encrypted = try await EncryptionService.shared.encrypt(payload)

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -129,6 +129,12 @@ struct CloudSyncSettingsView: View {
                             .font(.caption)
                             .foregroundColor(.orange)
                     }
+
+                    if passkeyManager.passkeyBackupNeedsAttention {
+                        Text("Your passkey backup could not be updated with the current encryption key. Re-add a passkey or reveal and save your backup key before signing out.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                    }
                     
                     Button(action: {
                         Task {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Surfaced stale passkey backup state in settings and blocked cloud writes until the device validates the current encryption key. This adds a clear warning and prevents accidental divergence.

- **Bug Fixes**
  - Show an orange warning in Cloud Sync settings when the passkey backup can’t be updated.
  - Track `passkeyBackupNeedsAttention` in `PasskeyManager`; reset on success, set on backup/create failures; preflight prevents new passkey if remote state isn’t empty (unless starting fresh).
  - Require an authorized primary key for project create/update/upload; throw `encryptionKeyRequired` with a clear message when not validated.

<sup>Written for commit 0503f1babc949a6d9b42f30fe63109054c370983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

