### PR TITLE
chore: sync data across devices more frequently

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -169,8 +169,8 @@ enum Constants {
     }
 
     enum Sync {
-        static let chatSyncIntervalSeconds: TimeInterval = 60.0
-        static let profileSyncIntervalSeconds: TimeInterval = 300.0  // 5 minutes
+        static let chatSyncIntervalSeconds: TimeInterval = 20.0
+        static let profileSyncIntervalSeconds: TimeInterval = 60.0  // 1 minute
         static let clientInitTimeoutSeconds: TimeInterval = 60.0
         static let backgroundTaskName = "CompleteStreamingResponse"
         static let maxReverseTimestamp: Int = 9999999999999


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase cross-device sync frequency to reduce delays for new messages and profile updates. Lowered `chatSyncIntervalSeconds` to 20s (from 60s) and `profileSyncIntervalSeconds` to 60s (from 300s).

<sup>Written for commit dfc7238fcbb29d0e1e741be3fc918ed3e958d4ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

