### PR TITLE
feat: use OAuth for chat inference tokens

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -86,6 +86,18 @@ enum Constants {
         }
     }
 
+    enum OAuth {
+        static let clientID = Bundle.main.object(forInfoDictionaryKey: "TINFOIL_OAUTH_CLIENT_ID") as? String ?? ""
+        static let authorizeURL = URL(string: "https://dash.tinfoil.sh/oauth/authorize")!
+        static let tokenURL = URL(string: "\(Constants.API.baseURL)/oauth/token")!
+        static let revokeURL = URL(string: "\(Constants.API.baseURL)/oauth/revoke")!
+        static let redirectScheme = "sh.tinfoil.tinfoilchat"
+        static let redirectURI = "\(redirectScheme)://oauth/callback"
+        static let scope = "inference:chat offline_access"
+        static let accessTokenExpiryBufferSeconds: TimeInterval = 60
+        static let codeVerifierByteCount = 32
+        static let stateByteCount = 16
+    }
 
     enum Legal {
         static let termsOfServiceURL = URL(string: "https://www.tinfoil.sh/terms")!
@@ -257,6 +269,7 @@ enum Constants {
             static let passkeyBackedUp = "tinfoil-secret-passkey-backed-up"
             static let passkeySyncVersion = "tinfoil-secret-passkey-sync-version"
             static let passkeyBundleVersion = "tinfoil-secret-passkey-bundle-version"
+            static let oauthRefreshToken = "tinfoil-secret-oauth-refresh-token"
 
             static func cloudKeyAuthorization(userId: String) -> String {
                 "tinfoil-secret-cloud-key-authorization-\(userId)"

--- a/TinfoilChat/Info.plist
+++ b/TinfoilChat/Info.plist
@@ -2,10 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>sh.tinfoil.TinfoilChat</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sh.tinfoil.tinfoilchat</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Tinfoil needs access to your camera to take photos and scan QR codes.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tinfoil needs access to your microphone for voice dictation.</string>
+	<key>TINFOIL_OAUTH_CLIENT_ID</key>
+	<string></string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UILaunchScreen</key>

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1133,6 +1133,11 @@ class SessionTokenManager {
 
     private init() {}
 
+    private func shouldUseOAuthSessionToken() -> Bool {
+        OAuthTokenManager.shared.isConfigured &&
+        (OAuthTokenManager.shared.hasRefreshToken || UserDefaults.standard.bool(forKey: Constants.StorageKeys.Auth.subscription))
+    }
+
     /// Retrieves the session token, returning the cached value if still valid
     /// - Returns: Session token string or empty string if unavailable
     func getSessionToken() async -> String {
@@ -1168,6 +1173,19 @@ class SessionTokenManager {
                             try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
                         }
                         continue
+                    }
+
+                    if shouldUseOAuthSessionToken() {
+                        do {
+                            if let oauthToken = try await OAuthTokenManager.shared.getAccessToken() {
+                                self.sessionToken = oauthToken.value
+                                self.sessionTokenExpiresAt = oauthToken.expiresAt
+                                self.rateLimitInfo = nil
+                                return oauthToken.value
+                            }
+                        } catch {
+                            return ""
+                        }
                     }
 
                     // Try fetching the session key with this JWT
@@ -1308,5 +1326,6 @@ class SessionTokenManager {
         sessionToken = nil
         sessionTokenExpiresAt = nil
         rateLimitInfo = nil
+        OAuthTokenManager.shared.clearAccessToken()
     }
 }

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1175,17 +1175,17 @@ class SessionTokenManager {
                         continue
                     }
 
+                    // Subscribed users authenticate inference through OAuth only.
+                    // The legacy key endpoint is reserved for anonymous/free users,
+                    // so never fall back to it once OAuth is in use.
                     if shouldUseOAuthSessionToken() {
-                        do {
-                            if let oauthToken = try await OAuthTokenManager.shared.getAccessToken() {
-                                self.sessionToken = oauthToken.value
-                                self.sessionTokenExpiresAt = oauthToken.expiresAt
-                                self.rateLimitInfo = nil
-                                return oauthToken.value
-                            }
-                        } catch {
+                        guard let oauthToken = try? await OAuthTokenManager.shared.getAccessToken() else {
                             return ""
                         }
+                        self.sessionToken = oauthToken.value
+                        self.sessionTokenExpiresAt = oauthToken.expiresAt
+                        self.rateLimitInfo = nil
+                        return oauthToken.value
                     }
 
                     // Try fetching the session key with this JWT

--- a/TinfoilChat/Services/OAuthTokenManager.swift
+++ b/TinfoilChat/Services/OAuthTokenManager.swift
@@ -62,6 +62,7 @@ final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextP
     private let keychain = KeychainHelper.shared
     private var accessToken: OAuthAccessToken?
     private var webAuthenticationSession: ASWebAuthenticationSession?
+    private var inFlightTask: Task<OAuthAccessToken?, Error>?
     private let decoder = JSONDecoder()
 
     private override init() {}
@@ -79,6 +80,24 @@ final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextP
             return nil
         }
 
+        if let accessToken, !isExpiring(accessToken.expiresAt) {
+            return accessToken
+        }
+
+        // Coalesce concurrent callers so a rotating refresh token is only spent
+        // once and only a single authorization session is ever presented.
+        if let inFlightTask {
+            return try await inFlightTask.value
+        }
+
+        let task = Task { try await self.resolveAccessToken() }
+        inFlightTask = task
+        defer { inFlightTask = nil }
+
+        return try await task.value
+    }
+
+    private func resolveAccessToken() async throws -> OAuthAccessToken? {
         if let accessToken, !isExpiring(accessToken.expiresAt) {
             return accessToken
         }

--- a/TinfoilChat/Services/OAuthTokenManager.swift
+++ b/TinfoilChat/Services/OAuthTokenManager.swift
@@ -1,0 +1,323 @@
+//
+//  OAuthTokenManager.swift
+//  TinfoilChat
+//
+//  Created on 05/29/26.
+//  Copyright © 2026 Tinfoil. All rights reserved.
+//
+
+import AuthenticationServices
+import CryptoKit
+import Foundation
+import Security
+import UIKit
+
+struct OAuthAccessToken {
+    let value: String
+    let expiresAt: Date
+}
+
+enum OAuthTokenManagerError: LocalizedError {
+    case notConfigured
+    case randomBytesUnavailable
+    case invalidAuthorizationURL
+    case invalidCallbackState
+    case missingAuthorizationCode
+    case cancelled
+    case requestFailed(statusCode: Int, code: String?)
+    case invalidTokenResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "OAuth client ID is not configured."
+        case .randomBytesUnavailable:
+            return "Could not generate secure random bytes."
+        case .invalidAuthorizationURL:
+            return "Could not build the OAuth authorization URL."
+        case .invalidCallbackState:
+            return "OAuth callback state did not match."
+        case .missingAuthorizationCode:
+            return "OAuth callback did not include an authorization code."
+        case .cancelled:
+            return "OAuth authorization was cancelled."
+        case .requestFailed(let statusCode, let code):
+            return code ?? "OAuth token request failed with status \(statusCode)."
+        case .invalidTokenResponse:
+            return "OAuth token response was invalid."
+        }
+    }
+
+    var shouldClearRefreshToken: Bool {
+        if case .requestFailed(_, let code) = self {
+            return code == "invalid_grant" || code == "invalid_client"
+        }
+        return false
+    }
+}
+
+final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextProviding {
+    static let shared = OAuthTokenManager()
+
+    private let keychain = KeychainHelper.shared
+    private var accessToken: OAuthAccessToken?
+    private var webAuthenticationSession: ASWebAuthenticationSession?
+    private let decoder = JSONDecoder()
+
+    private override init() {}
+
+    var isConfigured: Bool {
+        !Constants.OAuth.clientID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var hasRefreshToken: Bool {
+        loadRefreshToken() != nil
+    }
+
+    func getAccessToken() async throws -> OAuthAccessToken? {
+        guard isConfigured else {
+            return nil
+        }
+
+        if let accessToken, !isExpiring(accessToken.expiresAt) {
+            return accessToken
+        }
+
+        if hasRefreshToken {
+            do {
+                if let refreshed = try await refreshAccessToken() {
+                    return refreshed
+                }
+            } catch let error as OAuthTokenManagerError where error.shouldClearRefreshToken {
+                clearTokens()
+            }
+        }
+
+        return try await authorize()
+    }
+
+    func clearAccessToken() {
+        accessToken = nil
+    }
+
+    func clearTokens() {
+        accessToken = nil
+        keychain.delete(for: Constants.StorageKeys.Secret.oauthRefreshToken)
+    }
+
+    func revokeAndClearTokens() async {
+        let tokenToRevoke = loadRefreshToken() ?? accessToken?.value
+
+        defer {
+            clearTokens()
+        }
+
+        guard isConfigured, let tokenToRevoke else {
+            return
+        }
+
+        var request = URLRequest(url: Constants.OAuth.revokeURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = formBody([
+            "client_id": Constants.OAuth.clientID,
+            "token": tokenToRevoke
+        ])
+
+        _ = try? await URLSession.shared.data(for: request)
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+
+    private func authorize() async throws -> OAuthAccessToken {
+        guard isConfigured else {
+            throw OAuthTokenManagerError.notConfigured
+        }
+
+        let state = try Self.randomBase64URL(byteCount: Constants.OAuth.stateByteCount)
+        let codeVerifier = try Self.randomBase64URL(byteCount: Constants.OAuth.codeVerifierByteCount)
+        let codeChallenge = Self.codeChallenge(for: codeVerifier)
+
+        var components = URLComponents(url: Constants.OAuth.authorizeURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: Constants.OAuth.clientID),
+            URLQueryItem(name: "redirect_uri", value: Constants.OAuth.redirectURI),
+            URLQueryItem(name: "scope", value: Constants.OAuth.scope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256")
+        ]
+
+        guard let authorizationURL = components?.url else {
+            throw OAuthTokenManagerError.invalidAuthorizationURL
+        }
+
+        let callbackURL = try await startAuthenticationSession(url: authorizationURL)
+        let callbackComponents = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+        let callbackState = callbackComponents?.queryItems?.first { $0.name == "state" }?.value
+
+        guard callbackState == state else {
+            throw OAuthTokenManagerError.invalidCallbackState
+        }
+
+        guard let code = callbackComponents?.queryItems?.first(where: { $0.name == "code" })?.value else {
+            throw OAuthTokenManagerError.missingAuthorizationCode
+        }
+
+        return try await exchangeAuthorizationCode(code, codeVerifier: codeVerifier)
+    }
+
+    @MainActor
+    private func startAuthenticationSession(url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: Constants.OAuth.redirectScheme
+            ) { [weak self] callbackURL, error in
+                Task { @MainActor in
+                    self?.webAuthenticationSession = nil
+                }
+
+                if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                    return
+                }
+
+                if let authError = error as? ASWebAuthenticationSessionError,
+                   authError.code == .canceledLogin {
+                    continuation.resume(throwing: OAuthTokenManagerError.cancelled)
+                    return
+                }
+
+                continuation.resume(throwing: error ?? OAuthTokenManagerError.cancelled)
+            }
+
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            webAuthenticationSession = session
+
+            if !session.start() {
+                webAuthenticationSession = nil
+                continuation.resume(throwing: OAuthTokenManagerError.cancelled)
+            }
+        }
+    }
+
+    private func exchangeAuthorizationCode(_ code: String, codeVerifier: String) async throws -> OAuthAccessToken {
+        try await requestToken([
+            "grant_type": "authorization_code",
+            "client_id": Constants.OAuth.clientID,
+            "code": code,
+            "code_verifier": codeVerifier,
+            "redirect_uri": Constants.OAuth.redirectURI
+        ])
+    }
+
+    private func refreshAccessToken() async throws -> OAuthAccessToken? {
+        guard let refreshToken = loadRefreshToken() else {
+            return nil
+        }
+
+        return try await requestToken([
+            "grant_type": "refresh_token",
+            "client_id": Constants.OAuth.clientID,
+            "refresh_token": refreshToken
+        ])
+    }
+
+    private func requestToken(_ params: [String: String]) async throws -> OAuthAccessToken {
+        var request = URLRequest(url: Constants.OAuth.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = formBody(params)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OAuthTokenManagerError.invalidTokenResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let errorResponse = try? decoder.decode(OAuthErrorResponse.self, from: data)
+            throw OAuthTokenManagerError.requestFailed(
+                statusCode: httpResponse.statusCode,
+                code: errorResponse?.error
+            )
+        }
+
+        let tokenResponse = try decoder.decode(OAuthTokenResponse.self, from: data)
+        guard tokenResponse.tokenType.caseInsensitiveCompare("Bearer") == .orderedSame else {
+            throw OAuthTokenManagerError.invalidTokenResponse
+        }
+
+        let token = OAuthAccessToken(
+            value: tokenResponse.accessToken,
+            expiresAt: Date().addingTimeInterval(TimeInterval(tokenResponse.expiresIn))
+        )
+        accessToken = token
+
+        if let refreshToken = tokenResponse.refreshToken, !refreshToken.isEmpty {
+            keychain.save(refreshToken, for: Constants.StorageKeys.Secret.oauthRefreshToken)
+        }
+
+        return token
+    }
+
+    private func loadRefreshToken() -> String? {
+        keychain.loadString(for: Constants.StorageKeys.Secret.oauthRefreshToken)
+    }
+
+    private func isExpiring(_ expiresAt: Date) -> Bool {
+        expiresAt.timeIntervalSinceNow <= Constants.OAuth.accessTokenExpiryBufferSeconds
+    }
+
+    private func formBody(_ params: [String: String]) -> Data? {
+        var components = URLComponents()
+        components.queryItems = params.map { URLQueryItem(name: $0.key, value: $0.value) }
+        return components.percentEncodedQuery?.data(using: .utf8)
+    }
+
+    private static func codeChallenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64URL(Data(digest))
+    }
+
+    private static func randomBase64URL(byteCount: Int) throws -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes)
+        guard status == errSecSuccess else {
+            throw OAuthTokenManagerError.randomBytesUnavailable
+        }
+        return base64URL(Data(bytes))
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private struct OAuthTokenResponse: Decodable {
+    let accessToken: String
+    let tokenType: String
+    let expiresIn: Int
+    let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
+}
+
+private struct OAuthErrorResponse: Decodable {
+    let error: String?
+}

