### PR TITLE
Implement accessibility features

### DIFF
--- a/TinfoilChat/Extensions/View+Accessibility.swift
+++ b/TinfoilChat/Extensions/View+Accessibility.swift
@@ -1,0 +1,18 @@
+//
+//  View+Accessibility.swift
+//  TinfoilChat
+//
+//  Copyright © 2025 Tinfoil. All rights reserved.
+
+import SwiftUI
+
+extension View {
+    /// Expands an interactive element's hit area to at least `minSize` points
+    /// in each dimension, matching the 44pt minimum touch target recommended
+    /// by Apple's Human Interface Guidelines. The contained icon keeps its own
+    /// size; only the tappable region grows.
+    func accessibleHitTarget(minSize: CGFloat = 44) -> some View {
+        frame(minWidth: minSize, minHeight: minSize)
+            .contentShape(Rectangle())
+    }
+}

--- a/TinfoilChat/Views/AttachmentPreviewBar.swift
+++ b/TinfoilChat/Views/AttachmentPreviewBar.swift
@@ -84,6 +84,8 @@ private struct AttachmentPreviewChip: View {
                 .fill(isDarkMode ? Color.white.opacity(0.1) : Color.black.opacity(0.05))
         )
         .frame(maxWidth: Constants.Attachments.previewMaxWidth)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Attachment, \(attachment.fileName), \(accessibilityStatus)")
         .padding(.top, 6)
         .padding(.trailing, 6)
         .overlay(alignment: .topTrailing) {
@@ -92,7 +94,14 @@ private struct AttachmentPreviewChip: View {
                     .font(.system(size: 16))
                     .foregroundColor(.secondary)
             }
+            .accessibilityLabel("Remove attachment")
         }
+    }
+
+    private var accessibilityStatus: String {
+        if attachment.processingState == .processing { return "Processing" }
+        if attachment.processingState == .failed { return "Failed" }
+        return formattedFileSize
     }
 
     @ViewBuilder

--- a/TinfoilChat/Views/Authentication/AuthenticationHelpers.swift
+++ b/TinfoilChat/Views/Authentication/AuthenticationHelpers.swift
@@ -132,6 +132,7 @@ struct UIKitTextField: UIViewRepresentable {
         let textField = UITextField()
         textField.delegate = context.coordinator
         textField.placeholder = placeholder
+        textField.accessibilityLabel = placeholder
         textField.keyboardType = keyboardType
         textField.isSecureTextEntry = isSecure
         textField.backgroundColor = .systemBackground

--- a/TinfoilChat/Views/Authentication/ForgotPasswordView.swift
+++ b/TinfoilChat/Views/Authentication/ForgotPasswordView.swift
@@ -39,6 +39,7 @@ struct ForgotPasswordView: View {
                             .font(.system(size: 16, weight: .bold))
                             .foregroundColor(Color(.systemGray))
                     }
+                    .accessibilityLabel("Close")
                 }
                 .padding(.horizontal)
                 

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -355,6 +355,9 @@ struct ChatSidebar: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Projects")
+            .accessibilityValue(isProjectsExpanded ? "Expanded" : "Collapsed")
+            .accessibilityHint(isProjectsExpanded ? "Collapses the projects list" : "Expands the projects list")
 
             if isProjectsExpanded {
                 Button {
@@ -397,6 +400,8 @@ struct ChatSidebar: View {
                     }
                     .buttonStyle(.plain)
                     .disabled(project.decryptionFailed == true)
+                    .accessibilityLabel(project.decryptionFailed == true ? "\(project.name), encrypted, unavailable" : project.name)
+                    .accessibilityHint(project.decryptionFailed == true ? "" : "Opens the project")
                 }
             }
         }
