### PR TITLE
Cloud sync improvements

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -157,6 +157,12 @@ enum Constants {
         // both clients keep the same drain budget.
         static let migrationPollIntervalSeconds: TimeInterval = 2.0
         static let migrationPollTimeoutSeconds: TimeInterval = 15 * 60.0
+
+        // How long sync must stay paused before the UI escalates from
+        // the quiet settings status line to the attention badge.
+        // Transient network blips and enclave restarts resolve well
+        // inside this window; anything longer deserves attention.
+        static let pausedAttentionWindowSeconds: TimeInterval = 5 * 60.0
     }
 
     enum Verification {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -298,6 +298,11 @@ class CloudSyncService: ObservableObject {
         emptyRemoteRegistration = task
         let result = await task.value
         emptyRemoteRegistration = nil
+        if result {
+            // The local key just became the enclave's registered key, so
+            // any surfaced key problem is stale.
+            SyncHealthStore.shared.reportKeyHealthy()
+        }
         return result
     }
     

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -256,7 +256,13 @@ class CloudSyncService: ObservableObject {
             return false
         }
 
-        return localKeyId == remoteKeyId
+        if localKeyId == remoteKeyId {
+            // The enclave just confirmed the local key is authoritative,
+            // so any surfaced key problem is stale.
+            SyncHealthStore.shared.reportKeyHealthy()
+            return true
+        }
+        return false
     }
 
     private var emptyRemoteRegistration: Task<Bool, Never>?
