### PR TITLE
Stop cloud settings sync from getting stuck

### DIFF
--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -555,7 +555,10 @@ class ProfileManager: ObservableObject {
         do {
             if let cloudProfile = try await profileSync.fetchProfile() {
                 let cloudVersion = cloudProfile.version ?? 0
-                
+
+                // DEBUG[profile-sync]: remove before merge.
+                print("[profile-sync] syncFromCloud cloudVersion=\(cloudVersion) lastSyncedVersion=\(lastSyncedVersion) willApply=\(cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile)) diff=\(profileDiffFields(cloudProfile, lastSyncedProfile))")
+
                 // Apply if cloud is newer by version OR content differs from our last-synced snapshot
                 if cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile) {
                     applyProfile(cloudProfile)
@@ -608,7 +611,10 @@ class ProfileManager: ObservableObject {
         guard !isPushing else { return }
         
         let profile = createProfileData()
-        
+
+        // DEBUG[profile-sync]: remove before merge.
+        print("[profile-sync] syncToCloud decide dirty=\(hasPendingLocalProfileChanges) willPush=\(hasProfileChanged(profile, lastSyncedProfile)) diff=\(profileDiffFields(profile, lastSyncedProfile)) baseVersion=\(lastSyncedVersion) updatedAt=\(String(describing: profile.updatedAt))")
+
         // Only push if there is a real change vs last synced baseline.
         // When nothing diverges, clear the pending flag so a phantom
         // dirty marker can't permanently block pulls from the cloud.
@@ -650,6 +656,8 @@ class ProfileManager: ObservableObject {
                 // If local state changed during the sync, schedule another upload
                 let currentAfter = createProfileData()
                 if hasProfileChanged(currentAfter, lastSyncedProfile) {
+                    // DEBUG[profile-sync]: remove before merge.
+                    print("[profile-sync] syncToCloud re-arm diff=\(profileDiffFields(currentAfter, lastSyncedProfile))")
                     debounceCloudSync()
                 }
             }
@@ -705,6 +713,36 @@ class ProfileManager: ObservableObject {
         baseline.version = version
         persistProfileToKeychain(baseline)
         lastSyncedProfile = baseline
+    }
+
+    // DEBUG[profile-sync]: temporary diagnostic. Names the fields that
+    // differ between two profiles so we can see what keeps the profile
+    // "dirty". Remove before merging to main.
+    private func profileDiffFields(_ p1: ProfileData?, _ p2: ProfileData?) -> [String] {
+        guard let a = p1, let b = p2 else {
+            return (p1 == nil && p2 == nil) ? [] : ["<one-side-nil>"]
+        }
+        var fields: [String] = []
+        if a.isDarkMode != b.isDarkMode { fields.append("isDarkMode") }
+        if a.language != b.language { fields.append("language") }
+        if a.nickname != b.nickname { fields.append("nickname") }
+        if a.profession != b.profession { fields.append("profession") }
+        if a.traits != b.traits { fields.append("traits") }
+        if a.additionalContext != b.additionalContext { fields.append("additionalContext") }
+        if a.isUsingPersonalization != b.isUsingPersonalization { fields.append("isUsingPersonalization") }
+        if a.isUsingCustomPrompt != b.isUsingCustomPrompt { fields.append("isUsingCustomPrompt") }
+        if a.customSystemPrompt != b.customSystemPrompt { fields.append("customSystemPrompt") }
+        if a.customPromptPresets != b.customPromptPresets { fields.append("customPromptPresets") }
+        if a.favoritePromptPresetIds != b.favoritePromptPresetIds { fields.append("favoritePromptPresetIds") }
+        if a.selectedModel != b.selectedModel { fields.append("selectedModel") }
+        if a.reasoningEffort != b.reasoningEffort { fields.append("reasoningEffort") }
+        if a.thinkingEnabled != b.thinkingEnabled { fields.append("thinkingEnabled") }
+        if a.webSearchEnabled != b.webSearchEnabled { fields.append("webSearchEnabled") }
+        if a.codeExecutionEnabled != b.codeExecutionEnabled { fields.append("codeExecutionEnabled") }
+        if a.piiCheckEnabled != b.piiCheckEnabled { fields.append("piiCheckEnabled") }
+        if a.chatFont != b.chatFont { fields.append("chatFont") }
+        if a.projectUploadPreference != b.projectUploadPreference { fields.append("projectUploadPreference") }
+        return fields
     }
 
     /// Check if two profiles are different (excluding metadata)

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -558,9 +558,6 @@ class ProfileManager: ObservableObject {
             if let cloudProfile = try await profileSync.fetchProfile() {
                 let cloudVersion = cloudProfile.version ?? 0
 
-                // DEBUG[profile-sync]: remove before merge.
-                print("[profile-sync] syncFromCloud cloudVersion=\(cloudVersion) lastSyncedVersion=\(lastSyncedVersion) hasPendingEdit=\(hasPendingEdit) willApply=\(!hasPendingEdit && (cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile))) diff=\(profileDiffFields(cloudProfile, lastSyncedProfile))")
-
                 if hasPendingEdit {
                     // Record the server version so the pending push rebases
                     // onto it as a CAS update instead of a create; the
@@ -621,9 +618,6 @@ class ProfileManager: ObservableObject {
         
         let profile = createProfileData()
 
-        // DEBUG[profile-sync]: remove before merge.
-        print("[profile-sync] syncToCloud decide dirty=\(hasPendingLocalProfileChanges) willPush=\(hasProfileChanged(profile, lastSyncedProfile)) diff=\(profileDiffFields(profile, lastSyncedProfile)) baseVersion=\(lastSyncedVersion) updatedAt=\(String(describing: profile.updatedAt))")
-
         // Only push if there is a real change vs last synced baseline.
         // When nothing diverges, clear the pending flag so a phantom
         // dirty marker can't permanently block pulls from the cloud.
@@ -665,8 +659,6 @@ class ProfileManager: ObservableObject {
                 // If local state changed during the sync, schedule another upload
                 let currentAfter = createProfileData()
                 if hasProfileChanged(currentAfter, lastSyncedProfile) {
-                    // DEBUG[profile-sync]: remove before merge.
-                    print("[profile-sync] syncToCloud re-arm diff=\(profileDiffFields(currentAfter, lastSyncedProfile))")
                     debounceCloudSync()
                 }
             }
@@ -722,36 +714,6 @@ class ProfileManager: ObservableObject {
         baseline.version = version
         persistProfileToKeychain(baseline)
         lastSyncedProfile = baseline
-    }
-
-    // DEBUG[profile-sync]: temporary diagnostic. Names the fields that
-    // differ between two profiles so we can see what keeps the profile
-    // "dirty". Remove before merging to main.
-    private func profileDiffFields(_ p1: ProfileData?, _ p2: ProfileData?) -> [String] {
-        guard let a = p1, let b = p2 else {
-            return (p1 == nil && p2 == nil) ? [] : ["<one-side-nil>"]
-        }
-        var fields: [String] = []
-        if a.isDarkMode != b.isDarkMode { fields.append("isDarkMode") }
-        if a.language != b.language { fields.append("language") }
-        if a.nickname != b.nickname { fields.append("nickname") }
-        if a.profession != b.profession { fields.append("profession") }
-        if a.traits != b.traits { fields.append("traits") }
-        if a.additionalContext != b.additionalContext { fields.append("additionalContext") }
-        if a.isUsingPersonalization != b.isUsingPersonalization { fields.append("isUsingPersonalization") }
-        if a.isUsingCustomPrompt != b.isUsingCustomPrompt { fields.append("isUsingCustomPrompt") }
-        if a.customSystemPrompt != b.customSystemPrompt { fields.append("customSystemPrompt") }
-        if a.customPromptPresets != b.customPromptPresets { fields.append("customPromptPresets") }
-        if a.favoritePromptPresetIds != b.favoritePromptPresetIds { fields.append("favoritePromptPresetIds") }
-        if a.selectedModel != b.selectedModel { fields.append("selectedModel") }
-        if a.reasoningEffort != b.reasoningEffort { fields.append("reasoningEffort") }
-        if a.thinkingEnabled != b.thinkingEnabled { fields.append("thinkingEnabled") }
-        if a.webSearchEnabled != b.webSearchEnabled { fields.append("webSearchEnabled") }
-        if a.codeExecutionEnabled != b.codeExecutionEnabled { fields.append("codeExecutionEnabled") }
-        if a.piiCheckEnabled != b.piiCheckEnabled { fields.append("piiCheckEnabled") }
-        if a.chatFont != b.chatFont { fields.append("chatFont") }
-        if a.projectUploadPreference != b.projectUploadPreference { fields.append("projectUploadPreference") }
-        return fields
     }
 
     /// Check if two profiles are different (excluding metadata)

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -559,12 +559,21 @@ class ProfileManager: ObservableObject {
                 // Apply if cloud is newer by version OR content differs from our last-synced snapshot
                 if cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile) {
                     applyProfile(cloudProfile)
-                    
+
+                    // Use the round-tripped local snapshot as the baseline
+                    // rather than the raw remote: the remote may omit fields
+                    // this client always emits (e.g. defaulted reasoning or
+                    // thinking values), which would otherwise read back as a
+                    // phantom local change and wedge sync behind a
+                    // never-clearing dirty flag while looping STALE_BLOB pushes.
+                    var syncedProfile = createProfileData()
+                    syncedProfile.version = cloudVersion
+
                     // Save to keychain without triggering local change observers
-                    persistProfileToKeychain(cloudProfile)
+                    persistProfileToKeychain(syncedProfile)
                     
                     lastSyncedVersion = cloudVersion
-                    lastSyncedProfile = cloudProfile
+                    lastSyncedProfile = syncedProfile
                     clearLocalProfileChanged()
                     lastSyncDate = Date()
                     syncError = nil
@@ -632,7 +641,10 @@ class ProfileManager: ObservableObject {
                     // race; adopt its settings locally so both devices
                     // converge instead of keeping our now-stale edit.
                     applyProfile(remoteProfile)
-                    var adopted = remoteProfile
+                    // Baseline mirrors what we would re-serialize, not the
+                    // raw remote, so fields we emit but the peer omits don't
+                    // read back as a phantom change and re-arm the push loop.
+                    var adopted = createProfileData()
                     adopted.version = lastSyncedVersion
                     lastSyncedProfile = adopted
                     persistProfileToKeychain(adopted)
@@ -675,11 +687,16 @@ class ProfileManager: ObservableObject {
         do {
             if let decryptedProfile = try await profileSync.retryDecryptionWithNewKey() {
                 applyProfile(decryptedProfile)
-                persistProfileToKeychain(decryptedProfile)
                 if let version = decryptedProfile.version {
                     lastSyncedVersion = version
                 }
-                lastSyncedProfile = decryptedProfile
+                // Baseline mirrors what we would re-serialize, not the raw
+                // remote, so peer-omitted fields don't read back as a
+                // phantom local change after decryption recovery.
+                var syncedProfile = createProfileData()
+                syncedProfile.version = lastSyncedVersion
+                persistProfileToKeychain(syncedProfile)
+                lastSyncedProfile = syncedProfile
                 clearLocalProfileChanged()
                 syncError = nil
             }

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -543,12 +543,14 @@ class ProfileManager: ObservableObject {
             return
         }
 
-        guard !hasPendingLocalProfileChanges else {
-            return
-        }
-
         // Prevent overlapping pulls
         guard !isPulling else { return }
+        // A pending local edit must not be overwritten by the remote, but
+        // we still pull so we can learn the server's current version.
+        // Otherwise a client left "dirty" never establishes a base version
+        // and keeps trying to create the profile at version zero, which
+        // loops forever on STALE_BLOB and blocks all future pulls.
+        let hasPendingEdit = hasPendingLocalProfileChanges
         isPulling = true
         updateSyncingState()
         
@@ -557,10 +559,17 @@ class ProfileManager: ObservableObject {
                 let cloudVersion = cloudProfile.version ?? 0
 
                 // DEBUG[profile-sync]: remove before merge.
-                print("[profile-sync] syncFromCloud cloudVersion=\(cloudVersion) lastSyncedVersion=\(lastSyncedVersion) willApply=\(cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile)) diff=\(profileDiffFields(cloudProfile, lastSyncedProfile))")
+                print("[profile-sync] syncFromCloud cloudVersion=\(cloudVersion) lastSyncedVersion=\(lastSyncedVersion) hasPendingEdit=\(hasPendingEdit) willApply=\(!hasPendingEdit && (cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile))) diff=\(profileDiffFields(cloudProfile, lastSyncedProfile))")
 
-                // Apply if cloud is newer by version OR content differs from our last-synced snapshot
-                if cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile) {
+                if hasPendingEdit {
+                    // Record the server version so the pending push rebases
+                    // onto it as a CAS update instead of a create; the
+                    // last-write-wins arbitration on push decides the winner.
+                    if cloudVersion > lastSyncedVersion {
+                        lastSyncedVersion = cloudVersion
+                    }
+                } else if cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile) {
+                    // Apply if cloud is newer by version OR content differs from our last-synced snapshot
                     applyProfile(cloudProfile)
 
                     // Use the round-tripped local snapshot as the baseline

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -566,14 +566,9 @@ class ProfileManager: ObservableObject {
                     // thinking values), which would otherwise read back as a
                     // phantom local change and wedge sync behind a
                     // never-clearing dirty flag while looping STALE_BLOB pushes.
-                    var syncedProfile = createProfileData()
-                    syncedProfile.version = cloudVersion
+                    commitSyncedBaseline(createProfileData(), version: cloudVersion)
 
-                    // Save to keychain without triggering local change observers
-                    persistProfileToKeychain(syncedProfile)
-                    
                     lastSyncedVersion = cloudVersion
-                    lastSyncedProfile = syncedProfile
                     clearLocalProfileChanged()
                     lastSyncDate = Date()
                     syncError = nil
@@ -644,15 +639,9 @@ class ProfileManager: ObservableObject {
                     // Baseline mirrors what we would re-serialize, not the
                     // raw remote, so fields we emit but the peer omits don't
                     // read back as a phantom change and re-arm the push loop.
-                    var adopted = createProfileData()
-                    adopted.version = lastSyncedVersion
-                    lastSyncedProfile = adopted
-                    persistProfileToKeychain(adopted)
+                    commitSyncedBaseline(createProfileData(), version: lastSyncedVersion)
                 } else {
-                    var syncedProfile = profile
-                    syncedProfile.version = lastSyncedVersion
-                    lastSyncedProfile = syncedProfile
-                    persistProfileToKeychain(syncedProfile)
+                    commitSyncedBaseline(profile, version: lastSyncedVersion)
                 }
                 clearLocalProfileChanged()
                 lastSyncDate = Date()
@@ -693,10 +682,7 @@ class ProfileManager: ObservableObject {
                 // Baseline mirrors what we would re-serialize, not the raw
                 // remote, so peer-omitted fields don't read back as a
                 // phantom local change after decryption recovery.
-                var syncedProfile = createProfileData()
-                syncedProfile.version = lastSyncedVersion
-                persistProfileToKeychain(syncedProfile)
-                lastSyncedProfile = syncedProfile
+                commitSyncedBaseline(createProfileData(), version: lastSyncedVersion)
                 clearLocalProfileChanged()
                 syncError = nil
             }
@@ -706,7 +692,21 @@ class ProfileManager: ObservableObject {
     }
     
     // MARK: - Helpers
-    
+
+    /// Record `snapshot` as the synced baseline at `version`: stamp the
+    /// version, persist it to the keychain (without triggering local
+    /// change observers), and set it as the in-memory baseline. Callers
+    /// pass the round-tripped local snapshot (createProfileData()) rather
+    /// than the raw remote so fields this client always emits but a peer
+    /// omits never read back as a phantom local change that would wedge
+    /// sync behind a never-clearing dirty flag.
+    private func commitSyncedBaseline(_ snapshot: ProfileData, version: Int) {
+        var baseline = snapshot
+        baseline.version = version
+        persistProfileToKeychain(baseline)
+        lastSyncedProfile = baseline
+    }
+
     /// Check if two profiles are different (excluding metadata)
     private func hasProfileChanged(_ profile1: ProfileData?, _ profile2: ProfileData?) -> Bool {
         guard let p1 = profile1, let p2 = profile2 else {

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -197,6 +197,8 @@ class ProfileSyncService: ObservableObject {
         }
 
         do {
+            // DEBUG[profile-sync]: remove before merge.
+            print("[profile-sync] saveProfile push baseVersion=\(profile.version ?? 0) updatedAt=\(String(describing: profile.updatedAt))")
             let result = try await pushAtVersion(profile.version ?? 0)
             return (result.success, result.version, nil)
         } catch let error as SyncEnclaveError where Self.isStaleBlobConflict(error) {
@@ -204,6 +206,13 @@ class ProfileSyncService: ObservableObject {
             // version our push was not based on. Re-read it and
             // arbitrate last-write-wins by content modification time.
             let remote = try await fetchProfile()
+
+            // DEBUG[profile-sync]: remove before merge.
+            let remoteWon = remote != nil && SyncConflictResolver.remoteWins(
+                local: Self.parseISODate(profile.updatedAt),
+                remote: Self.parseISODate(remote?.updatedAt)
+            )
+            print("[profile-sync] saveProfile conflict (STALE_BLOB) localUpdatedAt=\(String(describing: profile.updatedAt)) remoteUpdatedAt=\(String(describing: remote?.updatedAt)) remoteVersion=\(String(describing: remote?.version)) remoteWins=\(remoteWon)")
 
             if let remote = remote,
                SyncConflictResolver.remoteWins(

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -197,8 +197,6 @@ class ProfileSyncService: ObservableObject {
         }
 
         do {
-            // DEBUG[profile-sync]: remove before merge.
-            print("[profile-sync] saveProfile push baseVersion=\(profile.version ?? 0) updatedAt=\(String(describing: profile.updatedAt))")
             let result = try await pushAtVersion(profile.version ?? 0)
             return (result.success, result.version, nil)
         } catch let error as SyncEnclaveError where Self.isStaleBlobConflict(error) {
@@ -206,13 +204,6 @@ class ProfileSyncService: ObservableObject {
             // version our push was not based on. Re-read it and
             // arbitrate last-write-wins by content modification time.
             let remote = try await fetchProfile()
-
-            // DEBUG[profile-sync]: remove before merge.
-            let remoteWon = remote != nil && SyncConflictResolver.remoteWins(
-                local: Self.parseISODate(profile.updatedAt),
-                remote: Self.parseISODate(remote?.updatedAt)
-            )
-            print("[profile-sync] saveProfile conflict (STALE_BLOB) localUpdatedAt=\(String(describing: profile.updatedAt)) remoteUpdatedAt=\(String(describing: remote?.updatedAt)) remoteVersion=\(String(describing: remote?.version)) remoteWins=\(remoteWon)")
 
             if let remote = remote,
                SyncConflictResolver.remoteWins(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops cloud settings sync from getting stuck by recording the synced baseline from a locally re-serialized profile instead of the raw remote. Also keeps sync from stalling when there are local edits by pulling to learn the server version and rebasing pending pushes.

- **Bug Fixes**
  - After pull, conflict adoption, and decryption recovery, record the baseline via `commitSyncedBaseline(createProfileData(), version: ...)` to clear the dirty flag and stop STALE_BLOB loops.
  - When local edits are pending, still pull and update `lastSyncedVersion` so the next push uses CAS instead of a create.
  - Removed temporary profile sync diagnostics.

<sup>Written for commit 7e7d9ebf8c7fa1cfcc5131c2bd324b2de9f677a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