@@ -440,6 +445,9 @@ struct ChatSidebar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Chats")
+        .accessibilityValue(isChatsExpanded ? "Expanded" : "Collapsed")
+        .accessibilityHint(isChatsExpanded ? "Collapses the chat list" : "Expands the chat list")
     }
     
     private var cloudLocalTabSwitcher: some View {
@@ -464,6 +472,8 @@ struct ChatSidebar: View {
                 .foregroundColor(activeTab == .cloud ? .primary : .secondary)
             }
             .buttonStyle(PlainButtonStyle())
+            .accessibilityLabel("Cloud chats")
+            .accessibilityAddTraits(activeTab == .cloud ? .isSelected : [])
 
             Button(action: { switchTab(to: .local) }) {
                 HStack(spacing: 4) {
@@ -485,6 +495,8 @@ struct ChatSidebar: View {
                 .foregroundColor(activeTab == .local ? .primary : .secondary)
             }
             .buttonStyle(PlainButtonStyle())
+            .accessibilityLabel("Local chats")
+            .accessibilityAddTraits(activeTab == .local ? .isSelected : [])
         }
         .padding(4)
         .background(
@@ -551,6 +563,7 @@ struct ChatListItem: View {
                             .onSubmit {
                                 onEdit()
                             }
+                            .accessibilityLabel("Chat title")
                         
                         // Save and Cancel buttons for editing mode
                         HStack(spacing: 12) {
@@ -558,10 +571,12 @@ struct ChatListItem: View {
                                 Image(systemName: "checkmark")
                                     .foregroundColor(.primary)
                             }
+                            .accessibilityLabel("Save title")
                             Button(action: { editingTitle = chat.title; onEdit() }) {
                                 Image(systemName: "xmark")
                                     .foregroundColor(.primary)
                             }
+                            .accessibilityLabel("Cancel editing")
                         }
                     } else {
                         HStack(spacing: 4) {
@@ -631,5 +646,42 @@ struct ChatListItem: View {
             RoundedRectangle(cornerRadius: 8)
                 .strokeBorder(Color.gray.opacity(0.1), lineWidth: 1)
         )
+        // Collapse the row into a single VoiceOver element when not editing so
+        // the title, timestamp and state read as one item; the nested edit and
+        // delete buttons are surfaced as custom actions instead of becoming
+        // unreachable elements inside the row button.
+        .accessibilityElement(children: isEditing ? .contain : .ignore)
+        .accessibilityLabel(rowAccessibilityLabel)
+        .accessibilityAddTraits(rowAccessibilityTraits)
+        .accessibilityHint(rowAccessibilityHint)
+        .if(showEditDelete && !chat.isBlankChat && !chat.decryptionFailed && !isEditing) { view in
+            view
+                .accessibilityAction(named: Text("Rename")) { onEdit() }
+                .accessibilityAction(named: Text("Delete")) { onDelete() }
+        }
+    }
+
+    private var rowAccessibilityLabel: String {
+        if chat.decryptionFailed {
+            return "Encrypted chat. Failed to decrypt, wrong key."
+        }
+        var components = [chat.title.isEmpty ? "Untitled chat" : chat.title]
+        if chat.isBlankChat {
+            components.append("New chat")
+        } else if !timeString.isEmpty {
+            components.append(timeString)
+        }
+        return components.joined(separator: ", ")
+    }
+
+    private var rowAccessibilityTraits: AccessibilityTraits {
+        isSelected ? [.isButton, .isSelected] : .isButton
+    }
+
+    private var rowAccessibilityHint: String {
+        if isEditing || chat.decryptionFailed {
+            return ""
+        }
+        return "Opens the conversation"
     }
 }

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -248,12 +248,17 @@ struct ChatContainer: View {
                             .frame(width: 24, height: 24)
                             .foregroundColor(toolbarContentColor)
                     }
+                    .accessibilityLabel("Back")
+                    .accessibleHitTarget()
                 } else {
                     Button(action: toggleSidebar) {
                         MenuToXButton(isX: isSidebarOpen)
                             .frame(width: 24, height: 24)
                             .foregroundColor(toolbarContentColor)
                     }
+                    .accessibilityLabel(isSidebarOpen ? "Close menu" : "Open menu")
+                    .accessibilityHint(isSidebarOpen ? "" : "Shows chats, projects and settings")
+                    .accessibleHitTarget()
                 }
             }
             ToolbarItem(placement: .principal) {
@@ -263,10 +268,13 @@ struct ChatContainer: View {
                         .scaledToFit()
                         .frame(height: 22)
                         .opacity(isSidebarOpen && viewModel.activeProject == nil ? 1 : 0)
+                        .accessibilityLabel("Tinfoil")
+                        .accessibilityHidden(!(isSidebarOpen && viewModel.activeProject == nil))
 
                     if !viewModel.isTemporaryMode && viewModel.activeProject == nil && authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled && viewModel.activeStorageTab == .local {
                         chatStorageLabel
                             .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
+                            .accessibilityHidden(isSidebarOpen || isVerificationBadgeExpanded)
                     }
 
                     if let activeProject = viewModel.activeProject {
@@ -281,6 +289,9 @@ struct ChatContainer: View {
                                 .foregroundColor(.accentColor)
                         }
                         .opacity(isVerificationBadgeExpanded ? 0 : 1)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Project: \(activeProject.name)")
+                        .accessibilityHidden(isVerificationBadgeExpanded)
                     }
 
                     if viewModel.isTemporaryMode && viewModel.activeProject == nil {
@@ -292,6 +303,9 @@ struct ChatContainer: View {
                                 .foregroundColor(.accentColor)
                         }
                         .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Temporary chat")
+                        .accessibilityHidden(isSidebarOpen || isVerificationBadgeExpanded)
                     }
                 }
                 .offset(x: (isSidebarOpen && UIDevice.current.userInterfaceIdiom == .pad) ? sidebarWidth / 2 : 0)
@@ -317,6 +331,7 @@ struct ChatContainer: View {
                         )
                     }
                     .accessibilityLabel(viewModel.isTemporaryMode ? "Exit temporary chat" : "Start temporary chat")
+                    .accessibleHitTarget()
                 }
             }
             // Only show new chat button when chat has messages (not a new/blank chat)