--- a/TinfoilChat/Services/OAuthTokenManager.swift
+++ b/TinfoilChat/Services/OAuthTokenManager.swift
@@ -60,6 +60,10 @@ final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextP
     static let shared = OAuthTokenManager()
 
     private let keychain = KeychainHelper.shared
+    // Guards `accessToken` and `inFlightTask`, which may be touched concurrently
+    // by callers on different threads. `webAuthenticationSession` is only ever
+    // mutated on the main actor and so does not need the lock.
+    private let stateLock = NSLock()
     private var accessToken: OAuthAccessToken?
     private var webAuthenticationSession: ASWebAuthenticationSession?
     private var inFlightTask: Task<OAuthAccessToken?, Error>?
@@ -80,26 +84,18 @@ final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextP
             return nil
         }
 
-        if let accessToken, !isExpiring(accessToken.expiresAt) {
-            return accessToken
+        if let cached = validCachedToken() {
+            return cached
         }
 
         // Coalesce concurrent callers so a rotating refresh token is only spent
         // once and only a single authorization session is ever presented.
-        if let inFlightTask {
-            return try await inFlightTask.value
-        }
-
-        let task = Task { try await self.resolveAccessToken() }
-        inFlightTask = task
-        defer { inFlightTask = nil }
-
-        return try await task.value
+        return try await currentFetchTask().value
     }
 
     private func resolveAccessToken() async throws -> OAuthAccessToken? {
-        if let accessToken, !isExpiring(accessToken.expiresAt) {
-            return accessToken
+        if let cached = validCachedToken() {
+            return cached
         }
 
         if hasRefreshToken {
@@ -115,17 +111,65 @@ final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextP
         return try await authorize()
     }
 
+    private func currentFetchTask() -> Task<OAuthAccessToken?, Error> {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        if let inFlightTask {
+            return inFlightTask
+        }
+
+        let task = Task { [weak self] () throws -> OAuthAccessToken? in
+            guard let self = self else { return nil }
+            defer { self.clearFetchTask() }
+            return try await self.resolveAccessToken()
+        }
+        inFlightTask = task
+        return task
+    }
+
+    private func clearFetchTask() {
+        stateLock.lock()
+        inFlightTask = nil
+        stateLock.unlock()
+    }
+
+    private func validCachedToken() -> OAuthAccessToken? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard let accessToken, !isExpiring(accessToken.expiresAt) else {
+            return nil
+        }
+        return accessToken
+    }
+
+    private func setAccessToken(_ token: OAuthAccessToken) {
+        stateLock.lock()
+        accessToken = token
+        stateLock.unlock()
+    }
+
+    private func currentAccessTokenValue() -> String? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return accessToken?.value
+    }
+
     func clearAccessToken() {
+        stateLock.lock()
         accessToken = nil
+        stateLock.unlock()
     }
 
     func clearTokens() {
+        stateLock.lock()
         accessToken = nil
+        stateLock.unlock()
         keychain.delete(for: Constants.StorageKeys.Secret.oauthRefreshToken)
     }
 
     func revokeAndClearTokens() async {
-        let tokenToRevoke = loadRefreshToken() ?? accessToken?.value
+        let tokenToRevoke = loadRefreshToken() ?? currentAccessTokenValue()
 
         defer {
             clearTokens()
@@ -278,7 +322,7 @@ final class OAuthTokenManager: NSObject, ASWebAuthenticationPresentationContextP
             value: tokenResponse.accessToken,
             expiresAt: Date().addingTimeInterval(TimeInterval(tokenResponse.expiresIn))
         )
-        accessToken = token
+        setAccessToken(token)
 
         if let refreshToken = tokenResponse.refreshToken, !refreshToken.isEmpty {
             keychain.save(refreshToken, for: Constants.StorageKeys.Secret.oauthRefreshToken)

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -46,6 +46,10 @@ struct TinfoilChatApp: App {
                                 .environmentObject(authManager)
                         }
                             .onOpenURL { url in
+                                if url.scheme == Constants.OAuth.redirectScheme {
+                                    return
+                                }
+
                                 // Handle URL redirects from authentication
                                 // Immediately check auth state when app reopens from OAuth
                                 Task {

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -213,11 +213,14 @@ class AuthManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: authStateKey)
         UserDefaults.standard.removeObject(forKey: userDataKey)
         UserDefaults.standard.removeObject(forKey: subscriptionKey)
+        OAuthTokenManager.shared.clearTokens()
 
     }
     
     func signOut() async {
         do {
+            await OAuthTokenManager.shared.revokeAndClearTokens()
+
             // If we have a Clerk instance, use it, otherwise fall back to Clerk.shared
             let clerk = self.clerk ?? Clerk.shared
             try await clerk.auth.signOut()
@@ -306,6 +309,8 @@ class AuthManager: ObservableObject {
             
             // Delete the user's account
             try await user.delete()
+
+            await OAuthTokenManager.shared.revokeAndClearTokens()
             
             // Clear local state
             clearAuthState()

--- a/TinfoilChatTests/OAuthTokenManagerTests.swift
+++ b/TinfoilChatTests/OAuthTokenManagerTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import TinfoilChat
+
+@Suite("OAuth Token Manager Tests")
+struct OAuthTokenManagerTests {
+
+    @Test("Clears refresh state on invalid_grant")
+    func clearsRefreshTokenOnInvalidGrant() {
+        let error = OAuthTokenManagerError.requestFailed(statusCode: 400, code: "invalid_grant")
+        #expect(error.shouldClearRefreshToken == true)
+    }
+
+    @Test("Clears refresh state on invalid_client")
+    func clearsRefreshTokenOnInvalidClient() {
+        let error = OAuthTokenManagerError.requestFailed(statusCode: 401, code: "invalid_client")
+        #expect(error.shouldClearRefreshToken == true)
+    }
+
+    @Test("Does not clear refresh state on transient server errors")
+    func keepsRefreshTokenOnServerError() {
+        let error = OAuthTokenManagerError.requestFailed(statusCode: 500, code: "server_error")
+        #expect(error.shouldClearRefreshToken == false)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds OAuth-based auth for chat inference tokens with PKCE and an in‑app callback; subscribed users always use OAuth, while others fall back to JWT when OAuth isn’t configured. Refresh tokens are stored in Keychain and revoked on sign out or account deletion.

- **New Features**
  - Introduced `OAuthTokenManager` using `ASWebAuthenticationSession` + PKCE to authorize, refresh, and revoke tokens.
  - `SessionTokenManager` now prefers OAuth access tokens when configured or when a refresh token/subscription is present; subscribed users never fall back to the legacy key endpoint; others fall back to JWT.
  - Securely stores the refresh token in Keychain (`oauthRefreshToken`) and auto-clears on `invalid_grant`/`invalid_client`.
  - Coalesces concurrent token requests and guards token state with locking to avoid duplicate sign-in prompts and race conditions.
  - Added URL scheme handling and client ID in `Info.plist`; OAuth callbacks are ignored by `onOpenURL`. Added tests for refresh-token clearing.

- **Migration**
  - Set `TINFOIL_OAUTH_CLIENT_ID` in `Info.plist`.
  - Register the redirect URI `sh.tinfoil.tinfoilchat://oauth/callback` with the OAuth app.

<sup>Written for commit 6ecac0544e17d8195d31805e06610b24bf718eaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

