### PR TITLE
Keep editing a chat from dropping its unsynced changes

### DIFF
--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1848,8 +1848,21 @@ class CloudSyncService: ObservableObject {
             // pre-upload client ids.
             try await applyAttachmentRewrites(chatId: chat.id, rewrites: result.rewrites)
         }
-        await markChatAsSynced(chat.id, version: newVersion)
-        SyncHealthStore.shared.reportChatSynced(chat.id)
+        // Guard against clobbering an edit made while this upload was in
+        // flight. We uploaded the snapshot captured before the request;
+        // if the on-disk copy has advanced past it, the freshest content
+        // was never sent. Clearing locallyModified here would mark that
+        // edit synced and it would never upload. Adopt the new etag as
+        // the CAS base but keep the dirty flag set so the next cycle
+        // re-uploads the newer content.
+        let current = await loadChatFromStorage(chat.id)
+        let editedDuringUpload = current.map { $0.updatedAt > chat.updatedAt } ?? false
+        if editedDuringUpload {
+            await rebaseSyncVersion(chat.id, version: newVersion)
+        } else {
+            await markChatAsSynced(chat.id, version: newVersion)
+            SyncHealthStore.shared.reportChatSynced(chat.id)
+        }
     }
 
     /// Apply enclave-minted attachment ids/keys to the freshest local


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a data-loss bug where edits made during an in-flight chat upload could be marked as synced and never re-uploaded. After upload, if the local chat changed, we adopt the new server version but keep the dirty flag so the latest content uploads in the next sync.

<sup>Written for commit db2c9ae177da183bd5fc1a88114715f5d9037b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