@@ -327,6 +342,8 @@ struct ChatContainer: View {
                             .font(.system(size: 18, weight: .medium))
                             .foregroundColor(toolbarContentColor)
                     }
+                    .accessibilityLabel("New chat")
+                    .accessibleHitTarget()
                 }
             }
             if !authManager.isAuthenticated {
@@ -527,6 +544,8 @@ struct ChatContainer: View {
             .foregroundColor(.secondary)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(isLocal ? "Local storage" : "Cloud storage")
+        .accessibilityHint("Switches between local and cloud chats")
     }
     
     /// Shows the memory view
@@ -1023,6 +1042,16 @@ struct VerificationStatusIndicator: View {
         }
     }
 
+    private var verificationAccessibilityLabel: String {
+        if viewModel.isVerified && viewModel.verificationError == nil {
+            return "Privacy verified"
+        } else if viewModel.isVerifying {
+            return "Verifying privacy"
+        } else {
+            return "Verification failed"
+        }
+    }
+
 
     var body: some View {
         Button(action: { viewModel.showVerifier() }) {
@@ -1054,6 +1083,8 @@ struct VerificationStatusIndicator: View {
             }
             .animation(.easeInOut(duration: 0.35), value: isCollapsed)
         }
+        .accessibilityLabel(verificationAccessibilityLabel)
+        .accessibilityHint("Shows verification details")
         .onAppear {
             if viewModel.isVerified && viewModel.verificationError == nil {
                 isBadgeExpanded = true
@@ -1123,6 +1154,8 @@ struct ModelPicker: View {
                 .scaledToFit()
                 .frame(width: 22, height: 22)
         }
+        .accessibilityLabel("Select model")
+        .accessibilityValue(viewModel.currentModel.displayName)
     }
 }
 

--- a/TinfoilChat/Views/CloudSyncOnboardingView.swift
+++ b/TinfoilChat/Views/CloudSyncOnboardingView.swift
@@ -104,6 +104,7 @@ struct CloudSyncOnboardingView: View {
                 HStack {
                     Button(action: { handleClose() }) {
                         Image(systemName: "xmark")
+                            .accessibilityLabel("Close")
                             .font(.system(size: 12, weight: .bold))
                             .foregroundColor(.secondary)
                             .frame(width: 30, height: 30)
@@ -253,6 +254,7 @@ struct CloudSyncOnboardingView: View {
                     Toggle("", isOn: $cloudSyncToggle)
                         .labelsHidden()
                         .tint(Color.accentPrimary)
+                        .accessibilityLabel("Enable Cloud Sync")
                 }
                 .padding()
                 .background(
@@ -421,6 +423,7 @@ struct CloudSyncOnboardingView: View {
                                 .background(Color(UIColor.tertiarySystemBackground))
                                 .cornerRadius(8)
                         }
+                        .accessibilityLabel("Save to Files")
 
                         // Copy button
                         Button(action: { copyKeyToClipboard() }) {
@@ -431,6 +434,7 @@ struct CloudSyncOnboardingView: View {
                                 .background(isCopied ? Color.green : Color(UIColor.tertiarySystemBackground))
                                 .cornerRadius(8)
                         }
+                        .accessibilityLabel(isCopied ? "Key copied" : "Copy key")
                     }
                     .padding()
                     .background(
@@ -511,6 +515,7 @@ struct CloudSyncOnboardingView: View {
                             .background(Color(UIColor.secondarySystemBackground))
                             .cornerRadius(14)
                     }
+                    .accessibilityLabel("Import key from file")
                 }
                 .padding(.horizontal, 24)
 

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -170,6 +170,7 @@ struct CloudSyncSettingsView: View {
                                     Image(systemName: copiedToClipboard ? "checkmark.circle.fill" : "doc.on.doc")
                                         .foregroundColor(copiedToClipboard ? .adaptiveAccent : .primary)
                                 }
+                                .accessibilityLabel(copiedToClipboard ? "Key copied" : "Copy key")
                             }
                             .padding(8)
                             .frame(maxWidth: .infinity)

--- a/TinfoilChat/Views/EncryptionKeyInputView.swift
+++ b/TinfoilChat/Views/EncryptionKeyInputView.swift
@@ -69,6 +69,7 @@ struct EncryptionKeyInputView: View {
                             .autocapitalization(.none)
                             .disableAutocorrection(true)
                             .font(.system(.body, design: .monospaced))
+                            .accessibilityLabel("Encryption key")
                             .focused($isKeyFieldFocused)
                             .onChange(of: keyInput) { _, newValue in
                                 validateKey(newValue)
@@ -97,6 +98,7 @@ struct EncryptionKeyInputView: View {
                                     .background(Color(UIColor.secondarySystemBackground))
                                     .cornerRadius(12)
                             }
+                            .accessibilityLabel(isKeyVisible ? "Hide key" : "Show key")
                         }
                         
                         if let error = keyError {

--- a/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
@@ -113,6 +113,8 @@ private struct ArtifactPreviewView: View {
             .genUICard(isDarkMode: isDarkMode, padding: 14)
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Opens preview")
         .sheet(isPresented: $showSheet) {
             ArtifactDetailSheet(args: args, isDarkMode: isDarkMode)
         }

--- a/TinfoilChat/Views/GenUI/Widgets/ChartWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ChartWidget.swift
@@ -199,6 +199,22 @@ private struct ChartEntry: Identifiable {
     let value: Double
 }
 
+private func formatChartValue(_ value: Double) -> String {
+    if value.truncatingRemainder(dividingBy: 1) == 0 {
+        return String(Int(value))
+    }
+    return String(value)
+}
+
+private func chartAccessibilityLabel(kind: String, title: String?, entries: [ChartEntry]) -> String {
+    var parts: [String] = []
+    if let title, !title.isEmpty { parts.append(title) }
+    parts.append(kind)
+    let points = entries.map { "\($0.label) \(formatChartValue($0.value))" }
+    if !points.isEmpty { parts.append(points.joined(separator: ", ")) }
+    return parts.joined(separator: ". ")
+}
+
 /// Shared categorical X-axis modifier so bar and line charts use the
 /// same downsampling and label formatting.
 private struct CategoricalXAxisModifier: ViewModifier {
@@ -263,6 +279,8 @@ private struct BarChartView: View {
             }
             .categoricalXAxis(labels: resolved.entries.map(\.label))
             .frame(height: GenUIStyle.chartHeight)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(chartAccessibilityLabel(kind: "Bar chart", title: args.title, entries: resolved.entries))
         }
         .genUICard(isDarkMode: isDarkMode)
     }
@@ -298,6 +316,8 @@ private struct LineChartView: View {
             }
             .categoricalXAxis(labels: resolved.entries.map(\.label))
             .frame(height: GenUIStyle.chartHeight)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(chartAccessibilityLabel(kind: "Line chart", title: args.title, entries: resolved.entries))
         }
         .genUICard(isDarkMode: isDarkMode)
     }
@@ -340,6 +360,7 @@ private struct PieChartView: View {
                     .cornerRadius(2)
                 }
                 .frame(width: 180, height: 180)
+                .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(slices) { slice in
@@ -356,6 +377,7 @@ private struct PieChartView: View {
                                 .font(.caption.weight(.medium))
                                 .foregroundColor(GenUIStyle.mutedText(isDarkMode))
                         }
+                        .accessibilityElement(children: .combine)
                     }
                 }
             }

--- a/TinfoilChat/Views/GenUI/Widgets/ChartWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ChartWidget.swift
@@ -200,7 +200,10 @@ private struct ChartEntry: Identifiable {
 }
 
 private func formatChartValue(_ value: Double) -> String {
-    if value.truncatingRemainder(dividingBy: 1) == 0 {
+    if value.isFinite,
+       value >= Double(Int.min),
+       value <= Double(Int.max),
+       value.truncatingRemainder(dividingBy: 1) == 0 {
         return String(Int(value))
     }
     return String(value)

--- a/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
@@ -109,6 +109,10 @@ private struct LinkPreviewView: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(displayTitle), \(displaySiteName)")
+        .accessibilityHint("Opens link")
+        .accessibilityAddTraits(.isLink)
         .task(id: args.url) {
             await MainActor.run { metadata = nil }
             do {

--- a/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
@@ -335,6 +335,8 @@ private struct RecipeCardView: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(checked ? .isSelected : [])
+        .accessibilityHint(checked ? "Mark as not done" : "Mark as done")
     }
 
     private func ingredientText(_ ingredient: RecipeCardWidget.Ingredient, checked: Bool) -> Text {
@@ -412,6 +414,8 @@ private struct RecipeCardView: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(done ? .isSelected : [])
+        .accessibilityHint(done ? "Mark step as not done" : "Mark step as done")
     }
 
     @ViewBuilder

--- a/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
@@ -82,7 +82,19 @@ private struct StatCardsView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .genUICard(isDarkMode: isDarkMode, padding: 12)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(statAccessibilityLabel(stat))
             }
         }
+    }
+
+    private func statAccessibilityLabel(_ stat: StatCardsWidget.Stat) -> String {
+        var label = "\(stat.label), \(stat.value.stringValue)"
+        if stat.trend == "up" {
+            label += ", trending up"
+        } else if stat.trend == "down" {
+            label += ", trending down"
+        }
+        return label
     }
 }

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -1072,6 +1072,9 @@ struct LaTeXView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Math equation")
+            .accessibilityValue(latex)
         } else {
             MathView(
                 latex: latex,
@@ -1081,6 +1084,9 @@ struct LaTeXView: View {
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 2)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Math equation")
+            .accessibilityValue(latex)
         }
     }
 }
