### PR TITLE
feat: authenticate subscribers with signed session tokens

### DIFF
--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "7867e9f7f9553e95ef07324e6039a817d9275f25",
-        "version" : "0.0.8"
+        "revision" : "f617227dd3657fe59dbf7fed2aaa9b4342119275",
+        "version" : "0.0.9"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "3314e5a06042bfa1209dd7afa20fabd03f1b85fb",
-        "version" : "0.5.3"
+        "revision" : "4c140fd40148a91fdf50d3b23aa986f3f9996767",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -83,6 +83,9 @@ enum Constants {
 
         enum ErrorCode {
             static let invalidAPIKey = "invalid_api_key"
+            /// Wire code returned with a 429 when a subscriber exceeds the
+            /// per-account hourly inference-token cap.
+            static let hourlyLimitReached = "HOURLY_LIMIT_REACHED"
         }
     }
 

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1296,14 +1296,15 @@ class SessionTokenManager {
 
             if let responseDict = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                let key = responseDict["key"] as? String {
-                self.sessionToken = key
+                let expiresAt: Date
                 if let expiresAtString = responseDict["expires_at"] as? String,
                    let parsed = ISO8601DateFormatter().date(from: expiresAtString) {
-                    self.sessionTokenExpiresAt = parsed
+                    expiresAt = parsed
                 } else {
                     // Fallback: assume a conservative expiry so we don't refetch on every call
-                    self.sessionTokenExpiresAt = Date().addingTimeInterval(Constants.API.sessionTokenExpiryBufferSeconds * 2)
+                    expiresAt = Date().addingTimeInterval(Constants.API.sessionTokenExpiryBufferSeconds * 2)
                 }
+                storeToken(key, expiresAt: expiresAt)
 
                 // Parse rate limit info for free-tier users
                 let isFreeTier = responseDict["is_free_tier"] as? Bool ?? false
@@ -1344,9 +1345,8 @@ class SessionTokenManager {
     private func fetchAuthenticatedSessionToken(jwt: String) async -> String? {
         switch await fetchChatJWT(jwt: jwt) {
         case .token(let key, let expiresAt):
-            self.sessionToken = key
-            self.sessionTokenExpiresAt = expiresAt
-                ?? Date().addingTimeInterval(Constants.API.sessionTokenExpiryBufferSeconds * 2)
+            storeToken(key, expiresAt: expiresAt
+                ?? Date().addingTimeInterval(Constants.API.sessionTokenExpiryBufferSeconds * 2))
             // Subscribers are not subject to the free-tier daily limit.
             self.rateLimitInfo = nil
             return key
@@ -1356,8 +1356,9 @@ class SessionTokenManager {
             // let the limit be bypassed. Reuse the cached token only while it is
             // still valid so an in-flight session is not dropped; once it has
             // expired there is no usable token to return.
-            if let token = sessionToken,
-               let expiresAt = sessionTokenExpiresAt,
+            let snapshot = tokenSnapshot()
+            if let token = snapshot.token,
+               let expiresAt = snapshot.expiresAt,
                expiresAt.timeIntervalSinceNow > 0 {
                 return token
             }
@@ -1444,8 +1445,7 @@ class SessionTokenManager {
 
     /// Clears the cached session token and rate limit info
     func clearSessionToken() {
-        sessionToken = nil
-        sessionTokenExpiresAt = nil
+        storeToken(nil, expiresAt: nil)
         rateLimitInfo = nil
     }
 }

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1111,6 +1111,14 @@ class SessionTokenManager {
     private let sessionTokenEndpoint = "\(Constants.API.baseURL)/api/keys/chat"
     private let chatTokenEndpoint = "\(Constants.API.baseURL)/api/chat/token"
 
+    /// Serializes access to `sessionToken` / `sessionTokenExpiresAt` so the
+    /// synchronous `currentToken` provider can be read from the SDK's
+    /// request-building thread while async refreshes update it.
+    private let stateLock = NSLock()
+
+    /// Deduplicates background refreshes kicked off from `currentToken`.
+    private var backgroundRefreshInFlight = false
+
     /// Current rate limit info for free-tier users (nil for premium)
     private(set) var rateLimitInfo: RateLimitInfo? {
         didSet { onRateLimitChanged?(rateLimitInfo) }
@@ -1127,20 +1135,73 @@ class SessionTokenManager {
 
     /// Returns true if the cached token is expired or near expiry and needs refresh
     var needsRefresh: Bool {
-        guard sessionToken != nil else { return true }
-        guard let expiresAt = sessionTokenExpiresAt else { return true }
+        let snapshot = tokenSnapshot()
+        guard snapshot.token != nil, let expiresAt = snapshot.expiresAt else { return true }
         return expiresAt.timeIntervalSinceNow <= Constants.API.sessionTokenExpiryBufferSeconds
     }
 
     private init() {}
 
+    /// Thread-safe write of the cached token and its expiry.
+    private func storeToken(_ token: String?, expiresAt: Date?) {
+        stateLock.lock()
+        sessionToken = token
+        sessionTokenExpiresAt = expiresAt
+        stateLock.unlock()
+    }
+
+    /// Thread-safe read of the cached token and its expiry.
+    private func tokenSnapshot() -> (token: String?, expiresAt: Date?) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return (sessionToken, sessionTokenExpiresAt)
+    }
+
+    /// Synchronous, thread-safe accessor for the freshest cached token. Used as
+    /// the SDK's dynamic token provider so the bearer can rotate per request
+    /// without rebuilding the attested client. When the cached token is missing
+    /// or near expiry a background refresh is kicked off (deduplicated) and the
+    /// current value is returned for the in-flight request; the reactive 401
+    /// retry covers the rare case where it has already hard-expired.
+    var currentToken: String {
+        let snapshot = tokenSnapshot()
+        let isStale = snapshot.expiresAt.map {
+            $0.timeIntervalSinceNow <= Constants.API.sessionTokenExpiryBufferSeconds
+        } ?? true
+        if isStale {
+            triggerBackgroundRefresh()
+        }
+        return snapshot.token ?? ""
+    }
+
+    /// Kicks off a single background token refresh, coalescing concurrent
+    /// callers so a burst of requests does not trigger a stampede of fetches.
+    private func triggerBackgroundRefresh() {
+        stateLock.lock()
+        if backgroundRefreshInFlight {
+            stateLock.unlock()
+            return
+        }
+        backgroundRefreshInFlight = true
+        stateLock.unlock()
+
+        Task { [weak self] in
+            guard let self else { return }
+            _ = await self.fetchFreshSessionToken()
+            self.stateLock.lock()
+            self.backgroundRefreshInFlight = false
+            self.stateLock.unlock()
+        }
+    }
+
     /// Retrieves the session token, returning the cached value if still valid
     /// - Returns: Session token string or empty string if unavailable
     func getSessionToken() async -> String {
-        if let existingToken = sessionToken,
-           let expiresAt = sessionTokenExpiresAt,
+        let snapshot = tokenSnapshot()
+        if let token = snapshot.token,
+           let expiresAt = snapshot.expiresAt,
            expiresAt.timeIntervalSinceNow > Constants.API.sessionTokenExpiryBufferSeconds {
-            return existingToken
+            return token
         }
 
         return await fetchFreshSessionToken()

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -649,6 +649,10 @@ struct Message: Identifiable, Codable, Equatable {
     var streamError: String? = nil
     var isRequestError: Bool = false
     var isRateLimitError: Bool = false
+    /// True when the rate-limit error is the subscriber hourly usage cap rather
+    /// than the free-tier daily limit, so the UI shows a transient
+    /// "try again shortly" message instead of an upgrade prompt.
+    var isHourlyLimitError: Bool = false
     var generationTimeSeconds: Double? = nil
     var contentChunks: [ContentChunk] = []
     var thinkingChunks: [ThinkingChunk] = []
@@ -744,7 +748,7 @@ struct Message: Identifiable, Codable, Equatable {
     // MARK: - Codable Implementation
     
     enum CodingKeys: String, CodingKey {
-        case id, role, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, generationTimeSeconds, webSearchState
+        case id, role, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, generationTimeSeconds, webSearchState
         case webSearch // Alternative key used by React app
         case urlFetches
         case attachments
@@ -782,6 +786,7 @@ struct Message: Identifiable, Codable, Equatable {
         streamError = try container.decodeIfPresent(String.self, forKey: .streamError)
         isRequestError = try container.decodeIfPresent(Bool.self, forKey: .isRequestError) ?? false
         isRateLimitError = try container.decodeIfPresent(Bool.self, forKey: .isRateLimitError) ?? false
+        isHourlyLimitError = try container.decodeIfPresent(Bool.self, forKey: .isHourlyLimitError) ?? false
         generationTimeSeconds = try container.decodeIfPresent(Double.self, forKey: .generationTimeSeconds)
         // contentChunks and thinkingChunks are transient UI rendering state — never decoded from storage
         contentChunks = []
@@ -949,6 +954,7 @@ struct Message: Identifiable, Codable, Equatable {
         try container.encodeIfPresent(streamError, forKey: .streamError)
         if isRequestError { try container.encode(isRequestError, forKey: .isRequestError) }
         if isRateLimitError { try container.encode(isRateLimitError, forKey: .isRateLimitError) }
+        if isHourlyLimitError { try container.encode(isHourlyLimitError, forKey: .isHourlyLimitError) }
         try container.encodeIfPresent(generationTimeSeconds, forKey: .generationTimeSeconds)
         // contentChunks is transient UI rendering state — never encode it
         // Encode as "webSearch" for React app compatibility
@@ -1093,14 +1099,40 @@ enum HapticFeedback {
 
 // MARK: - Rate Limit Info
 
-/// Rate limit information returned by the backend for free-tier users
+/// Rate limit information surfaced to the UI.
 struct RateLimitInfo {
+    /// Distinguishes the anonymous/free-tier daily request limit from the
+    /// per-account hourly usage cap that subscribers hit. Both flow through the
+    /// same channel but render differently: the hourly cap is transient, does
+    /// not block input, and offers no upgrade (the user already subscribes).
+    enum Kind {
+        case freeDaily
+        case hourly
+    }
+
     var maxRequests: Int
     var remaining: Int
     var resetsAt: String
+    var kind: Kind = .freeDaily
 }
 
 // MARK: - Session Token Management
+
+/// Errors surfaced while acquiring a session/inference token for a send.
+enum SessionTokenError: Error, LocalizedError {
+    /// The signed-in subscriber is over the per-account hourly usage cap. The
+    /// cap is enforced when the inference token is minted (the inference path
+    /// never checks it), so it is surfaced at acquisition before any request
+    /// is sent rather than inferred from a downstream failure.
+    case hourlyLimitReached(resetsAt: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .hourlyLimitReached:
+            return "You have reached your hourly usage limit."
+        }
+    }
+}
 
 /// Manages session token retrieval and rate limit tracking
 class SessionTokenManager {
@@ -1205,6 +1237,22 @@ class SessionTokenManager {
         }
 
         return await fetchFreshSessionToken()
+    }
+
+    /// Acquires a usable inference token for an outgoing send, mirroring the web
+    /// client: a subscriber over the per-account hourly cap is surfaced here and
+    /// the call throws, so the caller aborts before firing a request the
+    /// inference path cannot satisfy (the cap is a mint-time decision and is
+    /// never checked on inference). Coasting on a still-valid cached token is
+    /// preserved; the throw happens only when no usable token could be obtained
+    /// because the cap was hit.
+    /// - Parameter forceRefresh: bypass the cached token (used on a 401 retry).
+    func acquireTokenForSend(forceRefresh: Bool) async throws {
+        let token = forceRefresh ? await fetchFreshSessionToken() : await getSessionToken()
+        if !token.isEmpty { return }
+        if rateLimitInfo?.kind == .hourly {
+            throw SessionTokenError.hourlyLimitReached(resetsAt: rateLimitInfo?.resetsAt)
+        }
     }
 
     /// Forces a fresh session token fetch, ignoring any cached value
@@ -1316,7 +1364,8 @@ class SessionTokenManager {
                     self.rateLimitInfo = RateLimitInfo(
                         maxRequests: maxRequests,
                         remaining: remaining,
-                        resetsAt: resetsAt
+                        resetsAt: resetsAt,
+                        kind: .freeDaily
                     )
                 } else {
                     self.rateLimitInfo = nil
@@ -1334,7 +1383,7 @@ class SessionTokenManager {
     /// Outcome of attempting to mint a stateless JWT inference token.
     private enum ChatJWTResult {
         case token(key: String, expiresAt: Date?)
-        case rateLimited
+        case rateLimited(resetsAt: String?)
         case unavailable
     }
 
@@ -1350,12 +1399,20 @@ class SessionTokenManager {
             // Subscribers are not subject to the free-tier daily limit.
             self.rateLimitInfo = nil
             return key
-        case .rateLimited:
-            // Subscriber over the per-account hourly cap. Do not fall back to the
-            // opaque /api/keys/chat path, which is not subject to the cap and would
-            // let the limit be bypassed. Reuse the cached token only while it is
-            // still valid so an in-flight session is not dropped; once it has
-            // expired there is no usable token to return.
+        case .rateLimited(let resetsAt):
+            // Subscriber over the per-account hourly cap. Surface it through the
+            // shared rate-limit channel so the UI can show an hourly-limit
+            // indicator, and do not fall back to the opaque /api/keys/chat path,
+            // which is not subject to the cap and would let it be bypassed.
+            // Reuse the cached token only while it is still valid so an in-flight
+            // session is not dropped; once it has expired there is no usable
+            // token to return.
+            self.rateLimitInfo = RateLimitInfo(
+                maxRequests: 0,
+                remaining: 0,
+                resetsAt: resetsAt ?? "",
+                kind: .hourly
+            )
             let snapshot = tokenSnapshot()
             if let token = snapshot.token,
                let expiresAt = snapshot.expiresAt,
@@ -1397,8 +1454,11 @@ class SessionTokenManager {
                 return .token(key: key, expiresAt: expiresAt)
             }
 
-            if httpResponse.statusCode == 429 {
-                return .rateLimited
+            let body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            let isHourlyLimit = httpResponse.statusCode == 429
+                || (body?["code"] as? String) == Constants.API.ErrorCode.hourlyLimitReached
+            if isHourlyLimit {
+                return .rateLimited(resetsAt: body?["resets_at"] as? String)
             }
 
             return .unavailable

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1292,9 +1292,15 @@ class SessionTokenManager {
         case .rateLimited:
             // Subscriber over the per-account hourly cap. Do not fall back to the
             // opaque /api/keys/chat path, which is not subject to the cap and would
-            // let the limit be bypassed. Keep any still-valid cached token so an
-            // in-flight session is not dropped.
-            return sessionToken ?? ""
+            // let the limit be bypassed. Reuse the cached token only while it is
+            // still valid so an in-flight session is not dropped; once it has
+            // expired there is no usable token to return.
+            if let token = sessionToken,
+               let expiresAt = sessionTokenExpiresAt,
+               expiresAt.timeIntervalSinceNow > 0 {
+                return token
+            }
+            return ""
         case .unavailable:
             return await fetchSessionKey(jwt: jwt)
         }

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1109,6 +1109,7 @@ class SessionTokenManager {
     private var sessionToken: String?
     private var sessionTokenExpiresAt: Date?
     private let sessionTokenEndpoint = "\(Constants.API.baseURL)/api/keys/chat"
+    private let chatTokenEndpoint = "\(Constants.API.baseURL)/api/chat/token"
 
     /// Current rate limit info for free-tier users (nil for premium)
     private(set) var rateLimitInfo: RateLimitInfo? {
@@ -1170,8 +1171,9 @@ class SessionTokenManager {
                         continue
                     }
 
-                    // Try fetching the session key with this JWT
-                    let result = await fetchSessionKey(jwt: jwt)
+                    // Resolve a token with this JWT: subscribers mint a stateless
+                    // JWT inference token, everyone else falls back to an opaque key.
+                    let result = await fetchAuthenticatedSessionToken(jwt: jwt)
 
                     if let key = result {
                         return key
@@ -1189,7 +1191,7 @@ class SessionTokenManager {
                     _ = try? await Clerk.shared.refreshClient()
                     let refreshedSession = await Clerk.shared.session
                     if let refreshedToken = try? await refreshedSession?.getToken() {
-                        if let key = await fetchSessionKey(jwt: refreshedToken) {
+                        if let key = await fetchAuthenticatedSessionToken(jwt: refreshedToken) {
                             return key
                         }
                     }
@@ -1264,6 +1266,76 @@ class SessionTokenManager {
             return nil
         } catch {
             return nil
+        }
+    }
+
+    /// Outcome of attempting to mint a stateless JWT inference token.
+    private enum ChatJWTResult {
+        case token(key: String, expiresAt: Date?)
+        case rateLimited
+        case unavailable
+    }
+
+    /// Resolves a usable inference token for an authenticated user. Subscribers
+    /// mint a stateless JWT via /api/chat/token; everyone else falls back to an
+    /// opaque key from /api/keys/chat. Returns nil only when no definitive answer
+    /// was reached, so the caller can retry with a refreshed Clerk JWT.
+    private func fetchAuthenticatedSessionToken(jwt: String) async -> String? {
+        switch await fetchChatJWT(jwt: jwt) {
+        case .token(let key, let expiresAt):
+            self.sessionToken = key
+            self.sessionTokenExpiresAt = expiresAt
+                ?? Date().addingTimeInterval(Constants.API.sessionTokenExpiryBufferSeconds * 2)
+            // Subscribers are not subject to the free-tier daily limit.
+            self.rateLimitInfo = nil
+            return key
+        case .rateLimited:
+            // Subscriber over the per-account hourly cap. Do not fall back to the
+            // opaque /api/keys/chat path, which is not subject to the cap and would
+            // let the limit be bypassed. Keep any still-valid cached token so an
+            // in-flight session is not dropped.
+            return sessionToken ?? ""
+        case .unavailable:
+            return await fetchSessionKey(jwt: jwt)
+        }
+    }
+
+    /// Mints a stateless JWT inference token for a subscribed user via
+    /// /api/chat/token. Returns `.unavailable` on any non-rate-limit failure
+    /// (no subscription, endpoint disabled, network error) so the caller falls
+    /// back to the opaque /api/keys/chat path.
+    private func fetchChatJWT(jwt: String) async -> ChatJWTResult {
+        do {
+            var request = URLRequest(url: URL(string: chatTokenEndpoint)!)
+            request.httpMethod = "GET"
+            request.addValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .unavailable
+            }
+
+            if httpResponse.statusCode == 200 {
+                guard let responseDict = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let key = responseDict["key"] as? String,
+                      !key.isEmpty else {
+                    return .unavailable
+                }
+                var expiresAt: Date? = nil
+                if let expiresAtString = responseDict["expires_at"] as? String {
+                    expiresAt = ISO8601DateFormatter().date(from: expiresAtString)
+                }
+                return .token(key: key, expiresAt: expiresAt)
+            }
+
+            if httpResponse.statusCode == 429 {
+                return .rateLimited
+            }
+
+            return .unavailable
+        } catch {
+            return .unavailable
         }
     }
 

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -277,13 +277,13 @@ class AuthManager: ObservableObject {
                         NotificationCenter.default.post(name: NSNotification.Name("SubscriptionStatusUpdated"), object: nil)
                     }
 
-                    // If subscription became active, clear cached session token to force refetch
+                    // If subscription became active, swap the free-tier key for a
+                    // subscriber token. Refetch in place rather than clearing first so
+                    // in-flight requests keep using the still-valid key until the new
+                    // token is stored, instead of briefly sending an empty bearer.
                     if self.hasActiveSubscription && !wasActive {
-                        SessionTokenManager.shared.clearSessionToken()
-
-                        // Proactively fetch new session token
                         Task {
-                            let _ = await SessionTokenManager.shared.getSessionToken()
+                            let _ = await SessionTokenManager.shared.fetchFreshSessionToken()
                         }
                     }
                 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -524,11 +524,13 @@ class ChatViewModel: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            // Proactively refresh the session token and recreate the client
-            // if the token is expired or near expiry, so requests don't fail.
+            // Proactively refresh the session token if it is expired or near
+            // expiry so the first request after returning to the foreground
+            // doesn't have to fail and retry. The attested client persists and
+            // picks up the new token through its provider.
             Task { @MainActor in
                 if SessionTokenManager.shared.needsRefresh {
-                    await self?.refreshClientForRetry()
+                    await self?.refreshSessionTokenForRetry()
                 }
             }
 
@@ -614,10 +616,14 @@ class ChatViewModel: ObservableObject {
         Task {
             do {
                 await AppConfig.shared.waitForInitialization()
-                let sessionToken = await AppConfig.shared.getSessionToken()
+                // Pre-warm the cached token so the first request has a bearer.
+                // The client then reads the live token per request via the
+                // provider, so the bearer can rotate without rebuilding the
+                // attested client or re-running enclave verification.
+                _ = await AppConfig.shared.getSessionToken()
 
                 client = try await TinfoilAI.create(
-                    apiKey: sessionToken,
+                    apiKeyProvider: { SessionTokenManager.shared.currentToken },
                     // Opt into the router's inline progress markers so
                     // live web search and URL-fetch status drives the
                     // same WebSearchState / URLFetchState UI the app
@@ -1572,15 +1578,6 @@ class ChatViewModel: ObservableObject {
             var hasRetriedWithFreshKey = false
 
             retryLoop: do {
-                // Proactively refresh the session token and client when the
-                // cached token is expired or near expiry, so the request isn't
-                // sent with a stale token and forced through a 401 retry.
-                // Stateless JWTs are short-lived, so this happens routinely
-                // during a long session.
-                if client != nil, !isClientInitializing, SessionTokenManager.shared.needsRefresh {
-                    await refreshClientForRetry()
-                }
-
                 // Wait for client initialization if needed
                 if client == nil || isClientInitializing {
                     // If client setup hasn't started, start it
@@ -2467,7 +2464,7 @@ class ChatViewModel: ObservableObject {
 
                 if shouldRetry {
                     hasRetriedWithFreshKey = true
-                    await self.refreshClientForRetry()
+                    await self.refreshSessionTokenForRetry()
                     if await MainActor.run(body: { self.client != nil }) {
                         continue retryLoop
                     }
@@ -2615,17 +2612,11 @@ class ChatViewModel: ObservableObject {
         return false
     }
 
-    /// Refreshes the session token and recreates the client
-    private func refreshClientForRetry() async {
-        SessionTokenManager.shared.clearSessionToken()
-        setupTinfoilClient()
-
-        // Wait for client initialization to complete
-        let maxWaitTime = Constants.Sync.clientInitTimeoutSeconds
-        let startTime = Date()
-        while isClientInitializing && Date().timeIntervalSince(startTime) < maxWaitTime {
-            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-        }
+    /// Mints a fresh session token in place for a retry. The attested client
+    /// reads the bearer through its provider, so the token can rotate without
+    /// rebuilding the client or re-running enclave verification.
+    private func refreshSessionTokenForRetry() async {
+        _ = await SessionTokenManager.shared.fetchFreshSessionToken()
     }
 
     /// Cancels the current message generation
@@ -4021,7 +4012,7 @@ extension ChatViewModel {
         } catch {
             // Retry once with a fresh token if the error is an auth failure
             if ChatViewModel.isAuthenticationError(error) {
-                await refreshClientForRetry()
+                await refreshSessionTokenForRetry()
                 if let retryClient = self.client {
                     do {
                         let transcription = try await AudioRecordingService.shared.transcribe(

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1398,7 +1398,10 @@ class ChatViewModel: ObservableObject {
             print("[Chat] sendMessage: no rate limit info (premium or not yet fetched)")
         }
         #endif
-        if let rl = rateLimit, rl.remaining <= 0 {
+        // The free-tier daily limit blocks sending and offers an upgrade; the
+        // subscriber hourly cap is transient, so it neither blocks input nor
+        // shows the paywall.
+        if let rl = rateLimit, rl.remaining <= 0, rl.kind != .hourly {
             showRateLimitPaywall = true
             return
         }
@@ -1598,6 +1601,15 @@ class ChatViewModel: ObservableObject {
                     throw NSError(domain: "TinfoilChat", code: 1,
                                 userInfo: [NSLocalizedDescriptionKey: "Service temporarily unavailable. Please try again."])
                 }
+
+                // Acquire the inference token before streaming. The per-account
+                // hourly cap is enforced when the token is minted, not on the
+                // inference request, so surfacing it here lets us abort cleanly
+                // instead of firing a request that can only fail. The retry pass
+                // forces a fresh mint to bypass a stale cached token.
+                try await SessionTokenManager.shared.acquireTokenForSend(
+                    forceRefresh: hasRetriedWithFreshKey
+                )
 
                 // Create the stream with proper parameters
                 let modelId = currentModel.modelName
@@ -2464,7 +2476,8 @@ class ChatViewModel: ObservableObject {
 
                 if shouldRetry {
                     hasRetriedWithFreshKey = true
-                    await self.refreshSessionTokenForRetry()
+                    // The token is reminted by acquireTokenForSend at the top of
+                    // the retry pass (forceRefresh), so no separate refresh here.
                     if await MainActor.run(body: { self.client != nil }) {
                         continue retryLoop
                     }
@@ -2509,9 +2522,20 @@ class ChatViewModel: ObservableObject {
 
                             // Set the stream error - the ErrorMessageView will display it nicely
                             // Keep any partial content that was received
+                            // The hourly cap is surfaced deterministically at
+                            // token acquisition (the inference path never checks
+                            // it), so the only signal here is that typed error —
+                            // no inference-failure heuristic.
+                            let hitHourlyCap: Bool
+                            if case SessionTokenError.hourlyLimitReached = error {
+                                hitHourlyCap = true
+                            } else {
+                                hitHourlyCap = false
+                            }
                             chat.messages[lastIndex].isRequestError = self.isRequestError(error)
                             chat.messages[lastIndex].streamError = userFriendlyError
-                            chat.messages[lastIndex].isRateLimitError = self.isRateLimitError(error)
+                            chat.messages[lastIndex].isRateLimitError = self.isRateLimitError(error) || hitHourlyCap
+                            chat.messages[lastIndex].isHourlyLimitError = hitHourlyCap
 
                             self.updateChat(chat)
                         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1572,6 +1572,15 @@ class ChatViewModel: ObservableObject {
             var hasRetriedWithFreshKey = false
 
             retryLoop: do {
+                // Proactively refresh the session token and client when the
+                // cached token is expired or near expiry, so the request isn't
+                // sent with a stale token and forced through a 401 retry.
+                // Stateless JWTs are short-lived, so this happens routinely
+                // during a long session.
+                if client != nil, !isClientInitializing, SessionTokenManager.shared.needsRefresh {
+                    await refreshClientForRetry()
+                }
+
                 // Wait for client initialization if needed
                 if client == nil || isClientInitializing {
                     // If client setup hasn't started, start it

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -166,7 +166,18 @@ struct MessageInputView: View {
     /// Small label shown above the input when remaining free requests are low
     @ViewBuilder
     private var rateLimitLabel: some View {
-        if let rl = viewModel.rateLimit, rl.remaining <= Constants.RateLimit.warningThreshold {
+        if let rl = viewModel.rateLimit, rl.kind == .hourly {
+            Text("Hourly limit reached")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.orange)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    Capsule()
+                        .fill(Color.orange.opacity(0.15))
+                )
+                .transition(.opacity)
+        } else if let rl = viewModel.rateLimit, rl.remaining <= Constants.RateLimit.warningThreshold {
             Text(rl.remaining <= 0
                  ? "No requests left"
                  : "\(rl.remaining) request\(rl.remaining == 1 ? "" : "s") left")

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -591,8 +591,9 @@ struct MessageView: View {
                         isDarkMode: isDarkMode,
                         isRequestError: message.isRequestError,
                         isRateLimitError: message.isRateLimitError,
+                        isHourlyLimit: message.isHourlyLimitError,
                         onRegenerate: isLastMessage ? { viewModel.regenerateLastResponse() } : nil,
-                        onUpgrade: message.isRateLimitError ? { viewModel.showRateLimitPaywall = true } : nil
+                        onUpgrade: (message.isRateLimitError && !message.isHourlyLimitError) ? { viewModel.showRateLimitPaywall = true } : nil
                     )
                     .padding(.top, message.content.isEmpty && message.thoughts == nil ? 0 : 8)
                 }
@@ -1628,6 +1629,7 @@ struct ErrorMessageView: View {
     let isDarkMode: Bool
     var isRequestError: Bool = false
     var isRateLimitError: Bool = false
+    var isHourlyLimit: Bool = false
     var onRegenerate: (() -> Void)? = nil
     var onUpgrade: (() -> Void)? = nil
 
@@ -1647,6 +1649,7 @@ struct ErrorMessageView: View {
     }
 
     private var headerText: String {
+        if isHourlyLimit { return "Hourly Limit Reached" }
         if isRateLimitError { return "Rate Limit Reached" }
         if isConnectionError { return "Connection Lost" }
         return "Something Went Wrong"
@@ -1666,7 +1669,12 @@ struct ErrorMessageView: View {
                 Spacer()
             }
 
-            if isRateLimitError {
+            if isHourlyLimit {
+                Text("You've reached your hourly usage limit. Please try again in a little while — it resets at the top of the hour.")
+                    .font(.subheadline)
+                    .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.7))
+                    .multilineTextAlignment(.leading)
+            } else if isRateLimitError {
                 Text("You've reached your daily limit of free requests. Your limit will reset tomorrow, or you can upgrade to Premium for unlimited access.")
                     .font(.subheadline)
                     .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.7))
@@ -1679,7 +1687,7 @@ struct ErrorMessageView: View {
             }
 
             HStack(spacing: 8) {
-                if let onRegenerate = onRegenerate, !isRateLimitError {
+                if let onRegenerate = onRegenerate, !isRateLimitError || isHourlyLimit {
                     Button(action: onRegenerate) {
                         HStack(spacing: 6) {
                             Image(systemName: "arrow.clockwise")
@@ -1698,7 +1706,7 @@ struct ErrorMessageView: View {
                     .buttonStyle(PlainButtonStyle())
                 }
 
-                if let onUpgrade = onUpgrade, isRateLimitError {
+                if let onUpgrade = onUpgrade, isRateLimitError, !isHourlyLimit {
                     Button(action: onUpgrade) {
                         Text("Upgrade to Premium")
                             .font(.subheadline.weight(.medium))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Authenticate subscribers with stateless JWT chat tokens and rotate session tokens per request without rebuilding the secure client. Also adds clear, non‑blocking hourly cap handling in the UI.

- **New Features**
  - Mint JWT inference tokens via `/api/chat/token` for subscribers; fall back to `/api/keys/chat` when unavailable; no fallback on 429/`HOURLY_LIMIT_REACHED`.
  - Rotate tokens per request via `apiKeyProvider`; pre‑warm on client init and when returning to foreground; acquire tokens before send to surface hourly cap early.
  - Distinguish free‑tier daily vs subscriber hourly limits; show “Hourly limit reached” label and error; no paywall, input remains unblocked.

- **Bug Fixes**
  - Thread‑safe token cache with coalesced background refresh to prevent duplicate fetches and stampedes.
  - Refresh tokens in place for 401s and after subscription upgrades to avoid empty bearers and client rebuilds.
  - Only treat auth/429 or `HOURLY_LIMIT_REACHED` as the hourly cap; avoid mislabeling network/5xx errors.

Also updates `openai-swift-fork` to 0.0.9 and `tinfoil-swift` to 0.6.0.

<sup>Written for commit a20c1c296cd73b6b16093f9ea0ed6b52f82a1f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

