### PR TITLE
Markdown rendering crash and hang fixes

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/textual";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.7;
+				minimumVersion = 0.0.8;
 			};
 		};
 		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "5e7b311582a7c55e3d8f0163f17d44ddb90c005c",
-        "version" : "0.0.7"
+        "revision" : "e765ae4da8c501e06c34d6059321d5e80e1759a3",
+        "version" : "0.0.8"
       }
     },
     {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -55,6 +55,12 @@ enum Constants {
         /// Individual markdown segments larger than this are split at
         /// paragraph boundaries to bound CoreText measurement time.
         static let maxMarkdownSegmentCharacters = 8_000
+        /// Assistant messages larger than this render without inline text
+        /// selection. The selection overlay installs a custom UITextInput per
+        /// fragment, which is the most expensive and crash-prone path on long
+        /// content; users can still select large messages via the full-text
+        /// selection sheet.
+        static let maxInlineSelectionCharacters = 10_000
     }
 
     enum StreamingBuffer {

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -47,7 +47,8 @@ struct MessageView: View {
     }
 
     private var inlineAssistantTextSelectionEnabled: Bool {
-        !(isLoading && isLastMessage)
+        guard !(isLoading && isLastMessage) else { return false }
+        return message.content.count <= Constants.Rendering.maxInlineSelectionCharacters
     }
 
     /// Runs of adjacent segments collapsed for inline rendering. Adjacent


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents crashes and hangs when rendering long assistant messages by updating markdown rendering and turning off inline text selection for very large responses.

- **Bug Fixes**
  - Disable inline text selection for assistant messages over 10,000 characters to avoid costly `UITextInput` overlays and crash-prone paths. Users can still select via the full-text selection sheet.

- **Dependencies**
  - Bump `textual` to `0.0.8` for markdown rendering stability fixes.

<sup>Written for commit 6bceeecc03991ed63467c13793c92619a0e749e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