@@ -1156,6 +1162,7 @@ struct StreamingIndicatorDot: View {
                 width: Constants.UI.streamingIndicatorIconColumnWidth,
                 alignment: .center
             )
+            .accessibilityHidden(true)
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     isPulsing = true

--- a/TinfoilChat/Views/MessageAttachmentIndicator.swift
+++ b/TinfoilChat/Views/MessageAttachmentIndicator.swift
@@ -105,6 +105,17 @@ struct MessageAttachmentIndicator: View {
         .padding(.bottom, 4)
     }
 
+    private func openImageViewer(for attachment: Attachment) {
+        let allImages = (viewModel.currentChat?.messages ?? [])
+            .flatMap { $0.attachments }
+            .filter { $0.type == .image && $0.base64 != nil }
+        if let index = allImages.firstIndex(where: { $0.id == attachment.id }) {
+            viewModel.imageViewerImages = allImages
+            viewModel.imageViewerIndex = index
+            viewModel.showImageViewer = true
+        }
+    }
+
     @ViewBuilder
     private var imageGrid: some View {
         let size = Constants.Attachments.messageThumbnailSize
@@ -115,16 +126,12 @@ struct MessageAttachmentIndicator: View {
                 HStack(spacing: 4) {
                     ForEach(row) { attachment in
                         ImageThumbnail(attachment: attachment, size: size)
-                            .onTapGesture {
-                                let allImages = (viewModel.currentChat?.messages ?? [])
-                                    .flatMap { $0.attachments }
-                                    .filter { $0.type == .image && $0.base64 != nil }
-                                if let index = allImages.firstIndex(where: { $0.id == attachment.id }) {
-                                    viewModel.imageViewerImages = allImages
-                                    viewModel.imageViewerIndex = index
-                                    viewModel.showImageViewer = true
-                                }
-                            }
+                            .onTapGesture { openImageViewer(for: attachment) }
+                            .accessibilityElement()
+                            .accessibilityLabel("Image attachment")
+                            .accessibilityAddTraits(.isButton)
+                            .accessibilityHint("Opens full screen")
+                            .accessibilityAction { openImageViewer(for: attachment) }
                     }
                 }
             }
@@ -153,6 +160,8 @@ private struct AttachmentChip: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(isDarkMode ? Color.white.opacity(0.08) : Color.black.opacity(0.06))
         )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Attachment, \(attachment.fileName)")
     }
 
     private var iconName: String {
@@ -257,6 +266,7 @@ struct ImageViewerOverlay: View {
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
                             .background(.ultraThinMaterial, in: Capsule())
+                            .accessibilityLabel("Image \(currentIndex + 1) of \(images.count)")
                     }
 
                     Spacer()
@@ -268,6 +278,7 @@ struct ImageViewerOverlay: View {
                             .font(.system(size: 30))
                             .foregroundStyle(.white.opacity(0.8))
                     }
+                    .accessibilityLabel("Close image viewer")
                 }
                 .padding()
 
