### PR TITLE
Sync generative UI setting

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -280,6 +280,7 @@ enum Constants {
             static let hapticFeedbackEnabled = "tinfoil-settings-haptic-feedback-enabled"
             static let selectedLanguage = "tinfoil-settings-selected-language"
             static let webSearchEnabled = "tinfoil-settings-web-search-enabled"
+            static let genUIEnabled = "tinfoil-settings-genui-enabled"
             static let reasoningEffort = "tinfoil-settings-reasoning-effort"
             static let thinkingEnabled = "tinfoil-settings-thinking-enabled"
             static let cloudSyncEnabled = "tinfoil-settings-cloud-sync-enabled"

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -402,6 +402,7 @@ struct ProfileData: Codable {
     var webSearchEnabled: Bool?
     var codeExecutionEnabled: Bool?
     var piiCheckEnabled: Bool?
+    var genUIEnabled: Bool?
     var chatFont: String?
     var projectUploadPreference: String?
     

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -205,6 +205,7 @@ class ProfileManager: ObservableObject {
             webSearchEnabled: SettingsManager.shared.webSearchEnabled,
             codeExecutionEnabled: codeExecutionEnabled,
             piiCheckEnabled: piiCheckEnabled,
+            genUIEnabled: SettingsManager.shared.genUIEnabled,
             chatFont: chatFont,
             projectUploadPreference: projectUploadPreference,
             version: lastSyncedVersion,  // Will be incremented by ProfileSyncService
@@ -272,6 +273,9 @@ class ProfileManager: ObservableObject {
         }
         if let piiCheckEnabled = profile.piiCheckEnabled {
             self.piiCheckEnabled = piiCheckEnabled
+        }
+        if let genUIEnabled = profile.genUIEnabled {
+            SettingsManager.shared.genUIEnabled = genUIEnabled
         }
         if let chatFont = profile.chatFont {
             self.chatFont = chatFont
@@ -739,6 +743,7 @@ class ProfileManager: ObservableObject {
                p1.webSearchEnabled != p2.webSearchEnabled ||
                p1.codeExecutionEnabled != p2.codeExecutionEnabled ||
                p1.piiCheckEnabled != p2.piiCheckEnabled ||
+               p1.genUIEnabled != p2.genUIEnabled ||
                p1.chatFont != p2.chatFont ||
                p1.projectUploadPreference != p2.projectUploadPreference
     }

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -809,8 +809,23 @@ class ProfileManager: ObservableObject {
     
     /// Get custom system prompt if enabled
     func getCustomSystemPrompt() -> String? {
-        guard isUsingCustomPrompt, !customSystemPrompt.isEmpty else { return nil }
-        return customSystemPrompt
+        guard isUsingCustomPrompt else { return nil }
+        return Self.normalizeSystemPromptForSending(customSystemPrompt)
+    }
+
+    static func normalizeSystemPromptForSending(_ prompt: String) -> String {
+        systemPromptHasContent(prompt) ? prompt : ""
+    }
+
+    static func systemPromptHasContent(_ prompt: String) -> Bool {
+        var result = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if result.hasPrefix("<system>") {
+            result = String(result.dropFirst("<system>".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if result.hasSuffix("</system>") {
+            result = String(result.dropLast("</system>".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return !result.isEmpty
     }
     
     /// Clear all profile data

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -39,7 +39,7 @@ class ProfileSyncService: ObservableObject {
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
         "favoritePromptPresetIds", "selectedModel", "reasoningEffort",
         "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
-        "piiCheckEnabled", "chatFont", "projectUploadPreference",
+        "piiCheckEnabled", "genUIEnabled", "chatFont", "projectUploadPreference",
         "version", "updatedAt",
     ]
 

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -79,7 +79,9 @@ struct ChatQueryBuilder {
 
         if useSystemRole {
             let fullPrompt = rules.isEmpty ? effectiveSystemPrompt : effectiveSystemPrompt + "\n\n" + rules
-            messages.append(.system(.init(content: .textContent(fullPrompt))))
+            if !fullPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                messages.append(.system(.init(content: .textContent(fullPrompt))))
+            }
         }
 
         let recentMessages = TokenEstimation.selectMessagesWithinBudget(conversationMessages, contextWindow: contextWindow)
@@ -92,8 +94,10 @@ struct ChatQueryBuilder {
                 // For models that don't use system role (e.g. DeepSeek): inject system instructions as a separate user message
                 if !hasAddedSystemInstructions {
                     let rawInstructions = rules.isEmpty ? effectiveSystemPrompt : effectiveSystemPrompt + "\n\n" + rules
-                    let systemContent = "<system>\n\(rawInstructions)\n</system>"
-                    messages.append(.user(.init(content: .string(systemContent))))
+                    if !rawInstructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        let systemContent = "<system>\n\(rawInstructions)\n</system>"
+                        messages.append(.user(.init(content: .string(systemContent))))
+                    }
                     hasAddedSystemInstructions = true
                 }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1788,7 +1788,8 @@ class ChatViewModel: ObservableObject {
                     isMultimodal: self.currentModel.isMultimodal,
                     reasoningConfig: self.currentModel.reasoningConfig,
                     reasoningEffort: self.reasoningEffort,
-                    thinkingEnabled: self.thinkingEnabled
+                    thinkingEnabled: self.thinkingEnabled,
+                    genUIEnabled: SettingsManager.shared.genUIEnabled
                 )
 
                 // Web search state tracking

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1699,14 +1699,17 @@ class ChatViewModel: ObservableObject {
                 let settingsManager = SettingsManager.shared
                 let profileManager = ProfileManager.shared
                 var systemPrompt: String
+                var suppressDefaultRules = false
                 
                 // Precedence: per-chat prompt preset > custom prompt toggle > default
                 if let preset = profileManager.promptPreset(for: currentChat?.promptPresetId) {
                     systemPrompt = preset.systemPrompt
                 } else if let customPrompt = profileManager.getCustomSystemPrompt() {
                     systemPrompt = customPrompt
-                } else if settingsManager.isUsingCustomPrompt && !settingsManager.customSystemPrompt.isEmpty {
-                    systemPrompt = settingsManager.customSystemPrompt
+                    suppressDefaultRules = !ProfileManager.systemPromptHasContent(customPrompt)
+                } else if settingsManager.isUsingCustomPrompt {
+                    systemPrompt = ProfileManager.normalizeSystemPromptForSending(settingsManager.customSystemPrompt)
+                    suppressDefaultRules = !ProfileManager.systemPromptHasContent(systemPrompt)
                 } else {
                     systemPrompt = AppConfig.shared.systemPrompt
                 }
@@ -1762,7 +1765,7 @@ class ChatViewModel: ObservableObject {
                 )
                 
                 // Process rules with same replacements
-                var processedRules = AppConfig.shared.rules
+                var processedRules = suppressDefaultRules ? "" : AppConfig.shared.rules
                 if !processedRules.isEmpty {
                     processedRules = processedRules.replacingOccurrences(of: "{MODEL_NAME}", with: currentModel.fullName)
                     processedRules = processedRules.replacingOccurrences(of: "{LANGUAGE}", with: languageToUse)

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -89,6 +89,16 @@ class SettingsManager: ObservableObject {
         }
     }
 
+    // Generative UI toggle. When off, no render_* tool capabilities are sent.
+    @Published var genUIEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(genUIEnabled, forKey: Constants.StorageKeys.Settings.genUIEnabled)
+            if !isApplyingSharedProfile {
+                ProfileManager.shared.sharedSettingsDidChange()
+            }
+        }
+    }
+
     // Cloud sync toggle
     @Published var isCloudSyncEnabled: Bool {
         didSet {
@@ -134,6 +144,9 @@ class SettingsManager: ObservableObject {
         // Initialize web search setting
         self.webSearchEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.webSearchEnabled) as? Bool ?? true
 
+        // Initialize Generative UI setting (defaults to on)
+        self.genUIEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.genUIEnabled) as? Bool ?? true
+
         // Initialize cloud sync setting
         // If no explicit value has been stored, auto-enable for existing users who already have an encryption key
         if let storedValue = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.cloudSyncEnabled) as? Bool {
@@ -173,6 +186,7 @@ class SettingsManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.webSearchEnabled)
+        UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.genUIEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.cloudSyncEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.localOnlyModeEnabled)
 
@@ -187,6 +201,7 @@ class SettingsManager: ObservableObject {
         isUsingCustomPrompt = false
         customSystemPrompt = ""
         webSearchEnabled = true
+        genUIEnabled = true
         isCloudSyncEnabled = false
         isLocalOnlyModeEnabled = false
     }
@@ -517,8 +532,12 @@ struct SettingsView: View {
         Section {
             Toggle("Haptic Feedback", isOn: $settings.hapticFeedbackEnabled)
                 .tint(Color.accentPrimary)
+            Toggle("Generative UI", isOn: $settings.genUIEnabled)
+                .tint(Color.accentPrimary)
         } header: {
             Text("Preferences")
+        } footer: {
+            Text("Let the AI render interactive widgets like charts and timelines. When off, no tool capabilities are sent to the model.")
         }
         .listRowBackground(Color.cardSurface(for: colorScheme))
     }

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -184,4 +184,48 @@ struct ChatQueryBuilderReasoningTests {
         #expect(kwargs?["thinking"] as? Bool == true)
         #expect(kwargs?["reasoning_effort"] as? String == "max")
     }
+
+    @Test @MainActor
+    func emptyPromptDoesNotEmitSystemMessage() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "gpt-oss-120b",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [
+                Message(role: .user, content: "hello")
+            ],
+            stream: false,
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        #expect(messages.count == 1)
+        #expect(messages.first?["role"] as? String == "user")
+        #expect(messages.first?["content"] as? String == "hello")
+    }
+
+    @Test @MainActor
+    func emptyPromptDoesNotEmitSyntheticSystemWrapper() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "deepseek-v4-pro",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [
+                Message(role: .user, content: "hello")
+            ],
+            stream: false,
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        #expect(messages.count == 1)
+        #expect(messages.first?["role"] as? String == "user")
+        #expect(messages.first?["content"] as? String == "hello")
+    }
+
+    private func encodedMessages(from query: ChatQuery) throws -> [[String: Any]] {
+        let data = try JSONEncoder().encode(query)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return object?["messages"] as? [[String: Any]] ?? []
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a cloud-synced “Generative UI” setting and ensures we don’t send empty system prompts, preventing unintended prompt steering.

- **New Features**
  - Added Generative UI toggle in Settings (defaults on). When off, no render_* tool capabilities are sent.
  - Synced `genUIEnabled` across devices via profile sync (`ProfileData`, `ProfileManager`, `ProfileSyncService`).
  - Persisted with `UserDefaults` at `Constants.StorageKeys.Settings.genUIEnabled`.

- **Bug Fixes**
  - Avoid sending empty system prompts or synthetic `<system>` wrappers.
  - Normalized custom system prompts and suppressed default rules when the custom prompt is enabled but empty.
  - Updated `ChatQueryBuilder` to only include system instructions when non-empty.
  - Added tests to ensure empty prompts don’t emit system messages.

<sup>Written for commit fb7e2be4fec42e04430157bcad0e568678538506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

