### PR TITLE
Fix chat scroll and prompt suggestions

### DIFF
--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -16,6 +16,7 @@ struct ChatListView: View {
 
     @State private var isAtBottom = true
     @State private var userHasScrolled = false
+    @State private var isInputExpanded = false
     @State private var showPromptLibrary = false
     @State private var isKeyboardVisible = false
     @State private var keyboardHeight: CGFloat = 0
@@ -90,15 +91,17 @@ struct ChatListView: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
-                if messages.isEmpty {
+                if messages.isEmpty && !isInputExpanded {
                     PromptSuggestionsBar(
                         viewModel: viewModel,
                         onOpenLibrary: { showPromptLibrary = true }
                     )
+                    .transition(.opacity)
                 }
                 MessageInputView(
                     messageText: $messageText,
                     viewModel: viewModel,
+                    isInputExpanded: $isInputExpanded,
                     isKeyboardVisible: isKeyboardVisible
                 )
                 .environmentObject(viewModel.authManager ?? AuthManager())

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -18,6 +18,9 @@ struct MessageInputView: View {
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject private var authManager: AuthManager
     @State private var textHeight: CGFloat = Layout.defaultHeight
+    /// Reflects whether the editor has grown beyond a single line, so callers
+    /// can hide content that would otherwise be pushed off-screen.
+    var isInputExpanded: Binding<Bool>? = nil
     var isKeyboardVisible: Bool = false
 
     private var isDarkMode: Bool { colorScheme == .dark }
@@ -68,6 +71,15 @@ struct MessageInputView: View {
     @ViewBuilder
     var body: some View {
         inputContent
+            .onChange(of: textHeight) { _, newHeight in
+                guard let isInputExpanded else { return }
+                let expanded = newHeight > Layout.minimumHeight + 1
+                if isInputExpanded.wrappedValue != expanded {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isInputExpanded.wrappedValue = expanded
+                    }
+                }
+            }
             .alert("Microphone Access Required", isPresented: $viewModel.showMicrophonePermissionAlert) {
                 Button("Open Settings") {
                     openSettings()

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -200,13 +200,34 @@ struct MessageTableView: UIViewRepresentable {
                 }
             }
 
+            // Capture the user's intent before any layout change. If they were
+            // actively scrolling through the response, keep their reading
+            // position; otherwise follow down to the end of the finished message.
+            let wasFollowing = !userHasScrolled
+
             DispatchQueue.main.async {
                 UIView.performWithoutAnimation {
-                    context.coordinator.isUserMessageScrollMode = false
+                    // Temporarily inflate the bottom inset so the collapsing
+                    // streaming buffer cannot clamp the offset and snap the view
+                    // to the bottom before the final inset is settled below.
                     let currentOffset = tableView.contentOffset.y
-                    context.coordinator.updateContentInset()
+                    tableView.contentInset.bottom = tableView.bounds.height
                     tableView.layoutIfNeeded()
                     tableView.contentOffset.y = currentOffset
+                }
+
+                DispatchQueue.main.async {
+                    if wasFollowing {
+                        context.coordinator.isUserMessageScrollMode = false
+                        context.coordinator.scrollToBottom(animated: false)
+                    } else {
+                        UIView.performWithoutAnimation {
+                            let currentOffset = tableView.contentOffset.y
+                            context.coordinator.updateContentInset()
+                            tableView.layoutIfNeeded()
+                            tableView.contentOffset.y = currentOffset
+                        }
+                    }
                 }
             }
         }
@@ -466,6 +487,11 @@ struct MessageTableView: UIViewRepresentable {
                 }
             } else if parent.isLoading && isUserMessageScrollMode {
                 targetInset = insetForUserMessageAtTop(tableView)
+            } else if isUserMessageScrollMode {
+                // Streaming has ended but the user is still reading with their
+                // message near the top; keep enough bottom inset to hold that
+                // position instead of snapping to the bottom of the response.
+                targetInset = max(0, insetForUserMessageAtTop(tableView))
             } else {
                 targetInset = 0
             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scroll snapping when a response finishes and hides prompt suggestions when the composer expands. Users keep their reading position if they were scrolling; otherwise the view follows to the end.

- **Bug Fixes**
  - Preserve scroll position at end of streaming if the user was reading; otherwise auto-scroll to bottom.
  - Prevent snap-to-bottom by temporarily inflating bottom inset and then settling correct insets.

- **New Features**
  - Hide prompt suggestions when the input grows beyond one line, with a fade transition; only show when the thread is empty and the input is not expanded.
  - Added `isInputExpanded` binding to `MessageInputView` and wired it to `ChatListView` to control suggestions visibility.

<sup>Written for commit 5a7bb6992213a4c5b659857f74a0f93090b082bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