@@ -286,6 +297,7 @@ struct ImageViewerOverlay: View {
                                 .foregroundStyle(.white.opacity(currentIndex > 0 ? 0.7 : 0.2))
                         }
                         .disabled(currentIndex == 0)
+                        .accessibilityLabel("Previous image")
 
                         Spacer()
 
@@ -299,6 +311,7 @@ struct ImageViewerOverlay: View {
                                 .foregroundStyle(.white.opacity(currentIndex < images.count - 1 ? 0.7 : 0.2))
                         }
                         .disabled(currentIndex == images.count - 1)
+                        .accessibilityLabel("Next image")
                     }
                     .padding(.horizontal, 20)
                     .padding(.bottom, 40)
@@ -337,6 +350,7 @@ struct ZoomableImagePage: View {
                 Image(uiImage: decodedImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+                    .accessibilityLabel("Image")
                     .scaleEffect(scale)
                     .gesture(
                         MagnifyGesture()

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -328,6 +328,9 @@ struct MessageInputView: View {
                             isPulsing = isRecording
                         }
                         .disabled(viewModel.isLoading || viewModel.isTranscribing)
+                        .accessibleHitTarget()
+                        .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Voice input")
+                        .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
                         .padding(.trailing, 4)
                     }
 
@@ -342,6 +345,7 @@ struct MessageInputView: View {
                     .glassEffect(.regular.interactive(), in: .circle)
                     .clipShape(.circle)
                     .tint(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
+                    .accessibilityLabel(viewModel.isLoading ? "Stop generating" : "Send message")
                     .padding(.trailing, 8)
                 }
                 .padding(.vertical, 8)
@@ -431,6 +435,9 @@ struct MessageInputView: View {
                             isPulsing = isRecording
                         }
                         .disabled(viewModel.isLoading || viewModel.isTranscribing)
+                        .accessibleHitTarget()
+                        .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Voice input")
+                        .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
                         .padding(.trailing, 4)
                     }
 
@@ -445,6 +452,8 @@ struct MessageInputView: View {
                                 .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
                         }
                     }
+                    .accessibilityLabel(viewModel.isLoading ? "Stop generating" : "Send message")
+                    .accessibleHitTarget()
                     .padding(.trailing, 8)
                 }
                 .padding(.vertical, 8)
