### PR TITLE
feat: announce chat status and add message navigation for VoiceOver

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -45,6 +45,22 @@ enum Constants {
         static let iPadInputBottomPadding: CGFloat = 16
     }
 
+    enum Accessibility {
+        /// VoiceOver status announcements posted as generation state changes,
+        /// giving non-visual users a live cue equivalent to the web app's
+        /// aria-live region.
+        static let generatingResponse = "Generating response"
+        static let responseComplete = "Response complete"
+        static let generationStopped = "Generation stopped"
+        static let responseFailed = "Response failed"
+
+        /// Name of the VoiceOver custom rotor used to jump between messages
+        /// in the conversation pane.
+        static let messagesRotorName = "Messages"
+
+        static let scrollToLatestMessage = "Scroll to latest message"
+    }
+
     enum Rendering {
         /// Code blocks larger than this skip JS-based syntax highlighting
         /// to avoid blocking the main thread via JavaScriptCore.

--- a/TinfoilChat/Utilities/AccessibilityAnnouncer.swift
+++ b/TinfoilChat/Utilities/AccessibilityAnnouncer.swift
@@ -1,0 +1,27 @@
+//
+//  AccessibilityAnnouncer.swift
+//  TinfoilChat
+//
+//  VoiceOver status announcements (live-region equivalent)
+//
+
+import UIKit
+
+/// Posts VoiceOver announcements for transient status changes that have no
+/// persistent on-screen control to focus, such as a response starting,
+/// finishing, or being stopped. This mirrors the web app's aria-live region.
+enum AccessibilityAnnouncer {
+    /// Speaks `message` through VoiceOver. No-ops when VoiceOver is not
+    /// running so non-assistive-tech users are unaffected.
+    static func announce(_ message: String) {
+        guard UIAccessibility.isVoiceOverRunning else { return }
+
+        // High priority keeps the status cue from being dropped while
+        // VoiceOver is mid-utterance reading streamed content.
+        let announcement = NSAttributedString(
+            string: message,
+            attributes: [.accessibilitySpeechAnnouncementPriority: UIAccessibilityPriority.high]
+        )
+        UIAccessibility.post(notification: .announcement, argument: announcement)
+    }
+}

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1619,6 +1619,7 @@ class ChatViewModel: ObservableObject {
 
         // Update UI state
         isLoading = true
+        AccessibilityAnnouncer.announce(Constants.Accessibility.generatingResponse)
 
         // Create initial empty assistant message as a placeholder
         let assistantMessage = Message(role: .assistant, content: "", isCollapsed: true)
@@ -2570,6 +2571,8 @@ class ChatViewModel: ObservableObject {
                     // the first assistant response to appear truncated.
                     self.updateChat(chat)
                     self.isLoading = false
+                    AccessibilityAnnouncer.announce(Constants.Accessibility.responseComplete)
+                    HapticFeedback.trigger(.success)
 
                     return chat
                 }
@@ -2624,6 +2627,8 @@ class ChatViewModel: ObservableObject {
                 // Handle error
                 await MainActor.run {
                     self.isLoading = false
+                    AccessibilityAnnouncer.announce(Constants.Accessibility.responseFailed)
+                    HapticFeedback.trigger(.error)
                     self.thinkingSummary = ""
                     self.webSearchSummary = ""
 
@@ -2850,6 +2855,7 @@ class ChatViewModel: ObservableObject {
         currentTask?.cancel()
         currentTask = nil
         isLoading = false
+        AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
         thinkingSummary = ""
         webSearchSummary = ""
 

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -70,6 +70,7 @@ struct ChatListView: View {
                         }
                         .buttonStyle(.glass)
                         .clipShape(Circle())
+                        .accessibilityLabel(Constants.Accessibility.scrollToLatestMessage)
                     } else {
                         Button(action: {
                             userHasScrolled = false
@@ -83,6 +84,7 @@ struct ChatListView: View {
                                 .background(Color.gray.opacity(0.8))
                                 .clipShape(Circle())
                         }
+                        .accessibilityLabel(Constants.Accessibility.scrollToLatestMessage)
                     }
                 }
                 .padding(.bottom, 16)

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -45,6 +45,7 @@ struct MessageTableView: UIViewRepresentable {
         }
 
         context.coordinator.tableView = tableView
+        tableView.accessibilityCustomRotors = [context.coordinator.makeMessagesRotor()]
 
         return tableView
     }
@@ -571,6 +572,47 @@ struct MessageTableView: UIViewRepresentable {
 
             let userMessageIndexPath = IndexPath(row: numberOfRows - 2, section: 0)
             tableView.scrollToRow(at: userMessageIndexPath, at: .top, animated: animated)
+        }
+
+        /// VoiceOver rotor that lets users flick up/down to jump between
+        /// whole messages instead of stepping element-by-element from the top.
+        func makeMessagesRotor() -> UIAccessibilityCustomRotor {
+            UIAccessibilityCustomRotor(name: Constants.Accessibility.messagesRotorName) { [weak self] predicate in
+                guard let self = self, let tableView = self.tableView else { return nil }
+                let rowCount = tableView.numberOfRows(inSection: 0)
+                guard rowCount > 0, !self.parent.messages.isEmpty else { return nil }
+
+                let forward = predicate.searchDirection == .next
+                let targetRow: Int
+                if let currentRow = self.rowForRotorElement(predicate.currentItem.targetElement, in: tableView) {
+                    targetRow = forward ? currentRow + 1 : currentRow - 1
+                } else {
+                    targetRow = forward ? 0 : rowCount - 1
+                }
+
+                guard targetRow >= 0, targetRow < rowCount else { return nil }
+
+                let indexPath = IndexPath(row: targetRow, section: 0)
+                tableView.scrollToRow(at: indexPath, at: .middle, animated: false)
+                tableView.layoutIfNeeded()
+                guard let cell = tableView.cellForRow(at: indexPath) else { return nil }
+                return UIAccessibilityCustomRotorItemResult(targetElement: cell, targetRange: nil)
+            }
+        }
+
+        /// Resolves the table row that owns the currently focused accessibility
+        /// element by mapping its on-screen frame back into table coordinates.
+        private func rowForRotorElement(_ element: Any?, in tableView: UITableView) -> Int? {
+            guard let object = element as? NSObject,
+                  let window = tableView.window else { return nil }
+
+            let screenFrame = object.accessibilityFrame
+            guard !screenFrame.isNull, !screenFrame.isEmpty else { return nil }
+
+            let windowFrame = window.convert(screenFrame, from: window.screen.coordinateSpace)
+            let tableFrame = tableView.convert(windowFrame, from: window)
+            let center = CGPoint(x: tableFrame.midX, y: tableFrame.midY)
+            return tableView.indexPathForRow(at: center)?.row
         }
 
         func checkIfAtBottom() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add VoiceOver announcements for chat status and a custom Messages rotor to jump between messages. Also adds an accessibility label for “scroll to latest” and haptics on success/error.

- **New Features**
  - VoiceOver announces chat status changes: generating, complete, stopped, failed.
  - Added “Messages” rotor to navigate between whole messages with flick up/down.
  - Labeled the “scroll to latest” button for VoiceOver.
  - Triggered haptics on response success and error.

<sup>Written for commit 3b7f62ea5f9e8c3dbb74c3e6a788a5524eed8908. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

