### PR TITLE
Fix UI and UX issues

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/textual";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.6;
+				minimumVersion = 0.0.7;
 			};
 		};
 		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "005baa6df114f7578c5ce82650ed0370be077954",
-        "version" : "0.0.6"
+        "revision" : "5e7b311582a7c55e3d8f0163f17d44ddb90c005c",
+        "version" : "0.0.7"
       }
     },
     {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -202,9 +202,9 @@ enum Constants {
     }
 
     enum WebApp {
-        /// Deep link into the web app's settings; the `#settings/export`
+        /// Deep link into the web app's settings; the `#settings/cloud-sync`
         /// fragment opens the tab hosting chat export.
-        static let exportChatsURL = URL(string: "https://chat.tinfoil.sh/#settings/export")!
+        static let exportChatsURL = URL(string: "https://chat.tinfoil.sh/#settings/cloud-sync")!
     }
 
     enum Share {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -55,6 +55,13 @@ enum Constants {
         /// Individual markdown segments larger than this are split at
         /// paragraph boundaries to bound CoreText measurement time.
         static let maxMarkdownSegmentCharacters = 8_000
+        /// Font-scaled (em) spacing above a markdown horizontal rule.
+        static let thematicBreakTopSpacing: CGFloat = 1.6
+        /// Font-scaled (em) spacing below a markdown horizontal rule.
+        /// Smaller than the top spacing because the following paragraph
+        /// contributes its own 0.8 em top spacing, which makes the
+        /// perceived gap symmetric.
+        static let thematicBreakBottomSpacing: CGFloat = 0.8
     }
 
     enum StreamingBuffer {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -55,13 +55,6 @@ enum Constants {
         /// Individual markdown segments larger than this are split at
         /// paragraph boundaries to bound CoreText measurement time.
         static let maxMarkdownSegmentCharacters = 8_000
-        /// Font-scaled (em) spacing above a markdown horizontal rule.
-        static let thematicBreakTopSpacing: CGFloat = 1.6
-        /// Font-scaled (em) spacing below a markdown horizontal rule.
-        /// Smaller than the top spacing because the following paragraph
-        /// contributes its own 0.8 em top spacing, which makes the
-        /// perceived gap symmetric.
-        static let thematicBreakBottomSpacing: CGFloat = 0.8
     }
 
     enum StreamingBuffer {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -202,8 +202,7 @@ enum Constants {
     }
 
     enum WebApp {
-        /// Deep link into the web app's settings; the `#settings/cloud-sync`
-        /// fragment opens the tab hosting chat export.
+        /// Chat export lives on the web app's cloud-sync settings tab.
         static let exportChatsURL = URL(string: "https://chat.tinfoil.sh/#settings/cloud-sync")!
     }
 

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -199,6 +199,12 @@ enum Constants {
         static let numberOfChannels: Int = 1  // Mono
     }
 
+    enum WebApp {
+        /// Deep link into the web app's settings; the `#settings/export`
+        /// fragment opens the tab hosting chat export.
+        static let exportChatsURL = URL(string: "https://chat.tinfoil.sh/#settings/export")!
+    }
+
     enum Share {
         static let shareBaseURL = "https://chat.tinfoil.sh"
         static let shareAPIPath = "/api/shares"

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -119,8 +119,17 @@ enum Constants {
     }
 
     enum Context {
-        static let defaultMaxMessages = 75
-        static let maxMessagesLimit = 200
+        /// Approximate characters per token used by the estimation heuristic.
+        static let charsPerToken: Double = 4
+        /// Fraction of the model's context window usable by conversation
+        /// history. The remainder is headroom for the system prompt and the
+        /// model's response. Mirrors the webapp's CONTEXT_WINDOW_USAGE_RATIO.
+        static let contextWindowUsageRatio: Double = 0.9
+        /// Fallback context window size when a model doesn't report one.
+        static let defaultContextWindowTokens = 64_000
+        /// Usage percentage at which the context indicator switches to the
+        /// warning color.
+        static let warningThresholdPercent = 80
     }
 
     enum CloudSync {
@@ -228,7 +237,6 @@ enum Constants {
             static let selectedModel = "tinfoil-settings-selected-model"
             static let hapticFeedbackEnabled = "tinfoil-settings-haptic-feedback-enabled"
             static let selectedLanguage = "tinfoil-settings-selected-language"
-            static let maxPromptMessages = "tinfoil-settings-max-prompt-messages"
             static let webSearchEnabled = "tinfoil-settings-web-search-enabled"
             static let reasoningEffort = "tinfoil-settings-reasoning-effort"
             static let thinkingEnabled = "tinfoil-settings-thinking-enabled"
@@ -362,7 +370,6 @@ enum StorageKeysMigration {
             ("lastSelectedModel", Constants.StorageKeys.Settings.selectedModel),
             ("hapticFeedbackEnabled", Constants.StorageKeys.Settings.hapticFeedbackEnabled),
             ("selectedLanguage", Constants.StorageKeys.Settings.selectedLanguage),
-            ("maxPromptMessages", Constants.StorageKeys.Settings.maxPromptMessages),
             ("webSearchEnabled", Constants.StorageKeys.Settings.webSearchEnabled),
             ("cloudSyncEnabled", Constants.StorageKeys.Settings.cloudSyncEnabled),
             ("cloudSyncActiveTab", Constants.StorageKeys.Settings.cloudSyncActiveTab),

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -146,7 +146,6 @@ enum Constants {
         static let backgroundTaskName = "CompleteStreamingResponse"
         static let maxReverseTimestamp: Int = 9999999999999
         static let reverseTimestampDigits: Int = String(maxReverseTimestamp).count
-        static let keyValidationProbeCount: Int = 3
 
         static let createdAtFallbackThresholdSeconds: TimeInterval = 5.0
         static let uploadBaseDelaySeconds: TimeInterval = 1.0

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -102,6 +102,9 @@ enum Constants {
         /// Hard per-page cap the enclave's list-status endpoint
         /// enforces; requests above it are clamped server-side.
         static let listStatusPageLimit = 500
+        /// How many full chat blobs to request per pull call. Keeps
+        /// individual response payloads bounded when syncing many chats.
+        static let pullBatchSize = 20
     }
 
 

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -340,7 +340,6 @@ struct ProfileData: Codable {
     var themeMode: String?
     
     // Chat settings
-    var maxPromptMessages: Int?
     var language: String?
     
     // Personalization settings

--- a/TinfoilChat/Services/CloudKeyPreflightValidator.swift
+++ b/TinfoilChat/Services/CloudKeyPreflightValidator.swift
@@ -2,12 +2,14 @@
 //  CloudKeyPreflightValidator.swift
 //  TinfoilChat
 //
-//  Validates that the locally-loaded primary CEK matches the
-//  user's existing cloud data by probing the enclave directly.
-//  With the v2 sync architecture, validation collapses to "ask the
-//  enclave to unseal a row with this CEK and check whether it
-//  refuses". The enclave returns UNKNOWN_KEY when the supplied key
-//  doesn't match, and plaintext otherwise.
+//  Validates that the locally-loaded primary CEK is consistent with
+//  what the enclave reports as the user's current key. The enclave
+//  owns key identity — the authoritative answer is "does the local
+//  CEK derive the same key id the enclave has registered?". Legacy
+//  (un-keyed) data never blocks the local key: which rows a key can
+//  unseal is only provable by decrypting, and the migration sweep is
+//  self-guarding — the enclave rewraps only rows it successfully
+//  decrypts, leaving the rest on cooldown.
 //
 
 import Foundation
@@ -22,16 +24,6 @@ enum CloudRemoteState {
     case empty
     case exists
     case unknown
-}
-
-/// Result of probing the local key-set against existing remote rows.
-/// Mirrors the webapp's `LegacyKeyProbeOutcome` so both platforms reach
-/// the same verdict when deciding whether a key may be bound.
-enum LocalKeyProbeOutcome {
-    case decryptable
-    case undecryptable
-    case noSample
-    case transientFailure
 }
 
 struct CloudKeyValidationResult {
@@ -49,12 +41,6 @@ final class CloudKeyPreflightValidator {
     private let profileSync = ProfileSyncService.shared
     private let cloudStorage = CloudStorageService.shared
     private let encryptionService = EncryptionService.shared
-
-    /// Every data scope the probe samples, matching the webapp's
-    /// `LEGACY_KEY_PROBE_SCOPES`. Project data can exist without any
-    /// profile or chat, so all four must be checked before concluding
-    /// the remote is empty.
-    private static let probeScopes: [SyncScope] = [.chat, .profile, .project, .projectDocument]
 
     private init() {}
 
@@ -78,92 +64,53 @@ final class CloudKeyPreflightValidator {
         }
     }
 
-    /// Validate the currently-loaded key-set by asking the enclave to
-    /// unseal a sample of real rows across every data scope. A row the
-    /// keys cannot open (`UNKNOWN_KEY`) blocks binding even when other
-    /// rows decrypt; a decryptable sample confirms the key; an empty
-    /// sample means there is nothing to strand. Mirrors the webapp's
-    /// shared decrypt probe so both platforms gate identically.
+    /// Validate the local CEK against the enclave's current key id.
+    ///
+    ///  - No local key loaded                    → unknown / canWrite=false
+    ///  - Enclave unreachable                    → unknown / canWrite=false
+    ///  - No remote key and no data              → empty   / canWrite=true
+    ///  - Legacy data but no registered key      → exists  / canWrite=true
+    ///  - Local key id matches the enclave's     → exists  / canWrite=true
+    ///  - Local key id differs from the enclave  → exists  / canWrite=false
+    ///
+    /// Legacy (un-keyed) data never blocks the local key: which rows the
+    /// key can actually unseal is only provable by decrypting, and the
+    /// migration sweep is self-guarding — the enclave rewraps only rows
+    /// it successfully decrypts, leaving the rest on cooldown. Blocking
+    /// on a decrypt probe produced false negatives for mixed-key v1
+    /// accounts (rows sealed under several historical keys) and silently
+    /// prevented any migration at all. Mirrors the webapp's preflight.
     func validateCurrentPrimaryKey() async -> CloudKeyValidationResult {
-        guard encryptionService.getKey() != nil else {
+        let cek: Data
+        do {
+            cek = try encryptionService.getKeyBytesOrThrow()
+        } catch {
             return unknownResult(message: CloudKeyValidationMessages.noEncryptionKey)
         }
 
-        switch await probeKeysAcrossScopes(CEKEncoding.keyValidationProbeKeys()) {
-        case .undecryptable:
-            return blockedResult()
-        case .transientFailure:
+        let current: EnclaveKeyCurrentResponse
+        do {
+            current = try await SyncEnclaveAPI.keyCurrent()
+        } catch {
             return unknownResult(message: CloudKeyValidationMessages.unknownRemoteState)
-        case .decryptable:
-            return validResult()
-        case .noSample:
+        }
+
+        guard let remoteKeyId = current.keyId else {
+            if current.hasData {
+                return validResult()
+            }
             return CloudKeyValidationResult(
                 remoteState: .empty,
                 canWrite: true,
                 message: nil
             )
         }
-    }
 
-    /// Pull a small sample from each data scope with the supplied
-    /// candidate key-set and classify whether those keys can unseal
-    /// whatever the enclave already holds. The probe never
-    /// short-circuits on the first decryptable row: a single
-    /// `UNKNOWN_KEY` anywhere is enough to refuse the bind, since binding
-    /// a key that cannot open existing rows would strand that data. A
-    /// transient pull failure is not proof of mismatch, so it is
-    /// reported separately and the caller treats it as retryable.
-    /// Also used by recovery flows that must verify a recovered CEK
-    /// against existing cloud data before binding it to the enclave.
-    func probeKeysAcrossScopes(_ keys: [EnclavePullKey]) async -> LocalKeyProbeOutcome {
-        guard !keys.isEmpty else { return .undecryptable }
-
-        var sawDecryptable = false
-        var sawUndecryptable = false
-
-        for scope in Self.probeScopes {
-            let request: EnclavePullRequest
-            if scope == .profile {
-                request = EnclavePullRequest(
-                    scope: .profile,
-                    ids: ["profile"],
-                    all: nil,
-                    cursor: nil,
-                    limit: nil,
-                    keys: keys
-                )
-            } else {
-                request = EnclavePullRequest(
-                    scope: scope,
-                    ids: nil,
-                    all: true,
-                    cursor: nil,
-                    limit: Constants.Sync.keyValidationProbeCount,
-                    keys: keys
-                )
-            }
-
-            do {
-                let response = try await SyncEnclaveAPI.pull(request)
-                for item in response.items {
-                    if item.ok {
-                        sawDecryptable = true
-                    } else if item.code == WireCodes.unknownKey {
-                        sawUndecryptable = true
-                    }
-                }
-            } catch {
-                // A row an earlier scope already failed to unseal is
-                // definitive proof of mismatch; a later transient pull
-                // failure must not soften that verdict into "retryable".
-                if sawUndecryptable { return .undecryptable }
-                return .transientFailure
-            }
+        guard let localKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek) else {
+            return blockedResult()
         }
 
-        if sawUndecryptable { return .undecryptable }
-        if sawDecryptable { return .decryptable }
-        return .noSample
+        return localKeyId == remoteKeyId ? validResult() : blockedResult()
     }
 
     private func unknownResult(message: String) -> CloudKeyValidationResult {

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -573,48 +573,56 @@ class CloudStorageService: ObservableObject {
 
     // MARK: - Helpers
 
-    private func attachInlineContent(_ conversations: inout [RemoteChat]) async {
-        guard let keys = CEKEncoding.pullKeysIfAvailable() else { return }
+    /// Pull the full content for the given chats and merge it into the
+    /// array in place. Requests are batched so payloads stay bounded no
+    /// matter how many chats need content. Chats whose pull fails keep
+    /// metadata only; callers fall back to per-chat downloads.
+    func attachInlineContent(_ conversations: inout [RemoteChat]) async {
+        guard !conversations.isEmpty,
+              let keys = CEKEncoding.pullKeysIfAvailable() else { return }
         let ids = conversations.map(\.id)
-        do {
-            let response = try await SyncEnclaveAPI.pull(
-                EnclavePullRequest(
-                    scope: .chat,
-                    ids: ids,
-                    all: nil,
-                    cursor: nil,
-                    limit: nil,
-                    keys: keys
+        var pulledById: [String: (content: String, syncVersion: Int?)] = [:]
+        for batchStart in stride(from: 0, to: ids.count, by: Constants.SyncEnclave.pullBatchSize) {
+            let batch = Array(ids[batchStart..<min(batchStart + Constants.SyncEnclave.pullBatchSize, ids.count)])
+            do {
+                let response = try await SyncEnclaveAPI.pull(
+                    EnclavePullRequest(
+                        scope: .chat,
+                        ids: batch,
+                        all: nil,
+                        cursor: nil,
+                        limit: nil,
+                        keys: keys
+                    )
                 )
+                for item in response.items {
+                    if !item.ok { continue }
+                    guard let b64 = item.plaintext,
+                          let data = Data(base64Encoded: b64),
+                          let content = String(data: data, encoding: .utf8) else { continue }
+                    pulledById[item.id] = (content, etagToSyncVersion(item.etag))
+                }
+            } catch {
+                // Listing succeeded; surface only metadata when content
+                // pulls fail. Callers fall back to per-chat downloads.
+            }
+        }
+        for index in conversations.indices {
+            let existing = conversations[index]
+            guard let pulled = pulledById[existing.id] else { continue }
+            conversations[index] = RemoteChat(
+                id: existing.id,
+                key: existing.key,
+                createdAt: existing.createdAt,
+                updatedAt: existing.updatedAt,
+                title: existing.title,
+                messageCount: existing.messageCount,
+                syncVersion: pulled.syncVersion ?? existing.syncVersion,
+                size: existing.size,
+                content: pulled.content,
+                formatVersion: 2,
+                projectId: existing.projectId
             )
-            var pulledById: [String: (content: String, syncVersion: Int?)] = [:]
-            for item in response.items {
-                if !item.ok { continue }
-                guard let b64 = item.plaintext,
-                      let data = Data(base64Encoded: b64),
-                      let content = String(data: data, encoding: .utf8) else { continue }
-                pulledById[item.id] = (content, etagToSyncVersion(item.etag))
-            }
-            for index in conversations.indices {
-                let existing = conversations[index]
-                guard let pulled = pulledById[existing.id] else { continue }
-                conversations[index] = RemoteChat(
-                    id: existing.id,
-                    key: existing.key,
-                    createdAt: existing.createdAt,
-                    updatedAt: existing.updatedAt,
-                    title: existing.title,
-                    messageCount: existing.messageCount,
-                    syncVersion: pulled.syncVersion ?? existing.syncVersion,
-                    size: existing.size,
-                    content: pulled.content,
-                    formatVersion: 2,
-                    projectId: existing.projectId
-                )
-            }
-        } catch {
-            // Listing succeeded; surface only metadata when content
-            // pulls fail. Callers fall back to per-chat downloads.
         }
     }
 

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -224,10 +224,9 @@ class CloudSyncService: ObservableObject {
         guard let remoteKeyId = response.keyId else {
             if response.hasData {
                 // Un-migrated legacy data with no registered key: pushing
-                // now would only earn a stale-key rejection, and adopting
-                // the key here would bypass the migration path's decrypt
-                // probe. Defer; once the migration adopts the key the
-                // next pass clears this gate.
+                // now would only earn a stale-key rejection. Defer; the
+                // migration path adopts the key and the next pass clears
+                // this gate.
                 return false
             }
             // Only ever bind a key the user has actually committed and

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -175,6 +175,11 @@ class CloudSyncService: ObservableObject {
     /// Chats whose upload is queued or in flight, so list rows can
     /// show a per-chat syncing indicator.
     @Published var pendingUploadChatIds: Set<String> = []
+    /// Reference counts behind `pendingUploadChatIds`. Uploads of the same
+    /// chat can overlap, and an earlier upload's completion may be scheduled
+    /// after a later `backupChat` call; plain Set removal would then clear
+    /// the indicator while the later upload is still in flight.
+    private var pendingUploadCounts: [String: Int] = [:]
     
     // MARK: - Private Properties
     private lazy var uploadCoalescer: UploadCoalescer = {
@@ -348,18 +353,33 @@ class CloudSyncService: ObservableObject {
             return
         }
 
-        pendingUploadChatIds.insert(chatId)
+        beginPendingUpload(chatId)
         await uploadCoalescer.enqueue(chatId)
         Task { [weak self] in
             await self?.uploadCoalescer.waitForUpload(chatId)
-            self?.pendingUploadChatIds.remove(chatId)
+            self?.endPendingUpload(chatId)
         }
 
         if ensureLatestUpload {
             await uploadCoalescer.waitForUpload(chatId)
         }
     }
-    
+
+    private func beginPendingUpload(_ chatId: String) {
+        pendingUploadCounts[chatId, default: 0] += 1
+        pendingUploadChatIds.insert(chatId)
+    }
+
+    private func endPendingUpload(_ chatId: String) {
+        let remaining = (pendingUploadCounts[chatId] ?? 1) - 1
+        if remaining <= 0 {
+            pendingUploadCounts.removeValue(forKey: chatId)
+            pendingUploadChatIds.remove(chatId)
+        } else {
+            pendingUploadCounts[chatId] = remaining
+        }
+    }
+
     private func doBackupChat(_ chatId: String, idempotencyKey: String) async throws {
         guard await canWriteToCloud() else { return }
 

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -814,50 +814,70 @@ class CloudSyncService: ObservableObject {
             // the remote history so older chats that predate this device's
             // local copy are pulled down too. The periodic and launch syncs
             // stay first-page-only for bandwidth.
+            //
+            // Pages carry metadata only; content is pulled afterwards for
+            // just the chats that need processing. Pulling content for every
+            // listed chat made a deep refresh O(history) in round trips and
+            // payload, which left pull-to-refresh spinning for minutes on
+            // large accounts. Metadata pages use the server's maximum page
+            // size for the same reason: tombstone-heavy histories paginate
+            // by deletes too, and small pages multiply the round trips.
             var continuationToken: String? = nil
             repeat {
                 let remoteList = try await cloudStorage.listChats(
-                    limit: Constants.Pagination.chatsPerPage,
+                    limit: deep ? Constants.SyncEnclave.listStatusPageLimit : Constants.Pagination.chatsPerPage,
                     continuationToken: continuationToken,
-                    includeContent: true
+                    includeContent: false
                 )
                 let remoteConversations = remoteList.conversations
 
-                // Process remote chats sequentially to avoid connection exhaustion
-            for remoteChat in remoteConversations {
-                // First validate if this remote chat should be processed
-                if !(await shouldProcessRemoteChat(remoteChat)) {
-                    // Clean up invalid chats from cloud
-                    cleanupInvalidRemoteChat(remoteChat)
-                    continue
-                }
-
-                let localChat = localChatMap[remoteChat.id]
-
-                // Process if:
-                // 1. Chat doesn't exist locally
-                // 2. Remote is newer (based on updatedAt > syncedAt) AND chat is not locally modified
-                // 3. Chat failed decryption (to retry with new key)
-                // 4. Never overwrite if chat has active stream or is locally modified
-                let remoteTimestamp = parseISODate(remoteChat.updatedAt)?.timeIntervalSince1970 ?? 0
-
-                // Skip if chat is locally modified or has active stream
-                if let localChat = localChat {
-                    if localChat.locallyModified || localChat.hasActiveStream {
+                // First pass: decide which chats need processing.
+                var chatsToProcess: [RemoteChat] = []
+                for remoteChat in remoteConversations {
+                    // First validate if this remote chat should be processed
+                    if !(await shouldProcessRemoteChat(remoteChat)) {
+                        // Clean up invalid chats from cloud
+                        cleanupInvalidRemoteChat(remoteChat)
                         continue
                     }
 
-                    // Also check if chat is currently streaming using the tracker
-                    if streamingTracker.isStreaming(localChat.id) {
-                        continue
+                    let localChat = localChatMap[remoteChat.id]
+
+                    // Process if:
+                    // 1. Chat doesn't exist locally
+                    // 2. Remote is newer (based on updatedAt > syncedAt) AND chat is not locally modified
+                    // 3. Chat failed decryption (to retry with new key)
+                    // 4. Never overwrite if chat has active stream or is locally modified
+                    let remoteTimestamp = parseISODate(remoteChat.updatedAt)?.timeIntervalSince1970 ?? 0
+
+                    // Skip if chat is locally modified or has active stream
+                    if let localChat = localChat {
+                        if localChat.locallyModified || localChat.hasActiveStream {
+                            continue
+                        }
+
+                        // Also check if chat is currently streaming using the tracker
+                        if streamingTracker.isStreaming(localChat.id) {
+                            continue
+                        }
+                    }
+
+                    let shouldProcess = localChat == nil ||
+                        (!remoteTimestamp.isNaN && remoteTimestamp > (localChat?.syncedAt?.timeIntervalSince1970 ?? 0)) ||
+                        (localChat?.decryptionFailed == true)
+
+                    if shouldProcess {
+                        chatsToProcess.append(remoteChat)
                     }
                 }
 
-                let shouldProcess = localChat == nil ||
-                    (!remoteTimestamp.isNaN && remoteTimestamp > (localChat?.syncedAt?.timeIntervalSince1970 ?? 0)) ||
-                    (localChat?.decryptionFailed == true)
+                // Fetch content only for the chats that passed the checks.
+                await cloudStorage.attachInlineContent(&chatsToProcess)
 
-                if shouldProcess {
+                // Process sequentially to avoid connection exhaustion
+                for remoteChat in chatsToProcess {
+                    let localChat = localChatMap[remoteChat.id]
+
                     if let content = remoteChat.content {
                         if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
                             // Validate the content
@@ -912,7 +932,6 @@ class CloudSyncService: ObservableObject {
                         }
                     }
                 }
-            }
 
                 let nextToken = remoteList.nextContinuationToken?.isEmpty == false
                     ? remoteList.nextContinuationToken

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -172,6 +172,9 @@ class CloudSyncService: ObservableObject {
     @Published var syncStatus: String = ""
     @Published var lastSyncDate: Date?
     @Published var syncErrors: [String] = []
+    /// Chats whose upload is queued or in flight, so list rows can
+    /// show a per-chat syncing indicator.
+    @Published var pendingUploadChatIds: Set<String> = []
     
     // MARK: - Private Properties
     private lazy var uploadCoalescer: UploadCoalescer = {
@@ -346,7 +349,12 @@ class CloudSyncService: ObservableObject {
             return
         }
 
+        pendingUploadChatIds.insert(chatId)
         await uploadCoalescer.enqueue(chatId)
+        Task { [weak self] in
+            await self?.uploadCoalescer.waitForUpload(chatId)
+            self?.pendingUploadChatIds.remove(chatId)
+        }
 
         if ensureLatestUpload {
             await uploadCoalescer.waitForUpload(chatId)

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -762,7 +762,7 @@ class CloudSyncService: ObservableObject {
     }
 
     /// Sync all chats (upload local changes, download remote changes)
-    func syncAllChats(deep: Bool = false) async -> SyncResult {
+    func syncAllChats() async -> SyncResult {
         guard !isSyncing else {
             return SyncResult()
         }
@@ -775,12 +775,12 @@ class CloudSyncService: ObservableObject {
             lastSyncDate = Date()
         }
 
-        let result = await doSyncAllChats(deep: deep)
+        let result = await doSyncAllChats()
         syncErrors = result.errors
         return result
     }
 
-    private func doSyncAllChats(deep: Bool = false) async -> SyncResult {
+    private func doSyncAllChats() async -> SyncResult {
         var result = SyncResult()
 
         // Delete local chats that were deleted on another device
@@ -810,134 +810,120 @@ class CloudSyncService: ObservableObject {
             // Create maps for easy lookup
             let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
 
-            // A deep sync (pull-to-refresh) keeps paging through the rest of
-            // the remote history so older chats that predate this device's
-            // local copy are pulled down too. The periodic and launch syncs
-            // stay first-page-only for bandwidth.
-            //
-            // Pages carry metadata only; content is pulled afterwards for
-            // just the chats that need processing. Pulling content for every
-            // listed chat made a deep refresh O(history) in round trips and
-            // payload, which left pull-to-refresh spinning for minutes on
-            // large accounts. Metadata pages use the server's maximum page
-            // size for the same reason: tombstone-heavy histories paginate
-            // by deletes too, and small pages multiply the round trips.
-            var continuationToken: String? = nil
-            repeat {
-                let remoteList = try await cloudStorage.listChats(
-                    limit: deep ? Constants.SyncEnclave.listStatusPageLimit : Constants.Pagination.chatsPerPage,
-                    continuationToken: continuationToken,
-                    includeContent: false
-                )
-                let remoteConversations = remoteList.conversations
+            // Every entry point (pull-to-refresh, Sync Now, periodic and
+            // launch syncs) syncs the first page only, like the webapp.
+            // Older history is reachable through chat-list pagination, so
+            // refresh work stays bounded regardless of account size. The
+            // page carries metadata only; content is pulled afterwards for
+            // just the chats that need processing.
+            let remoteList = try await cloudStorage.listChats(
+                limit: Constants.Pagination.chatsPerPage,
+                continuationToken: nil,
+                includeContent: false
+            )
+            let remoteConversations = remoteList.conversations
 
-                // First pass: decide which chats need processing.
-                var chatsToProcess: [RemoteChat] = []
-                for remoteChat in remoteConversations {
-                    // First validate if this remote chat should be processed
-                    if !(await shouldProcessRemoteChat(remoteChat)) {
-                        // Clean up invalid chats from cloud
-                        cleanupInvalidRemoteChat(remoteChat)
+            // First pass: decide which chats need processing.
+            var chatsToProcess: [RemoteChat] = []
+            for remoteChat in remoteConversations {
+                // First validate if this remote chat should be processed
+                if !(await shouldProcessRemoteChat(remoteChat)) {
+                    // Clean up invalid chats from cloud
+                    cleanupInvalidRemoteChat(remoteChat)
+                    continue
+                }
+
+                let localChat = localChatMap[remoteChat.id]
+
+                // Process if:
+                // 1. Chat doesn't exist locally
+                // 2. Remote is newer (based on updatedAt > syncedAt) AND chat is not locally modified
+                // 3. Chat failed decryption (to retry with new key)
+                // 4. Never overwrite if chat has active stream or is locally modified
+                let remoteTimestamp = parseISODate(remoteChat.updatedAt)?.timeIntervalSince1970 ?? 0
+
+                // Skip if chat is locally modified or has active stream
+                if let localChat = localChat {
+                    if localChat.locallyModified || localChat.hasActiveStream {
                         continue
                     }
 
-                    let localChat = localChatMap[remoteChat.id]
-
-                    // Process if:
-                    // 1. Chat doesn't exist locally
-                    // 2. Remote is newer (based on updatedAt > syncedAt) AND chat is not locally modified
-                    // 3. Chat failed decryption (to retry with new key)
-                    // 4. Never overwrite if chat has active stream or is locally modified
-                    let remoteTimestamp = parseISODate(remoteChat.updatedAt)?.timeIntervalSince1970 ?? 0
-
-                    // Skip if chat is locally modified or has active stream
-                    if let localChat = localChat {
-                        if localChat.locallyModified || localChat.hasActiveStream {
-                            continue
-                        }
-
-                        // Also check if chat is currently streaming using the tracker
-                        if streamingTracker.isStreaming(localChat.id) {
-                            continue
-                        }
-                    }
-
-                    let shouldProcess = localChat == nil ||
-                        (!remoteTimestamp.isNaN && remoteTimestamp > (localChat?.syncedAt?.timeIntervalSince1970 ?? 0)) ||
-                        (localChat?.decryptionFailed == true)
-
-                    if shouldProcess {
-                        chatsToProcess.append(remoteChat)
+                    // Also check if chat is currently streaming using the tracker
+                    if streamingTracker.isStreaming(localChat.id) {
+                        continue
                     }
                 }
 
-                // Fetch content only for the chats that passed the checks.
-                await cloudStorage.attachInlineContent(&chatsToProcess)
+                let shouldProcess = localChat == nil ||
+                    (!remoteTimestamp.isNaN && remoteTimestamp > (localChat?.syncedAt?.timeIntervalSince1970 ?? 0)) ||
+                    (localChat?.decryptionFailed == true)
 
-                // Process sequentially to avoid connection exhaustion
-                for remoteChat in chatsToProcess {
-                    let localChat = localChatMap[remoteChat.id]
+                if shouldProcess {
+                    chatsToProcess.append(remoteChat)
+                }
+            }
 
-                    if let content = remoteChat.content {
-                        if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
-                            // Validate the content
-                            if decrypted.chat.messages.isEmpty {
-                                cleanupInvalidRemoteChat(remoteChat)
-                                continue
-                            }
+            // Fetch content only for the chats that passed the checks.
+            await cloudStorage.attachInlineContent(&chatsToProcess)
 
-                            await saveChatToStorage(decrypted.chat)
-                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
-                            result = SyncResult(
-                                uploaded: result.uploaded,
-                                downloaded: result.downloaded + 1,
-                                deleted: result.deleted,
-                                errors: result.errors
-                            )
-                        } else {
-                            // Only save a placeholder if there is no valid local copy.
-                            // When a good local version exists (non-empty messages, not
-                            // already failed), preserve it to avoid replacing decrypted
-                            // content with an empty encrypted placeholder (e.g. after
-                            // the remote was re-encrypted with a key we don't have yet).
-                            let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
-                            if !hasValidLocal {
-                                let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
-                                await saveChatToStorage(placeholder)
-                                result = SyncResult(
-                                    uploaded: result.uploaded,
-                                    downloaded: result.downloaded + 1,
-                                    deleted: result.deleted,
-                                    errors: result.errors
-                                )
-                            }
+            // Process sequentially to avoid connection exhaustion
+            for remoteChat in chatsToProcess {
+                let localChat = localChatMap[remoteChat.id]
+
+                if let content = remoteChat.content {
+                    if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
+                        // Validate the content
+                        if decrypted.chat.messages.isEmpty {
+                            cleanupInvalidRemoteChat(remoteChat)
+                            continue
                         }
+
+                        await saveChatToStorage(decrypted.chat)
+                        await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                        result = SyncResult(
+                            uploaded: result.uploaded,
+                            downloaded: result.downloaded + 1,
+                            deleted: result.deleted,
+                            errors: result.errors
+                        )
                     } else {
-                        // No inline content - fetch via downloadChat (handles its own decryption)
-                        do {
-                            try await downloadAndSaveRemoteChat(remoteChat)
+                        // Only save a placeholder if there is no valid local copy.
+                        // When a good local version exists (non-empty messages, not
+                        // already failed), preserve it to avoid replacing decrypted
+                        // content with an empty encrypted placeholder (e.g. after
+                        // the remote was re-encrypted with a key we don't have yet).
+                        let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
+                        if !hasValidLocal {
+                            let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
+                            await saveChatToStorage(placeholder)
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
                                 deleted: result.deleted,
                                 errors: result.errors
                             )
-                        } catch {
-                            result = SyncResult(
-                                uploaded: result.uploaded,
-                                downloaded: result.downloaded,
-                                deleted: result.deleted,
-                                errors: result.errors + ["Failed to download chat \(remoteChat.id): \(error.localizedDescription)"]
-                            )
                         }
                     }
+                } else {
+                    // No inline content - fetch via downloadChat (handles its own decryption)
+                    do {
+                        try await downloadAndSaveRemoteChat(remoteChat)
+                        result = SyncResult(
+                            uploaded: result.uploaded,
+                            downloaded: result.downloaded + 1,
+                            deleted: result.deleted,
+                            errors: result.errors
+                        )
+                    } catch {
+                        result = SyncResult(
+                            uploaded: result.uploaded,
+                            downloaded: result.downloaded,
+                            deleted: result.deleted,
+                            errors: result.errors + ["Failed to download chat \(remoteChat.id): \(error.localizedDescription)"]
+                        )
+                    }
                 }
-
-                let nextToken = remoteList.nextContinuationToken?.isEmpty == false
-                    ? remoteList.nextContinuationToken
-                    : nil
-                continuationToken = (deep && remoteList.hasMore) ? nextToken : nil
-            } while continuationToken != nil
+            }
 
             // Refresh cached sync status so subsequent smart-syncs have up-to-date info
             await refreshSyncStatusCache()

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1652,6 +1652,17 @@ class CloudSyncService: ObservableObject {
     // MARK: - Delete Operations
     
     /// Delete a chat from cloud storage
+    /// Bulk-delete every chat the user owns from cloud storage. Returns the
+    /// number of rows deleted. Callers are responsible for tombstoning local
+    /// IDs only after this succeeds, mirroring the webapp's ordering.
+    @discardableResult
+    func deleteAllFromCloud() async throws -> Int {
+        guard await cloudStorage.isAuthenticated() else {
+            throw CloudStorageError.authenticationRequired
+        }
+        return try await cloudStorage.deleteAllChats()
+    }
+
     func deleteFromCloud(_ chatId: String) async throws {
         // Mark as deleted locally first
         deletedChatsTracker.markAsDeleted(chatId)

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -21,6 +21,17 @@ enum PasskeyRecoveryResult {
     case recoveryFailed
 }
 
+// MARK: - KeyMismatchResolution
+
+/// Outcome of reconciling a loaded local CEK against the enclave's
+/// registered key at launch.
+enum KeyMismatchResolution {
+    case noMismatch
+    case resolvedSilently
+    case passkeyPromptShown
+    case manualRecoveryRequired
+}
+
 // MARK: - PasskeyManager
 
 @MainActor
@@ -151,6 +162,53 @@ final class PasskeyManager: ObservableObject {
 
         passkeySetupAvailable = true
         return .manualRecoveryRequired
+    }
+
+    /// Reconcile a loaded local CEK that derives a different key id
+    /// than the enclave's registered key. A stale device in that state
+    /// can never write or migrate, so route it onto the registered key:
+    /// try a silent passkey unlock first, surface the recovery-choice
+    /// sheet when the key has bundles but the silent ceremony failed,
+    /// and report `manualRecoveryRequired` when the key was adopted
+    /// bundleless (e.g. by the migration path on another device) so the
+    /// caller can open manual key entry. The replaced local key is kept
+    /// in the key history, so the next migration sweep can still rewrap
+    /// rows sealed under it.
+    func resolveKeyMismatchAtLaunch() async -> KeyMismatchResolution {
+        guard let cek = try? EncryptionService.shared.getKeyBytesOrThrow(),
+              let localKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek) else {
+            return .noMismatch
+        }
+        guard let state = try? await SyncEnclaveAPI.keyCurrent(),
+              let remoteKeyId = state.keyId,
+              remoteKeyId != localKeyId else {
+            return .noMismatch
+        }
+
+        guard !state.bundles.isEmpty else {
+            return .manualRecoveryRequired
+        }
+
+        let result = await PasskeyKeyFlow.unlockFromServer(
+            prefer: UserDefaults.standard.string(
+                forKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId
+            ),
+            silent: true
+        )
+        if case .success(let recoveredCek, let keyIdHex, _, _) = result {
+            do {
+                try await applyRecoveredCek(cek: recoveredCek)
+            } catch {
+                showPasskeyRecoveryChoice = true
+                return .passkeyPromptShown
+            }
+            persistEnclaveKeyId(keyIdHex)
+            activatePasskey()
+            onKeyRefreshedFromBackup?()
+            return .resolvedSilently
+        }
+        showPasskeyRecoveryChoice = true
+        return .passkeyPromptShown
     }
 
     /// Apply a successful passkey unlock/recovery result to local state,

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -15,7 +15,6 @@ class ProfileManager: ObservableObject {
     
     // Published properties for UI binding
     @Published var isDarkMode: Bool = true
-    @Published var maxPromptMessages: Int = Constants.Context.defaultMaxMessages
     @Published var language: String = "English"
     
     // Personalization settings
@@ -135,7 +134,6 @@ class ProfileManager: ObservableObject {
     private func createProfileData() -> ProfileData {
         return ProfileData(
             isDarkMode: isDarkMode,
-            maxPromptMessages: maxPromptMessages,
             language: language,
             nickname: nickname,
             profession: profession,
@@ -155,9 +153,6 @@ class ProfileManager: ObservableObject {
         
         if let isDarkMode = profile.isDarkMode {
             self.isDarkMode = isDarkMode
-        }
-        if let maxPromptMessages = profile.maxPromptMessages {
-            self.maxPromptMessages = maxPromptMessages
         }
         if let language = profile.language {
             self.language = language
@@ -202,13 +197,6 @@ class ProfileManager: ObservableObject {
             }
             .store(in: &cancellables)
         
-        $maxPromptMessages
-            .dropFirst()
-            .sink { [weak self] _ in
-                guard !(self?.isApplyingProfile ?? false) else { return }
-                self?.saveToKeychain()
-            }
-            .store(in: &cancellables)
         
         $language
             .dropFirst()
@@ -467,7 +455,6 @@ class ProfileManager: ObservableObject {
         }
         
         return p1.isDarkMode != p2.isDarkMode ||
-               p1.maxPromptMessages != p2.maxPromptMessages ||
                p1.language != p2.language ||
                p1.nickname != p2.nickname ||
                p1.profession != p2.profession ||
@@ -537,7 +524,6 @@ class ProfileManager: ObservableObject {
     func clearProfile() {
         // Reset to defaults
         isDarkMode = true
-        maxPromptMessages = Constants.Context.defaultMaxMessages
         language = "English"
         nickname = ""
         profession = ""

--- a/TinfoilChat/Services/SyncEnclave/CEKEncoding.swift
+++ b/TinfoilChat/Services/SyncEnclave/CEKEncoding.swift
@@ -32,41 +32,6 @@ enum CEKEncoding {
         return [EnclavePullKey(key: primary)]
     }
 
-    /// Keys to probe existing cloud data with when validating the
-    /// currently-loaded primary key. When the loaded primary is one of
-    /// the device's persisted keys, probe with the full persisted set:
-    /// historical alternatives belong to the same user and the
-    /// migration sweep can rewrap rows sealed under them. When the
-    /// loaded primary is a newly staged key that has not been persisted
-    /// yet, probe with the staged set alone — a leftover persisted key
-    /// must not vouch for a different key that cannot actually unlock
-    /// the data, and a fresh device with no persisted keys must still
-    /// get its staged key probed.
-    static func keyValidationProbeKeys() -> [EnclavePullKey] {
-        let service = EncryptionService.shared
-        let active = service.getActiveKeys()
-        guard let primary = active.primary,
-              let primaryBytes = try? service.getAlternativeKeyBytes(primary) else { return [] }
-        let primaryB64 = primaryBytes.base64EncodedString()
-
-        var out = [EnclavePullKey(key: primaryB64)]
-        var seen: Set<String> = [primaryB64]
-        func add(_ b64: String) {
-            guard seen.insert(b64).inserted else { return }
-            out.append(EnclavePullKey(key: b64))
-        }
-
-        let persisted = migrationKeys()
-        if persisted.contains(where: { $0.key == primaryB64 }) {
-            for entry in persisted { add(entry.key) }
-        }
-        for alt in active.alternatives {
-            guard let bytes = try? service.getAlternativeKeyBytes(alt) else { continue }
-            add(bytes.base64EncodedString())
-        }
-        return out
-    }
-
     /// Build the `keys` array for the migration path: primary first,
     /// then every alternative (history) key the local service still has
     /// on file, base64-encoded. The enclave tries each in turn when

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -87,7 +87,6 @@ enum LegacyBlobMigration {
             // passkey wrapping it stays promotable afterwards. Mirrors the
             // webapp's migration adoption.
             if current.keyId == nil, current.hasData,
-                await localKeysCanDecryptRemoteData(),
                 await adoptLocalKeyForMigration(keyB64: targetKeyB64)
             {
                 current = try await SyncEnclaveAPI.keyCurrent()
@@ -202,36 +201,6 @@ enum LegacyBlobMigration {
     /// never strands a backup. register-key's if_match='*' fails safely on
     /// a concurrent register. Returns true when the key was adopted.
     /// Mirrors the webapp's migration adoption.
-    /// Probe whether the local key set can actually unseal the user's
-    /// existing remote data before adopting the local CEK as the
-    /// registered current key. Adoption permanently binds the registry
-    /// to this key, so registering a stale Keychain CEK over data sealed
-    /// under a different key would strand the data and block the correct
-    /// key from ever being promoted. Delegates to the shared cross-scope
-    /// probe: a single row the keys cannot unseal refuses adoption even
-    /// when other rows decrypt. When no row can be sampled at all,
-    /// adoption proceeds (nothing observable to contradict the key, and
-    /// a wrong adoption only blocks rewraps, which recovery can later
-    /// fix).
-    private static func localKeysCanDecryptRemoteData() async -> Bool {
-        let keys = CEKEncoding.migrationKeys()
-        guard !keys.isEmpty else { return false }
-
-        switch await CloudKeyPreflightValidator.shared.probeKeysAcrossScopes(keys) {
-        case .decryptable, .noSample:
-            return true
-        case .undecryptable:
-            #if DEBUG
-            print("[LegacyBlobMigration] skip adoption: local keys cannot unseal existing remote data")
-            #endif
-            return false
-        case .transientFailure:
-            // Transient probe failure: don't adopt on this pass; the
-            // next launch retries with the gate still closed.
-            return false
-        }
-    }
-
     private static func adoptLocalKeyForMigration(keyB64: String) async -> Bool {
         do {
             _ = try await SyncEnclaveAPI.registerKey(

--- a/TinfoilChat/Services/SyncEnclave/PasskeyKeyFlow.swift
+++ b/TinfoilChat/Services/SyncEnclave/PasskeyKeyFlow.swift
@@ -417,34 +417,6 @@ enum PasskeyKeyFlow {
         }
 
         if enclaveKeyId == nil {
-            // The legacy bundle may wrap a rotated-away CEK while the
-            // user's un-migrated rows are sealed under a different key.
-            // Registering it would permanently bind the registry to a
-            // key that cannot open that data, so confirm the recovered
-            // key set unseals a sample of the remote rows first.
-            var probeKeys = [EnclavePullKey(key: dataToBase64(cek))]
-            for alt in legacyAlternatives {
-                guard let bytes = try? EncryptionService.shared.getAlternativeKeyBytes(alt) else { continue }
-                let b64 = dataToBase64(bytes)
-                if !probeKeys.contains(where: { $0.key == b64 }) {
-                    probeKeys.append(EnclavePullKey(key: b64))
-                }
-            }
-            switch await CloudKeyPreflightValidator.shared.probeKeysAcrossScopes(probeKeys) {
-            case .undecryptable:
-                return .failure(
-                    .keyIdMismatch,
-                    message: "recovered legacy key cannot unlock existing cloud data"
-                )
-            case .transientFailure:
-                return .failure(
-                    .enclaveUnavailable,
-                    message: "could not verify the recovered key against existing cloud data"
-                )
-            case .decryptable, .noSample:
-                break
-            }
-
             // No enclave key yet — register the recovered CEK + initial
             // bundle so the user becomes a first-class v2 user.
             do {
@@ -491,9 +463,9 @@ enum PasskeyKeyFlow {
         }
 
         // Only retain the bundle's historical keys once the recovery is
-        // accepted: a rejected recovery (rotated-away CEK, failed probe)
-        // must not pollute the local key history with alternatives that
-        // were never adopted.
+        // accepted: a rejected recovery (rotated-away CEK) must not
+        // pollute the local key history with alternatives that were
+        // never adopted.
         retainLegacyAlternatives(legacyAlternatives)
 
         return .success(

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -82,7 +82,6 @@ struct ChatQueryBuilder {
             messages.append(.system(.init(content: .textContent(fullPrompt))))
         }
 
-        // Add conversation history that fits within the model's context budget
         let recentMessages = TokenEstimation.selectMessagesWithinBudget(conversationMessages, contextWindow: contextWindow)
         var hasAddedSystemInstructions = useSystemRole
 

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -30,7 +30,8 @@ struct ChatQueryBuilder {
     ///   - systemPrompt: The base system prompt with placeholders already replaced
     ///   - rules: Additional rules to include (will be combined with system prompt based on model)
     ///   - conversationMessages: The message history from the chat
-    ///   - maxMessages: Maximum number of messages to include from history
+    ///   - contextWindow: The model's context window (e.g. "64k tokens") used
+    ///     to budget how much history is included
     ///   - stream: Whether to stream the response (default: true)
     ///   - webSearchEnabled: Whether to enable web search for this query (default: false)
     ///   - isMultimodal: Whether the current model supports image content parts
@@ -50,7 +51,7 @@ struct ChatQueryBuilder {
         systemPrompt: String,
         rules: String,
         conversationMessages: [Message],
-        maxMessages: Int,
+        contextWindow: String? = nil,
         stream: Bool = true,
         webSearchEnabled: Bool = false,
         isMultimodal: Bool = false,
@@ -81,8 +82,8 @@ struct ChatQueryBuilder {
             messages.append(.system(.init(content: .textContent(fullPrompt))))
         }
 
-        // Add conversation history
-        let recentMessages = Array(conversationMessages.suffix(maxMessages))
+        // Add conversation history that fits within the model's context budget
+        let recentMessages = TokenEstimation.selectMessagesWithinBudget(conversationMessages, contextWindow: contextWindow)
         var hasAddedSystemInstructions = useSystemRole
 
         for msg in recentMessages {

--- a/TinfoilChat/Utilities/TokenEstimation.swift
+++ b/TinfoilChat/Utilities/TokenEstimation.swift
@@ -1,0 +1,80 @@
+//
+//  TokenEstimation.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+//
+
+import Foundation
+
+/// Heuristic token estimation and context-window budgeting.
+///
+/// Mirrors the webapp's `src/utils/token-estimation.ts` so both platforms
+/// archive the same messages for a given conversation and model.
+enum TokenEstimation {
+
+    /// Roughly estimate token count based on character length.
+    static func estimateTokenCount(_ text: String?) -> Int {
+        guard let text, !text.isEmpty else { return 0 }
+        return Int(ceil(Double(text.count) / Constants.Context.charsPerToken))
+    }
+
+    /// Parse a model's human-readable context window string (e.g. "64k tokens")
+    /// into a token count, falling back to the default when unknown.
+    static func parseContextWindowTokens(_ contextWindow: String?) -> Int {
+        guard let contextWindow, !contextWindow.isEmpty else {
+            return Constants.Context.defaultContextWindowTokens
+        }
+        guard let match = contextWindow.firstMatch(of: /(\d+)([kK])?/),
+              let value = Int(match.1) else {
+            return Constants.Context.defaultContextWindowTokens
+        }
+        return match.2 != nil ? value * 1000 : value
+    }
+
+    /// The token budget available to conversation history for a model.
+    static func contextTokenBudget(_ contextWindow: String?) -> Int {
+        Int(floor(Double(parseContextWindowTokens(contextWindow)) * Constants.Context.contextWindowUsageRatio))
+    }
+
+    /// Estimate the prompt tokens contributed by a single message, including
+    /// tool calls and attachment text. Thoughts are excluded because they are
+    /// never sent back in prompts.
+    static func estimateMessageTokens(_ message: Message) -> Int {
+        var tokens = estimateTokenCount(message.content)
+        if let searchReasoning = message.searchReasoning {
+            tokens += estimateTokenCount(searchReasoning)
+        }
+        for toolCall in message.toolCalls {
+            tokens += estimateTokenCount(toolCall.name)
+            tokens += estimateTokenCount(toolCall.arguments)
+        }
+        for attachment in message.attachments {
+            tokens += estimateTokenCount(attachment.textContent)
+            tokens += estimateTokenCount(attachment.description)
+        }
+        return tokens
+    }
+
+    /// Returns the index of the first message (from the end) that fits within
+    /// the token budget. Messages before this index are "archived" and
+    /// excluded from the prompt. The most recent message is always included,
+    /// even if it alone exceeds the budget.
+    static func findContextStartIndex(messages: [Message], budgetTokens: Int) -> Int {
+        var usedTokens = 0
+        for i in stride(from: messages.count - 1, through: 0, by: -1) {
+            usedTokens += estimateMessageTokens(messages[i])
+            if usedTokens > budgetTokens && i < messages.count - 1 {
+                return i + 1
+            }
+        }
+        return 0
+    }
+
+    /// The trailing slice of messages that fits within the model's context
+    /// token budget.
+    static func selectMessagesWithinBudget(_ messages: [Message], contextWindow: String?) -> [Message] {
+        let budget = contextTokenBudget(contextWindow)
+        return Array(messages[findContextStartIndex(messages: messages, budgetTokens: budget)...])
+    }
+}

--- a/TinfoilChat/Utilities/TokenEstimation.swift
+++ b/TinfoilChat/Utilities/TokenEstimation.swift
@@ -44,7 +44,11 @@ enum TokenEstimation {
 
     /// Estimate the prompt tokens contributed by a single message, including
     /// tool calls and attachment text. Thoughts are excluded because they are
-    /// never sent back in prompts.
+    /// never sent back in prompts. Search reasoning is counted even though
+    /// this app's query builder doesn't resend it yet: the webapp sends it
+    /// for multi-turn context and counts it, and matching its estimate keeps
+    /// the archive boundary identical across platforms (erring toward a
+    /// smaller prompt, never an overflow).
     static func estimateMessageTokens(_ message: Message) -> Int {
         var tokens = estimateTokenCount(message.content)
         if let searchReasoning = message.searchReasoning {

--- a/TinfoilChat/Utilities/TokenEstimation.swift
+++ b/TinfoilChat/Utilities/TokenEstimation.swift
@@ -13,7 +13,10 @@ import Foundation
 /// archive the same messages for a given conversation and model.
 enum TokenEstimation {
 
-    /// Roughly estimate token count based on character length.
+    /// Uses the same chars-per-token heuristic as the webapp (~4 characters
+    /// per token for typical English text), rounding up so short fragments
+    /// still cost at least one token. Deliberately not a real tokenizer:
+    /// archiving only needs both platforms to agree, not exact counts.
     static func estimateTokenCount(_ text: String?) -> Int {
         guard let text, !text.isEmpty else { return 0 }
         return Int(ceil(Double(text.count) / Constants.Context.charsPerToken))
@@ -32,7 +35,9 @@ enum TokenEstimation {
         return match.2 != nil ? value * 1000 : value
     }
 
-    /// The token budget available to conversation history for a model.
+    /// Applies the usage ratio to the parsed window size, keeping the
+    /// remainder of the window reserved for the model's reply, the system
+    /// prompt, and the slack in our character-based estimates.
     static func contextTokenBudget(_ contextWindow: String?) -> Int {
         Int(floor(Double(parseContextWindowTokens(contextWindow)) * Constants.Context.contextWindowUsageRatio))
     }

--- a/TinfoilChat/Utilities/TokenEstimation.swift
+++ b/TinfoilChat/Utilities/TokenEstimation.swift
@@ -58,14 +58,22 @@ enum TokenEstimation {
 
     /// Returns the index of the first message (from the end) that fits within
     /// the token budget. Messages before this index are "archived" and
-    /// excluded from the prompt. The most recent message is always included,
-    /// even if it alone exceeds the budget.
+    /// excluded from the prompt. The most recent substantive message is always
+    /// included, even if it alone exceeds the budget: zero-token messages
+    /// (like the empty assistant placeholder appended before streaming) must
+    /// not satisfy that guarantee on their own, or the latest user message
+    /// could be dropped from the prompt.
     static func findContextStartIndex(messages: [Message], budgetTokens: Int) -> Int {
         var usedTokens = 0
+        var hasIncludedSubstantiveMessage = false
         for i in stride(from: messages.count - 1, through: 0, by: -1) {
-            usedTokens += estimateMessageTokens(messages[i])
-            if usedTokens > budgetTokens && i < messages.count - 1 {
+            let messageTokens = estimateMessageTokens(messages[i])
+            usedTokens += messageTokens
+            if usedTokens > budgetTokens && hasIncludedSubstantiveMessage {
                 return i + 1
+            }
+            if messageTokens > 0 {
+                hasIncludedSubstantiveMessage = true
             }
         }
         return 0

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -901,6 +901,18 @@ class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Permanently deletes every project the user owns, mirroring the
+    /// webapp's bulk action. Throws so callers can surface the failure and
+    /// leave local state untouched for a retry.
+    @MainActor
+    func deleteAllProjects() async throws {
+        _ = try await projectStorage.deleteAllProjects()
+        projects = []
+        if activeProject != nil {
+            exitProject()
+        }
+    }
+
     func deleteActiveProject() async {
         guard let project = activeProject else { return }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3501,6 +3501,29 @@ class ChatViewModel: ObservableObject {
     
     // MARK: - Cloud Sync Methods
 
+    /// Permanently deletes every chat, mirroring the webapp: the cloud
+    /// bulk-delete runs first so a failure leaves local state untouched and
+    /// the user can retry without partial-deletion side effects.
+    @MainActor
+    func deleteAllChats() async throws {
+        let localIds = chats.map(\.id) + localChats.map(\.id)
+
+        if authManager?.isAuthenticated == true && EncryptionService.shared.hasEncryptionKey() {
+            try await cloudSync.deleteAllFromCloud()
+        }
+
+        // Tombstone so an in-flight sync pass can't resurrect wiped chats
+        for id in localIds {
+            DeletedChatsTracker.shared.markAsDeleted(id)
+        }
+
+        await clearAllChatsFromDevice()
+        // The device wipe clears the in-memory key reference; restore it so
+        // newly created chats keep syncing.
+        reloadEncryptionKey()
+        createNewChat()
+    }
+
     /// Removes all cloud (non-local) chats from the device
     @MainActor
     func deleteNonLocalChats() async {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3520,7 +3520,14 @@ class ChatViewModel: ObservableObject {
     func deleteAllChats() async throws {
         let localIds = chats.map(\.id) + localChats.map(\.id)
 
-        if authManager?.isAuthenticated == true && EncryptionService.shared.hasEncryptionKey() {
+        // When the cloud backup is in play (key present, or sync enabled but
+        // the key is missing) this must succeed or throw: skipping it would
+        // report success while encrypted chats survive on the server. Only a
+        // signed-in account that never set up cloud sync gets a local-only
+        // wipe.
+        let isAuthenticated = authManager?.isAuthenticated == true
+        let hasKey = EncryptionService.shared.hasEncryptionKey()
+        if isAuthenticated && (hasKey || SettingsManager.shared.isCloudSyncEnabled) {
             try await cloudSync.deleteAllFromCloud()
         }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3425,6 +3425,18 @@ class ChatViewModel: ObservableObject {
                         }
                     }
 
+                    // A local key that mismatches the enclave's registered
+                    // key can never sync or migrate. Converge silently via
+                    // passkey when possible; otherwise prompt the user to
+                    // recover so this stale device enters v2.
+                    if SettingsManager.shared.isCloudSyncEnabled,
+                       await self.passkeyManager.resolveKeyMismatchAtLaunch() == .manualRecoveryRequired {
+                        await MainActor.run {
+                            self.cloudSyncOnboardingMode = .recovery
+                            self.showCloudSyncOnboarding = true
+                        }
+                    }
+
                     // Check passkey state for users who already have keys
                     await self.passkeyManager.checkPasskeyStateForExistingKey()
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1672,13 +1672,12 @@ class ChatViewModel: ObservableObject {
                 }
 
                 // Use ChatQueryBuilder to create query with model-specific system prompt handling
-                let maxMessages = profileManager.maxPromptMessages > 0 ? profileManager.maxPromptMessages : settingsManager.maxMessages
                 let chatQuery = ChatQueryBuilder.buildQuery(
                     modelId: modelId,
                     systemPrompt: systemPrompt,
                     rules: processedRules,
                     conversationMessages: self.messages,
-                    maxMessages: maxMessages,
+                    contextWindow: self.currentModel.contextWindow,
                     webSearchEnabled: self.isWebSearchEnabled,
                     isMultimodal: self.currentModel.isMultimodal,
                     reasoningConfig: self.currentModel.reasoningConfig,

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3811,6 +3811,11 @@ class ChatViewModel: ObservableObject {
             // Only append to the visible chats array
             if !uniqueNewChats.isEmpty {
                 self.chats.append(contentsOf: uniqueNewChats)
+                self.chats.sort { chat1, chat2 in
+                    if chat1.isBlankChat { return true }
+                    if chat2.isBlankChat { return false }
+                    return chat1.updatedAt > chat2.updatedAt
+                }
             }
             
             // Update pagination state

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3945,7 +3945,7 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Perform a full sync with the cloud
-    func performFullSync(deep: Bool = false) async {
+    func performFullSync() async {
         // Gate sync when cloud sync is disabled
         if !SettingsManager.shared.isCloudSyncEnabled {
             return
@@ -3961,7 +3961,7 @@ class ChatViewModel: ObservableObject {
             self.syncErrors = []
         }
         
-        let result = await cloudSync.syncAllChats(deep: deep)
+        let result = await cloudSync.syncAllChats()
         
         // Update chats if there were changes (await this before marking sync complete)
         if result.downloaded > 0 || result.uploaded > 0 || result.deleted > 0 {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2607,9 +2607,20 @@ class ChatViewModel: ObservableObject {
             return "Authentication error. Please sign in again."
         }
         
-        // Rate limit (OpenAI SDK error)
-        if case OpenAIError.statusError(_, let statusCode) = error, statusCode == 429 {
-            return "You've reached your daily limit of free requests. Your limit will reset tomorrow, or you can upgrade to Premium for unlimited access."
+        // HTTP status errors from the OpenAI SDK. Handle every code here so
+        // the raw enum dump (including the NSHTTPURLResponse description)
+        // never reaches the UI.
+        if case OpenAIError.statusError(_, let statusCode) = error {
+            switch statusCode {
+            case 401:
+                return "Authentication error. Please sign in again."
+            case 429:
+                return "You've reached your daily limit of free requests. Your limit will reset tomorrow, or you can upgrade to Premium for unlimited access."
+            case 500...599:
+                return "The service is having trouble right now. Please try again in a moment, or switch to a different model."
+            default:
+                return "The model couldn't process this request. Please try again, or start a new chat if the problem persists."
+            }
         }
 
         // Server issues
@@ -2623,9 +2634,62 @@ class ChatViewModel: ObservableObject {
                 break
             }
         }
-        
+
+        // Map raw backend/SDK error text to a human-readable explanation,
+        // mirroring the webapp's `explainError`.
+        if let explained = Self.explainRawError(error.localizedDescription) {
+            return explained
+        }
+
         // Default error message if nothing specific matches
-        return "An error occurred: \(error.localizedDescription)"
+        return "Please try again. If the problem persists, contact support."
+    }
+
+    /// Maps raw error text to a friendly explanation. Returns nil when no
+    /// known pattern matches. Mirrors the webapp's `explainError` patterns.
+    static func explainRawError(_ rawMessage: String) -> String? {
+        let lower = rawMessage.lowercased()
+
+        if lower.contains("context deadline exceeded") ||
+            lower.contains("client.timeout") ||
+            lower.contains("timed out") ||
+            lower.contains("timeout") {
+            return "The model took too long to respond. This is usually a temporary problem on our side. Please try again in a moment."
+        }
+
+        if lower.contains("context length") ||
+            lower.contains("context window") ||
+            lower.contains("maximum context") ||
+            lower.contains("too many tokens") ||
+            lower.contains("token limit") ||
+            lower.contains("prompt length") ||
+            lower.contains("max_model_len") ||
+            lower.contains("input is too long") {
+            return "This conversation is too long for the model. Remove an attachment, shorten your message, or switch to a model with a larger context window."
+        }
+
+        // Secure-channel failures (EHBP) happen when the inference router is
+        // unreachable and a proxy answers without the encryption headers.
+        if lower.contains("ehbp") ||
+            lower.contains("missing header") ||
+            lower.contains("decryption failed") ||
+            lower.contains("invalid response") ||
+            lower.contains("overloaded") ||
+            lower.contains("capacity") ||
+            lower.contains("service unavailable") ||
+            lower.contains("bad gateway") ||
+            lower.contains("internal server error") ||
+            lower.range(of: #"\b5\d\d\b"#, options: .regularExpression) != nil {
+            return "The service is having trouble right now. Please try again in a moment, or switch to a different model."
+        }
+
+        if lower.contains("network") ||
+            lower.contains("connection") ||
+            lower.contains("offline") {
+            return "Connection problem. Check your internet connection and try again."
+        }
+
+        return nil
     }
 
     /// Checks if an error indicates the user has hit their rate limit

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -21,13 +21,17 @@ struct ChatListView: View {
     @State private var scrollTrigger = UUID()
     @State private var scrollToUserTrigger = UUID()
     @State private var tableOpacity = 1.0
+    @State private var archivedMessagesStartIndex = 0
 
     private var messages: [Message] {
         viewModel.messages
     }
 
-    private var archivedMessagesStartIndex: Int {
-        TokenEstimation.findContextStartIndex(
+    /// Token estimation walks every message, so the result is cached and
+    /// refreshed only when the conversation, model, or message count changes
+    /// instead of on every body evaluation during streaming.
+    private func refreshArchivedMessagesStartIndex() {
+        archivedMessagesStartIndex = TokenEstimation.findContextStartIndex(
             messages: messages,
             budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
         )
@@ -100,12 +104,17 @@ struct ChatListView: View {
         }
         .onAppear {
             setupKeyboardObservers()
+            refreshArchivedMessagesStartIndex()
         }
         .onDisappear {
             removeKeyboardObservers()
             viewModel.isScrollInteractionActive = false
         }
+        .onChange(of: viewModel.currentModel.id) { _, _ in
+            refreshArchivedMessagesStartIndex()
+        }
         .onChange(of: messages.count) { oldCount, newCount in
+            refreshArchivedMessagesStartIndex()
             if newCount > oldCount {
                 let newMessages = messages.suffix(newCount - oldCount)
                 let hasUserMessage = newMessages.contains { $0.role == .user }
@@ -123,6 +132,7 @@ struct ChatListView: View {
             }
         }
         .onChange(of: viewModel.currentChat?.createdAt) { _, _ in
+            refreshArchivedMessagesStartIndex()
             userHasScrolled = false
             viewModel.isScrollInteractionActive = false
 

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -12,7 +12,6 @@ struct ChatListView: View {
     let isLoading: Bool
     let onRequestSignIn: () -> Void
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
-    @ObservedObject private var settings = SettingsManager.shared
     @Binding var messageText: String
 
     @State private var isAtBottom = true
@@ -28,7 +27,10 @@ struct ChatListView: View {
     }
 
     private var archivedMessagesStartIndex: Int {
-        max(0, messages.count - settings.maxMessages)
+        TokenEstimation.findContextStartIndex(
+            messages: messages,
+            budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
+        )
     }
 
     var body: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -77,6 +77,11 @@ struct ChatSidebar: View {
             return "\(months)mo ago"
         }
     }
+
+    private func lastUpdatedString(for chat: Chat) -> String {
+        let relative = relativeTimeString(from: chat.updatedAt)
+        return relative == "Just now" ? "Updated just now" : "Updated \(relative)"
+    }
     
     var body: some View {
         sidebarContent
@@ -192,7 +197,7 @@ struct ChatSidebar: View {
                     isSelected: viewModel.currentChat?.id == chat.id,
                     isEditing: editingChatId == chat.id,
                     editingTitle: $editingTitle,
-                    timeString: chat.isBlankChat ? "" : relativeTimeString(from: chat.createdAt),
+                    timeString: chat.isBlankChat ? "" : lastUpdatedString(for: chat),
                     onSelect: {
                         viewModel.selectChat(chat)
                     },

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -175,7 +175,7 @@ struct ChatSidebar: View {
             .applyAlwaysBounceIfAvailable()
             .refreshable {
                 await authManager.initializeAuthState()
-                await viewModel.performFullSync(deep: true)
+                await viewModel.performFullSync()
             }
             .frame(maxHeight: .infinity)
 

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -79,10 +79,8 @@ struct ChatSidebar: View {
         }
     }
 
-    private func lastUpdatedString(for chat: Chat) -> String {
-        let created = relativeTimeString(from: chat.createdAt)
-        let updated = relativeTimeString(from: chat.updatedAt).lowercased()
-        return "\(created) · Updated \(updated)"
+    private func updatedTimeString(for chat: Chat) -> String {
+        "Updated \(relativeTimeString(from: chat.updatedAt).lowercased())"
     }
     
     var body: some View {
@@ -199,7 +197,8 @@ struct ChatSidebar: View {
                     isSelected: viewModel.currentChat?.id == chat.id,
                     isEditing: editingChatId == chat.id,
                     editingTitle: $editingTitle,
-                    timeString: chat.isBlankChat ? "" : lastUpdatedString(for: chat),
+                    createdTimeString: chat.isBlankChat ? "" : relativeTimeString(from: chat.createdAt),
+                    updatedTimeString: chat.isBlankChat ? "" : updatedTimeString(for: chat),
                     isSyncing: !chat.isBlankChat && cloudSync.pendingUploadChatIds.contains(chat.id),
                     onSelect: {
                         viewModel.selectChat(chat)
@@ -538,7 +537,8 @@ struct ChatListItem: View {
     let isSelected: Bool
     let isEditing: Bool
     @Binding var editingTitle: String
-    let timeString: String
+    let createdTimeString: String
+    let updatedTimeString: String
     var isSyncing: Bool = false
     let onSelect: () -> Void
     let onEdit: () -> Void
@@ -605,11 +605,13 @@ struct ChatListItem: View {
                 
                 // Timestamp inside the cell
                 if !isEditing {
-                    if !timeString.isEmpty {
+                    if !createdTimeString.isEmpty {
                         HStack(spacing: 4) {
-                            Text(timeString)
+                            (Text(createdTimeString)
+                                .foregroundColor(Color(UIColor.secondaryLabel))
+                                + Text(" · \(updatedTimeString)")
+                                .foregroundColor(Color(UIColor.tertiaryLabel)))
                                 .font(.caption)
-                                .foregroundColor(.gray)
                             if isSyncing {
                                 Image(systemName: "icloud.and.arrow.up")
                                     .font(.caption2)
@@ -659,8 +661,9 @@ struct ChatListItem: View {
         var components = [chat.title.isEmpty ? "Untitled chat" : chat.title]
         if chat.isBlankChat {
             components.append("New chat")
-        } else if !timeString.isEmpty {
-            components.append(timeString)
+        } else if !createdTimeString.isEmpty {
+            components.append("Created \(createdTimeString)")
+            components.append(updatedTimeString)
         }
         if isSyncing {
             components.append("Syncing with cloud")

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -79,9 +79,9 @@ struct ChatSidebar: View {
     }
 
     private func lastUpdatedString(for chat: Chat) -> String {
-        let created = relativeTimeString(from: chat.createdAt).lowercased()
+        let created = relativeTimeString(from: chat.createdAt)
         let updated = relativeTimeString(from: chat.updatedAt).lowercased()
-        return "Created \(created) · Updated \(updated)"
+        return "\(created) · Updated \(updated)"
     }
     
     var body: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -24,6 +24,7 @@ struct ChatSidebar: View {
     @State private var isProjectsExpanded: Bool = false
     @State private var isChatsExpanded: Bool = true
     @ObservedObject private var settings = SettingsManager.shared
+    @ObservedObject private var cloudSync = CloudSyncService.shared
 
     private var activeTab: ChatStorageTab {
         viewModel.activeStorageTab
@@ -199,6 +200,7 @@ struct ChatSidebar: View {
                     isEditing: editingChatId == chat.id,
                     editingTitle: $editingTitle,
                     timeString: chat.isBlankChat ? "" : lastUpdatedString(for: chat),
+                    isSyncing: !chat.isBlankChat && cloudSync.pendingUploadChatIds.contains(chat.id),
                     onSelect: {
                         viewModel.selectChat(chat)
                     },
@@ -537,6 +539,7 @@ struct ChatListItem: View {
     let isEditing: Bool
     @Binding var editingTitle: String
     let timeString: String
+    var isSyncing: Bool = false
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -603,9 +606,16 @@ struct ChatListItem: View {
                 // Timestamp inside the cell
                 if !isEditing {
                     if !timeString.isEmpty {
-                        Text(timeString)
-                            .font(.caption)
-                            .foregroundColor(.gray)
+                        HStack(spacing: 4) {
+                            Text(timeString)
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                            if isSyncing {
+                                Image(systemName: "icloud.and.arrow.up")
+                                    .font(.caption2)
+                                    .foregroundColor(.blue)
+                            }
+                        }
                     } else {
                         // Placeholder for new chats to maintain consistent height
                         Text(" ")
@@ -651,6 +661,9 @@ struct ChatListItem: View {
             components.append("New chat")
         } else if !timeString.isEmpty {
             components.append(timeString)
+        }
+        if isSyncing {
+            components.append("Syncing with cloud")
         }
         return components.joined(separator: ", ")
     }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -79,8 +79,9 @@ struct ChatSidebar: View {
     }
 
     private func lastUpdatedString(for chat: Chat) -> String {
-        let relative = relativeTimeString(from: chat.updatedAt)
-        return relative == "Just now" ? "Updated just now" : "Updated \(relative)"
+        let created = relativeTimeString(from: chat.createdAt).lowercased()
+        let updated = relativeTimeString(from: chat.updatedAt).lowercased()
+        return "Created \(created) · Updated \(updated)"
     }
     
     var body: some View {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -79,8 +79,13 @@ struct ChatSidebar: View {
         }
     }
 
+    /// Empty when the updated time would read the same as the created
+    /// time, so rows don't repeat "14m ago · Updated 14m ago".
     private func updatedTimeString(for chat: Chat) -> String {
-        "Updated \(relativeTimeString(from: chat.updatedAt).lowercased())"
+        let created = relativeTimeString(from: chat.createdAt)
+        let updated = relativeTimeString(from: chat.updatedAt)
+        guard updated != created else { return "" }
+        return "Updated \(updated.lowercased())"
     }
     
     var body: some View {
@@ -609,7 +614,7 @@ struct ChatListItem: View {
                         HStack(spacing: 4) {
                             (Text(createdTimeString)
                                 .foregroundColor(Color(UIColor.secondaryLabel))
-                                + Text(" · \(updatedTimeString)")
+                                + Text(updatedTimeString.isEmpty ? "" : " · \(updatedTimeString)")
                                 .foregroundColor(Color(UIColor.tertiaryLabel)))
                                 .font(.caption)
                             if isSyncing {
@@ -663,7 +668,9 @@ struct ChatListItem: View {
             components.append("New chat")
         } else if !createdTimeString.isEmpty {
             components.append("Created \(createdTimeString)")
-            components.append(updatedTimeString)
+            if !updatedTimeString.isEmpty {
+                components.append(updatedTimeString)
+            }
         }
         if isSyncing {
             components.append("Syncing with cloud")

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -281,12 +281,12 @@ struct ChatContainer: View {
                         HStack(spacing: 6) {
                             Image(systemName: "folder")
                                 .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(.accentColor)
+                                .foregroundColor(toolbarContentColor)
                             Text(activeProject.name)
                                 .font(.caption)
                                 .fontWeight(.semibold)
                                 .lineLimit(1)
-                                .foregroundColor(.accentColor)
+                                .foregroundColor(toolbarContentColor)
                         }
                         .opacity(isVerificationBadgeExpanded ? 0 : 1)
                         .accessibilityElement(children: .combine)
@@ -296,11 +296,11 @@ struct ChatContainer: View {
 
                     if viewModel.isTemporaryMode && viewModel.activeProject == nil {
                         HStack(spacing: 6) {
-                            GhostIcon(size: 14, color: .accentColor, style: .filled)
+                            GhostIcon(size: 14, color: toolbarContentColor, style: .filled)
                             Text("Temporary")
                                 .font(.caption)
                                 .fontWeight(.semibold)
-                                .foregroundColor(.accentColor)
+                                .foregroundColor(toolbarContentColor)
                         }
                         .opacity(isSidebarOpen || isVerificationBadgeExpanded ? 0 : 1)
                         .accessibilityElement(children: .combine)
@@ -326,7 +326,7 @@ struct ChatContainer: View {
                     Button(action: toggleTemporaryMode) {
                         GhostIcon(
                             size: 17,
-                            color: viewModel.isTemporaryMode ? .accentColor : toolbarContentColor,
+                            color: toolbarContentColor,
                             style: viewModel.isTemporaryMode ? .filled : .outline
                         )
                     }

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -55,6 +55,9 @@ struct CloudSyncSettingsView: View {
     
     @State private var copiedToClipboard: Bool = false
     @State private var showBackupKeySheet: Bool = false
+    @State private var passkeyBundles: [EnclaveKeyCurrentBundle] = []
+    @State private var removingPasskeyId: String? = nil
+    @State private var passkeyBundleError: String? = nil
     
     var body: some View {
         List {
@@ -189,6 +192,8 @@ struct CloudSyncSettingsView: View {
             .listRowBackground(Color.cardSurface(for: colorScheme))
             } // end if settings.isCloudSyncEnabled
 
+            passkeySection
+
             // Local-Only Mode Section
             Section {
                 VStack(alignment: .leading, spacing: 6) {
@@ -220,6 +225,9 @@ struct CloudSyncSettingsView: View {
         .background(Color.settingsBackground(for: colorScheme))
         .navigationTitle("Cloud Sync Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .task(id: [settings.isCloudSyncEnabled, passkeyManager.passkeyActive]) {
+            await refreshPasskeyBundles()
+        }
         .onAppear {
             // Reset navigation bar to use system colors for settings screens
             let appearance = UINavigationBarAppearance()
@@ -250,6 +258,247 @@ struct CloudSyncSettingsView: View {
             }
     }
     
+    @ViewBuilder
+    private var passkeySection: some View {
+        if passkeyManager.passkeyActive
+            || !passkeyBundles.isEmpty
+            || passkeyBundleError != nil
+            || passkeyManager.passkeyAddDeviceAvailable
+            || passkeyManager.passkeySetupAvailable {
+            Section {
+                if passkeyManager.passkeyActive {
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "person.badge.key.fill")
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                            Text("Sync and backup using Passkeys")
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                        }
+                        Text("Use Face ID or Touch ID to sync chats across devices")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.shield.fill")
+                                .font(.caption)
+                                .foregroundColor(.green)
+                            Text("Passkey active")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundColor(.green)
+                        }
+                        .padding(.top, 2)
+                    }
+                    .padding(.vertical, 2)
+                }
+
+                if !passkeyBundles.isEmpty || passkeyBundleError != nil {
+                    passkeyBundleInventory
+                }
+
+                if passkeyManager.passkeyAddDeviceAvailable && EncryptionService.shared.hasEncryptionKey() {
+                    Button(action: {
+                        Task {
+                            await passkeyManager.createPasskeyBackup()
+                        }
+                    }) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "person.badge.key.fill")
+                                    .font(.subheadline)
+                                    .foregroundColor(.primary)
+                                Text("Set Up Passkey on This Device")
+                                    .font(.subheadline)
+                                    .foregroundColor(.primary)
+                            }
+                            Text("Your other devices use a passkey already. Add one here for one-tap access.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                } else if passkeyManager.passkeySetupAvailable && EncryptionService.shared.hasEncryptionKey() {
+                    Button(action: {
+                        Task {
+                            await passkeyManager.createPasskeyBackup()
+                        }
+                    }) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "person.badge.key.fill")
+                                    .font(.subheadline)
+                                    .foregroundColor(.primary)
+                                Text("Add Passkey for seamless sync")
+                                    .font(.subheadline)
+                                    .foregroundColor(.primary)
+                            }
+                            Text("Use Face ID or Touch ID to sync chats across devices")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                } else if passkeyManager.passkeySetupAvailable && !EncryptionService.shared.hasEncryptionKey() {
+                    Button(action: {
+                        Task {
+                            let result = await passkeyManager.retryPasskeySetup()
+                            switch result {
+                            case .manualSetupRequired:
+                                await MainActor.run {
+                                    viewModel.cloudSyncOnboardingMode = .setup
+                                    viewModel.showCloudSyncOnboarding = true
+                                }
+                            case .manualRecoveryRequired:
+                                await MainActor.run {
+                                    viewModel.cloudSyncOnboardingMode = .recovery
+                                    viewModel.showCloudSyncOnboarding = true
+                                }
+                            default:
+                                break
+                            }
+                        }
+                    }) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "person.badge.key.fill")
+                                    .font(.subheadline)
+                                    .foregroundColor(.primary)
+                                Text("Add Passkey for seamless sync")
+                                    .font(.subheadline)
+                                    .foregroundColor(.primary)
+                            }
+                            Text("Create a passkey to sync chats across devices")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            } header: {
+                Text("Passkeys")
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+        }
+    }
+
+    private var passkeyBundleInventory: some View {
+        let localCredentialId = UserDefaults.standard.string(
+            forKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId
+        )
+        let sorted = passkeyBundles.sorted { a, b in
+            if a.credentialId == localCredentialId { return true }
+            if b.credentialId == localCredentialId { return false }
+            return (a.createdAt ?? "") > (b.createdAt ?? "")
+        }
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Registered platforms (\(sorted.count))")
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundColor(.secondary)
+                .textCase(.uppercase)
+            ForEach(sorted, id: \.credentialId) { bundle in
+                passkeyBundleRow(
+                    bundle: bundle,
+                    isCurrentPlatform: bundle.credentialId == localCredentialId
+                )
+            }
+            if let passkeyBundleError {
+                Text(passkeyBundleError)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func passkeyBundleRow(
+        bundle: EnclaveKeyCurrentBundle,
+        isCurrentPlatform: Bool
+    ) -> some View {
+        let credLabel = bundle.credentialId.count <= 12
+            ? bundle.credentialId
+            : "\(bundle.credentialId.prefix(6))…\(bundle.credentialId.suffix(4))"
+        let dateLabel: String
+        if let created = bundle.createdAt, !created.isEmpty {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let date = formatter.date(from: created)
+                ?? ISO8601DateFormatter().date(from: created)
+            if let date {
+                let display = DateFormatter()
+                display.dateStyle = .medium
+                dateLabel = display.string(from: date)
+            } else {
+                dateLabel = "Date unknown"
+            }
+        } else {
+            dateLabel = "Date unknown"
+        }
+        let isRemoving = removingPasskeyId == bundle.credentialId
+        return HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Image(systemName: "person.badge.key.fill")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(isCurrentPlatform ? "This platform" : "Other platform")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                }
+                Text("\(credLabel) · \(dateLabel)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button(action: {
+                Task { await removeBundle(bundle.credentialId) }
+            }) {
+                Text(isRemoving ? "Removing…" : "Remove")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(isRemoving ? .secondary : .red)
+            }
+            .disabled(removingPasskeyId != nil)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func refreshPasskeyBundles() async {
+        guard settings.isCloudSyncEnabled else {
+            passkeyBundles = []
+            passkeyBundleError = nil
+            return
+        }
+        do {
+            passkeyBundles = try await passkeyManager.listPasskeyBundles()
+            passkeyBundleError = nil
+        } catch {
+            // Keep the previous inventory: clearing it would make a
+            // load failure indistinguishable from "no passkeys
+            // registered" for a security-relevant list.
+            passkeyBundleError = "Couldn't load registered passkeys. Please try again later."
+        }
+    }
+
+    private func removeBundle(_ credentialId: String) async {
+        // One removal at a time: the in-flight UI state is single-valued
+        // and concurrent deletes would race it and duplicate requests.
+        guard removingPasskeyId == nil else { return }
+        removingPasskeyId = credentialId
+        defer { removingPasskeyId = nil }
+        do {
+            try await passkeyManager.removePasskeyBundle(credentialId: credentialId)
+            await refreshPasskeyBundles()
+        } catch {
+            passkeyBundleError = "Couldn't remove the passkey. Please try again."
+        }
+    }
+
     private func maskKey(_ key: String) -> String {
         guard key.count > 12 else { return key }
         let visibleChars = 12 // Show first 12 characters

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -298,87 +298,72 @@ struct CloudSyncSettingsView: View {
                 }
 
                 if passkeyManager.passkeyAddDeviceAvailable && EncryptionService.shared.hasEncryptionKey() {
-                    Button(action: {
-                        Task {
-                            await passkeyManager.createPasskeyBackup()
-                        }
-                    }) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.badge.key.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                                Text("Set Up Passkey on This Device")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                            }
-                            Text("Your other devices use a passkey already. Add one here for one-tap access.")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 2)
+                    passkeyActionButton(
+                        title: "Set Up Passkey on This Device",
+                        subtitle: "Your other devices use a passkey already. Add one here for one-tap access."
+                    ) {
+                        await passkeyManager.createPasskeyBackup()
                     }
                 } else if passkeyManager.passkeySetupAvailable && EncryptionService.shared.hasEncryptionKey() {
-                    Button(action: {
-                        Task {
-                            await passkeyManager.createPasskeyBackup()
-                        }
-                    }) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.badge.key.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                                Text("Add Passkey for seamless sync")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                            }
-                            Text("Use Face ID or Touch ID to sync chats across devices")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 2)
+                    passkeyActionButton(
+                        title: "Add Passkey for seamless sync",
+                        subtitle: "Use Face ID or Touch ID to sync chats across devices"
+                    ) {
+                        await passkeyManager.createPasskeyBackup()
                     }
                 } else if passkeyManager.passkeySetupAvailable && !EncryptionService.shared.hasEncryptionKey() {
-                    Button(action: {
-                        Task {
-                            let result = await passkeyManager.retryPasskeySetup()
-                            switch result {
-                            case .manualSetupRequired:
-                                await MainActor.run {
-                                    viewModel.cloudSyncOnboardingMode = .setup
-                                    viewModel.showCloudSyncOnboarding = true
-                                }
-                            case .manualRecoveryRequired:
-                                await MainActor.run {
-                                    viewModel.cloudSyncOnboardingMode = .recovery
-                                    viewModel.showCloudSyncOnboarding = true
-                                }
-                            default:
-                                break
+                    passkeyActionButton(
+                        title: "Add Passkey for seamless sync",
+                        subtitle: "Create a passkey to sync chats across devices"
+                    ) {
+                        let result = await passkeyManager.retryPasskeySetup()
+                        switch result {
+                        case .manualSetupRequired:
+                            await MainActor.run {
+                                viewModel.cloudSyncOnboardingMode = .setup
+                                viewModel.showCloudSyncOnboarding = true
                             }
-                        }
-                    }) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.badge.key.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                                Text("Add Passkey for seamless sync")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
+                        case .manualRecoveryRequired:
+                            await MainActor.run {
+                                viewModel.cloudSyncOnboardingMode = .recovery
+                                viewModel.showCloudSyncOnboarding = true
                             }
-                            Text("Create a passkey to sync chats across devices")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
+                        default:
+                            break
                         }
-                        .padding(.vertical, 2)
                     }
                 }
             } header: {
                 Text("Passkeys")
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
+        }
+    }
+
+    private func passkeyActionButton(
+        title: String,
+        subtitle: String,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button(action: {
+            Task {
+                await action()
+            }
+        }) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Image(systemName: "person.badge.key.fill")
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                    Text(title)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                }
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 2)
         }
     }
 

--- a/TinfoilChat/Views/ContextUsageIndicator.swift
+++ b/TinfoilChat/Views/ContextUsageIndicator.swift
@@ -1,0 +1,77 @@
+//
+//  ContextUsageIndicator.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+//
+
+import SwiftUI
+
+/// Context window usage for the current conversation against the selected
+/// model's token budget. Mirrors the webapp's `ContextUsage` shape.
+struct ContextUsage {
+    let percentage: Double
+    let usedTokens: Int
+    let limitTokens: Int
+}
+
+/// Small ring gauge plus percentage label showing how much of the model's
+/// context window the conversation uses. Mirrors the webapp's
+/// `ContextUsageIndicator`.
+struct ContextUsageIndicator: View {
+    let usage: ContextUsage
+
+    private static let ringDiameter: CGFloat = 14
+    private static let ringLineWidth: CGFloat = 2
+
+    private var clampedPercentage: Int {
+        min(Int(usage.percentage.rounded()), 100)
+    }
+
+    private var isNearLimit: Bool {
+        clampedPercentage >= Constants.Context.warningThresholdPercent
+    }
+
+    private var isFull: Bool {
+        clampedPercentage >= 100
+    }
+
+    private var ringColor: Color {
+        isNearLimit ? .orange : .secondary
+    }
+
+    private var accessibilityText: String {
+        if isFull {
+            return "Context window full (~\(Self.formatTokens(usage.limitTokens)) tokens). Older messages are archived and no longer sent to the model."
+        }
+        return "Context window \(clampedPercentage)% used (~\(Self.formatTokens(usage.usedTokens)) of \(Self.formatTokens(usage.limitTokens)) tokens)"
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .stroke(Color.secondary.opacity(0.25), lineWidth: Self.ringLineWidth)
+                Circle()
+                    .trim(from: 0, to: CGFloat(clampedPercentage) / 100)
+                    .stroke(ringColor, style: StrokeStyle(lineWidth: Self.ringLineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+            }
+            .frame(width: Self.ringDiameter, height: Self.ringDiameter)
+
+            Text("\(clampedPercentage)%")
+                .font(.caption2.weight(.medium))
+                .monospacedDigit()
+                .foregroundColor(ringColor)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    private static func formatTokens(_ tokens: Int) -> String {
+        if tokens >= 1000 {
+            return "\(Int((Double(tokens) / 1000).rounded()))k"
+        }
+        return "\(tokens)"
+    }
+}

--- a/TinfoilChat/Views/ContextUsageIndicator.swift
+++ b/TinfoilChat/Views/ContextUsageIndicator.swift
@@ -7,8 +7,7 @@
 
 import SwiftUI
 
-/// Context window usage for the current conversation against the selected
-/// model's token budget. Mirrors the webapp's `ContextUsage` shape.
+/// Mirrors the webapp's `ContextUsage` shape.
 struct ContextUsage {
     let percentage: Double
     let usedTokens: Int

--- a/TinfoilChat/Views/GenUI/Widgets/TimelineWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/TimelineWidget.swift
@@ -96,6 +96,10 @@ private struct TimelineEventsView: View {
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                    // Hug the text's ideal height so the greedy connector
+                    // line cannot stretch the row when a large height is
+                    // proposed (e.g. by the streaming cell buffer).
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -11,6 +11,19 @@ import Textual
 import SwiftMath
 import UIKit
 
+/// Thematic break style with spacing balanced against the default
+/// paragraph style, so horizontal rules sit evenly between blocks.
+struct ChatThematicBreakStyle: StructuredText.ThematicBreakStyle {
+    func makeBody(configuration _: Configuration) -> some View {
+        Divider()
+            .frame(minHeight: 1)
+            .textual.blockSpacing(.fontScaled(
+                top: Constants.Rendering.thematicBreakTopSpacing,
+                bottom: Constants.Rendering.thematicBreakBottomSpacing
+            ))
+    }
+}
+
 private enum SegmentKind: Sendable {
     case markdown(String)
     case latex(String, isDisplay: Bool)
@@ -178,6 +191,7 @@ struct LaTeXMarkdownView: View, Equatable {
                 markdownFallback(content: content)
             }
         }
+        .textual.thematicBreakStyle(ChatThematicBreakStyle())
         .padding(.horizontal, horizontalPadding)
         .frame(maxWidth: horizontalPadding > 0 ? .infinity : nil, alignment: maxWidthAlignment)
         .transaction { transaction in

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -11,19 +11,6 @@ import Textual
 import SwiftMath
 import UIKit
 
-/// Thematic break style with spacing balanced against the default
-/// paragraph style, so horizontal rules sit evenly between blocks.
-struct ChatThematicBreakStyle: StructuredText.ThematicBreakStyle {
-    func makeBody(configuration _: Configuration) -> some View {
-        Divider()
-            .frame(minHeight: 1)
-            .textual.blockSpacing(.fontScaled(
-                top: Constants.Rendering.thematicBreakTopSpacing,
-                bottom: Constants.Rendering.thematicBreakBottomSpacing
-            ))
-    }
-}
-
 private enum SegmentKind: Sendable {
     case markdown(String)
     case latex(String, isDisplay: Bool)
@@ -191,7 +178,6 @@ struct LaTeXMarkdownView: View, Equatable {
                 markdownFallback(content: content)
             }
         }
-        .textual.thematicBreakStyle(ChatThematicBreakStyle())
         .padding(.horizontal, horizontalPadding)
         .frame(maxWidth: horizontalPadding > 0 ? .infinity : nil, alignment: maxWidthAlignment)
         .transaction { transaction in

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -312,7 +312,8 @@ struct MessageInputView: View {
                                  onFocusHandled: { viewModel.shouldFocusInput = false },
                                  onSendMessage: { text in viewModel.sendMessage(text: text) },
                                  onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) })
+                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
+                                 onPasteFileError: { message in viewModel.attachmentError = message })
                     .frame(height: textHeight)
                     .padding(.horizontal)
 
@@ -422,7 +423,8 @@ struct MessageInputView: View {
                                  onFocusHandled: { viewModel.shouldFocusInput = false },
                                  onSendMessage: { text in viewModel.sendMessage(text: text) },
                                  onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) })
+                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
+                                 onPasteFileError: { message in viewModel.attachmentError = message })
                     .frame(height: textHeight)
                     .padding(.horizontal)
 
@@ -785,12 +787,14 @@ struct CustomTextEditor: UIViewRepresentable {
     var onSendMessage: (String) -> Void
     var onPasteImage: ((Data, String) -> Void)? = nil
     var onPasteFile: ((URL, String) -> Void)? = nil
+    var onPasteFileError: ((String) -> Void)? = nil
 
     func makeUIView(context: Context) -> UITextView {
         let textView = PastingTextView()
         textView.allowsImagePaste = allowsImagePaste
         textView.onPasteImage = onPasteImage
         textView.onPasteFile = onPasteFile
+        textView.onPasteFileError = onPasteFileError
         textView.delegate = context.coordinator
         textView.font = UIFont.preferredFont(forTextStyle: .body)
         textView.backgroundColor = .clear
@@ -826,6 +830,7 @@ struct CustomTextEditor: UIViewRepresentable {
             pastingView.allowsImagePaste = allowsImagePaste
             pastingView.onPasteImage = onPasteImage
             pastingView.onPasteFile = onPasteFile
+            pastingView.onPasteFileError = onPasteFileError
         }
         let isCurrentlyEditing = context.coordinator.isEditing
 
@@ -984,6 +989,7 @@ final class PastingTextView: UITextView {
     var allowsImagePaste = false
     var onPasteImage: ((Data, String) -> Void)?
     var onPasteFile: ((URL, String) -> Void)?
+    var onPasteFileError: ((String) -> Void)?
 
     private var pasteboardFileURLs: [URL] {
         guard !UIPasteboard.general.hasStrings else { return [] }
@@ -1032,17 +1038,30 @@ final class PastingTextView: UITextView {
 
     /// Copies a pasted file into the app's temp directory so the attachment
     /// pipeline can read it after the pasteboard's access window closes.
+    /// Oversized files are rejected up front: the pipeline would refuse them
+    /// anyway, and copying or reading them first would waste disk and memory.
     private func importPastedFile(url: URL, onPasteFile: (URL, String) -> Void) {
         let fileName = url.lastPathComponent
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString + "_" + fileName)
         let didAccess = url.startAccessingSecurityScopedResource()
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+
+        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           Int64(fileSize) > Constants.Attachments.maxFileSizeBytes {
+            let message = DocumentProcessingService.ProcessingError
+                .fileTooLarge(Int64(fileSize)).errorDescription
+            onPasteFileError?(message ?? "File is too large.")
+            return
+        }
+
         do {
             try FileManager.default.copyItem(at: url, to: tempURL)
             onPasteFile(tempURL, fileName)
         } catch {
-            guard let data = try? Data(contentsOf: url) else { return }
+            // Memory-mapped so an unexpectedly large file (when the size
+            // probe above fails) is never loaded into RAM wholesale.
+            guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return }
             do {
                 try data.write(to: tempURL)
                 onPasteFile(tempURL, fileName)

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -193,6 +193,11 @@ struct MessageInputView: View {
                 )
                 .transition(.opacity)
                 .animation(.easeInOut(duration: 0.25), value: rl.remaining)
+                .onTapGesture {
+                    if rl.remaining <= 0 {
+                        viewModel.showRateLimitPaywall = true
+                    }
+                }
         }
     }
 

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1055,15 +1055,7 @@ final class PastingTextView: UITextView {
             try FileManager.default.copyItem(at: url, to: tempURL)
             onPasteFile(tempURL, fileName)
         } catch {
-            // Memory-mapped so an unexpectedly large file (when the size
-            // probe above fails) is never loaded into RAM wholesale.
-            guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return }
-            do {
-                try data.write(to: tempURL)
-                onPasteFile(tempURL, fileName)
-            } catch {
-                return
-            }
+            onPasteFileError?("Couldn't read the pasted file. Try attaching it with the + button instead.")
         }
     }
 } 

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -129,6 +129,7 @@ struct MessageInputView: View {
                 AddToSheetView(
                     viewModel: viewModel,
                     isDarkMode: isDarkMode,
+                    contextUsage: showContextIndicator ? contextUsage : nil,
                     onCamera: {
                         pendingPickerAction = .camera
                         viewModel.showAddSheet = false
@@ -143,7 +144,7 @@ struct MessageInputView: View {
                     }
                 )
                 .environmentObject(authManager)
-                .presentationDetents([.height(280)])
+                .presentationDetents([.height(showContextIndicator ? 324 : 280)])
                 .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
             }
             .sheet(isPresented: $viewModel.showRateLimitPaywall) {
@@ -331,11 +332,6 @@ struct MessageInputView: View {
                         .padding(.leading, 4)
                     }
 
-                    if showContextIndicator {
-                        ContextUsageIndicator(usage: contextUsage)
-                            .padding(.leading, 4)
-                    }
-
                     Spacer()
 
                     // Microphone button
@@ -444,11 +440,6 @@ struct MessageInputView: View {
                             thinkingEnabled: $viewModel.thinkingEnabled
                         )
                         .padding(.leading, 4)
-                    }
-
-                    if showContextIndicator {
-                        ContextUsageIndicator(usage: contextUsage)
-                            .padding(.leading, 4)
                     }
 
                     Spacer()
@@ -623,6 +614,7 @@ struct AddToSheetView: View {
     @EnvironmentObject private var authManager: AuthManager
     @ObservedObject private var settings = SettingsManager.shared
     let isDarkMode: Bool
+    let contextUsage: ContextUsage?
     let onCamera: () -> Void
     let onPhotos: () -> Void
     let onFiles: () -> Void
@@ -666,6 +658,15 @@ struct AddToSheetView: View {
                     settings.webSearchEnabled = newValue
                 }
                 .padding(.horizontal, 20)
+
+                if let contextUsage {
+                    HStack {
+                        Label("Context Used", systemImage: "text.alignleft")
+                        Spacer()
+                        ContextUsageIndicator(usage: contextUsage)
+                    }
+                    .padding(.horizontal, 20)
+                }
             }
             .padding(.top, 8)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -160,6 +160,7 @@ struct MessageInputView: View {
             .sheet(isPresented: $viewModel.showModelSelectorSheet) {
                 ModelSelectorSheetView(viewModel: viewModel, isDarkMode: isDarkMode)
                     .presentationDetents([.medium, .large])
+                    .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
             }
     }
 
@@ -706,6 +707,7 @@ struct ModelSelectorSheetView: View {
                 .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
             .navigationTitle("Select Model")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -283,6 +283,24 @@ struct MessageInputView: View {
         }
     }
 
+    /// Shared between the iOS 26 and pre-26 input layouts so the editor's
+    /// growing list of paste/send hooks stays defined in one place.
+    private var messageTextEditor: some View {
+        CustomTextEditor(text: $messageText,
+                         textHeight: $textHeight,
+                         placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
+                         shouldFocusInput: viewModel.shouldFocusInput,
+                         isLoading: viewModel.isLoading,
+                         allowsImagePaste: viewModel.currentModel.isMultimodal,
+                         onFocusHandled: { viewModel.shouldFocusInput = false },
+                         onSendMessage: { text in viewModel.sendMessage(text: text) },
+                         onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
+                         onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
+                         onPasteFileError: { message in viewModel.attachmentError = message })
+            .frame(height: textHeight)
+            .padding(.horizontal)
+    }
+
     @ViewBuilder
     private var standardInputContent: some View {
         if #available(iOS 26, *) {
@@ -303,19 +321,7 @@ struct MessageInputView: View {
                 }
 
                 // Text input area
-                CustomTextEditor(text: $messageText,
-                                 textHeight: $textHeight,
-                                 placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
-                                 shouldFocusInput: viewModel.shouldFocusInput,
-                                 isLoading: viewModel.isLoading,
-                                 allowsImagePaste: viewModel.currentModel.isMultimodal,
-                                 onFocusHandled: { viewModel.shouldFocusInput = false },
-                                 onSendMessage: { text in viewModel.sendMessage(text: text) },
-                                 onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
-                                 onPasteFileError: { message in viewModel.attachmentError = message })
-                    .frame(height: textHeight)
-                    .padding(.horizontal)
+                messageTextEditor
 
                 // Bottom row with action buttons
                 HStack {
@@ -414,19 +420,7 @@ struct MessageInputView: View {
                 }
 
                 // Text input area
-                CustomTextEditor(text: $messageText,
-                                 textHeight: $textHeight,
-                                 placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
-                                 shouldFocusInput: viewModel.shouldFocusInput,
-                                 isLoading: viewModel.isLoading,
-                                 allowsImagePaste: viewModel.currentModel.isMultimodal,
-                                 onFocusHandled: { viewModel.shouldFocusInput = false },
-                                 onSendMessage: { text in viewModel.sendMessage(text: text) },
-                                 onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
-                                 onPasteFileError: { message in viewModel.attachmentError = message })
-                    .frame(height: textHeight)
-                    .padding(.horizontal)
+                messageTextEditor
 
                 // Bottom row with action buttons
                 HStack {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -985,9 +985,11 @@ final class PastingTextView: UITextView {
     var onPasteFile: ((URL, String) -> Void)?
     var onPasteFileError: ((String) -> Void)?
 
+    /// File URLs win over any string representation on the pasteboard:
+    /// copying a file (e.g. from the Files app) often includes its name as
+    /// plain text, and pasting that name instead of the file would be wrong.
     private var pasteboardFileURLs: [URL] {
-        guard !UIPasteboard.general.hasStrings else { return [] }
-        return UIPasteboard.general.urls?.filter { $0.isFileURL } ?? []
+        UIPasteboard.general.urls?.filter { $0.isFileURL } ?? []
     }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -307,8 +307,11 @@ struct MessageInputView: View {
                                  placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
                                  shouldFocusInput: viewModel.shouldFocusInput,
                                  isLoading: viewModel.isLoading,
+                                 allowsImagePaste: viewModel.currentModel.isMultimodal,
                                  onFocusHandled: { viewModel.shouldFocusInput = false },
-                                 onSendMessage: { text in viewModel.sendMessage(text: text) })
+                                 onSendMessage: { text in viewModel.sendMessage(text: text) },
+                                 onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
+                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) })
                     .frame(height: textHeight)
                     .padding(.horizontal)
 
@@ -419,8 +422,11 @@ struct MessageInputView: View {
                                  placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
                                  shouldFocusInput: viewModel.shouldFocusInput,
                                  isLoading: viewModel.isLoading,
+                                 allowsImagePaste: viewModel.currentModel.isMultimodal,
                                  onFocusHandled: { viewModel.shouldFocusInput = false },
-                                 onSendMessage: { text in viewModel.sendMessage(text: text) })
+                                 onSendMessage: { text in viewModel.sendMessage(text: text) },
+                                 onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
+                                 onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) })
                     .frame(height: textHeight)
                     .padding(.horizontal)
 
@@ -773,11 +779,17 @@ struct CustomTextEditor: UIViewRepresentable {
     var placeholderText: String
     var shouldFocusInput: Bool
     var isLoading: Bool
+    var allowsImagePaste: Bool = false
     var onFocusHandled: () -> Void
     var onSendMessage: (String) -> Void
+    var onPasteImage: ((Data, String) -> Void)? = nil
+    var onPasteFile: ((URL, String) -> Void)? = nil
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+        let textView = PastingTextView()
+        textView.allowsImagePaste = allowsImagePaste
+        textView.onPasteImage = onPasteImage
+        textView.onPasteFile = onPasteFile
         textView.delegate = context.coordinator
         textView.font = UIFont.preferredFont(forTextStyle: .body)
         textView.backgroundColor = .clear
@@ -809,6 +821,11 @@ struct CustomTextEditor: UIViewRepresentable {
     
     func updateUIView(_ uiView: UITextView, context: Context) {
         context.coordinator.parent = self
+        if let pastingView = uiView as? PastingTextView {
+            pastingView.allowsImagePaste = allowsImagePaste
+            pastingView.onPasteImage = onPasteImage
+            pastingView.onPasteFile = onPasteFile
+        }
         let isCurrentlyEditing = context.coordinator.isEditing
 
         if shouldFocusInput && !context.coordinator.hasFocusedFromFlag {
@@ -956,6 +973,81 @@ struct CustomTextEditor: UIViewRepresentable {
                 textView.textColor = .lightGray
             }
             refreshAccessibility(textView)
+        }
+    }
+}
+
+/// UITextView that accepts images and file URLs from the pasteboard in
+/// addition to plain text, turning them into attachments.
+final class PastingTextView: UITextView {
+    var allowsImagePaste = false
+    var onPasteImage: ((Data, String) -> Void)?
+    var onPasteFile: ((URL, String) -> Void)?
+
+    private var pasteboardFileURLs: [URL] {
+        guard !UIPasteboard.general.hasStrings else { return [] }
+        return UIPasteboard.general.urls?.filter { $0.isFileURL } ?? []
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)) {
+            if allowsImagePaste && UIPasteboard.general.hasImages && onPasteImage != nil {
+                return true
+            }
+            if !pasteboardFileURLs.isEmpty && onPasteFile != nil {
+                return true
+            }
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func paste(_ sender: Any?) {
+        let pasteboard = UIPasteboard.general
+
+        if allowsImagePaste, pasteboard.hasImages,
+           let onPasteImage, let images = pasteboard.images, !images.isEmpty {
+            for (index, image) in images.enumerated() {
+                guard let data = image.jpegData(
+                    compressionQuality: CGFloat(Constants.Attachments.imageCompressionQuality)
+                ) else { continue }
+                let fileName = images.count > 1 ? "Pasted Image \(index + 1).jpg" : "Pasted Image.jpg"
+                onPasteImage(data, fileName)
+            }
+            return
+        }
+
+        if let onPasteFile {
+            let fileURLs = pasteboardFileURLs
+            if !fileURLs.isEmpty {
+                for url in fileURLs {
+                    importPastedFile(url: url, onPasteFile: onPasteFile)
+                }
+                return
+            }
+        }
+
+        super.paste(sender)
+    }
+
+    /// Copies a pasted file into the app's temp directory so the attachment
+    /// pipeline can read it after the pasteboard's access window closes.
+    private func importPastedFile(url: URL, onPasteFile: (URL, String) -> Void) {
+        let fileName = url.lastPathComponent
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + "_" + fileName)
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+        do {
+            try FileManager.default.copyItem(at: url, to: tempURL)
+            onPasteFile(tempURL, fileName)
+        } catch {
+            guard let data = try? Data(contentsOf: url) else { return }
+            do {
+                try data.write(to: tempURL)
+                onPasteFile(tempURL, fileName)
+            } catch {
+                return
+            }
         }
     }
 } 

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -202,6 +202,37 @@ struct MessageInputView: View {
         }
     }
 
+    /// The indicator is hidden on a blank chat, matching the webapp's
+    /// welcome screen behavior.
+    private var showContextIndicator: Bool {
+        !(viewModel.currentChat?.messages.isEmpty ?? true)
+    }
+
+    /// Estimated context usage for the conversation: non-archived messages
+    /// plus the draft input and pending attachments, against the current
+    /// model's token budget. Mirrors the webapp's calculation.
+    private var contextUsage: ContextUsage {
+        let limitTokens = TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
+        var usedTokens = TokenEstimation.estimateTokenCount(messageText)
+
+        let messages = viewModel.messages
+        let startIndex = TokenEstimation.findContextStartIndex(messages: messages, budgetTokens: limitTokens)
+        for i in startIndex..<messages.count {
+            usedTokens += TokenEstimation.estimateMessageTokens(messages[i])
+        }
+
+        for attachment in viewModel.pendingAttachments {
+            usedTokens += TokenEstimation.estimateTokenCount(attachment.textContent)
+            usedTokens += TokenEstimation.estimateTokenCount(attachment.description)
+        }
+
+        return ContextUsage(
+            percentage: Double(usedTokens) / Double(limitTokens) * 100,
+            usedTokens: usedTokens,
+            limitTokens: limitTokens
+        )
+    }
+
     /// When the latest assistant message ends in an input-surface
     /// GenUI tool call, the chat input is replaced by the widget.
     private var pendingInputToolCall: PendingInputToolCall? {
@@ -295,6 +326,11 @@ struct MessageInputView: View {
                             thinkingEnabled: $viewModel.thinkingEnabled
                         )
                         .padding(.leading, 4)
+                    }
+
+                    if showContextIndicator {
+                        ContextUsageIndicator(usage: contextUsage)
+                            .padding(.leading, 4)
                     }
 
                     Spacer()
@@ -402,6 +438,11 @@ struct MessageInputView: View {
                             thinkingEnabled: $viewModel.thinkingEnabled
                         )
                         .padding(.leading, 4)
+                    }
+
+                    if showContextIndicator {
+                        ContextUsageIndicator(usage: contextUsage)
+                            .padding(.leading, 4)
                     }
 
                     Spacer()

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1255,6 +1255,7 @@ struct MarkdownText: View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
             .textual.textSelection(.enabled)
+            .textual.thematicBreakStyle(ChatThematicBreakStyle())
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, horizontalPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1276,6 +1277,7 @@ struct AdaptiveMarkdownText: View {
     var body: some View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
+            .textual.thematicBreakStyle(ChatThematicBreakStyle())
             .fixedSize(horizontal: false, vertical: true)
             .padding(.bottom, -16)
             .padding(.horizontal, horizontalPadding)

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1255,7 +1255,6 @@ struct MarkdownText: View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
             .textual.textSelection(.enabled)
-            .textual.thematicBreakStyle(ChatThematicBreakStyle())
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, horizontalPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1277,7 +1276,6 @@ struct AdaptiveMarkdownText: View {
     var body: some View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
-            .textual.thematicBreakStyle(ChatThematicBreakStyle())
             .fixedSize(horizontal: false, vertical: true)
             .padding(.bottom, -16)
             .padding(.horizontal, horizontalPadding)

--- a/TinfoilChat/Views/OptimizedChatListView.swift
+++ b/TinfoilChat/Views/OptimizedChatListView.swift
@@ -13,7 +13,6 @@ struct OptimizedChatListView: View {
     let isLoading: Bool
     let onRequestSignIn: () -> Void
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
-    @ObservedObject private var settings = SettingsManager.shared
     @Binding var messageText: String
 
     @State private var isAtBottom = true
@@ -25,7 +24,10 @@ struct OptimizedChatListView: View {
     @State private var keyboardObservers: [Any] = []
 
     private var archivedMessagesStartIndex: Int {
-        max(0, messages.count - settings.maxMessages)
+        TokenEstimation.findContextStartIndex(
+            messages: messages,
+            budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
+        )
     }
 
     private var visibleMessages: ArraySlice<Message> {

--- a/TinfoilChat/Views/OptimizedChatListView.swift
+++ b/TinfoilChat/Views/OptimizedChatListView.swift
@@ -22,9 +22,13 @@ struct OptimizedChatListView: View {
     @State private var lastAIMessageID: String? = nil
     @State private var scrollTrigger = UUID()
     @State private var keyboardObservers: [Any] = []
+    @State private var archivedMessagesStartIndex = 0
 
-    private var archivedMessagesStartIndex: Int {
-        TokenEstimation.findContextStartIndex(
+    /// Token estimation walks every message, so the result is cached and
+    /// refreshed only when the conversation, model, or message count changes
+    /// instead of on every body evaluation during streaming.
+    private func refreshArchivedMessagesStartIndex() {
+        archivedMessagesStartIndex = TokenEstimation.findContextStartIndex(
             messages: messages,
             budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
         )
@@ -103,12 +107,17 @@ struct OptimizedChatListView: View {
         }
         .onAppear {
             setupKeyboardObservers()
+            refreshArchivedMessagesStartIndex()
         }
         .onDisappear {
             removeKeyboardObservers()
             viewModel.isScrollInteractionActive = false
         }
+        .onChange(of: viewModel.currentModel.id) { _, _ in
+            refreshArchivedMessagesStartIndex()
+        }
         .onChange(of: messages.count) { oldCount, newCount in
+            refreshArchivedMessagesStartIndex()
             if newCount > oldCount {
                 let newMessages = messages.suffix(newCount - oldCount)
                 let hasUserMessage = newMessages.contains { $0.role == .user }
@@ -126,6 +135,7 @@ struct OptimizedChatListView: View {
             }
         }
         .onChange(of: viewModel.currentChat?.createdAt) { _, _ in
+            refreshArchivedMessagesStartIndex()
             userHasScrolled = false
             viewModel.isScrollInteractionActive = false
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -169,6 +169,7 @@ struct ProjectPage: View {
             } label: {
                 Label("Delete", systemImage: "trash")
             }
+            .tint(.red)
             Button {
                 Task {
                     await viewModel.removeChatFromProject(chatId: chat.id)
@@ -373,6 +374,7 @@ struct ProjectDocumentsView: View {
             } label: {
                 Label("Delete", systemImage: "trash")
             }
+            .tint(.red)
         }
     }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -150,7 +150,7 @@ struct ProjectPage: View {
                         .foregroundColor(.primary)
                         .lineLimit(1)
                     if !chat.isBlankChat {
-                        Text(relativeTimeString(from: chat.createdAt))
+                        Text(lastUpdatedString(from: chat.updatedAt))
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -213,6 +213,11 @@ struct ProjectPage: View {
         } else {
             return "\(Int(difference / 604800))w ago"
         }
+    }
+
+    private func lastUpdatedString(from date: Date) -> String {
+        let relative = relativeTimeString(from: date)
+        return relative == "Just now" ? "Updated just now" : "Updated \(relative)"
     }
 }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -150,7 +150,7 @@ struct ProjectPage: View {
                         .foregroundColor(.primary)
                         .lineLimit(1)
                     if !chat.isBlankChat {
-                        Text(lastUpdatedString(from: chat.updatedAt))
+                        Text(timestampString(for: chat))
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -215,9 +215,10 @@ struct ProjectPage: View {
         }
     }
 
-    private func lastUpdatedString(from date: Date) -> String {
-        let relative = relativeTimeString(from: date)
-        return relative == "Just now" ? "Updated just now" : "Updated \(relative)"
+    private func timestampString(for chat: Chat) -> String {
+        let created = relativeTimeString(from: chat.createdAt).lowercased()
+        let updated = relativeTimeString(from: chat.updatedAt).lowercased()
+        return "Created \(created) · Updated \(updated)"
     }
 }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -216,10 +216,12 @@ struct ProjectPage: View {
 
     private func timestampText(for chat: Chat) -> Text {
         let created = relativeTimeString(from: chat.createdAt)
-        let updated = relativeTimeString(from: chat.updatedAt).lowercased()
-        return Text(created)
+        let updated = relativeTimeString(from: chat.updatedAt)
+        let createdText = Text(created)
             .foregroundColor(Color(UIColor.secondaryLabel))
-            + Text(" · Updated \(updated)")
+        guard updated != created else { return createdText }
+        return createdText
+            + Text(" · Updated \(updated.lowercased())")
             .foregroundColor(Color(UIColor.tertiaryLabel))
     }
 }

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -150,9 +150,8 @@ struct ProjectPage: View {
                         .foregroundColor(.primary)
                         .lineLimit(1)
                     if !chat.isBlankChat {
-                        Text(timestampString(for: chat))
+                        timestampText(for: chat)
                             .font(.caption)
-                            .foregroundColor(.secondary)
                     }
                 }
                 Spacer()
@@ -215,10 +214,13 @@ struct ProjectPage: View {
         }
     }
 
-    private func timestampString(for chat: Chat) -> String {
+    private func timestampText(for chat: Chat) -> Text {
         let created = relativeTimeString(from: chat.createdAt)
         let updated = relativeTimeString(from: chat.updatedAt).lowercased()
-        return "\(created) · Updated \(updated)"
+        return Text(created)
+            .foregroundColor(Color(UIColor.secondaryLabel))
+            + Text(" · Updated \(updated)")
+            .foregroundColor(Color(UIColor.tertiaryLabel))
     }
 }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -216,9 +216,9 @@ struct ProjectPage: View {
     }
 
     private func timestampString(for chat: Chat) -> String {
-        let created = relativeTimeString(from: chat.createdAt).lowercased()
+        let created = relativeTimeString(from: chat.createdAt)
         let updated = relativeTimeString(from: chat.updatedAt).lowercased()
-        return "Created \(created) · Updated \(updated)"
+        return "\(created) · Updated \(updated)"
     }
 }
 

--- a/TinfoilChat/Views/ReasoningEffortSelector.swift
+++ b/TinfoilChat/Views/ReasoningEffortSelector.swift
@@ -59,7 +59,22 @@ struct ReasoningEffortSelector: View {
     var body: some View {
         if !supportsEffort && !supportsToggle {
             EmptyView()
-        } else if supportsToggle && !supportsEffort {
+        } else if #available(iOS 26, *) {
+            // On iOS 26 the menu label disappears while the menu is open and
+            // re-animates on dismissal; without a glass identity on the label
+            // and a clipped container the pill visibly drops and bounces back.
+            GlassEffectContainer {
+                menuContent
+                    .clipped()
+            }
+        } else {
+            menuContent
+        }
+    }
+
+    @ViewBuilder
+    private var menuContent: some View {
+        if supportsToggle && !supportsEffort {
             toggleOnlyMenu
         } else {
             effortMenu
@@ -128,13 +143,19 @@ struct ReasoningEffortSelector: View {
     /// effort menu. Uses the SF Symbols `lightbulb`/`lightbulb.slash`
     /// glyph pair — the system-provided slash variant adapts to both
     /// light and dark modes natively, so no manual overlay is needed.
+    @ViewBuilder
     private func iconLabel(active: Bool) -> some View {
-        Image(systemName: active ? "lightbulb" : "lightbulb.slash")
+        let pill = Image(systemName: active ? "lightbulb" : "lightbulb.slash")
             .font(.system(size: 12, weight: .semibold))
             .foregroundColor(active ? .primary : .primary.opacity(0.9))
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
             .background(Color.secondary.opacity(0.12))
             .clipShape(Capsule())
+        if #available(iOS 26, *) {
+            pill.glassEffect(.identity)
+        } else {
+            pill
+        }
     }
 }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -317,52 +317,8 @@ struct SettingsView: View {
     private var accountSection: some View {
         Section {
             if authManager.isAuthenticated {
-                HStack {
-                    userAvatar
-                        .frame(width: 40, height: 40)
-                        .clipShape(Circle())
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        if let user = clerk.user {
-                            Text("\(user.firstName ?? "") \(user.lastName ?? "")")
-                                .font(.body)
-                                .foregroundColor(.primary)
-                            if let email = user.emailAddresses.first?.emailAddress {
-                                Text(email)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        } else if let userData = authManager.localUserData {
-                            Text((userData["name"] as? String) ?? "User")
-                                .font(.body)
-                                .foregroundColor(.primary)
-                            if let email = userData["email"] as? String {
-                                Text(email)
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                    }
-
-                    Spacer()
-                }
-                .padding(.vertical, 4)
-
-                Button(action: {
-                    if let user = clerk.user {
-                        editingFirstName = user.firstName ?? ""
-                        editingLastName = user.lastName ?? ""
-                        showProfileEditor = true
-                    }
-                }) {
-                    HStack {
-                        Text("Edit Profile")
-                            .foregroundColor(.primary)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.caption2)
-                            .foregroundColor(Color(UIColor.quaternaryLabel))
-                    }
+                NavigationLink(destination: manageAccountPage) {
+                    accountSummaryRow
                 }
 
                 Button(action: {
@@ -371,16 +327,6 @@ struct SettingsView: View {
                     HStack {
                         Text("Sign Out")
                             .foregroundColor(.primary)
-                        Spacer()
-                    }
-                }
-
-                Button(action: {
-                    showDeleteConfirmation = true
-                }) {
-                    HStack {
-                        Text("Delete Account")
-                            .foregroundColor(.red)
                         Spacer()
                     }
                 }
@@ -399,6 +345,127 @@ struct SettingsView: View {
             Text("Account")
         }
         .listRowBackground(Color.cardSurface(for: colorScheme))
+    }
+
+    private var accountSummaryRow: some View {
+        HStack {
+            userAvatar
+                .frame(width: 40, height: 40)
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 2) {
+                if let user = clerk.user {
+                    Text("\(user.firstName ?? "") \(user.lastName ?? "")")
+                        .font(.body)
+                        .foregroundColor(.primary)
+                    if let email = user.emailAddresses.first?.emailAddress {
+                        Text(email)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                } else if let userData = authManager.localUserData {
+                    Text((userData["name"] as? String) ?? "User")
+                        .font(.body)
+                        .foregroundColor(.primary)
+                    if let email = userData["email"] as? String {
+                        Text(email)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var manageAccountPage: some View {
+        Form {
+            Section {
+                accountSummaryRow
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
+            Section {
+                Button(action: {
+                    if let user = clerk.user {
+                        editingFirstName = user.firstName ?? ""
+                        editingLastName = user.lastName ?? ""
+                        showProfileEditor = true
+                    }
+                }) {
+                    HStack {
+                        Text("Edit Profile")
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundColor(Color(UIColor.quaternaryLabel))
+                    }
+                }
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
+            Section {
+                Button(action: {
+                    showDeleteConfirmation = true
+                }) {
+                    HStack {
+                        Text("Delete Account")
+                            .foregroundColor(.red)
+                        Spacer()
+                    }
+                }
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.settingsBackground(for: colorScheme))
+        .navigationTitle("Manage Account")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Delete Account", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) {
+                Task {
+                    do {
+                        try await clerk.user?.delete()
+                        await performFullDataCleanup()
+                        await authManager.signOut()
+                        dismiss()
+                    } catch {
+                        accountDeletionError = error.localizedDescription
+                    }
+                }
+            }
+        } message: {
+            Text("Are you sure you want to delete your account? This action cannot be undone.")
+        }
+        .alert("Account Deletion Failed", isPresented: Binding(
+            get: { accountDeletionError != nil },
+            set: { if !$0 { accountDeletionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(accountDeletionError ?? "")
+        }
+        .sheet(isPresented: $showProfileEditor) {
+            ProfileEditorView(
+                firstName: $editingFirstName,
+                lastName: $editingLastName,
+                isUpdating: $isUpdatingProfile,
+                errorMessage: $profileUpdateError,
+                onSave: {
+                    Task {
+                        await updateProfile()
+                    }
+                },
+                onCancel: {
+                    showProfileEditor = false
+                }
+            )
+            .environment(clerk)
+        }
     }
 
     private var preferencesSection: some View {
@@ -925,48 +992,6 @@ struct SettingsView: View {
                     ? "All local data will be cleared. You can recover your chats by signing back in."
                     : "All local data will be cleared. You will need your encryption key to recover your chats.")
             }
-        }
-        .alert("Delete Account", isPresented: $showDeleteConfirmation) {
-            Button("Cancel", role: .cancel) { }
-            Button("Delete", role: .destructive) {
-                Task {
-                    do {
-                        try await clerk.user?.delete()
-                        await performFullDataCleanup()
-                        await authManager.signOut()
-                        dismiss()
-                    } catch {
-                        accountDeletionError = error.localizedDescription
-                    }
-                }
-            }
-        } message: {
-            Text("Are you sure you want to delete your account? This action cannot be undone.")
-        }
-        .alert("Account Deletion Failed", isPresented: Binding(
-            get: { accountDeletionError != nil },
-            set: { if !$0 { accountDeletionError = nil } }
-        )) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text(accountDeletionError ?? "")
-        }
-        .sheet(isPresented: $showProfileEditor) {
-            ProfileEditorView(
-                firstName: $editingFirstName,
-                lastName: $editingLastName,
-                isUpdating: $isUpdatingProfile,
-                errorMessage: $profileUpdateError,
-                onSave: {
-                    Task {
-                        await updateProfile()
-                    }
-                },
-                onCancel: {
-                    showProfileEditor = false
-                }
-            )
-            .environment(clerk)
         }
         .sheet(isPresented: $showPremiumModal) {
             PaywallView(displayCloseButton: true)

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -704,44 +704,54 @@ struct SettingsView: View {
         }
     }
 
-    /// Re-checks the typed phrase before deleting, mirroring the webapp's
-    /// defense-in-depth gate on the same action.
     private func confirmDeleteAllChats() {
-        let typed = deleteAllChatsConfirmText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let typed = deleteAllChatsConfirmText
         deleteAllChatsConfirmText = ""
-        guard typed == Self.deleteAllChatsConfirmPhrase else {
-            dataActionMessage = "Deletion cancelled: the confirmation phrase didn't match."
-            return
-        }
-        isDeletingAllChats = true
-        Task {
-            do {
-                try await chatViewModel.deleteAllChats()
-                dataActionMessage = "All chats have been deleted."
-            } catch {
-                dataActionMessage = "Failed to delete all chats. Please try again."
-            }
-            isDeletingAllChats = false
+        confirmBulkDelete(
+            typed: typed,
+            phrase: Self.deleteAllChatsConfirmPhrase,
+            itemsName: "chats",
+            setDeleting: { isDeletingAllChats = $0 }
+        ) {
+            try await chatViewModel.deleteAllChats()
         }
     }
 
-    /// Same defense-in-depth confirmation gate as `confirmDeleteAllChats`.
     private func confirmDeleteAllProjects() {
-        let typed = deleteAllProjectsConfirmText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let typed = deleteAllProjectsConfirmText
         deleteAllProjectsConfirmText = ""
-        guard typed == Self.deleteAllProjectsConfirmPhrase else {
+        confirmBulkDelete(
+            typed: typed,
+            phrase: Self.deleteAllProjectsConfirmPhrase,
+            itemsName: "projects",
+            setDeleting: { isDeletingAllProjects = $0 }
+        ) {
+            try await chatViewModel.deleteAllProjects()
+        }
+    }
+
+    /// Re-checks the typed phrase before deleting, mirroring the webapp's
+    /// defense-in-depth gate on its bulk delete actions.
+    private func confirmBulkDelete(
+        typed: String,
+        phrase: String,
+        itemsName: String,
+        setDeleting: @escaping (Bool) -> Void,
+        delete: @escaping () async throws -> Void
+    ) {
+        guard typed.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == phrase else {
             dataActionMessage = "Deletion cancelled: the confirmation phrase didn't match."
             return
         }
-        isDeletingAllProjects = true
+        setDeleting(true)
         Task {
             do {
-                try await chatViewModel.deleteAllProjects()
-                dataActionMessage = "All projects have been deleted."
+                try await delete()
+                dataActionMessage = "All \(itemsName) have been deleted."
             } catch {
-                dataActionMessage = "Failed to delete all projects. Please try again."
+                dataActionMessage = "Failed to delete all \(itemsName). Please try again."
             }
-            isDeletingAllProjects = false
+            setDeleting(false)
         }
     }
 

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -457,8 +457,15 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { }
             Button("Delete", role: .destructive) {
                 Task {
+                    // Require a live Clerk session before wiping anything:
+                    // without it the server-side account would survive while
+                    // local data is destroyed and the user is signed out.
+                    guard let user = clerk.user else {
+                        accountDeletionError = "Couldn't reach your account session. Please sign in again and retry."
+                        return
+                    }
                     do {
-                        try await clerk.user?.delete()
+                        try await user.delete()
                         await performFullDataCleanup()
                         await authManager.signOut()
                         dismiss()

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -320,16 +320,6 @@ struct SettingsView: View {
                 NavigationLink(destination: manageAccountPage) {
                     accountSummaryRow
                 }
-
-                Button(action: {
-                    showSignOutConfirmation = true
-                }) {
-                    HStack {
-                        Text("Sign Out")
-                            .foregroundColor(.primary)
-                        Spacer()
-                    }
-                }
             } else {
                 Button(action: {
                     showAuthView = true
@@ -404,6 +394,16 @@ struct SettingsView: View {
                             .foregroundColor(Color(UIColor.quaternaryLabel))
                     }
                 }
+
+                Button(action: {
+                    showSignOutConfirmation = true
+                }) {
+                    HStack {
+                        Text("Sign Out")
+                            .foregroundColor(.primary)
+                        Spacer()
+                    }
+                }
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
 
@@ -424,6 +424,26 @@ struct SettingsView: View {
         .background(Color.settingsBackground(for: colorScheme))
         .navigationTitle("Manage Account")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("Sign Out", isPresented: $showSignOutConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Sign Out") {
+                Task {
+                    await performFullDataCleanup()
+                    await authManager.signOut()
+                    dismiss()
+                }
+            }
+        } message: {
+            if settings.isLocalOnlyModeEnabled {
+                Text(passkeyManager.passkeyActive
+                    ? "All local data will be cleared. You can recover your chats by signing back in.\n\n⚠️ Your local chats will be deleted forever."
+                    : "All local data will be cleared. You will need your encryption key to recover your chats.\n\n⚠️ Your local chats will be deleted forever.")
+            } else {
+                Text(passkeyManager.passkeyActive
+                    ? "All local data will be cleared. You can recover your chats by signing back in."
+                    : "All local data will be cleared. You will need your encryption key to recover your chats.")
+            }
+        }
         .alert("Delete Account", isPresented: $showDeleteConfirmation) {
             Button("Cancel", role: .cancel) { }
             Button("Delete", role: .destructive) {
@@ -972,26 +992,6 @@ struct SettingsView: View {
             AuthenticationView()
                 .environment(Clerk.shared)
                 .environmentObject(authManager)
-        }
-        .alert("Sign Out", isPresented: $showSignOutConfirmation) {
-            Button("Cancel", role: .cancel) { }
-            Button("Sign Out") {
-                Task {
-                    await performFullDataCleanup()
-                    await authManager.signOut()
-                    dismiss()
-                }
-            }
-        } message: {
-            if settings.isLocalOnlyModeEnabled {
-                Text(passkeyManager.passkeyActive
-                    ? "All local data will be cleared. You can recover your chats by signing back in.\n\n⚠️ Your local chats will be deleted forever."
-                    : "All local data will be cleared. You will need your encryption key to recover your chats.\n\n⚠️ Your local chats will be deleted forever.")
-            } else {
-                Text(passkeyManager.passkeyActive
-                    ? "All local data will be cleared. You can recover your chats by signing back in."
-                    : "All local data will be cleared. You will need your encryption key to recover your chats.")
-            }
         }
         .sheet(isPresented: $showPremiumModal) {
             PaywallView(displayCloseButton: true)

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -258,11 +258,15 @@ struct SettingsView: View {
     @State private var showDeleteAllChatsConfirm = false
     @State private var deleteAllChatsConfirmText = ""
     @State private var isDeletingAllChats = false
-    @State private var deleteAllChatsResult: String? = nil
+    @State private var showDeleteAllProjectsConfirm = false
+    @State private var deleteAllProjectsConfirmText = ""
+    @State private var isDeletingAllProjects = false
+    @State private var dataActionMessage: String? = nil
 
-    /// Typed confirmation phrase gating the bulk chat deletion, matching the
-    /// webapp's safeguard for the same feature.
+    /// Typed confirmation phrases gating the bulk deletions, matching the
+    /// webapp's safeguard for the same features.
     private static let deleteAllChatsConfirmPhrase = "delete all chats"
+    private static let deleteAllProjectsConfirmPhrase = "delete all projects"
 
     var shouldOpenCloudSync: Bool = false
     
@@ -574,36 +578,89 @@ struct SettingsView: View {
                     }
                 }
             }
+
+            NavigationLink(destination: manageDataPage) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Manage Data")
+                        .font(.body)
+                    Text("Export or delete your chats and projects")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
         } header: {
             Text("Chat Settings")
         }
         .listRowBackground(Color.cardSurface(for: colorScheme))
     }
 
-    private var dataSection: some View {
-        Section {
-            Button(action: {
-                showDeleteAllChatsConfirm = true
-            }) {
-                HStack {
-                    Text("Delete All Chats")
-                        .foregroundColor(.red)
-                    Spacer()
-                    if isDeletingAllChats {
-                        ProgressView()
+    private var manageDataPage: some View {
+        Form {
+            Section {
+                Button(action: {
+                    UIApplication.shared.open(Constants.WebApp.exportChatsURL)
+                }) {
+                    HStack {
+                        Text("Export Chats")
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "arrow.up.forward.square")
+                            .font(.footnote)
+                            .foregroundColor(Color(UIColor.tertiaryLabel))
                     }
                 }
+            } header: {
+                Text("Export")
+            } footer: {
+                Text("Chats are exported from the Tinfoil web app. Sign in with the same account to download your conversations.")
+                    .font(.caption)
             }
-            .disabled(isDeletingAllChats)
-        } header: {
-            Text("Data")
-        } footer: {
-            Text(authManager.isAuthenticated
-                 ? "Permanently delete every chat from this device and your encrypted cloud backup. This cannot be undone."
-                 : "Permanently delete every chat from this device. This cannot be undone.")
-                .font(.caption)
+            .listRowBackground(Color.cardSurface(for: colorScheme))
+
+            Section {
+                Button(action: {
+                    showDeleteAllChatsConfirm = true
+                }) {
+                    HStack {
+                        Text("Delete All Chats")
+                            .foregroundColor(.red)
+                        Spacer()
+                        if isDeletingAllChats {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isDeletingAllChats)
+
+                if authManager.isAuthenticated && settings.isCloudSyncEnabled {
+                    Button(action: {
+                        showDeleteAllProjectsConfirm = true
+                    }) {
+                        HStack {
+                            Text("Delete All Projects")
+                                .foregroundColor(.red)
+                            Spacer()
+                            if isDeletingAllProjects {
+                                ProgressView()
+                            }
+                        }
+                    }
+                    .disabled(isDeletingAllProjects)
+                }
+            } header: {
+                Text("Delete")
+            } footer: {
+                Text(authManager.isAuthenticated
+                     ? "Permanently delete data from this device and your encrypted cloud backup. This cannot be undone."
+                     : "Permanently delete every chat from this device. This cannot be undone.")
+                    .font(.caption)
+            }
+            .listRowBackground(Color.cardSurface(for: colorScheme))
         }
-        .listRowBackground(Color.cardSurface(for: colorScheme))
+        .scrollContentBackground(.hidden)
+        .background(Color.settingsBackground(for: colorScheme))
+        .navigationTitle("Manage Data")
+        .navigationBarTitleDisplayMode(.inline)
         .alert("Delete All Chats", isPresented: $showDeleteAllChatsConfirm) {
             TextField(Self.deleteAllChatsConfirmPhrase, text: $deleteAllChatsConfirmText)
                 .autocorrectionDisabled()
@@ -617,13 +674,26 @@ struct SettingsView: View {
         } message: {
             Text("This permanently deletes every chat and cannot be undone. Type \"\(Self.deleteAllChatsConfirmPhrase)\" to confirm.")
         }
-        .alert("Delete All Chats", isPresented: Binding(
-            get: { deleteAllChatsResult != nil },
-            set: { if !$0 { deleteAllChatsResult = nil } }
+        .alert("Delete All Projects", isPresented: $showDeleteAllProjectsConfirm) {
+            TextField(Self.deleteAllProjectsConfirmPhrase, text: $deleteAllProjectsConfirmText)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            Button("Cancel", role: .cancel) {
+                deleteAllProjectsConfirmText = ""
+            }
+            Button("Delete", role: .destructive) {
+                confirmDeleteAllProjects()
+            }
+        } message: {
+            Text("This permanently deletes every project and cannot be undone. Type \"\(Self.deleteAllProjectsConfirmPhrase)\" to confirm.")
+        }
+        .alert("Manage Data", isPresented: Binding(
+            get: { dataActionMessage != nil },
+            set: { if !$0 { dataActionMessage = nil } }
         )) {
             Button("OK", role: .cancel) { }
         } message: {
-            Text(deleteAllChatsResult ?? "")
+            Text(dataActionMessage ?? "")
         }
     }
 
@@ -633,18 +703,38 @@ struct SettingsView: View {
         let typed = deleteAllChatsConfirmText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         deleteAllChatsConfirmText = ""
         guard typed == Self.deleteAllChatsConfirmPhrase else {
-            deleteAllChatsResult = "Deletion cancelled: the confirmation phrase didn't match."
+            dataActionMessage = "Deletion cancelled: the confirmation phrase didn't match."
             return
         }
         isDeletingAllChats = true
         Task {
             do {
                 try await chatViewModel.deleteAllChats()
-                deleteAllChatsResult = "All chats have been deleted."
+                dataActionMessage = "All chats have been deleted."
             } catch {
-                deleteAllChatsResult = "Failed to delete all chats. Please try again."
+                dataActionMessage = "Failed to delete all chats. Please try again."
             }
             isDeletingAllChats = false
+        }
+    }
+
+    /// Same defense-in-depth confirmation gate as `confirmDeleteAllChats`.
+    private func confirmDeleteAllProjects() {
+        let typed = deleteAllProjectsConfirmText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        deleteAllProjectsConfirmText = ""
+        guard typed == Self.deleteAllProjectsConfirmPhrase else {
+            dataActionMessage = "Deletion cancelled: the confirmation phrase didn't match."
+            return
+        }
+        isDeletingAllProjects = true
+        Task {
+            do {
+                try await chatViewModel.deleteAllProjects()
+                dataActionMessage = "All projects have been deleted."
+            } catch {
+                dataActionMessage = "Failed to delete all projects. Please try again."
+            }
+            isDeletingAllProjects = false
         }
     }
 
@@ -755,7 +845,6 @@ struct SettingsView: View {
                 subscriptionSection
                 chatSettingsSection
                 preferencesSection
-                dataSection
                 contactSection
                 legalSection
             }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -255,9 +255,6 @@ struct SettingsView: View {
     @State private var showSignOutConfirmation = false
     @State private var showPremiumModal = false
     @State private var accountDeletionError: String? = nil
-    @State private var passkeyBundles: [EnclaveKeyCurrentBundle] = []
-    @State private var removingPasskeyId: String? = nil
-    @State private var passkeyBundleError: String? = nil
 
     var shouldOpenCloudSync: Bool = false
     
@@ -527,115 +524,6 @@ struct SettingsView: View {
                     }
                 }
 
-                if passkeyManager.passkeyActive {
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(spacing: 6) {
-                            Image(systemName: "person.badge.key.fill")
-                                .font(.subheadline)
-                                .foregroundColor(.primary)
-                            Text("Sync and backup using Passkeys")
-                                .font(.subheadline)
-                                .foregroundColor(.primary)
-                        }
-                        Text("Use Face ID or Touch ID to sync chats across devices")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        HStack(spacing: 4) {
-                            Image(systemName: "checkmark.shield.fill")
-                                .font(.caption)
-                                .foregroundColor(.green)
-                            Text("Passkey active")
-                                .font(.caption)
-                                .fontWeight(.medium)
-                                .foregroundColor(.green)
-                        }
-                        .padding(.top, 2)
-                    }
-                    .padding(.vertical, 2)
-                }
-
-                if !passkeyBundles.isEmpty || passkeyBundleError != nil {
-                    passkeyBundleInventory
-                }
-
-                if passkeyManager.passkeyAddDeviceAvailable && EncryptionService.shared.hasEncryptionKey() {
-                    Button(action: {
-                        Task {
-                            await passkeyManager.createPasskeyBackup()
-                        }
-                    }) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.badge.key.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                                Text("Set Up Passkey on This Device")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                            }
-                            Text("Your other devices use a passkey already. Add one here for one-tap access.")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 2)
-                    }
-                } else if passkeyManager.passkeySetupAvailable && EncryptionService.shared.hasEncryptionKey() {
-                    Button(action: {
-                        Task {
-                            await passkeyManager.createPasskeyBackup()
-                        }
-                    }) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.badge.key.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                                Text("Add Passkey for seamless sync")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                            }
-                            Text("Use Face ID or Touch ID to sync chats across devices")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 2)
-                    }
-                } else if passkeyManager.passkeySetupAvailable && !EncryptionService.shared.hasEncryptionKey() {
-                    Button(action: {
-                        Task {
-                            let result = await passkeyManager.retryPasskeySetup()
-                            switch result {
-                            case .manualSetupRequired:
-                                await MainActor.run {
-                                    chatViewModel.cloudSyncOnboardingMode = .setup
-                                    chatViewModel.showCloudSyncOnboarding = true
-                                }
-                            case .manualRecoveryRequired:
-                                await MainActor.run {
-                                    chatViewModel.cloudSyncOnboardingMode = .recovery
-                                    chatViewModel.showCloudSyncOnboarding = true
-                                }
-                            default:
-                                break
-                            }
-                        }
-                    }) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.badge.key.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                                Text("Add Passkey for seamless sync")
-                                    .font(.subheadline)
-                                    .foregroundColor(.primary)
-                            }
-                            Text("Create a passkey to sync chats across devices")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 2)
-                    }
-                }
             }
 
             NavigationLink(destination: CustomSystemPromptView(
@@ -682,123 +570,6 @@ struct SettingsView: View {
             Text("Chat Settings")
         }
         .listRowBackground(Color.cardSurface(for: colorScheme))
-    }
-
-    private var passkeyBundleInventory: some View {
-        let localCredentialId = UserDefaults.standard.string(
-            forKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId
-        )
-        let sorted = passkeyBundles.sorted { a, b in
-            if a.credentialId == localCredentialId { return true }
-            if b.credentialId == localCredentialId { return false }
-            return (a.createdAt ?? "") > (b.createdAt ?? "")
-        }
-        return VStack(alignment: .leading, spacing: 8) {
-            Text("Registered platforms (\(sorted.count))")
-                .font(.caption)
-                .fontWeight(.medium)
-                .foregroundColor(.secondary)
-                .textCase(.uppercase)
-            ForEach(sorted, id: \.credentialId) { bundle in
-                passkeyBundleRow(
-                    bundle: bundle,
-                    isCurrentPlatform: bundle.credentialId == localCredentialId
-                )
-            }
-            if let passkeyBundleError {
-                Text(passkeyBundleError)
-                    .font(.caption)
-                    .foregroundColor(.red)
-            }
-        }
-        .padding(.vertical, 4)
-    }
-
-    private func passkeyBundleRow(
-        bundle: EnclaveKeyCurrentBundle,
-        isCurrentPlatform: Bool
-    ) -> some View {
-        let credLabel = bundle.credentialId.count <= 12
-            ? bundle.credentialId
-            : "\(bundle.credentialId.prefix(6))…\(bundle.credentialId.suffix(4))"
-        let dateLabel: String
-        if let created = bundle.createdAt, !created.isEmpty {
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            let date = formatter.date(from: created)
-                ?? ISO8601DateFormatter().date(from: created)
-            if let date {
-                let display = DateFormatter()
-                display.dateStyle = .medium
-                dateLabel = display.string(from: date)
-            } else {
-                dateLabel = "Date unknown"
-            }
-        } else {
-            dateLabel = "Date unknown"
-        }
-        let isRemoving = removingPasskeyId == bundle.credentialId
-        return HStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Image(systemName: "person.badge.key.fill")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Text(isCurrentPlatform ? "This platform" : "Other platform")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .foregroundColor(.primary)
-                }
-                Text("\(credLabel) · \(dateLabel)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-            }
-            Spacer()
-            Button(action: {
-                Task { await removeBundle(bundle.credentialId) }
-            }) {
-                Text(isRemoving ? "Removing…" : "Remove")
-                    .font(.caption)
-                    .fontWeight(.medium)
-                    .foregroundColor(isRemoving ? .secondary : .red)
-            }
-            .disabled(removingPasskeyId != nil)
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-        }
-        .padding(.vertical, 4)
-    }
-
-    private func refreshPasskeyBundles() async {
-        guard settings.isCloudSyncEnabled else {
-            passkeyBundles = []
-            passkeyBundleError = nil
-            return
-        }
-        do {
-            passkeyBundles = try await passkeyManager.listPasskeyBundles()
-            passkeyBundleError = nil
-        } catch {
-            // Keep the previous inventory: clearing it would make a
-            // load failure indistinguishable from "no passkeys
-            // registered" for a security-relevant list.
-            passkeyBundleError = "Couldn't load registered passkeys. Please try again later."
-        }
-    }
-
-    private func removeBundle(_ credentialId: String) async {
-        // One removal at a time: the in-flight UI state is single-valued
-        // and concurrent deletes would race it and duplicate requests.
-        guard removingPasskeyId == nil else { return }
-        removingPasskeyId = credentialId
-        defer { removingPasskeyId = nil }
-        do {
-            try await passkeyManager.removePasskeyBundle(credentialId: credentialId)
-            await refreshPasskeyBundles()
-        } catch {
-            passkeyBundleError = "Couldn't remove the passkey. Please try again."
-        }
     }
 
     private var subscriptionSection: some View {
@@ -924,9 +695,6 @@ struct SettingsView: View {
                     .accessibilityLabel("Close")
                 }
             }
-        }
-        .task(id: [settings.isCloudSyncEnabled, passkeyManager.passkeyActive]) {
-            await refreshPasskeyBundles()
         }
         .onAppear {
             // Reset navigation bar to use system colors for settings screens

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -255,6 +255,14 @@ struct SettingsView: View {
     @State private var showSignOutConfirmation = false
     @State private var showPremiumModal = false
     @State private var accountDeletionError: String? = nil
+    @State private var showDeleteAllChatsConfirm = false
+    @State private var deleteAllChatsConfirmText = ""
+    @State private var isDeletingAllChats = false
+    @State private var deleteAllChatsResult: String? = nil
+
+    /// Typed confirmation phrase gating the bulk chat deletion, matching the
+    /// webapp's safeguard for the same feature.
+    private static let deleteAllChatsConfirmPhrase = "delete all chats"
 
     var shouldOpenCloudSync: Bool = false
     
@@ -572,6 +580,74 @@ struct SettingsView: View {
         .listRowBackground(Color.cardSurface(for: colorScheme))
     }
 
+    private var dataSection: some View {
+        Section {
+            Button(action: {
+                showDeleteAllChatsConfirm = true
+            }) {
+                HStack {
+                    Text("Delete All Chats")
+                        .foregroundColor(.red)
+                    Spacer()
+                    if isDeletingAllChats {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isDeletingAllChats)
+        } header: {
+            Text("Data")
+        } footer: {
+            Text(authManager.isAuthenticated
+                 ? "Permanently delete every chat from this device and your encrypted cloud backup. This cannot be undone."
+                 : "Permanently delete every chat from this device. This cannot be undone.")
+                .font(.caption)
+        }
+        .listRowBackground(Color.cardSurface(for: colorScheme))
+        .alert("Delete All Chats", isPresented: $showDeleteAllChatsConfirm) {
+            TextField(Self.deleteAllChatsConfirmPhrase, text: $deleteAllChatsConfirmText)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            Button("Cancel", role: .cancel) {
+                deleteAllChatsConfirmText = ""
+            }
+            Button("Delete", role: .destructive) {
+                confirmDeleteAllChats()
+            }
+        } message: {
+            Text("This permanently deletes every chat and cannot be undone. Type \"\(Self.deleteAllChatsConfirmPhrase)\" to confirm.")
+        }
+        .alert("Delete All Chats", isPresented: Binding(
+            get: { deleteAllChatsResult != nil },
+            set: { if !$0 { deleteAllChatsResult = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(deleteAllChatsResult ?? "")
+        }
+    }
+
+    /// Re-checks the typed phrase before deleting, mirroring the webapp's
+    /// defense-in-depth gate on the same action.
+    private func confirmDeleteAllChats() {
+        let typed = deleteAllChatsConfirmText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        deleteAllChatsConfirmText = ""
+        guard typed == Self.deleteAllChatsConfirmPhrase else {
+            deleteAllChatsResult = "Deletion cancelled: the confirmation phrase didn't match."
+            return
+        }
+        isDeletingAllChats = true
+        Task {
+            do {
+                try await chatViewModel.deleteAllChats()
+                deleteAllChatsResult = "All chats have been deleted."
+            } catch {
+                deleteAllChatsResult = "Failed to delete all chats. Please try again."
+            }
+            isDeletingAllChats = false
+        }
+    }
+
     private var subscriptionSection: some View {
         Section {
             if authManager.hasActiveSubscription {
@@ -679,6 +755,7 @@ struct SettingsView: View {
                 subscriptionSection
                 chatSettingsSection
                 preferencesSection
+                dataSection
                 contactSection
                 legalSection
             }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -744,15 +744,18 @@ struct SettingsView: View {
                     }
                     showPremiumModal = true
                 }) {
-                    HStack {
-                        Text("Subscribe to Premium")
-                            .foregroundColor(Color.tinfoilAccentLight)
+                    HStack(spacing: 8) {
                         Spacer()
-                        Text("Unlock all models")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                        Image(systemName: "sparkles")
+                            .font(.subheadline.weight(.semibold))
+                        Text("Subscribe to Premium")
+                            .font(.body.weight(.semibold))
+                        Spacer()
                     }
+                    .foregroundColor(.white)
+                    .padding(.vertical, 4)
                 }
+                .listRowBackground(Color.tinfoilAccentDark)
             }
         } header: {
             Text("Subscription")

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -807,7 +807,7 @@ struct SettingsView: View {
                 }) {
                     HStack {
                         Text("Subscribe to Premium")
-                            .foregroundColor(.primary)
+                            .foregroundColor(Color.tinfoilAccentLight)
                         Spacer()
                         Text("Unlock all models")
                             .font(.caption)
@@ -876,9 +876,9 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 accountSection
-                preferencesSection
-                chatSettingsSection
                 subscriptionSection
+                chatSettingsSection
+                preferencesSection
                 contactSection
                 legalSection
             }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -60,13 +60,6 @@ class SettingsManager: ObservableObject {
         }
     }
     
-    // Max messages setting
-    @Published var maxMessages: Int {
-        didSet {
-            UserDefaults.standard.set(maxMessages, forKey: Constants.StorageKeys.Settings.maxPromptMessages)
-        }
-    }
-    
     // Custom system prompt settings
     @Published var isUsingCustomPrompt: Bool {
         didSet {
@@ -125,14 +118,6 @@ class SettingsManager: ObservableObject {
             self.selectedTraits = []
         }
         
-        // Initialize max messages setting
-        if let savedMaxMessages = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.maxPromptMessages) as? Int {
-            self.maxMessages = min(max(savedMaxMessages, 1), Constants.Context.maxMessagesLimit)
-        } else {
-            self.maxMessages = Constants.Context.defaultMaxMessages
-            UserDefaults.standard.set(Constants.Context.defaultMaxMessages, forKey: Constants.StorageKeys.Settings.maxPromptMessages)
-        }
-        
         // Initialize custom system prompt settings
         self.isUsingCustomPrompt = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled) as? Bool ?? false
         self.customSystemPrompt = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt) ?? ""
@@ -176,7 +161,6 @@ class SettingsManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.profession)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.traits)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.additionalContext)
-        UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.maxPromptMessages)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.webSearchEnabled)
@@ -191,7 +175,6 @@ class SettingsManager: ObservableObject {
         profession = ""
         selectedTraits = []
         additionalContext = ""
-        maxMessages = Constants.Context.defaultMaxMessages
         isUsingCustomPrompt = false
         customSystemPrompt = ""
         webSearchEnabled = true
@@ -568,50 +551,6 @@ struct SettingsView: View {
                 }
             }
 
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Messages in Context")
-                        .font(.body)
-                    Text("Maximum number of recent messages sent to the model (1-\(Constants.Context.maxMessagesLimit)). Longer contexts increase network usage and slow down responses.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-                HStack(spacing: 8) {
-                    Button(action: {
-                        if settings.maxMessages > 1 {
-                            settings.maxMessages -= 1
-                            ProfileManager.shared.maxPromptMessages = settings.maxMessages
-                        }
-                    }) {
-                        Image(systemName: "minus.circle")
-                            .foregroundColor(settings.maxMessages > 1 ? .accentColor : .gray)
-                    }
-                    .buttonStyle(BorderlessButtonStyle())
-                    .disabled(settings.maxMessages <= 1)
-                    .accessibilityLabel("Decrease messages in context")
-
-                    Text("\(settings.maxMessages)")
-                        .frame(minWidth: 40)
-                        .font(.system(.body, design: .monospaced))
-                        .accessibilityLabel("Messages in context: \(settings.maxMessages)")
-
-                    Button(action: {
-                        if settings.maxMessages < Constants.Context.maxMessagesLimit {
-                            settings.maxMessages += 1
-                            ProfileManager.shared.maxPromptMessages = settings.maxMessages
-                        }
-                    }) {
-                        Image(systemName: "plus.circle")
-                            .foregroundColor(settings.maxMessages < Constants.Context.maxMessagesLimit ? .accentColor : .gray)
-                    }
-                    .buttonStyle(BorderlessButtonStyle())
-                    .disabled(settings.maxMessages >= Constants.Context.maxMessagesLimit)
-                    .accessibilityLabel("Increase messages in context")
-                }
-            }
-            .padding(.vertical, 4)
-
             NavigationLink(destination: CustomSystemPromptView(
                 isUsingCustomPrompt: $settings.isUsingCustomPrompt,
                 customSystemPrompt: $settings.customSystemPrompt
@@ -926,11 +865,6 @@ struct SettingsView: View {
                         settings.selectedLanguage = profileManager.language
                     }
                     
-                    // Update max messages if different
-                    if profileManager.maxPromptMessages > 0 && profileManager.maxPromptMessages != settings.maxMessages {
-                        settings.maxMessages = profileManager.maxPromptMessages
-                    }
-                    
                     // Update custom prompt settings from single source of truth (ProfileManager)
                     settings.isUsingCustomPrompt = profileManager.isUsingCustomPrompt
                     settings.customSystemPrompt = profileManager.customSystemPrompt
@@ -949,11 +883,6 @@ struct SettingsView: View {
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
         // Keep UI settings in sync with ProfileManager when remote changes arrive
-        .onReceive(ProfileManager.shared.$maxPromptMessages) { newValue in
-            if newValue > 0 && settings.maxMessages != newValue {
-                settings.maxMessages = newValue
-            }
-        }
         .onReceive(ProfileManager.shared.$language) { newValue in
             if !newValue.isEmpty && settings.selectedLanguage != newValue {
                 settings.selectedLanguage = newValue

--- a/TinfoilChat/Views/VerifierViewController.swift
+++ b/TinfoilChat/Views/VerifierViewController.swift
@@ -11,9 +11,9 @@ import TinfoilAI
 // MARK: - Tab Model
 
 private enum VerificationTab: String, CaseIterable, Identifiable {
+    case runtime
     case encryption
     case code
-    case runtime
 
     var id: String { rawValue }
 
@@ -114,7 +114,7 @@ struct VerifierView: View {
             HStack(spacing: 0) {
                 ForEach(VerificationTab.allCases) { tab in
                     tabCard(tab: tab, status: .pending, isSelected: false)
-                    if tab != .runtime {
+                    if tab != .code {
                         Spacer(minLength: 12)
                     }
                 }
@@ -207,7 +207,7 @@ struct VerifierView: View {
                 tabCard(tab: tab, status: status, isSelected: selectedTab == tab)
                     .onTapGesture { selectedTab = tab }
                     .accessibilityAddTraits(.isButton)
-                if tab != .runtime {
+                if tab != .code {
                     Spacer(minLength: 12)
                 }
             }

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -171,7 +171,6 @@ struct ChatQueryBuilderReasoningTests {
             systemPrompt: "you are tin",
             rules: "",
             conversationMessages: [],
-            maxMessages: 10,
             stream: false,
             reasoningConfig: deepseekConfig(),
             reasoningEffort: .high,

--- a/TinfoilChatTests/ErrorExplanationTests.swift
+++ b/TinfoilChatTests/ErrorExplanationTests.swift
@@ -1,0 +1,44 @@
+//
+//  ErrorExplanationTests.swift
+//  TinfoilChatTests
+//
+//  Verifies that raw backend/SDK error text is mapped to friendly
+//  explanations, mirroring the webapp's `explainError` behavior.
+//
+
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ErrorExplanationTests {
+
+    @Test @MainActor
+    func mapsEHBPMissingHeaderToServiceTrouble() {
+        let raw = "Missing header: Ehbp-Response-Nonce"
+        let explained = ChatViewModel.explainRawError(raw)
+        #expect(explained?.contains("service is having trouble") == true)
+    }
+
+    @Test @MainActor
+    func mapsPromptLengthErrorToContextExplanation() {
+        let raw = """
+        pipeline failed at stage "agent": agent error: agent LLM call failed: POST \
+        "https://inference.tinfoil.sh/v1/responses": 400 Bad Request {"message":"The \
+        engine prompt length 227861 exceeds the max_model_len 131072. Please reduce \
+        prompt.","type":"invalid_request_error","param":"input","code":400}
+        """
+        let explained = ChatViewModel.explainRawError(raw)
+        #expect(explained?.contains("too long for the model") == true)
+    }
+
+    @Test @MainActor
+    func mapsTimeoutToFriendlyMessage() {
+        let explained = ChatViewModel.explainRawError("context deadline exceeded (Client.Timeout exceeded)")
+        #expect(explained?.contains("took too long") == true)
+    }
+
+    @Test @MainActor
+    func unknownErrorsHaveNoMapping() {
+        #expect(ChatViewModel.explainRawError("some inscrutable failure") == nil)
+    }
+}

--- a/TinfoilChatTests/TokenEstimationTests.swift
+++ b/TinfoilChatTests/TokenEstimationTests.swift
@@ -70,6 +70,17 @@ struct TokenEstimationTests {
         #expect(selected[0].id == messages[1].id)
     }
 
+    @Test func trailingEmptyPlaceholderDoesNotEvictLatestUserMessage() {
+        let messages = [
+            message(content: String(repeating: "a", count: 40)),
+            message(content: String(repeating: "a", count: 400)),
+            message(role: .assistant, content: ""),
+        ]
+        // Budget smaller than the latest user message alone: the user message
+        // must still be kept alongside the streaming placeholder.
+        #expect(TokenEstimation.findContextStartIndex(messages: messages, budgetTokens: 10) == 1)
+    }
+
     @Test func emptyMessagesSelectsNothing() {
         #expect(TokenEstimation.findContextStartIndex(messages: [], budgetTokens: 100) == 0)
         #expect(TokenEstimation.selectMessagesWithinBudget([], contextWindow: nil).isEmpty)

--- a/TinfoilChatTests/TokenEstimationTests.swift
+++ b/TinfoilChatTests/TokenEstimationTests.swift
@@ -1,0 +1,77 @@
+//
+//  TokenEstimationTests.swift
+//  TinfoilChatTests
+//
+//  Verifies the token estimation and context budgeting heuristics match the
+//  webapp's `token-estimation.ts` behavior so both platforms archive the
+//  same messages.
+//
+
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct TokenEstimationTests {
+
+    private func message(role: MessageRole = .user, content: String) -> Message {
+        Message(id: UUID().uuidString, role: role, content: content, timestamp: Date())
+    }
+
+    @Test func estimatesTokensFromCharacterCount() {
+        #expect(TokenEstimation.estimateTokenCount(nil) == 0)
+        #expect(TokenEstimation.estimateTokenCount("") == 0)
+        #expect(TokenEstimation.estimateTokenCount("abcd") == 1)
+        #expect(TokenEstimation.estimateTokenCount("abcde") == 2)
+    }
+
+    @Test func parsesContextWindowStrings() {
+        #expect(TokenEstimation.parseContextWindowTokens("64k tokens") == 64_000)
+        #expect(TokenEstimation.parseContextWindowTokens("256K tokens") == 256_000)
+        #expect(TokenEstimation.parseContextWindowTokens("32000") == 32_000)
+        #expect(TokenEstimation.parseContextWindowTokens(nil) == Constants.Context.defaultContextWindowTokens)
+        #expect(TokenEstimation.parseContextWindowTokens("unknown") == Constants.Context.defaultContextWindowTokens)
+    }
+
+    @Test func budgetIsUsageRatioOfWindow() {
+        #expect(TokenEstimation.contextTokenBudget("100k tokens") == 90_000)
+        #expect(TokenEstimation.contextTokenBudget(nil) ==
+                Int(Double(Constants.Context.defaultContextWindowTokens) * Constants.Context.contextWindowUsageRatio))
+    }
+
+    @Test func includesAttachmentAndToolCallTokens() {
+        var msg = message(content: "abcd")
+        msg.attachments = [
+            Attachment(type: .document, fileName: "doc.txt", textContent: "abcdefgh")
+        ]
+        msg.toolCalls = [GenUIToolCall(id: "1", name: "abcd", arguments: "abcd")]
+        // content 1 + attachment 2 + tool name 1 + tool args 1
+        #expect(TokenEstimation.estimateMessageTokens(msg) == 5)
+    }
+
+    @Test func archivesOldestMessagesBeyondBudget() {
+        // Each message is 40 chars = 10 tokens
+        let messages = (0..<5).map { _ in message(content: String(repeating: "a", count: 40)) }
+
+        // Budget fits exactly two messages
+        #expect(TokenEstimation.findContextStartIndex(messages: messages, budgetTokens: 20) == 3)
+        // Everything fits
+        #expect(TokenEstimation.findContextStartIndex(messages: messages, budgetTokens: 50) == 0)
+    }
+
+    @Test func newestMessageIsAlwaysKept() {
+        let messages = [
+            message(content: String(repeating: "a", count: 40)),
+            message(content: String(repeating: "a", count: 400)),
+        ]
+        // Budget smaller than even the newest message alone
+        #expect(TokenEstimation.findContextStartIndex(messages: messages, budgetTokens: 10) == 1)
+        let selected = TokenEstimation.selectMessagesWithinBudget(messages, contextWindow: "1")
+        #expect(selected.count == 1)
+        #expect(selected[0].id == messages[1].id)
+    }
+
+    @Test func emptyMessagesSelectsNothing() {
+        #expect(TokenEstimation.findContextStartIndex(messages: [], budgetTokens: 100) == 0)
+        #expect(TokenEstimation.selectMessagesWithinBudget([], contextWindow: nil).isEmpty)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-manages chat history by each model’s context window with a live usage readout, improves Cloud Sync recovery and indicators, and streamlines settings and error messages. Adds clipboard paste for images/files and a Manage Data page with export and bulk delete (shared confirmation), plus targeted UI fixes, refined chat timestamps, and a `textual` update.

- New Features
  - Auto-archive conversation history by model context size; removed “Messages in Context” setting. Uses `TokenEstimation` shared with the webapp.
  - Add-to-Chat sheet: shows context window usage with a near-limit warning, and lets you paste images/files into chat (works even when the clipboard also has text).
  - Cloud Sync: moved passkey management here. List/remove registered passkeys, set up on this device, and prompt stale devices to recover the registered key. Chat rows show a blue cloud while they sync.
  - Settings: new Manage Account page for profile edit, sign out, and delete. New Manage Data page with export and bulk delete for chats and projects (typed confirmation shared across actions). Bulk delete removes cloud copies first, then local.

- Bug Fixes
  - Chat list and project views ordered by last updated; rows show created and updated times, with the updated time toned down and hidden if it matches created. Dropped the “Created” label.
  - Pull-to-refresh now runs the same incremental sync as “Sync Now,” avoids re-downloading full chats, and batches content pulls to keep responses small.
  - Timeline rows no longer stretch; swipe-to-delete visible in dark mode; consistent toolbar and model selector sheet colors; tapping “out of requests” opens upgrade.
  - Project delete actions tinted red; verification tabs reordered.
  - Keeps the latest user message in prompt while a reply is pending; caches the archive separator for smoother streaming; stops the thinking button from bouncing on iOS 26.
  - Rejects oversized pasted files and tells you when a file can’t be imported; surfaces cloud errors during bulk delete; prevents account deletion without a live session.
  - Legacy cloud key adoption no longer blocks on decrypt-probing old data; the enclave’s current key id is authoritative and migration only rewraps rows it can decrypt.
  - Chat export now opens the Cloud Sync settings page.
  - Keeps the per-chat syncing indicator accurate when uploads overlap.
  - Update `textual` to 0.0.7 for markdown divider spacing fix.

<sup>Written for commit 0e66bf338137a27cbef5f78fb7d3c2582f7f3833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