@@ -480,6 +489,8 @@ struct MessageInputView: View {
                 .frame(width: 24, height: 24)
         }
         .disabled(viewModel.isLoading || viewModel.isProcessingAttachment)
+        .accessibilityLabel("Add attachment")
+        .accessibleHitTarget()
         .padding(.leading, 8)
     }
 
@@ -501,6 +512,9 @@ struct MessageInputView: View {
             .clipShape(Capsule())
         }
         .disabled(viewModel.isLoading)
+        .accessibilityLabel("Model")
+        .accessibilityValue(viewModel.currentModel.displayName)
+        .accessibilityHint("Changes the AI model")
         .padding(.leading, 4)
     }
 
@@ -613,6 +627,7 @@ struct AddToSheetView: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 18, weight: .medium))
                     }
+                    .accessibilityLabel("Close")
                 }
             }
         }
@@ -683,6 +698,7 @@ struct ModelSelectorSheetView: View {
                     .padding(.vertical, 4)
                 }
                 .listRowBackground(Color.clear)
+                .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
             }
             .listStyle(.plain)
             .navigationTitle("Select Model")
@@ -695,6 +711,7 @@ struct ModelSelectorSheetView: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 18, weight: .medium))
                     }
+                    .accessibilityLabel("Close")
                 }
             }
         }
@@ -724,6 +741,8 @@ struct CustomTextEditor: UIViewRepresentable {
         textView.textContainerInset = UIEdgeInsets(top: 16, left: 2, bottom: 8, right: 5)
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = UIColor.systemBlue
+        textView.adjustsFontForContentSizeCategory = true
+        textView.accessibilityLabel = "Message"
 
         // Initialize with placeholder or actual text
         if text.isEmpty {
@@ -735,7 +754,8 @@ struct CustomTextEditor: UIViewRepresentable {
                 return traitCollection.userInterfaceStyle == .dark ? .white : .black
             }
         }
-        
+
+        context.coordinator.refreshAccessibility(textView)
         return textView
     }
     
@@ -777,6 +797,7 @@ struct CustomTextEditor: UIViewRepresentable {
         }
 
         uiView.isEditable = true
+        context.coordinator.refreshAccessibility(uiView)
 
         let size = uiView.sizeThatFits(CGSize(width: uiView.frame.width, height: CGFloat.greatestFiniteMagnitude))
         let newHeight = min(MessageInputView.Layout.maximumHeight, max(MessageInputView.Layout.minimumHeight, size.height))
@@ -800,7 +821,16 @@ struct CustomTextEditor: UIViewRepresentable {
         init(_ parent: CustomTextEditor) {
             self.parent = parent
         }
-        
+
+        /// Keeps VoiceOver from reading the gray placeholder as if it were
+        /// entered text: the field always reports a stable "Message" label and
+        /// only exposes a value once real text has been typed.
+        func refreshAccessibility(_ textView: UITextView) {
+            textView.accessibilityLabel = "Message"
+            let isShowingPlaceholder = textView.textColor == .lightGray
+            textView.accessibilityValue = isShowingPlaceholder ? "" : textView.text
+        }
+
         func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
             // Check if Enter key was pressed (without Shift)
             if text == "\n" {
@@ -855,6 +885,7 @@ struct CustomTextEditor: UIViewRepresentable {
                     parent.textHeight = newHeight
                 }
             }
+            refreshAccessibility(textView)
         }
         
         func textViewDidBeginEditing(_ textView: UITextView) {
@@ -866,6 +897,7 @@ struct CustomTextEditor: UIViewRepresentable {
                     return traitCollection.userInterfaceStyle == .dark ? .white : .black
                 }
             }
