### PR TITLE
Fix GenUI tool calling

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.0;
+				minimumVersion = 0.5.3;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "baa3ae77cdd4f329225ec34bb480b009ace35ebf",
-        "version" : "0.0.7"
+        "revision" : "7867e9f7f9553e95ef07324e6039a817d9275f25",
+        "version" : "0.0.8"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "95ccaf65bd716fbe8d66b39aeeab7548724096ba",
-        "version" : "0.5.2"
+        "revision" : "3314e5a06042bfa1209dd7afa20fabd03f1b85fb",
+        "version" : "0.5.3"
       }
     }
   ],

--- a/TinfoilChat/Services/StreamingMarkdownChunker.swift
+++ b/TinfoilChat/Services/StreamingMarkdownChunker.swift
@@ -236,6 +236,7 @@ class StreamingMarkdownChunker {
         let lines = bufferedLines()
         guard lines.count >= 2 else { return nil }
 
+        var hasCompletedDataRow = false
         for (index, line) in lines.enumerated() where index >= 2 {
             let trimmed = line.text.trimmingCharacters(in: .whitespaces)
             let isIncompleteCurrentLine = index == lines.count - 1 && !line.hasTerminatingNewline
@@ -250,13 +251,14 @@ class StreamingMarkdownChunker {
             }
 
             guard isPotentialTableRow(line.text) else {
-                guard !isIncompleteCurrentLine || allowIncompleteTrailingContent else { return nil }
+                guard hasCompletedDataRow || !isIncompleteCurrentLine || allowIncompleteTrailingContent else { return nil }
                 let tableEnd = line.range.lowerBound
                 return (
                     table: String(workingBuffer[..<tableEnd]),
                     trailing: String(workingBuffer[tableEnd...])
                 )
             }
+            hasCompletedDataRow = true
         }
 
         return nil

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -147,9 +147,9 @@ struct ChatQueryBuilder {
                 // Emit `tool_calls` on the assistant message so the model
                 // sees its previously-rendered widgets, then synthesize
                 // `role: 'tool'` results so the API's tool-call/tool-result
-                // pairing rule is satisfied. GenUI tools are display-only
-                // (the client rendered the component); we acknowledge with
-                // a constant payload that mirrors the webapp.
+                // pairing rule is satisfied. Auto-continue tools have no
+                // real side effect, so we acknowledge with the same inert
+                // payload the router synthesises mid-turn for consistency.
                 let toolCallParams: [ChatQuery.ChatCompletionMessageParam.AssistantMessageParam.ToolCallParam]? = msg.toolCalls.isEmpty
                     ? nil
                     : msg.toolCalls.map { tc in
@@ -172,7 +172,7 @@ struct ChatQueryBuilder {
                 if let toolCallParams {
                     for param in toolCallParams {
                         messages.append(.tool(.init(
-                            content: .textContent("displayed"),
+                            content: .textContent("executed"),
                             toolCallId: param.id
                         )))
                     }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1900,12 +1900,6 @@ class ChatViewModel: ObservableObject {
                 //     that the webapp uses to track resolution state.
                 var streamingToolCalls: [Int: GenUIToolCall] = [:]
                 var timelineBlocks: [JSONValue] = []
-                // Once the assistant has emitted a tool call on this
-                // turn, drop subsequent `delta.content` — providers
-                // sometimes trail serialization noise (fragments of the
-                // tool name) through the content channel. Mirrors the
-                // webapp event-normalizer's `sawToolCall` gate.
-                var sawToolCall = false
                 let appendToolCallSegment: (String) -> Void = { toolCallId in
                     if !segments.contains(where: {
                         if case .toolCall(let id) = $0, id == toolCallId { return true }
@@ -1984,12 +1978,6 @@ class ChatViewModel: ObservableObject {
                     }
 
                     var content = chunk.choices.first?.delta.content ?? ""
-                    // Once a tool call has been seen on this turn, drop
-                    // any further `delta.content` to suppress provider
-                    // serialization noise. Mirrors the webapp.
-                    if sawToolCall {
-                        content = ""
-                    }
                     // Strip router-emitted `<tinfoil-event>` markers
                     // from the delta before any downstream logic sees
                     // it, and dispatch the decoded events so the same
@@ -2035,7 +2023,6 @@ class ChatViewModel: ObservableObject {
                                     name: mergedName,
                                     arguments: mergedArgs
                                 )
-                                sawToolCall = true
                             }
                             didMutateState = true
                         }

--- a/TinfoilChat/Views/GenUI/GenUIRegistry.swift
+++ b/TinfoilChat/Views/GenUI/GenUIRegistry.swift
@@ -48,6 +48,9 @@ final class GenUIRegistry {
     }
 
     /// Build the OpenAI `tools` array used on chat completion requests.
+    /// Each GenUI tool is flagged with the router's auto-continue header
+    /// so the model produces a single coherent turn (tool call followed
+    /// by surrounding prose) instead of ending at the tool boundary.
     func buildToolParams() -> [ChatQuery.ChatCompletionToolParam] {
         widgets.map { widget in
             ChatQuery.ChatCompletionToolParam(
@@ -55,7 +58,10 @@ final class GenUIRegistry {
                     name: widget.name,
                     description: widget.description,
                     parameters: widget.schema,
-                    strict: nil
+                    strict: nil,
+                    extra: [
+                        "x-tinfoil-tool-auto-continue": .bool(true),
+                    ]
                 )
             )
         }

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -373,13 +373,9 @@ struct LaTeXMarkdownView: View, Equatable {
             }
             j += 1
 
-            // Capture URL (everything up to the next `~`)
-            let urlStart = j
-            var urlEnd = j
             var foundTilde = false
             while j < count {
                 if chars[j] == "~" {
-                    urlEnd = j
                     foundTilde = true
                     break
                 }
@@ -413,20 +409,6 @@ struct LaTeXMarkdownView: View, Equatable {
             }
 
             if found {
-                // Convert citation to a markdown link: [domain](URL)
-                var urlView = String.UnicodeScalarView()
-                for k in urlStart..<urlEnd { urlView.append(chars[k]) }
-                let url = String(urlView)
-                let linkUrl = url.removingPercentEncoding ?? url
-                let domain: String
-                if let parsed = URL(string: linkUrl), let host = parsed.host {
-                    domain = host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
-                } else {
-                    domain = linkUrl
-                }
-                for c in " [\(domain)](\(linkUrl))".unicodeScalars {
-                    result.append(c)
-                }
                 i = j
             } else {
                 for k in i..<j {

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -164,7 +164,8 @@ struct ChatQueryBuilderReasoningTests {
         #expect(body == nil)
     }
 
-    @Test func extraBodyMakesItIntoEncodedChatQuery() throws {
+    @Test @MainActor
+    func extraBodyMakesItIntoEncodedChatQuery() throws {
         let query = ChatQueryBuilder.buildQuery(
             modelId: "deepseek-v4-pro",
             systemPrompt: "you are tin",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes GenUI tool calling so the model continues in one turn around widgets by enabling auto-continue and aligning tool-result payloads. Also improves streamed table parsing and cleans up inline citation markers.

- **Bug Fixes**
  - GenUI tools: add `x-tinfoil-tool-auto-continue`, synthesize `role: 'tool'` results with "executed", and stop dropping assistant deltas after a tool call.
  - Markdown: split streamed tables from following text only after a completed data row; remove inline citation markers without inserting links.

- **Dependencies**
  - Bump `tinfoil-swift` to 0.5.3.
  - Bump `openai-swift-fork` to 0.0.8.

<sup>Written for commit eb800f6856dc4a1e8fec6114f1b02944299e939d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

