### PR TITLE
fix: stop retrying chat migration when the key set is unchanged

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -319,6 +319,14 @@ enum Constants {
             /// that the legacy v0/v1 decrypt path used to handle. The enclave
             /// rewraps any orphan rows server-side; the next sync repopulates.
             static let legacyCloudChatsEvicted = "tinfoil-migration-legacy-cloud-chats-evicted"
+            /// Per-user fingerprint (suffixed with the clerk user id) of the
+            /// migration candidate key set whose last completed sweep left
+            /// rows blocked under every key this client holds. While it
+            /// matches the current key set the launch sweep is skipped so a
+            /// doomed migrate-all is not re-driven every launch; a changed
+            /// key set no longer matches and the sweep runs again. Cleared
+            /// once a sweep fully migrates with nothing blocked.
+            static let migrationExhaustedKeyset = "tinfoil-migration-exhausted-keyset"
         }
 
         /// Legacy UserDefaults keys that should be purged on app

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -230,15 +230,21 @@ enum LegacyBlobMigration {
     private static func candidateKeySetFingerprint() -> String? {
         let allKeys = EncryptionService.shared.getAllKeys()
         guard let primary = allKeys.primary else { return nil }
-        let candidates = [primary] + allKeys.alternatives.filter { $0 != primary }
-        var ids: [String] = []
-        for key in candidates {
-            guard let bytes = try? EncryptionService.shared.getAlternativeKeyBytes(key),
+        // Mirror CEKEncoding.migrationKeys(): without a readable primary
+        // there is no candidate key set, so the fingerprint must be nil
+        // rather than one built from alternatives alone. Otherwise the
+        // gate would diverge from the sweep, which never runs without a
+        // primary at keys[0].
+        guard let primaryBytes = try? EncryptionService.shared.getAlternativeKeyBytes(primary),
+            let primaryId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: primaryBytes)
+        else { return nil }
+        var ids: [String] = [primaryId]
+        for alt in allKeys.alternatives where alt != primary {
+            guard let bytes = try? EncryptionService.shared.getAlternativeKeyBytes(alt),
                 let id = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: bytes)
             else { continue }
             ids.append(id)
         }
-        guard !ids.isEmpty else { return nil }
         return ids.sorted().joined(separator: ",")
     }
 

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -17,6 +17,7 @@
 //  deltas — the enclave already owns the global counter.
 //
 