+            refreshAccessibility(textView)
         }
         
         func textViewDidEndEditing(_ textView: UITextView) {
@@ -875,6 +907,7 @@ struct CustomTextEditor: UIViewRepresentable {
                 textView.text = parent.placeholderText
                 textView.textColor = .lightGray
             }
+            refreshAccessibility(textView)
         }
     }
 } 

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -703,6 +703,8 @@ struct ObservableMessageCell: View {
                 }
                 .padding(.vertical, 16)
                 .padding(.horizontal, 24)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Older messages above are archived")
             }
 
             ZStack(alignment: .topLeading) {

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -624,6 +624,8 @@ struct MessageView: View {
                                 .contentShape(Rectangle())
                         }
                         .buttonStyle(PlainButtonStyle())
+                        .accessibilityLabel("Copy")
+                        .accessibleHitTarget()
 
                         // Regenerate button - only on the last assistant message
                         if isLastMessage && !viewModel.isLoading && messageIndex > 0 {
@@ -637,6 +639,8 @@ struct MessageView: View {
                                     .contentShape(Rectangle())
                             }
                             .buttonStyle(PlainButtonStyle())
+                            .accessibilityLabel("Regenerate response")
+                            .accessibleHitTarget()
                         }
 
                         // Share button - only on the last assistant message
@@ -651,6 +655,8 @@ struct MessageView: View {
                                     .contentShape(Rectangle())
                             }
                             .buttonStyle(PlainButtonStyle())
+                            .accessibilityLabel("Share")
+                            .accessibleHitTarget()
                         }
 
                         Spacer()
@@ -723,6 +729,10 @@ struct MessageView: View {
             }
         }
         .padding(.horizontal, 4)
+        // Announce who is speaking while keeping inner controls (links, tool
+        // calls, action buttons, text selection) individually accessible.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(message.role == .user ? "You said" : "Assistant said")
         .sheet(isPresented: $showLongMessageSheet) {
             LongMessageDetailView(
                 message: message
@@ -1318,6 +1328,7 @@ struct CollapsibleThinkingBox: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(NoHighlightButtonStyle())
+        .accessibilityHint("Shows the full reasoning")
     }
 }
 
@@ -1398,6 +1409,8 @@ struct LoadingDotsView: View {
             }
         }
         .foregroundColor(isDarkMode ? .white : .black)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Generating response")
     }
 }
 
@@ -1413,6 +1426,7 @@ struct InlineLoadingDotsView: View {
             }
         }
         .foregroundColor(isDarkMode ? .white.opacity(0.8) : Color.black.opacity(0.7))
+        .accessibilityHidden(true)
     }
 }
 
@@ -1881,6 +1895,9 @@ private struct SourcesButton: View {
         }
         .buttonStyle(PlainButtonStyle())
         .foregroundColor(isDarkMode ? .white : .black)
+        .accessibilityLabel("Sources")
+        .accessibilityValue("\(sources.count) source\(sources.count == 1 ? "" : "s")")
+        .accessibilityHint("Shows web sources")
     }
 }
 

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -291,6 +291,9 @@ private struct OnboardingPrivacyPage: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isPrivateOn ? .isSelected : [])
+        .accessibilityHint(isPrivateOn ? "" : "Enables privacy")
         .padding(.horizontal, 24)
     }
 
@@ -556,6 +559,8 @@ private struct OnboardingModelsPage: View {
                                     selectedModelIndex = index
                                 }
                             }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityAddTraits(index == selectedModelIndex ? [.isButton, .isSelected] : .isButton)
                     }
                 }
                 .padding(.horizontal, 24)

--- a/TinfoilChat/Views/PersonalizationView.swift
+++ b/TinfoilChat/Views/PersonalizationView.swift
@@ -35,6 +35,7 @@ struct TraitSelectionView: View {
                     .foregroundColor(selectedTraits.contains(trait) ? .white : .primary)
                 }
                 .buttonStyle(PlainButtonStyle())
+                .accessibilityAddTraits(selectedTraits.contains(trait) ? .isSelected : [])
             }
         }
     }

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -161,6 +161,7 @@ struct ProjectPage: View {
                     .foregroundColor(.secondary)
             }
         }
+        .accessibilityHint("Opens chat")
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
                 deletingChatId = chat.id
@@ -262,6 +263,7 @@ struct ProjectDetailsView: View {
                     }
                 }
                 .disabled(!hasPendingChanges || project == nil || isSaving)
+                .accessibilityLabel("Save")
             }
         }
         .onAppear(perform: syncEditingState)
@@ -338,6 +340,7 @@ struct ProjectDocumentsView: View {
                     Image(systemName: "plus")
                 }
                 .disabled(viewModel.isUploadingProjectDocument)
