### PR TITLE
Sync conflict last write wins

### DIFF
--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -7,6 +7,26 @@
 
 import Foundation
 
+// MARK: - Conflict Resolution
+
+/// Last-write-wins arbitration by content modification time, shared by
+/// every scope's conflict resolution (chats, profile) so the winner is
+/// the same on every device.
+enum SyncConflictResolver {
+    /// Returns true when the remote copy is the last write and should
+    /// overwrite local; false when the local copy is at least as fresh
+    /// and must be preserved (re-uploaded).
+    ///
+    /// A missing local timestamp means we cannot prove local is fresher,
+    /// so remote wins. A missing remote timestamp lets local win, since
+    /// we have a concrete local edit time to trust.
+    static func remoteWins(local: Date?, remote: Date?) -> Bool {
+        guard let local = local else { return true }
+        guard let remote = remote else { return false }
+        return remote > local
+    }
+}
+
 // MARK: - Sync Models
 
 /// Extended chat model with sync metadata

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -547,7 +547,10 @@ class CloudSyncService: ObservableObject {
             }
 
             let localChat = await loadChatFromStorage(chatId)
-            let remoteWins = localChat.map { downloadedChat.updatedAt > $0.updatedAt } ?? true
+            let remoteWins = SyncConflictResolver.remoteWins(
+                local: localChat?.updatedAt,
+                remote: downloadedChat.updatedAt
+            )
 
             if !remoteWins {
                 await rebaseSyncVersion(chatId, version: downloadedChat.syncVersion)

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -520,11 +520,23 @@ class CloudSyncService: ObservableObject {
         }
     }
 
