### PR TITLE
Let legacy users sync to the cloud again

### DIFF
--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -227,26 +227,50 @@ class CloudSyncService: ObservableObject {
         }
 
         guard let remoteKeyId = response.keyId else {
-            if response.hasData {
-                // Un-migrated legacy data with no registered key: pushing
-                // now would only earn a stale-key rejection. Defer; the
-                // migration path adopts the key and the next pass clears
-                // this gate.
-                return false
-            }
-            // Only ever bind a key the user has actually committed and
-            // only while cloud sync is on. During an activation ceremony
-            // the new key is staged in memory only; a concurrent
-            // background write must not register it before the ceremony
-            // finishes (a transient failure would roll the client back
-            // while the server stays bound to the discarded key).
+            // No key is registered. Only ever bind a key the user has
+            // actually committed and only while cloud sync is on. During
+            // an activation ceremony the new key is staged in memory
+            // only; a concurrent background write must not register it
+            // before the ceremony finishes (a transient failure would
+            // roll the client back while the server stays bound to the
+            // discarded key).
             guard SettingsManager.shared.isCloudSyncEnabled,
                   let persistedKey = EncryptionService.shared.persistedPrimaryKey(),
                   let persistedBytes = try? EncryptionService.shared.getAlternativeKeyBytes(persistedKey)
             else {
                 return false
             }
-            return await registerKeyForEmptyRemote(keyB64: dataToBase64(persistedBytes))
+            // The upload encrypts under the active in-memory CEK, but the
+            // gate only ever binds the committed key. If a ceremony has
+            // staged a different key in memory, registering the committed
+            // key now would bind the account to a key the upload won't
+            // use, and every push would then be rejected as a stale key.
+            // Defer until the active key and the committed key agree (the
+            // ceremony commits or rolls back) so the registered key and
+            // the upload key are always the same.
+            guard let activeKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek),
+                  let committedKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: persistedBytes),
+                  activeKeyId == committedKeyId
+            else {
+                return false
+            }
+            let persistedB64 = dataToBase64(persistedBytes)
+            if response.hasData {
+                // Un-migrated legacy data with no registered key: the
+                // controlplane rejects every push as a stale key until
+                // the local CEK is adopted as the current key. Adopt it
+                // here (created_via=recovery) so the write path
+                // establishes its own precondition instead of deferring
+                // forever while it waits for the out-of-band migration
+                // kick.
+                let adopted = await LegacyBlobMigration.adoptLocalKeyForMigration(
+                    keyB64: persistedB64)
+                if adopted {
+                    SyncHealthStore.shared.reportKeyHealthy()
+                }
+                return adopted
+            }
+            return await registerKeyForEmptyRemote(keyB64: persistedB64)
         }
 
         let localKeyId: String

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -300,7 +300,11 @@ enum LegacyBlobMigration {
     /// strands a backup. register-key's if_match='*' fails safely on
     /// a concurrent register. Returns true when the key was adopted.
     /// Mirrors the webapp's migration adoption.
-    private static func adoptLocalKeyForMigration(keyB64: String) async -> Bool {
+    ///
+    /// Reused by the cloud write gate (`canWriteToCloud`) so a legacy
+    /// user adopts their key on their next write instead of deferring
+    /// forever while they wait for the out-of-band migration kick.
+    static func adoptLocalKeyForMigration(keyB64: String) async -> Bool {
         let initialBundle = await initialBundleFromCachedPrf()
         do {
             _ = try await SyncEnclaveAPI.registerKey(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes cloud sync for legacy users by adopting the locally persisted key when the server has data but no registered key. Makes the next write succeed instead of deferring on stale-key rejections.

- **Bug Fixes**
  - In `CloudSyncService.canWriteToCloud`, when `hasData` and no `keyId`, adopt the persisted key (`created_via=recovery`) via `LegacyBlobMigration.adoptLocalKeyForMigration` and mark it healthy on success.
  - Added a precondition to avoid bad bindings during activation: only adopt/register when cloud sync is enabled and the active in-memory CEK matches the committed key; if the remote is empty, continue to `registerKeyForEmptyRemote`.

<sup>Written for commit c8afbcfa95b587fae7232964fd99924287bbcb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

