### PR TITLE
fix: stop thinking flicker and lost text in streamed replies

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1932,6 +1932,13 @@ class ChatViewModel: ObservableObject {
                 var thoughtsBuffer = ""
                 var isInThinkingMode = false
                 var isUsingReasoningFormat = false
+                // Reasoning deltas that arrive after the answer started are
+                // held here until they contain substantive text. Routers
+                // interleave trailing punctuation/whitespace crumbs of the
+                // previous reasoning (e.g. ". ") into the content stream,
+                // and re-entering thinking mode for those flickers the
+                // thinking UI mid-reply.
+                var pendingReasoningTail = ""
                 var didRecordWebSearchBeforeThinking = false
                 var webSearchBeforeThinking: Bool? = nil
                 var initialContentBuffer = ""
@@ -2107,22 +2114,60 @@ class ChatViewModel: ObservableObject {
                         Task { @MainActor in
                             ThinkingSummaryService.shared.reset()
                         }
+                        // Some routers attach content to the same chunk as
+                        // the first reasoning delta; close the thinking
+                        // session and emit it so the text isn't dropped.
+                        if !content.isEmpty {
+                            if let startTime = thinkStartTime {
+                                generationTimeSeconds = Date().timeIntervalSince(startTime)
+                            }
+                            isInThinkingMode = false
+                            thinkStartTime = nil
+                            thinkingChunker.finalize()
+                            if responseContent.isEmpty {
+                                responseContent = content
+                            } else {
+                                responseContent += content
+                            }
+                            chunker.appendToken(content)
+                            appendText(content)
+                        }
                     } else if isUsingReasoningFormat {
                         if !reasoningContent.isEmpty {
-                            thoughtsBuffer += reasoningContent
-                            thinkingChunker.appendToken(reasoningContent)
-                            currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                            isInThinkingMode = true
-                            didMutateState = true
-                            // Generate thinking summary (reuse existing client)
-                            let currentThoughtsForSummary = thoughtsBuffer
-                            Task { @MainActor [weak self] in
-                                ThinkingSummaryService.shared.generateSummary(thoughts: currentThoughtsForSummary) { summary in
-                                    self?.thinkingSummary = summary
+                            if isInThinkingMode {
+                                thoughtsBuffer += reasoningContent
+                                thinkingChunker.appendToken(reasoningContent)
+                                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                                didMutateState = true
+                                // Generate thinking summary (reuse existing client)
+                                let currentThoughtsForSummary = thoughtsBuffer
+                                Task { @MainActor [weak self] in
+                                    ThinkingSummaryService.shared.generateSummary(thoughts: currentThoughtsForSummary) { summary in
+                                        self?.thinkingSummary = summary
+                                    }
+                                }
+                            } else {
+                                pendingReasoningTail += reasoningContent
+                                if pendingReasoningTail.rangeOfCharacter(from: .alphanumerics) != nil {
+                                    isInThinkingMode = true
+                                    thoughtsBuffer += pendingReasoningTail
+                                    thinkingChunker.appendToken(pendingReasoningTail)
+                                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                                    pendingReasoningTail = ""
+                                    didMutateState = true
+                                    let currentThoughtsForSummary = thoughtsBuffer
+                                    Task { @MainActor [weak self] in
+                                        ThinkingSummaryService.shared.generateSummary(thoughts: currentThoughtsForSummary) { summary in
+                                            self?.thinkingSummary = summary
+                                        }
+                                    }
                                 }
                             }
                         }
 
+                        if !content.isEmpty {
+                            pendingReasoningTail = ""
+                        }
                         if !content.isEmpty && isInThinkingMode {
                             if let startTime = thinkStartTime {
                                 generationTimeSeconds = Date().timeIntervalSince(startTime)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes flickering “Thinking…” UI and missing text during streamed replies. Adds buffering to prevent re-entering thinking mode on punctuation-only deltas and ensures mixed reasoning/content chunks don’t drop tokens.

- **Bug Fixes**
  - Buffer late reasoning deltas (`pendingReasoningTail`) and only re-enter thinking when they include alphanumerics, stopping mid-reply flicker.
  - When routers send reasoning and content in the same chunk, finalize thinking and append content immediately to avoid lost text.
  - Keep thinking summary generation aligned with the current thinking state and clear the pending tail when content arrives.

<sup>Written for commit 4bfc71e1d641f2664488f23fc5e10eb9c645e312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