-    /// Last-write-wins conflict resolution. Pulls the remote chat
-    /// fresh from the enclave and overwrites the local copy so the
-    /// chat exits the stuck-row retry loop. If the pull itself
-    /// fails the chat stays locallyModified and the next sync
-    /// cycle retries.
+    /// Last-write-wins conflict resolution, arbitrated by content
+    /// modification time so the winner is the same on every device.
+    ///
+    /// On a STALE_BLOB / SYNC_CONFLICT the server holds a version our
+    /// upload was not based on. We download that remote row and compare
+    /// its updatedAt against the local copy:
+    ///
+    /// - Remote is strictly newer (or we have no local copy): the
+    ///   remote is the last write, so overwrite local with it.
+    /// - Local is at least as fresh: OUR edit is the last write, so we
+    ///   must not clobber unsynced local messages with the older remote
+    ///   snapshot. Rebase the local row onto the server's current
+    ///   version (so the next upload's CAS base matches) and re-upload,
+    ///   letting local win instead of looping on STALE_BLOB forever.
+    ///
+    /// If the pull itself fails the chat stays locallyModified and the
+    /// next sync cycle retries.
     private func resolveConflictByPullingRemote(_ chatId: String) async {
         do {
             guard var downloadedChat = try await cloudStorage.downloadChat(chatId) else {
@@ -533,6 +545,19 @@ class CloudSyncService: ObservableObject {
             if downloadedChat.modelType == nil {
                 downloadedChat.modelType = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first
             }
+
+            let localChat = await loadChatFromStorage(chatId)
+            let remoteWins = localChat.map { downloadedChat.updatedAt > $0.updatedAt } ?? true
+
+            if !remoteWins {
+                await rebaseSyncVersion(chatId, version: downloadedChat.syncVersion)
+                // Re-enqueue rather than wait: the coalescer worker will
+                // pick up the dirty flag and re-run the upload with the
+                // rebased version.
+                await backupChat(chatId)
+                return
+            }
+
             await saveChatToStorage(downloadedChat)
             await markChatAsSynced(downloadedChat.id, version: downloadedChat.syncVersion)
         } catch {
@@ -1869,6 +1894,24 @@ class CloudSyncService: ObservableObject {
             syncVersion: version,
             syncedAt: Date(),
             locallyModified: false
+        )
+    }
+
+    /// Rebase the local chat's sync version onto the server's current
+    /// version while keeping it locallyModified, so the next upload's
+    /// CAS base matches the enclave and the fresher local copy wins the
+    /// last-write-wins race instead of looping on STALE_BLOB. Unlike
+    /// markChatAsSynced this never clears the dirty flag, so the chat is
+    /// still uploaded; the existing syncedAt is preserved.
+    private func rebaseSyncVersion(_ chatId: String, version: Int) async {
+        guard let userId = await getCurrentUserId() else { return }
+        let existingSyncedAt = await loadChatFromStorage(chatId)?.syncedAt
+        try? await EncryptedFileStorage.cloud.updateSyncMetadata(
+            chatId: chatId,
+            userId: userId,
+            syncVersion: version,
+            syncedAt: existingSyncedAt ?? Date(),
+            locallyModified: true
         )
     }
 

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -62,6 +62,9 @@ class ProfileManager: ObservableObject {
     private let keychainKey = "userProfile"
     private let keychainService = "com.tinfoil.chat.profile"
     private let profileDirtyKey = "com.tinfoil.chat.profile.dirty"
+    // Content modification time of the pending local profile edit, used
+    // to arbitrate last-write-wins against a concurrently-updated remote.
+    private let profileChangedAtKey = "com.tinfoil.chat.profile.changed-at"
     
     private init() {
         loadFromKeychain()
@@ -122,11 +125,33 @@ class ProfileManager: ObservableObject {
 
     private func markLocalProfileChanged() {
         UserDefaults.standard.set(true, forKey: profileDirtyKey)
+        UserDefaults.standard.set(
+            ProfileManager.iso8601Formatter.string(from: Date()),
+            forKey: profileChangedAtKey
+        )
     }
 
     private func clearLocalProfileChanged() {
         UserDefaults.standard.removeObject(forKey: profileDirtyKey)
+        UserDefaults.standard.removeObject(forKey: profileChangedAtKey)
     }
+
+    /// Edit time of the pending local profile change, used to arbitrate
+    /// last-write-wins against the remote. Falls back to now so a local
+    /// edit is never treated as older than the remote it is replacing.
+    private func localProfileChangedAt() -> String {
+        if let stored = UserDefaults.standard.string(forKey: profileChangedAtKey),
+           ProfileManager.iso8601Formatter.date(from: stored) != nil {
+            return stored
+        }
+        return ProfileManager.iso8601Formatter.string(from: Date())
+    }
+
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
 
     private func persistProfileToKeychain(_ profile: ProfileData) {
         guard let data = try? JSONEncoder().encode(profile) else {
@@ -175,7 +200,7 @@ class ProfileManager: ObservableObject {
             chatFont: chatFont,
             projectUploadPreference: projectUploadPreference,
             version: lastSyncedVersion,  // Will be incremented by ProfileSyncService
-            updatedAt: ISO8601DateFormatter().string(from: Date())
+            updatedAt: localProfileChangedAt()
         )
     }
     
@@ -543,10 +568,22 @@ class ProfileManager: ObservableObject {
                     // Fallback: ensure we at least bump our local version
                     lastSyncedVersion = (profile.version ?? lastSyncedVersion) + 1
                 }
-                var syncedProfile = profile
-                syncedProfile.version = lastSyncedVersion
-                lastSyncedProfile = syncedProfile
-                persistProfileToKeychain(syncedProfile)
+
+                if let remoteProfile = result.remoteProfile {
+                    // A concurrently-updated device won the last-write
+                    // race; adopt its settings locally so both devices
+                    // converge instead of keeping our now-stale edit.
+                    applyProfile(remoteProfile)
+                    var adopted = remoteProfile
+                    adopted.version = lastSyncedVersion
+                    lastSyncedProfile = adopted
+                    persistProfileToKeychain(adopted)
+                } else {
+                    var syncedProfile = profile
+                    syncedProfile.version = lastSyncedVersion
+                    lastSyncedProfile = syncedProfile
+                    persistProfileToKeychain(syncedProfile)
+                }
                 clearLocalProfileChanged()
                 lastSyncDate = Date()
                 syncError = nil

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -129,8 +129,8 @@ class ProfileSyncService: ObservableObject {
     }
 
     /// Save profile to cloud through the enclave.
-    func saveProfile(_ profile: ProfileData) async throws -> (success: Bool, version: Int?) {
-        guard await isAuthenticated() else { return (false, nil) }
+    func saveProfile(_ profile: ProfileData) async throws -> (success: Bool, version: Int?, remoteProfile: ProfileData?) {
+        guard await isAuthenticated() else { return (false, nil, nil) }
         let keyB64 = try CEKEncoding.requirePrimaryKeyB64()
 
         // Push the local profile under a given base version. The
@@ -138,7 +138,9 @@ class ProfileSyncService: ObservableObject {
         // any positive version as a CAS update gated on the row's etag.
         func pushAtVersion(_ baseVersion: Int) async throws -> (success: Bool, version: Int?) {
             var profileWithMetadata = profile
-            profileWithMetadata.updatedAt = Self.iso8601Formatter.string(from: Date())
+            // Preserve the caller's edit time so other devices can
+            // arbitrate last-write-wins; only stamp now when absent.
+            profileWithMetadata.updatedAt = profile.updatedAt ?? Self.iso8601Formatter.string(from: Date())
             profileWithMetadata.version = baseVersion + 1
 
             let plaintext = try JSONEncoder().encode(profileWithMetadata)
@@ -166,15 +168,45 @@ class ProfileSyncService: ObservableObject {
         }
 
         do {
-            return try await pushAtVersion(profile.version ?? 0)
+            let result = try await pushAtVersion(profile.version ?? 0)
+            return (result.success, result.version, nil)
         } catch let error as SyncEnclaveError where Self.isStaleBlobConflict(error) {
-            // Optimistic-concurrency conflict: our base version is
-            // behind the server, or we tried to create a profile that
-            // already exists. Re-read the current version and retry once
-            // so local settings win instead of looping on STALE_BLOB.
+            // Optimistic-concurrency conflict: the server holds a
+            // version our push was not based on. Re-read it and
+            // arbitrate last-write-wins by content modification time.
             let remote = try await fetchProfile()
-            return try await pushAtVersion(remote?.version ?? 0)
+
+            if let remote = remote,
+               SyncConflictResolver.remoteWins(
+                   local: Self.parseISODate(profile.updatedAt),
+                   remote: Self.parseISODate(remote.updatedAt)
+               ) {
+                // The remote is the strictly newer write. Adopt it
+                // instead of clobbering, and hand it back so the caller
+                // can apply it locally; both devices then converge.
+                self.cachedProfile = remote
+                return (true, remote.version, remote)
+            }
+
+            // Our local edit is the last write. Rebase onto the
+            // server's current version and re-push so local wins
+            // instead of looping on STALE_BLOB forever.
+            let result = try await pushAtVersion(remote?.version ?? 0)
+            return (result.success, result.version, nil)
         }
+    }
+
+    /// Parse an ISO-8601 timestamp, tolerating values written with or
+    /// without fractional seconds so cross-device and cross-client
+    /// profiles compare correctly.
+    private static func parseISODate(_ string: String?) -> Date? {
+        guard let string = string else { return nil }
+        if let date = iso8601Formatter.date(from: string) {
+            return date
+        }
+        let fallback = ISO8601DateFormatter()
+        fallback.formatOptions = [.withInternetDateTime]
+        return fallback.date(from: string)
     }
 
     /// A STALE_BLOB (HTTP 412) push means our If-Match version no longer


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resolve sync conflicts with last-write-wins using content modification time for both chats and profiles. Prevents STALE_BLOB loops and ensures all devices converge on the same version.

- **Bug Fixes**
  - Introduced a shared last-write-wins `SyncConflictResolver` based on `updatedAt`.
  - Chats: on conflict, pull remote; if local is newer, rebase `syncVersion` and re-upload; otherwise overwrite local with remote.
  - Profiles: preserve local edit time; on conflict, compare timestamps and either adopt the newer remote or re-push local. Added `changed-at` tracking in `ProfileManager`.
  - ISO-8601 parsing now tolerates fractional seconds to compare timestamps reliably across devices.

<sup>Written for commit 5bc46003ed1938fa2be4b70cd585e1bf7d2cde19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

