### PR TITLE
Guard cloud key adoption during staged-key ceremonies

### DIFF
--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -234,12 +234,6 @@ class CloudSyncService: ObservableObject {
             // before the ceremony finishes (a transient failure would
             // roll the client back while the server stays bound to the
             // discarded key).
-            guard SettingsManager.shared.isCloudSyncEnabled,
-                  let persistedKey = EncryptionService.shared.persistedPrimaryKey(),
-                  let persistedBytes = try? EncryptionService.shared.getAlternativeKeyBytes(persistedKey)
-            else {
-                return false
-            }
             // The upload encrypts under the active in-memory CEK, but the
             // gate only ever binds the committed key. If a ceremony has
             // staged a different key in memory, registering the committed
@@ -248,9 +242,8 @@ class CloudSyncService: ObservableObject {
             // Defer until the active key and the committed key agree (the
             // ceremony commits or rolls back) so the registered key and
             // the upload key are always the same.
-            guard let activeKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek),
-                  let committedKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: persistedBytes),
-                  activeKeyId == committedKeyId
+            guard SettingsManager.shared.isCloudSyncEnabled,
+                  let persistedBytes = LegacyBlobMigration.committedKeyIfActiveMatches()
             else {
                 return false
             }
@@ -1558,6 +1551,10 @@ class CloudSyncService: ObservableObject {
     func clearSyncStatus() {
         UserDefaults.standard.removeObject(forKey: syncStatusKey)
         UserDefaults.standard.removeObject(forKey: allChatsSyncStatusKey)
+        // Drop any in-flight key registration so the next signed-in user
+        // never awaits a task started under the previous user's key.
+        emptyRemoteRegistration?.cancel()
+        emptyRemoteRegistration = nil
     }
 
     // MARK: - Sync Status Cache Helpers

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -87,8 +87,15 @@ enum LegacyBlobMigration {
             // passes. Safe because we already hold the CEK and a legacy
             // passkey wrapping it stays promotable afterwards. Mirrors the
             // webapp's migration adoption.
+            // Only ever bind the committed key, and only when it matches
+            // the active in-memory CEK. During a key-activation ceremony
+            // the new key is staged in memory only; registering it here
+            // would bind the account to a key the user may roll back. When
+            // they diverge the helper returns nil and adoption is skipped,
+            // so the gate below defers this sweep until the ceremony lands.
             if current.keyId == nil, current.hasData,
-                await adoptLocalKeyForMigration(keyB64: targetKeyB64)
+                let safeKey = committedKeyIfActiveMatches(),
+                await adoptLocalKeyForMigration(keyB64: dataToBase64(safeKey))
             {
                 current = try await SyncEnclaveAPI.keyCurrent()
             }
@@ -281,6 +288,26 @@ enum LegacyBlobMigration {
         if completedSweep, report.totalBlocked > 0, let fingerprint {
             defaults.set(fingerprint, forKey: key)
         }
+    }
+
+    /// The committed primary CEK bytes, but only when they match the
+    /// active in-memory CEK. Returns nil to mean "defer adoption": there
+    /// is no committed key, it cannot be read, or a key-activation
+    /// ceremony has staged a different key in memory that must not be
+    /// bound to the account yet. Callers register the returned bytes so a
+    /// staged, not-yet-committed key is never adopted as the current key.
+    /// Mirrors the webapp's staged-key adoption guard.
+    static func committedKeyIfActiveMatches() -> Data? {
+        guard let persistedKey = EncryptionService.shared.persistedPrimaryKey(),
+            let persistedBytes = try? EncryptionService.shared.getAlternativeKeyBytes(persistedKey),
+            let activeBytes = try? EncryptionService.shared.getKeyBytesOrThrow(),
+            let committedKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: persistedBytes),
+            let activeKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: activeBytes),
+            activeKeyId == committedKeyId
+        else {
+            return nil
+        }
+        return persistedBytes
     }
 
     /// Register the local primary CEK as the enclave's current key for a


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents binding a staged cloud encryption key during key-activation ceremonies by only adopting/registering the committed primary CEK. Aligns iOS behavior with the web app and avoids the server being bound to a key the user may roll back.

- **Bug Fixes**
  - Gate key adoption in migration and uploads using committed-vs-active checks (`committedKeyIfActiveMatches()`), deferring when they differ.
  - Cancel any in-flight empty key registration on sign-out to avoid the next user awaiting a previous user's task.

<sup>Written for commit 60f4aca4c902c5ec814c750ca141730760e6564c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

