### PR TITLE
Fix user message bubble clipping

### DIFF
--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "01b51875a5406eefc95f52a058cb059e7bc94dc4",
-        "version" : "0.5.0"
+        "revision" : "e765ae4da8c501e06c34d6059321d5e80e1759a3",
+        "version" : "0.0.8"
       }
     },
     {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -760,7 +760,7 @@ struct ObservableMessageCell: View {
 /// time per cell instead of once per `LaTeXMarkdownView` / `SegmentView`
 /// inside the cell, which is what was driving the long `compareLists` /
 /// `EnvironmentBox.update` hangs in production.
-private struct MarkdownStyleHost: ViewModifier {
+struct MarkdownStyleHost: ViewModifier {
     let isDarkMode: Bool
 
     func body(content: Content) -> some View {
@@ -771,7 +771,7 @@ private struct MarkdownStyleHost: ViewModifier {
 }
 
 extension View {
-    fileprivate func markdownStyleHost(isDarkMode: Bool) -> some View {
+    func markdownStyleHost(isDarkMode: Bool) -> some View {
         modifier(MarkdownStyleHost(isDarkMode: isDarkMode))
     }
 }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1262,6 +1262,17 @@ struct MarkdownText: View {
     }
 }
 
+/// Paragraph style for user message bubbles. Matches the GitHub look but drops
+/// the outer block spacing so the bubble hugs its text instead of relying on a
+/// negative bottom padding to trim the trailing gap.
+private struct UserBubbleParagraphStyle: StructuredText.ParagraphStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .textual.lineSpacing(.fontScaled(0.25))
+            .textual.blockSpacing(.init(top: 0, bottom: 0))
+    }
+}
+
 /// A specialized markdown text view for user messages
 struct AdaptiveMarkdownText: View {
     let content: String
@@ -1277,8 +1288,8 @@ struct AdaptiveMarkdownText: View {
     var body: some View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
+            .textual.paragraphStyle(UserBubbleParagraphStyle())
             .fixedSize(horizontal: false, vertical: true)
-            .padding(.bottom, -16)
             .padding(.horizontal, horizontalPadding)
     }
 }

--- a/TinfoilChat/Views/OptimizedChatListView.swift
+++ b/TinfoilChat/Views/OptimizedChatListView.swift
@@ -327,6 +327,7 @@ struct UIKitScrollView: UIViewRepresentable {
                                 isLoading: false,
                                 messageIndex: actualIndex
                             )
+                            .markdownStyleHost(isDarkMode: isDarkMode)
                             .id(message.id)
                             .if(isAIMessage && actualIndex == messages.count - 1) { view in
                                 view.onAppear {
@@ -465,6 +466,7 @@ struct StreamingMessageContainer: View {
                 isLoading: isLoading,
                 messageIndex: messageIndex
             )
+            .markdownStyleHost(isDarkMode: isDarkMode)
             .background(
                 GeometryReader { geometry in
                     Color.clear


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes clipped user message bubbles by replacing the bottom-padding hack with a custom paragraph style and applying markdown styling across chat cells.

- **Bug Fixes**
  - Added `UserBubbleParagraphStyle` to control line and block spacing for user messages; removed `padding(.bottom, -16)`.
  - Exposed `MarkdownStyleHost` and applied `.markdownStyleHost(isDarkMode:)` to message and streaming cells to ensure consistent markdown styling.

- **Dependencies**
  - Updated `textual` to `0.0.8` (fork) to use the paragraph styling API.

<sup>Written for commit 6426cbd0d504a8da101ac54ecf4516285d8473ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