+                .accessibilityLabel("Add document")
             }
         }
         .sheet(isPresented: $showDocumentPicker) {

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -559,10 +559,12 @@ struct SettingsView: View {
                     }
                     .buttonStyle(BorderlessButtonStyle())
                     .disabled(settings.maxMessages <= 1)
+                    .accessibilityLabel("Decrease messages in context")
 
                     Text("\(settings.maxMessages)")
                         .frame(minWidth: 40)
                         .font(.system(.body, design: .monospaced))
+                        .accessibilityLabel("Messages in context: \(settings.maxMessages)")
 
                     Button(action: {
                         if settings.maxMessages < Constants.Context.maxMessagesLimit {
@@ -575,6 +577,7 @@ struct SettingsView: View {
                     }
                     .buttonStyle(BorderlessButtonStyle())
                     .disabled(settings.maxMessages >= Constants.Context.maxMessagesLimit)
+                    .accessibilityLabel("Increase messages in context")
                 }
             }
             .padding(.vertical, 4)
@@ -596,6 +599,7 @@ struct SettingsView: View {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption)
                             .foregroundColor(.green)
+                            .accessibilityLabel("Enabled")
                     }
                 }
             }
@@ -614,6 +618,7 @@ struct SettingsView: View {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption)
                             .foregroundColor(.green)
+                            .accessibilityLabel("Enabled")
                     }
                 }
             }
@@ -740,6 +745,7 @@ struct SettingsView: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 18, weight: .medium))
                     }
+                    .accessibilityLabel("Close")
                 }
             }
         }
@@ -950,6 +956,7 @@ struct LanguagePickerView: View {
                 }
             }
             .foregroundColor(.primary)
+            .accessibilityAddTraits(selectedLanguage == language ? .isSelected : [])
             .listRowBackground(Color.cardSurface(for: colorScheme))
         }
         .scrollContentBackground(.hidden)
@@ -1135,6 +1142,7 @@ struct CustomSystemPromptView: View {
                     TextEditor(text: $editingPrompt)
                         .font(.system(.body, design: .monospaced))
                         .frame(minHeight: 200)
+                        .accessibilityLabel("Custom prompt")
                 } header: {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Custom Prompt")

--- a/TinfoilChat/Views/ShareChatView.swift
+++ b/TinfoilChat/Views/ShareChatView.swift
@@ -50,6 +50,7 @@ struct ShareChatView: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 18, weight: .medium))
                     }
+                    .accessibilityLabel("Close")
                 }
             }
         }
@@ -126,6 +127,7 @@ struct ShareChatView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 
     private var actionButton: some View {

--- a/TinfoilChat/Views/VerifierViewController.swift
+++ b/TinfoilChat/Views/VerifierViewController.swift
@@ -206,6 +206,7 @@ struct VerifierView: View {
                 let status = tabStatus(tab, doc: doc)
                 tabCard(tab: tab, status: status, isSelected: selectedTab == tab)
                     .onTapGesture { selectedTab = tab }
+                    .accessibilityAddTraits(.isButton)
                 if tab != .runtime {
                     Spacer(minLength: 12)
                 }
@@ -243,6 +244,18 @@ struct VerifierView: View {
         .overlay(alignment: .topTrailing) {
             statusBadge(status)
                 .offset(x: 6, y: -6)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(tab.label), \(statusAccessibilityText(status))")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func statusAccessibilityText(_ status: VerifierStatus) -> String {
+        switch status {
+        case .pending: return "pending"
+        case .loading: return "verifying"
+        case .success: return "verified"
+        case .error: return "failed"
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds broad accessibility support throughout the app to make it usable with VoiceOver. Labels, hints, selected states, and larger touch targets improve navigation, chats, messages, attachments, widgets, and settings.

- New Features
  - Introduced `accessibleHitTarget` to ensure 44pt touch targets on toolbar and action buttons.
  - Chat list and projects: combined row semantics, expanded/collapsed and selected state announcements, encrypted items labeled, and Rename/Delete exposed as accessibility actions.
  - Navigation and storage: back/menu/new chat/model picker/memory/verification controls labeled with clear hints and current values; verification status is announced.
  - Messages and input: speaker announced; copy/regenerate/share buttons labeled; voice input/send/attachment/model controls labeled; text editor reports a stable “Message” label and hides placeholder from VoiceOver.
  - Attachments and image viewer: chips and thumbnails labeled, thumbnails act as buttons with “open” actions, and viewer controls (close/prev/next/index) labeled.
  - Generated UI and settings: charts/pie/stats/recipe/link previews get meaningful labels and flattened semantics; chart values are safely formatted for announcements; math equations are labeled with their LaTeX content; Cloud Sync, Settings, onboarding, auth, sharing, and verifier tabs expose labels, selected states, and clear hints.

<sup>Written for commit b465b80fe36c0a24a55fc2b23760bca0629b8df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