@@ -437,9 +443,11 @@ class CloudSyncService: ObservableObject {
     /// Dispatch a sync-enclave error to the matching recovery
     /// surface. Re-throws for retryable cases so the coalescer can
     /// retry under the same idempotency key; swallows for
-    /// non-retryable cases after posting a notification so the
-    /// chat stays locallyModified and is picked up on the next
-    /// natural sync cycle without burning the retry budget.
+    /// non-retryable cases after reporting into the sync-health
+    /// store (which the settings status row and the sidebar badge
+    /// render) so the chat stays locallyModified and is picked up
+    /// on the next natural sync cycle without burning the retry
+    /// budget.
     private func handleUploadFailure(chatId: String, error: Error) async throws {
         let decision = EnclaveErrorRecovery.decide(error)
         #if DEBUG
@@ -449,26 +457,27 @@ class CloudSyncService: ObservableObject {
         case .retry:
             throw error
         case .refreshCurrentKeyAndRetry:
-            // Notify so a listener (e.g. PasskeyManager) refreshes
-            // the canonical enclave key, then re-throw so the
-            // coalescer retries under the same idempotency key.
-            // The retry replays after the listener (hopefully) has
-            // rotated the key; if it hasn't yet, the retry fails
-            // and the chat stays locallyModified for the next sync
-            // cycle.
-            postSyncEvent(.tinfoilSyncKeyRefreshNeeded)
+            // Surface the stale key, then re-throw so the coalescer
+            // retries under the same idempotency key. If a key
+            // refresh lands before retries exhaust, the retry
+            // succeeds and the healthy write gate clears the state;
+            // otherwise the chat stays locallyModified for the next
+            // sync cycle.
+            SyncHealthStore.shared.reportKeyActionRequired(.keyMismatch)
             throw error
         case .surfaceConflict:
-            postSyncEvent(.tinfoilSyncConflictDetected, userInfo: ["chatId": chatId])
             await resolveConflictByPullingRemote(chatId)
         case .surfaceExistingDataUnderOtherKey:
-            postSyncEvent(.tinfoilSyncExistingDataUnderOtherKey)
+            SyncHealthStore.shared.reportKeyActionRequired(.keyConflict)
         case .surfaceNotFound:
-            postSyncEvent(.tinfoilSyncChatNotFound, userInfo: ["chatId": chatId])
+            SyncHealthStore.shared.reportChatSyncFailed(
+                chatId,
+                message: "This chat no longer exists in the cloud"
+            )
         case .triggerRecoveryWizard:
-            postSyncEvent(.tinfoilSyncRecoveryNeeded)
+            SyncHealthStore.shared.reportKeyActionRequired(.keyRecovery)
         case .blockAllSync:
-            postSyncEvent(.tinfoilSyncAttestationFailed)
+            SyncHealthStore.shared.reportSyncPaused(.attestation)
         case .migrateLegacyAndRetry:
             // Re-throw so the coalescer retries the write. The legacy
             // re-seal runs out of band — on the next launch and right
@@ -478,15 +487,15 @@ class CloudSyncService: ObservableObject {
             // succeeds; otherwise the chat waits for the next cycle.
             throw error
         case .abort(let reason):
-            postSyncEvent(
-                .tinfoilSyncUploadAborted,
-                userInfo: ["chatId": chatId, "reason": reason.rawValue]
-            )
+            if reason == .forbidden {
+                SyncHealthStore.shared.reportKeyActionRequired(.accountBlocked)
+            } else {
+                SyncHealthStore.shared.reportChatSyncFailed(
+                    chatId,
+                    message: "This chat couldn't be synced"
+                )
+            }
         }
-    }
-
-    private func postSyncEvent(_ name: Notification.Name, userInfo: [String: Any]? = nil) {
-        NotificationCenter.default.post(name: name, object: nil, userInfo: userInfo)
     }
 
     /// Last-write-wins conflict resolution. Pulls the remote chat
@@ -551,6 +560,10 @@ class CloudSyncService: ObservableObject {
                     errors: result.errors
                 )
             } catch {
+                SyncHealthStore.shared.reportChatSyncFailed(
+                    chat.id,
+                    message: "This chat couldn't be synced"
+                )
                 result = SyncResult(
                     uploaded: result.uploaded,
                     downloaded: result.downloaded,
@@ -1710,6 +1723,7 @@ class CloudSyncService: ObservableObject {
             
             // Successfully deleted from cloud, can remove from tracker
             deletedChatsTracker.removeFromDeleted(chatId)
+            SyncHealthStore.shared.reportChatSynced(chatId)
             
         } catch {
             deletedChatsTracker.removeFromDeleted(chatId)
@@ -1781,6 +1795,7 @@ class CloudSyncService: ObservableObject {
             try await applyAttachmentRewrites(chatId: chat.id, rewrites: result.rewrites)
         }
         await markChatAsSynced(chat.id, version: newVersion)
+        SyncHealthStore.shared.reportChatSynced(chat.id)
     }
 
     /// Apply enclave-minted attachment ids/keys to the freshest local

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -273,17 +273,3 @@ enum EnclaveErrorRecovery {
         return false
     }
 }
-
-/// Notification names for sync recovery surface events. UI
-/// subscribers (banners, modals, recovery wizard) post these to
-/// drive their own state. Mirrors the webapp's `tinfoil:sync-*`
-/// window CustomEvents.
-extension Notification.Name {
-    static let tinfoilSyncKeyRefreshNeeded          = Notification.Name("tinfoil.sync.keyRefreshNeeded")
-    static let tinfoilSyncRecoveryNeeded            = Notification.Name("tinfoil.sync.recoveryNeeded")
-    static let tinfoilSyncAttestationFailed         = Notification.Name("tinfoil.sync.attestationFailed")
-    static let tinfoilSyncExistingDataUnderOtherKey = Notification.Name("tinfoil.sync.existingDataUnderOtherKey")
-    static let tinfoilSyncChatNotFound              = Notification.Name("tinfoil.sync.chatNotFound")
-    static let tinfoilSyncUploadAborted             = Notification.Name("tinfoil.sync.uploadAborted")
-    static let tinfoilSyncConflictDetected          = Notification.Name("tinfoil.sync.conflictDetected")
-}

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -82,7 +82,7 @@ enum LegacyBlobMigration {
             // passkey, or only an un-promoted legacy passkey, so none of
             // the passkey/recovery flows that register the key ever run,
             // and nothing else would migrate them. Adopt the local CEK as
-            // the current key here (bundleless, recovery) so the gate below
+            // the current key here (created_via=recovery) so the gate below
             // passes. Safe because we already hold the CEK and a legacy
             // passkey wrapping it stays promotable afterwards. Mirrors the
             // webapp's migration adoption.
@@ -192,16 +192,19 @@ enum LegacyBlobMigration {
     /// or only an un-promoted legacy passkey — could never migrate:
     /// nothing registers their CEK, so every rewrap is gated out.
     ///
-    /// Registered bundleless with created_via=recovery, which the
-    /// controlplane accepts non-destructively over legacy (key_id NULL)
-    /// rows. The caller only invokes this when no key is registered
-    /// (key_id == nil) and legacy data exists, so no enclave bundle can
-    /// exist; a legacy passkey wrapping this same CEK stays promotable
-    /// afterwards (recoverFromLegacyPasskey adds its bundle), so adopting
-    /// never strands a backup. register-key's if_match='*' fails safely on
+    /// Registered with created_via=recovery, which the controlplane
+    /// accepts non-destructively over legacy (key_id NULL) rows. When
+    /// this device holds a cached passkey PRF for a credential still on
+    /// the user's account, the CEK is wrapped under it and registered
+    /// with an initial bundle so the adopted key is passkey-recoverable
+    /// from day one; otherwise it is registered bundleless and a legacy
+    /// passkey wrapping this same CEK stays promotable afterwards
+    /// (recoverFromLegacyPasskey adds its bundle), so adopting never
+    /// strands a backup. register-key's if_match='*' fails safely on
     /// a concurrent register. Returns true when the key was adopted.
     /// Mirrors the webapp's migration adoption.
     private static func adoptLocalKeyForMigration(keyB64: String) async -> Bool {
+        let initialBundle = await initialBundleFromCachedPrf()
         do {
             _ = try await SyncEnclaveAPI.registerKey(
                 EnclaveKeyRegisterRequest(
@@ -209,7 +212,7 @@ enum LegacyBlobMigration {
                     ifMatch: IfMatchSentinels.anyKey,
                     createdVia: SyncEnclaveCreatedVia.recovery.rawValue,
                     idempotencyKey: newSyncEnclaveIdempotencyKey(),
-                    initialBundle: nil
+                    initialBundle: initialBundle
                 )
             )
         } catch {
@@ -219,9 +222,48 @@ enum LegacyBlobMigration {
             return false
         }
         #if DEBUG
-        print("[LegacyBlobMigration] adopted local key as current to enable migration")
+        print("[LegacyBlobMigration] adopted local key as current to enable migration (bundle: \(initialBundle != nil))")
         #endif
         return true
+    }
+
+    /// Best-effort initial bundle for key adoption: wrap the CEK being
+    /// registered under the KEK derived from this device's cached
+    /// passkey PRF. Adoption must never be blocked by bundle problems,
+    /// so every failure path returns nil and the caller registers
+    /// bundleless.
+    ///
+    /// The cached credential is only trusted when it still appears in
+    /// the user's stored credentials — a stale cache (passkey deleted
+    /// or re-created) must not attach an unopenable bundle, which would
+    /// make the account look passkey-recoverable when it is not.
+    private static func initialBundleFromCachedPrf() async -> EnclaveKeyRegisterBundleInput? {
+        guard let cached = await PasskeyService.shared.getCachedPrfResult() else {
+            return nil
+        }
+        let entries = await LegacyPasskeyCredentials.fetch()
+        guard entries.contains(where: { $0.id == cached.credentialId }) else {
+            return nil
+        }
+        do {
+            let cek = try EncryptionService.shared.getKeyBytesOrThrow()
+            let kek = PasskeyService.deriveKeyEncryptionKey(from: cached.prfOutput)
+            let bundle = try SyncEnclaveKeyBundle.wrapCek(
+                credentialId: cached.credentialId,
+                kek: kek,
+                cek: cek
+            )
+            return EnclaveKeyRegisterBundleInput(
+                credentialId: bundle.credentialId,
+                kekIvHex: bundle.kekIvHex,
+                encryptedKeysHex: bundle.wrappedKeyHex
+            )
+        } catch {
+            #if DEBUG
+            print("[LegacyBlobMigration] could not build initial bundle for adoption: \(error)")
+            #endif
+            return nil
+        }
     }
 
     private static func shouldKeepPolling(_ resp: EnclaveMigrateAllResponse?) -> Bool {

--- a/TinfoilChat/Services/SyncHealthStore.swift
+++ b/TinfoilChat/Services/SyncHealthStore.swift
@@ -1,0 +1,117 @@
+//
+//  SyncHealthStore.swift
+//  TinfoilChat
+//
+//  The single place where sync failures become user-visible state.
+//
+//  The upload recovery path used to post `tinfoil.sync.*`
+//  notifications that nothing observed, so every terminal failure
+//  was invisible. It now reports into this store instead, and the
+//  UI (the Cloud Sync settings status row, the sidebar settings
+//  badge, the per-chat "couldn't sync" icon) observes it.
+//
+//  State model:
+//   - `gate` is the account-wide condition. `actionRequired` (key
+//     problems, blocked account) outranks `paused` (attestation /
+//     network trouble that retries itself); a paused report never
+//     downgrades an actionRequired gate.
+//   - `failedChats` tracks per-chat terminal upload failures; an
+//     entry clears when that chat finally uploads or is deleted.
+//
+
+import Foundation
+
+@MainActor
+final class SyncHealthStore: ObservableObject {
+    static let shared = SyncHealthStore()
+
+    enum PausedReason: Equatable {
+        case attestation
+        case network
+    }
+
+    enum ActionReason: Equatable {
+        case keyRecovery
+        case keyMismatch
+        case keyConflict
+        case accountBlocked
+    }
+
+    enum Gate: Equatable {
+        case ok
+        case paused(reason: PausedReason, since: Date)
+        case actionRequired(reason: ActionReason, since: Date)
+    }
+
+    @Published private(set) var gate: Gate = .ok
+    /// chatId -> short human-readable failure description.
+    @Published private(set) var failedChats: [String: String] = [:]
+
+    private init() {}
+
+    /// The local key cannot write (stale after a rotation, unknown to
+    /// the enclave, or colliding with data under another key) or the
+    /// account is blocked. Requires a user-driven fix, so it sticks
+    /// until `reportKeyHealthy` confirms the key validates again.
+    func reportKeyActionRequired(_ reason: ActionReason) {
+        if case .actionRequired(let current, _) = gate, current == reason {
+            return
+        }
+        gate = .actionRequired(reason: reason, since: Date())
+    }
+
+    /// Sync is blocked by something that retries itself (attestation
+    /// failure, network trouble). Never downgrades an actionRequired
+    /// gate: a key problem stays the headline until it is fixed.
+    func reportSyncPaused(_ reason: PausedReason) {
+        if case .actionRequired = gate { return }
+        if case .paused(let current, _) = gate, current == reason {
+            return
+        }
+        gate = .paused(reason: reason, since: Date())
+    }
+
+    /// The enclave confirmed the local key is the registered current
+    /// key. Clears any gate — reaching that verdict required a healthy
+    /// enclave round trip, so a paused gate is stale too.
+    func reportKeyHealthy() {
+        if gate != .ok {
+            gate = .ok
+        }
+    }
+
+    func reportChatSyncFailed(_ chatId: String, message: String) {
+        if failedChats[chatId] == message { return }
+        failedChats[chatId] = message
+    }
+
+    /// Clears a chat's failure entry (successful upload or deletion).
+    func reportChatSynced(_ chatId: String) {
+        if failedChats[chatId] != nil {
+            failedChats.removeValue(forKey: chatId)
+        }
+    }
+
+    /// Full reset (sign-out).
+    func reset() {
+        if gate != .ok { gate = .ok }
+        if !failedChats.isEmpty { failedChats = [:] }
+    }
+
+    /// Whether the current state deserves the attention badge on the
+    /// settings entry point: a key problem, a chat that cannot sync,
+    /// or a pause that has outlived the self-healing window.
+    func needsAttention(now: Date = Date()) -> Bool {
+        switch gate {
+        case .actionRequired:
+            return true
+        case .paused(_, let since):
+            if now.timeIntervalSince(since) >= Constants.Sync.pausedAttentionWindowSeconds {
+                return true
+            }
+        case .ok:
+            break
+        }
+        return !failedChats.isEmpty
+    }
+}

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3260,6 +3260,7 @@ class ChatViewModel: ObservableObject {
         lastSyncDate = nil
         syncErrors = []
         isSyncing = false
+        SyncHealthStore.shared.reset()
         
         // Reset pagination state
         paginationToken = nil

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -25,6 +25,7 @@ struct ChatSidebar: View {
     @State private var isChatsExpanded: Bool = true
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var cloudSync = CloudSyncService.shared
+    @ObservedObject private var syncHealth = SyncHealthStore.shared
 
     private var activeTab: ChatStorageTab {
         viewModel.activeStorageTab
@@ -205,6 +206,7 @@ struct ChatSidebar: View {
                     createdTimeString: chat.isBlankChat ? "" : relativeTimeString(from: chat.createdAt),
                     updatedTimeString: chat.isBlankChat ? "" : updatedTimeString(for: chat),
                     isSyncing: !chat.isBlankChat && cloudSync.pendingUploadChatIds.contains(chat.id),
+                    syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
                     onSelect: {
                         viewModel.selectChat(chat)
                     },
@@ -288,6 +290,19 @@ struct ChatSidebar: View {
         }
     }
 
+    private var settingsGearIcon: some View {
+        Image(systemName: "gear")
+            .overlay(alignment: .topTrailing) {
+                if syncHealth.needsAttention() {
+                    Circle()
+                        .fill(Color.orange)
+                        .frame(width: 8, height: 8)
+                        .offset(x: 4, y: -4)
+                        .accessibilityLabel("Cloud sync needs attention")
+                }
+            }
+    }
+
     @ViewBuilder
     private var settingsButton: some View {
         if #available(iOS 26, *) {
@@ -295,7 +310,7 @@ struct ChatSidebar: View {
                 viewModel.showSidebarSettings = true
             } label: {
                 HStack {
-                    Image(systemName: "gear")
+                    settingsGearIcon
                     Text("Settings")
                 }
                 .padding(.vertical, 12)
@@ -308,7 +323,7 @@ struct ChatSidebar: View {
                 viewModel.showSidebarSettings = true
             } label: {
                 HStack {
-                    Image(systemName: "gear")
+                    settingsGearIcon
                     Text("Settings")
                 }
                 .padding(.vertical, 12)
@@ -545,6 +560,7 @@ struct ChatListItem: View {
     let createdTimeString: String
     let updatedTimeString: String
     var isSyncing: Bool = false
+    var syncFailed: Bool = false
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -617,7 +633,11 @@ struct ChatListItem: View {
                                 + Text(updatedTimeString.isEmpty ? "" : " · \(updatedTimeString)")
                                 .foregroundColor(Color(UIColor.tertiaryLabel)))
                                 .font(.caption)
-                            if isSyncing {
+                            if syncFailed {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .font(.caption2)
+                                    .foregroundColor(.orange)
+                            } else if isSyncing {
                                 Image(systemName: "icloud.and.arrow.up")
                                     .font(.caption2)
                                     .foregroundColor(.blue)
@@ -672,7 +692,9 @@ struct ChatListItem: View {
                 components.append(updatedTimeString)
             }
         }
-        if isSyncing {
+        if syncFailed {
+            components.append("Couldn't sync with cloud")
+        } else if isSyncing {
             components.append("Syncing with cloud")
         }
         return components.joined(separator: ", ")

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -15,6 +15,7 @@ struct CloudSyncSettingsView: View {
     @ObservedObject var authManager: AuthManager
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var passkeyManager = PasskeyManager.shared
+    @ObservedObject private var syncHealth = SyncHealthStore.shared
 
     private var cloudSyncBinding: Binding<Bool> {
         Binding(
@@ -116,6 +117,8 @@ struct CloudSyncSettingsView: View {
                             }
                         }
                     }
+
+                    syncHealthRows
 
                     if settings.isCloudSyncEnabled &&
                         CloudKeyAuthorizationStore.shared.currentMode() == nil {
@@ -258,6 +261,71 @@ struct CloudSyncSettingsView: View {
             }
     }
     
+    /// Gate-driven status rows from the sync-health store: explains
+    /// why sync is blocked, offers the recovery wizard for key
+    /// problems, and counts chats stuck on terminal upload failures.
+    @ViewBuilder
+    private var syncHealthRows: some View {
+        switch syncHealth.gate {
+        case .actionRequired(let reason, _):
+            VStack(alignment: .leading, spacing: 8) {
+                Label(actionRequiredMessage(for: reason), systemImage: "exclamationmark.circle")
+                    .font(.caption)
+                    .foregroundColor(reason == .accountBlocked ? .red : .orange)
+                if reason != .accountBlocked {
+                    Button {
+                        viewModel.cloudSyncOnboardingMode = .recovery
+                        viewModel.showCloudSyncOnboarding = true
+                    } label: {
+                        Text("Recover Key")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(Color.orange)
+                            .cornerRadius(6)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        case .paused(let reason, _):
+            Label(
+                reason == .attestation
+                    ? "The sync server couldn't be verified. Retrying automatically."
+                    : "Having trouble reaching the cloud. Retrying automatically.",
+                systemImage: "exclamationmark.triangle"
+            )
+            .font(.caption)
+            .foregroundColor(.orange)
+        case .ok:
+            EmptyView()
+        }
+
+        if !syncHealth.failedChats.isEmpty {
+            Text(
+                syncHealth.failedChats.count == 1
+                    ? "1 chat couldn't be synced. It's marked in the sidebar."
+                    : "\(syncHealth.failedChats.count) chats couldn't be synced. They're marked in the sidebar."
+            )
+            .font(.caption)
+            .foregroundColor(.orange)
+        }
+    }
+
+    private func actionRequiredMessage(for reason: SyncHealthStore.ActionReason) -> String {
+        switch reason {
+        case .keyRecovery:
+            return "Sync is paused because your encryption key needs to be recovered."
+        case .keyMismatch:
+            return "This device's encryption key is out of date and needs to be recovered."
+        case .keyConflict:
+            return "Your cloud data is protected by a different key than this device's."
+        case .accountBlocked:
+            return "Sync is unavailable for this account. Please contact support if this persists."
+        }
+    }
+
     @ViewBuilder
     private var passkeySection: some View {
         if passkeyManager.passkeyActive


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Surface cloud sync status across the app and make legacy migration safer. Adds a central SyncHealthStore, new UI indicators, backs up the sync key with the device passkey during migration, and clears stale key warnings after first-time key registration.

- New Features
  - Added `SyncHealthStore` to track account gate (ok/paused/actionRequired) and per‑chat failures; pause escalates to an attention badge after 5 minutes.
  - Settings shows clear sync messages, a “Recover Key” action when needed, and a count of chats that couldn’t sync; sidebar gear gets an attention badge; chats with terminal upload failures show an orange warning icon.
  - Legacy migration adopts the local key with an initial passkey-backed bundle when a valid cached PRF and credential exist; otherwise falls back to bundleless (never blocks migration).

- Refactors
  - Replaced `tinfoil.sync.*` notifications with `SyncHealthStore` in `CloudSyncService`; report key issues, paused states, per‑chat failures, and clear per‑chat failures on success/deletes.
  - Clear stale key warnings when the enclave confirms the local key or after the first successful key registration.
  - Added `Constants.Sync.pausedAttentionWindowSeconds`; reset the store on sign‑out.

<sup>Written for commit 3d0decf0d09e63fa8be2bdf226f1ac818693bff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