+import ClerkKit
 import Foundation
 
 struct ScopeMigrationResult {
@@ -101,6 +102,25 @@ enum LegacyBlobMigration {
             return .empty
         }
 
+        // Skip a sweep that already exhausted this exact candidate key
+        // set. A prior completed sweep that left rows blocked under every
+        // key this client holds will fail those same rows again (and
+        // re-stamp them on the controlplane) if retried with an unchanged
+        // key set. The gate clears the moment the key set changes (a
+        // newly recovered key has a different fingerprint), so a
+        // genuinely actionable retry still runs. Mirrors the webapp's
+        // migration key-set gate; the server 24h cooldown is the backstop.
+        let activeUserId = await Clerk.shared.user?.id
+        let keysetFingerprint = candidateKeySetFingerprint()
+        if let activeUserId, let keysetFingerprint,
+            loadExhaustedKeyset(activeUserId) == keysetFingerprint
+        {
+            #if DEBUG
+            print("[LegacyBlobMigration] skip: candidate key set already exhausted")
+            #endif
+            return .empty
+        }
+
         let keys = CEKEncoding.migrationKeys()
         let startedAt = Date()
         let pollInterval = Constants.Sync.migrationPollIntervalSeconds
@@ -148,6 +168,7 @@ enum LegacyBlobMigration {
         // that as a clean drain would clear the alternative keys after
         // nothing was rewrapped, stranding every legacy row.
         let jobFailed = lastResponse?.status == failedJobStatus
+        let completedSweep = (lastResponse?.partial == false) && !jobFailed
         if lastResponse?.partial != false || jobFailed {
             report.fullyMigrated = false
         }
@@ -156,16 +177,29 @@ enum LegacyBlobMigration {
         // though no scopes were touched.
         if snapshot.isEmpty {
             if let last = lastResponse, !last.partial, !jobFailed {
-                return MigrationReport(
+                let emptyDone = MigrationReport(
                     scopes: [],
                     totalMigrated: 0,
                     totalRemaining: 0,
                     totalBlocked: 0,
                     fullyMigrated: true
                 )
+                recordKeysetOutcome(
+                    userId: activeUserId,
+                    fingerprint: keysetFingerprint,
+                    report: emptyDone,
+                    completedSweep: true
+                )
+                return emptyDone
             }
             return .empty
         }
+        recordKeysetOutcome(
+            userId: activeUserId,
+            fingerprint: keysetFingerprint,
+            report: report,
+            completedSweep: completedSweep
+        )
         return report
     }
 
@@ -185,6 +219,63 @@ enum LegacyBlobMigration {
     }
 
     // MARK: - Private
+
+    /// Stable, non-secret fingerprint of the migration candidate key set
+    /// (primary plus alternatives) the way `CEKEncoding.migrationKeys()`
+    /// assembles it. Derived from each key's enclave key_id (a hex
+    /// digest, never the raw CEK), sorted and joined so the value is
+    /// order-independent and safe to persist. Returns nil when no
+    /// primary key is loaded. Mirrors the webapp's
+    /// `migrationKeySetFingerprint`.
+    private static func candidateKeySetFingerprint() -> String? {
+        let allKeys = EncryptionService.shared.getAllKeys()
+        guard let primary = allKeys.primary else { return nil }
+        let candidates = [primary] + allKeys.alternatives.filter { $0 != primary }
+        var ids: [String] = []
+        for key in candidates {
+            guard let bytes = try? EncryptionService.shared.getAlternativeKeyBytes(key),
+                let id = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: bytes)
+            else { continue }
+            ids.append(id)
+        }
+        guard !ids.isEmpty else { return nil }
+        return ids.sorted().joined(separator: ",")
+    }
+
+    private static func exhaustedKeysetStorageKey(_ userId: String) -> String {
+        Constants.StorageKeys.Migration.migrationExhaustedKeyset + "_" + userId
+    }
+
+    /// Persisted fingerprint of the candidate key set whose last completed
+    /// sweep left rows blocked, or nil when none is recorded.
+    private static func loadExhaustedKeyset(_ userId: String) -> String? {
+        UserDefaults.standard.string(forKey: exhaustedKeysetStorageKey(userId))
+    }
+
+    /// Persist or clear the exhausted-key-set fingerprint from a sweep
+    /// result. A completed sweep (not partial/failed) that still leaves
+    /// rows blocked marks this exact key set exhausted so later launches
+    /// skip the doomed re-sweep until the key set changes; a sweep that
+    /// fully migrates with nothing blocked clears the gate. A partial
+    /// sweep leaves the gate untouched so the next launch keeps making
+    /// progress.
+    private static func recordKeysetOutcome(
+        userId: String?,
+        fingerprint: String?,
+        report: MigrationReport,
+        completedSweep: Bool
+    ) {
+        guard let userId, !userId.isEmpty else { return }
+        let key = exhaustedKeysetStorageKey(userId)
+        let defaults = UserDefaults.standard
+        if report.fullyMigrated {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        if completedSweep, report.totalBlocked > 0, let fingerprint {
+            defaults.set(fingerprint, forKey: key)
+        }
+    }
 
     /// Register the local primary CEK as the enclave's current key for a
     /// user who has legacy data but no registered key. Without this a

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveKeyBundle.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveKeyBundle.swift
@@ -5,8 +5,8 @@
 //  Wrap / unwrap the user's content encryption key (CEK) under a
 //  passkey-PRF-derived KEK, in the shape the sync enclave expects.
 //
-//  The enclave wire (see syncplan.md §6 and Go `internal/server/types.go`)
-//  carries one wrapped CEK per registered passkey credential. There is no
+//  The enclave wire (Go `internal/server/types.go`) carries one wrapped
+//  CEK per registered passkey credential. There is no
 //  list of "alternative" keys: the enclave is the single source of truth,
 //  and legacy alternatives are handled by opportunistic migration.
 //


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops re-running the legacy chat migration when the candidate key set is unchanged. Adds a per-user key-set fingerprint and a safe skip gate; still runs when the primary key is unreadable.

- **Bug Fixes**
  - Added a stable fingerprint of the candidate key set (primary + alternatives). Persisted per user in `UserDefaults` as `migrationExhaustedKeyset`.
  - Skip the launch sweep when the fingerprint matches; retry only after the key set changes. Bypass the gate if the primary key is missing or unreadable.
  - Record outcomes: mark exhausted on completed sweeps with blocked rows; clear on full success; leave unchanged on partial/failed. Scoped by active user from `ClerkKit`.

- **Refactors**
  - Removed references to a retired sync planning doc in `SyncEnclaveKeyBundle.swift` comments.

<sup>Written for commit 4e179ed4827a64c08acbaf32137940e150c7b1e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

