### PR TITLE
Pin favorite prompts to the home screen

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -120,6 +120,13 @@ enum Constants {
         static let termsOfUseURL = URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/")!
     }
 
+    enum PromptLibrary {
+        /// Maximum number of prompt presets a user can pin as favorites.
+        static let maxFavorites = 3
+        /// Number of prompt suggestions shown on the welcome screen.
+        static let homeSuggestionCount = 3
+    }
+
     enum Pagination {
         static let chatsPerPage = 20
         static let projectsPerPage = 20

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -391,6 +391,9 @@ struct ProfileData: Codable {
     var isUsingCustomPrompt: Bool?
     var customSystemPrompt: String?
     var customPromptPresets: [SyncedPromptPreset]?
+    /// Ordered preset ids the user pinned as homescreen favorites.
+    /// Mixes `builtin:*` and `user:*` ids, shared with the webapp.
+    var favoritePromptPresetIds: [String]?
 
     // Shared chat defaults
     var selectedModel: String?

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -34,6 +34,9 @@ class ProfileManager: ObservableObject {
 
     // User-created prompt presets (synced through the shared profile row)
     @Published var customPromptPresets: [SyncedPromptPreset] = []
+
+    // Preset ids pinned as homescreen favorites (built-in or custom)
+    @Published var favoritePromptPresetIds: [String] = []
     
     // Sync state
     @Published var isSyncing: Bool = false
@@ -191,6 +194,7 @@ class ProfileManager: ObservableObject {
             isUsingCustomPrompt: isUsingCustomPrompt,
             customSystemPrompt: customSystemPrompt,
             customPromptPresets: customPromptPresets,
+            favoritePromptPresetIds: favoritePromptPresetIds,
             selectedModel: selectedModel,
             reasoningEffort: reasoningEffort,
             thinkingEnabled: thinkingEnabled,
@@ -241,6 +245,9 @@ class ProfileManager: ObservableObject {
         }
         if let customPromptPresets = profile.customPromptPresets {
             self.customPromptPresets = customPromptPresets
+        }
+        if let favoritePromptPresetIds = profile.favoritePromptPresetIds {
+            self.favoritePromptPresetIds = favoritePromptPresetIds
         }
         if let selectedModel = profile.selectedModel {
             UserDefaults.standard.set(selectedModel, forKey: Constants.StorageKeys.Settings.selectedModel)
@@ -376,6 +383,14 @@ class ProfileManager: ObservableObject {
                 self?.saveToKeychain()
             }
             .store(in: &cancellables)
+
+        $favoritePromptPresetIds
+            .dropFirst()
+            .sink { [weak self] _ in
+                guard !(self?.isApplyingProfile ?? false) else { return }
+                self?.saveToKeychain()
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Prompt Presets
@@ -426,6 +441,35 @@ class ProfileManager: ObservableObject {
     /// Delete a user preset.
     func deletePromptPreset(id: String) {
         customPromptPresets.removeAll { $0.id == id }
+        favoritePromptPresetIds.removeAll { $0 == id }
+    }
+
+    // MARK: - Favorites
+
+    /// Presets pinned as homescreen favorites, resolved in pinned order.
+    /// Ids that no longer resolve (e.g. a deleted custom preset synced from
+    /// another device) are skipped.
+    var favoritePromptPresets: [PromptPreset] {
+        favoritePromptPresetIds.compactMap { promptPreset(for: $0) }
+    }
+
+    func isFavoritePreset(_ id: String) -> Bool {
+        favoritePromptPresetIds.contains(id)
+    }
+
+    /// Whether another preset can still be pinned given the favorites cap.
+    var canAddFavorite: Bool {
+        favoritePromptPresetIds.count < Constants.PromptLibrary.maxFavorites
+    }
+
+    /// Toggle a preset's favorite status. Pinning is ignored once the cap is
+    /// reached; unpinning always works.
+    func toggleFavoritePreset(_ id: String) {
+        if let index = favoritePromptPresetIds.firstIndex(of: id) {
+            favoritePromptPresetIds.remove(at: index)
+        } else if canAddFavorite {
+            favoritePromptPresetIds.append(id)
+        }
     }
 
     /// Duplicate a built-in or user preset into a new editable user preset.
@@ -648,6 +692,7 @@ class ProfileManager: ObservableObject {
                p1.isUsingCustomPrompt != p2.isUsingCustomPrompt ||
                p1.customSystemPrompt != p2.customSystemPrompt ||
                p1.customPromptPresets != p2.customPromptPresets ||
+               p1.favoritePromptPresetIds != p2.favoritePromptPresetIds ||
                p1.selectedModel != p2.selectedModel ||
                p1.reasoningEffort != p2.reasoningEffort ||
                p1.thinkingEnabled != p2.thinkingEnabled ||
@@ -736,6 +781,7 @@ class ProfileManager: ObservableObject {
         isUsingCustomPrompt = false
         customSystemPrompt = ""
         customPromptPresets = []
+        favoritePromptPresetIds = []
         
         // Clear from keychain
         keychainHelper.delete(for: keychainKey, service: keychainService)

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -140,14 +140,18 @@ class ProfileManager: ObservableObject {
     }
 
     /// Edit time of the pending local profile change, used to arbitrate
-    /// last-write-wins against the remote. Falls back to now so a local
-    /// edit is never treated as older than the remote it is replacing.
-    private func localProfileChangedAt() -> String {
+    /// last-write-wins against the remote. Returns nil when the edit time
+    /// is unknown (e.g. a dirty flag left by an older build, or partially
+    /// cleared storage) so unknown-age local data cannot win the
+    /// arbitration and clobber a genuinely newer remote: conflict
+    /// resolution then defers to the remote, while a non-conflicting push
+    /// still stamps the current time.
+    private func localProfileChangedAt() -> String? {
         if let stored = UserDefaults.standard.string(forKey: profileChangedAtKey),
            ProfileManager.iso8601Formatter.date(from: stored) != nil {
             return stored
         }
-        return ProfileManager.iso8601Formatter.string(from: Date())
+        return nil
     }
 
     private static let iso8601Formatter: ISO8601DateFormatter = {

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -458,8 +458,18 @@ class ProfileManager: ObservableObject {
     }
 
     /// Whether another preset can still be pinned given the favorites cap.
+    /// Capacity is measured against favorites that actually resolve to a
+    /// preset, so stale ids (e.g. a custom preset deleted on another device,
+    /// or one not yet synced here) never count toward the cap and block
+    /// adding a valid favorite.
     var canAddFavorite: Bool {
-        favoritePromptPresetIds.count < Constants.PromptLibrary.maxFavorites
+        favoritePromptPresets.count < Constants.PromptLibrary.maxFavorites
+    }
+
+    /// Whether the favorite toggle for a preset should be enabled: already
+    /// pinned presets can always be unpinned, others only while under the cap.
+    func canToggleFavorite(_ id: String) -> Bool {
+        isFavoritePreset(id) || canAddFavorite
     }
 
     /// Toggle a preset's favorite status. Pinning is ignored once the cap is

--- a/TinfoilChat/Views/PromptLibraryView.swift
+++ b/TinfoilChat/Views/PromptLibraryView.swift
@@ -202,11 +202,12 @@ struct PromptLibraryView: View {
                 onRequestDelete: { presetPendingDelete = $0 }
             )
         } label: {
-            HStack(spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
                 Image(systemName: preset.iconName)
                     .font(.system(size: 16))
                     .foregroundColor(.secondary)
                     .frame(width: 24)
+                    .alignmentGuide(.top) { $0[.top] - 2 }
                 VStack(alignment: .leading, spacing: 2) {
                     Text(preset.name)
                         .font(.body)
@@ -282,25 +283,25 @@ struct PromptDetailView: View {
         let isActive = activePresetId == preset.id
         Form {
             Section {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 12) {
-                        Image(systemName: preset.iconName)
-                            .font(.system(size: 20))
-                            .foregroundColor(.secondary)
-                            .frame(width: 28, alignment: .center)
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: preset.iconName)
+                        .font(.system(size: 20))
+                        .foregroundColor(.secondary)
+                        .frame(width: 28, alignment: .center)
+                    VStack(alignment: .leading, spacing: 6) {
                         Text(preset.name)
                             .font(.headline)
-                        Spacer(minLength: 0)
-                    }
-                    if !preset.description.isEmpty {
-                        Text(preset.description)
-                            .font(.subheadline)
+                        if !preset.description.isEmpty {
+                            Text(preset.description)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Text(preset.isBuiltIn ? "Built-in" : "Custom")
+                            .font(.caption2)
                             .foregroundColor(.secondary)
+                            .textCase(.uppercase)
                     }
-                    Text(preset.isBuiltIn ? "Built-in" : "Custom")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .textCase(.uppercase)
+                    Spacer(minLength: 0)
                 }
 
                 if let viewModel {

--- a/TinfoilChat/Views/PromptLibraryView.swift
+++ b/TinfoilChat/Views/PromptLibraryView.swift
@@ -42,13 +42,18 @@ struct PromptSuggestionsBar: View {
         viewModel.currentChat?.promptPresetId
     }
 
-    /// User-pinned favorites when set, otherwise the first built-in presets.
+    /// User-pinned favorites, with any remaining slots filled by the default
+    /// built-in presets so the home screen always offers a full set.
     private var suggestions: [PromptPreset] {
-        let favorites = profileManager.favoritePromptPresets
-        if !favorites.isEmpty {
-            return favorites
+        let target = Constants.PromptLibrary.homeSuggestionCount
+        var result = profileManager.favoritePromptPresets
+        let pinnedIds = Set(result.map { $0.id })
+        for preset in PromptPreset.builtIns where result.count < target {
+            if !pinnedIds.contains(preset.id) {
+                result.append(preset)
+            }
         }
-        return Array(PromptPreset.builtIns.prefix(Constants.PromptLibrary.homeSuggestionCount))
+        return Array(result.prefix(target))
     }
 
     var body: some View {

--- a/TinfoilChat/Views/PromptLibraryView.swift
+++ b/TinfoilChat/Views/PromptLibraryView.swift
@@ -35,16 +35,24 @@ func ensureSystemTags(_ prompt: String) -> String {
 /// opens the full library.
 struct PromptSuggestionsBar: View {
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
+    @ObservedObject private var profileManager = ProfileManager.shared
     var onOpenLibrary: () -> Void
-
-    private static let suggestionCount = 3
 
     private var activePresetId: String? {
         viewModel.currentChat?.promptPresetId
     }
 
+    /// User-pinned favorites when set, otherwise the first built-in presets.
+    private var suggestions: [PromptPreset] {
+        let favorites = profileManager.favoritePromptPresets
+        if !favorites.isEmpty {
+            return favorites
+        }
+        return Array(PromptPreset.builtIns.prefix(Constants.PromptLibrary.homeSuggestionCount))
+    }
+
     var body: some View {
-        let suggested = Array(PromptPreset.builtIns.prefix(Self.suggestionCount))
+        let suggested = suggestions
         let columns = [
             GridItem(.flexible(), spacing: 8),
             GridItem(.flexible(), spacing: 8)
@@ -123,6 +131,8 @@ struct PromptLibraryView: View {
                 }
             } header: {
                 Text("Built-in")
+            } footer: {
+                Text("Pin up to \(Constants.PromptLibrary.maxFavorites) favorites to show them on the home screen.")
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
 
@@ -208,6 +218,12 @@ struct PromptLibraryView: View {
                     }
                 }
                 Spacer()
+                if profileManager.isFavoritePreset(preset.id) {
+                    Image(systemName: "star.fill")
+                        .font(.caption)
+                        .foregroundColor(.yellow)
+                        .accessibilityLabel("Favorite")
+                }
                 if activePresetId == preset.id {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.caption)
@@ -215,6 +231,19 @@ struct PromptLibraryView: View {
                         .accessibilityLabel("Active")
                 }
             }
+        }
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            let isFavorite = profileManager.isFavoritePreset(preset.id)
+            Button {
+                profileManager.toggleFavoritePreset(preset.id)
+            } label: {
+                Label(
+                    isFavorite ? "Unfavorite" : "Favorite",
+                    systemImage: isFavorite ? "star.slash" : "star"
+                )
+            }
+            .tint(.yellow)
+            .disabled(!isFavorite && !profileManager.canAddFavorite)
         }
     }
 }
@@ -308,6 +337,17 @@ struct PromptDetailView: View {
                         }
                     }
                 }
+
+                let isFavorite = profileManager.isFavoritePreset(preset.id)
+                Button {
+                    profileManager.toggleFavoritePreset(preset.id)
+                } label: {
+                    HStack {
+                        Image(systemName: isFavorite ? "star.slash" : "star")
+                        Text(isFavorite ? "Remove from Favorites" : "Add to Favorites")
+                    }
+                }
+                .disabled(!isFavorite && !profileManager.canAddFavorite)
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
 

--- a/TinfoilChat/Views/PromptLibraryView.swift
+++ b/TinfoilChat/Views/PromptLibraryView.swift
@@ -244,7 +244,7 @@ struct PromptLibraryView: View {
                 )
             }
             .tint(.yellow)
-            .disabled(!isFavorite && !profileManager.canAddFavorite)
+            .disabled(!profileManager.canToggleFavorite(preset.id))
         }
     }
 }
@@ -348,7 +348,7 @@ struct PromptDetailView: View {
                         Text(isFavorite ? "Remove from Favorites" : "Add to Favorites")
                     }
                 }
-                .disabled(!isFavorite && !profileManager.canAddFavorite)
+                .disabled(!profileManager.canToggleFavorite(preset.id))
             }
             .listRowBackground(Color.cardSurface(for: colorScheme))
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin up to 3 favorite prompt presets and show them on the home screen; favorites sync across devices and any empty slots are filled with built-ins.

- **New Features**
  - Home suggestions show up to 3 favorites first; remaining slots are filled with default built-ins.
  - Persist and sync `favoritePromptPresetIds` (ordered; supports `builtin:*`/`user:*`; ignores missing/stale ids; deleting a user preset auto-unpins it).
  - UI adds swipe to Favorite/Unfavorite, a star icon on favorites, and a detail view button; pinning is disabled at the cap; icons aligned with titles.

- **Bug Fixes**
  - Prevent stale local profile data from overwriting newer remote changes during sync.

<sup>Written for commit f21534039ab9037f9e52b558b9a7faf9d015b606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

