### PR TITLE
Fix Swift strict concurrency build errors

### DIFF
--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -1377,9 +1377,9 @@ class SessionTokenManager {
         Task { [weak self] in
             guard let self else { return }
             _ = await self.fetchFreshSessionToken()
-            self.stateLock.lock()
-            self.backgroundRefreshInFlight = false
-            self.stateLock.unlock()
+            self.stateLock.withLock {
+                self.backgroundRefreshInFlight = false
+            }
         }
     }
 

--- a/TinfoilChat/Services/SyncEnclave/LegacyChatEviction.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyChatEviction.swift
@@ -54,8 +54,8 @@ enum LegacyChatEviction {
                 _ = try await storage.deleteChatIfEvictable(
                     chatId: entry.id,
                     userId: userId,
-                    shouldEvict: shouldEvict,
-                    shouldEvictOnLoadError: isPermanentlyUnreadable
+                    shouldEvict: { shouldEvict($0) },
+                    shouldEvictOnLoadError: { isPermanentlyUnreadable($0) }
                 )
             } catch {
                 allDeletesSucceeded = false

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -25,6 +25,12 @@ struct TinfoilChatApp: App {
         StorageKeysMigration.migrateIfNeeded()
         Clerk.configure(publishableKey: AppConfig.shared.clerkPublishableKey)
         _clerk = State(initialValue: Clerk.shared)
+        // Build the profile manager before any view can read it. Its
+        // initializer applies the stored profile, which writes shared
+        // settings on other observable singletons; doing that lazily
+        // from a view's property initializer would publish those
+        // changes mid view update.
+        _ = ProfileManager.shared
     }
     
     var body: some Scene {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2114,7 +2114,7 @@ class ChatViewModel: ObservableObject {
                     if let deltas = chunk.choices.first?.delta.toolCalls {
                         thinkingClosedByContent = false
                         for delta in deltas {
-                            let index = delta.index ?? 0
+                            let index = delta.index
                             let existing = streamingToolCalls[index]
                             let mergedId = delta.id ?? existing?.id ?? ""
                             let mergedName = delta.function?.name ?? existing?.name ?? ""

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -123,10 +123,10 @@ struct LaTeXMarkdownView: View, Equatable {
     @State private var segments: [ContentSegment]? = nil
 
     // Pre-compiled regex patterns (compiled once, reused across all renders)
-    private static let codeBlockRegex = try? NSRegularExpression(pattern: "```[\\s\\S]*?```", options: [])
-    private static let inlineCodeRegex = try? NSRegularExpression(pattern: "`[^`]+`", options: [])
-    private static let displayLatexRegex = try? NSRegularExpression(pattern: "\\\\\\[(.+?)\\\\\\]", options: [.dotMatchesLineSeparators])
-    private static let inlineLatexRegex = try? NSRegularExpression(pattern: "\\\\\\((.+?)\\\\\\)", options: [])
+    private nonisolated static let codeBlockRegex = try? NSRegularExpression(pattern: "```[\\s\\S]*?```", options: [])
+    private nonisolated static let inlineCodeRegex = try? NSRegularExpression(pattern: "`[^`]+`", options: [])
+    private nonisolated static let displayLatexRegex = try? NSRegularExpression(pattern: "\\\\\\[(.+?)\\\\\\]", options: [.dotMatchesLineSeparators])
+    private nonisolated static let inlineLatexRegex = try? NSRegularExpression(pattern: "\\\\\\((.+?)\\\\\\)", options: [])
     static func == (lhs: LaTeXMarkdownView, rhs: LaTeXMarkdownView) -> Bool {
         lhs.content == rhs.content &&
         lhs.isDarkMode == rhs.isDarkMode &&


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Initialize the profile manager at app startup to prevent it from publishing changes during view updates. Resolve strict Swift concurrency build errors by marking regex statics as nonisolated, using `withLock` on state locks, and passing closures to eviction helpers.

<sup>Written for commit db69b87b2a12bf4a038497bba2030361b76e6506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

