### PR TITLE
Bulletproof sync clocks

### DIFF
--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -35,6 +35,13 @@ struct Chat: Identifiable, Codable {
     var syncedAt: Date?
     var locallyModified: Bool = true
     var updatedAt: Date
+
+    // Logical edit clock for conflict arbitration. Round-tripped across
+    // platforms; clockVersion records the syncVersion the clock was
+    // maintained at so a reader knows whether to trust it.
+    var clock: Int?
+    var writer: String?
+    var clockVersion: Int?
     
     // For handling encrypted chats that failed to decrypt
     var decryptionFailed: Bool = false
@@ -179,6 +186,7 @@ struct Chat: Identifiable, Codable {
         case id, title, titleState, messages, createdAt, modelType, language, userId
         case syncVersion, syncedAt, locallyModified, updatedAt
         case decryptionFailed, dataCorrupted, formatVersion, isLocalOnly, projectId, promptPresetId
+        case clock, writer, clockVersion
     }
 
     init(from decoder: Decoder) throws {
@@ -208,6 +216,9 @@ struct Chat: Identifiable, Codable {
         isLocalOnly = try container.decodeIfPresent(Bool.self, forKey: .isLocalOnly) ?? false
         projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
         promptPresetId = try container.decodeIfPresent(String.self, forKey: .promptPresetId)
+        clock = try container.decodeIfPresent(Int.self, forKey: .clock)
+        writer = try container.decodeIfPresent(String.self, forKey: .writer)
+        clockVersion = try container.decodeIfPresent(Int.self, forKey: .clockVersion)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -235,6 +246,9 @@ struct Chat: Identifiable, Codable {
         try container.encode(isLocalOnly, forKey: .isLocalOnly)
         try container.encodeIfPresent(projectId, forKey: .projectId)
         try container.encodeIfPresent(promptPresetId, forKey: .promptPresetId)
+        try container.encodeIfPresent(clock, forKey: .clock)
+        try container.encodeIfPresent(writer, forKey: .writer)
+        try container.encodeIfPresent(clockVersion, forKey: .clockVersion)
     }
     
     // MARK: - Haptic Feedback Methods

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -25,6 +25,34 @@ enum SyncConflictResolver {
         guard let remote = remote else { return false }
         return remote > local
     }
+
+    /// Clock-aware arbitration. When both sides carry a trusted edit
+    /// clock the winner is the higher `(v, w)` pair, a total order that
+    /// removes wall-clock skew from the decision and converges across
+    /// devices. When either clock is absent it falls back to the
+    /// timestamp arbitration so behavior matches a clock-unaware client.
+    ///
+    /// Callers MUST pass clocks only when both are trusted (the row's
+    /// server version equals the stamped clockVersion); otherwise pass
+    /// nil so the timestamp fallback governs.
+    static func remoteWins(
+        localClock: EditClock?,
+        remoteClock: EditClock?,
+        localUpdatedAt: Date?,
+        remoteUpdatedAt: Date?
+    ) -> Bool {
+        if let localClock = localClock, let remoteClock = remoteClock {
+            if remoteClock.v != localClock.v {
+                return remoteClock.v > localClock.v
+            }
+            if remoteClock.w != localClock.w {
+                return remoteClock.w > localClock.w
+            }
+            // Identical clock: the same logical write. No overwrite.
+            return false
+        }
+        return remoteWins(local: localUpdatedAt, remote: remoteUpdatedAt)
+    }
 }
 
 // MARK: - Sync Models
@@ -61,6 +89,14 @@ struct StoredChat: Codable {
 
     // For tracking streaming state
     var hasActiveStream: Bool?
+
+    // Logical edit clock for conflict arbitration, round-tripped across
+    // platforms so a peer's clock is never dropped. clockVersion records
+    // the syncVersion the clock was maintained at; a reader trusts the
+    // clock only when clockVersion equals the row's current version.
+    var clock: Int?
+    var writer: String?
+    var clockVersion: Int?
     
     /// Creates a placeholder for a chat the enclave declined to unseal
     /// (e.g. UNKNOWN_KEY). The ciphertext is never carried client-side
@@ -126,6 +162,9 @@ struct StoredChat: Codable {
         self.projectId = chat.projectId
         self.promptPresetId = chat.promptPresetId
         self.hasActiveStream = chat.hasActiveStream
+        self.clock = chat.clock
+        self.writer = chat.writer
+        self.clockVersion = chat.clockVersion
     }
     
     @MainActor
@@ -166,6 +205,10 @@ struct StoredChat: Codable {
             chat.hasActiveStream = hasActiveStream
         }
 
+        chat.clock = clock
+        chat.writer = writer
+        chat.clockVersion = clockVersion
+
         return chat
     }
     
@@ -176,6 +219,7 @@ struct StoredChat: Codable {
         case syncVersion, syncedAt, locallyModified
         case decryptionFailed, dataCorrupted, formatVersion, projectId
         case promptPresetId = "presetId"
+        case clock, writer, clockVersion
     }
 
     func encode(to encoder: Encoder) throws {
@@ -208,6 +252,9 @@ struct StoredChat: Codable {
         try container.encodeIfPresent(formatVersion, forKey: .formatVersion)
         try container.encodeIfPresent(projectId, forKey: .projectId)
         try container.encodeIfPresent(promptPresetId, forKey: .promptPresetId)
+        try container.encodeIfPresent(clock, forKey: .clock)
+        try container.encodeIfPresent(writer, forKey: .writer)
+        try container.encodeIfPresent(clockVersion, forKey: .clockVersion)
         // hasActiveStream is transient UI state — never encode it to the sync blob
     }
     
@@ -268,6 +315,9 @@ struct StoredChat: Codable {
         formatVersion = try container.decodeIfPresent(Int.self, forKey: .formatVersion)
         projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
         promptPresetId = try container.decodeIfPresent(String.self, forKey: .promptPresetId)
+        clock = try container.decodeIfPresent(Int.self, forKey: .clock)
+        writer = try container.decodeIfPresent(String.self, forKey: .writer)
+        clockVersion = try container.decodeIfPresent(Int.self, forKey: .clockVersion)
         // hasActiveStream is transient UI state — always reset to nil on decode
         hasActiveStream = nil
     }
@@ -409,6 +459,13 @@ struct ProfileData: Codable {
     // Metadata
     var version: Int?
     var updatedAt: String?
+
+    // Per-field edit clocks and the row version they were maintained at.
+    // fieldClocks is trusted for the field-level merge only when
+    // clockVersion equals the profile row's server version; otherwise a
+    // clock-unaware write intervened and merge falls back to updatedAt.
+    var fieldClocks: [String: EditClock]?
+    var clockVersion: Int?
 }
 
 // MARK: - Sync Status Models

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -547,9 +547,37 @@ class CloudSyncService: ObservableObject {
             }
 
             let localChat = await loadChatFromStorage(chatId)
+
+            // A chat's edit clock is trusted only when it was maintained
+            // at the row's current synced version; otherwise a
+            // clock-unaware write intervened and we fall back to
+            // updatedAt arbitration.
+            func trustedClock(
+                clock: Int?, writer: String?, clockVersion: Int?, syncVersion: Int
+            ) -> EditClock? {
+                guard let clock = clock, let writer = writer,
+                      let clockVersion = clockVersion, clockVersion == syncVersion
+                else { return nil }
+                return EditClock(v: clock, w: writer)
+            }
+
+            let localClock = localChat.flatMap {
+                trustedClock(
+                    clock: $0.clock, writer: $0.writer,
+                    clockVersion: $0.clockVersion, syncVersion: $0.syncVersion
+                )
+            }
+            let remoteClock = trustedClock(
+                clock: downloadedChat.clock, writer: downloadedChat.writer,
+                clockVersion: downloadedChat.clockVersion,
+                syncVersion: downloadedChat.syncVersion
+            )
+
             let remoteWins = SyncConflictResolver.remoteWins(
-                local: localChat?.updatedAt,
-                remote: downloadedChat.updatedAt
+                localClock: localClock,
+                remoteClock: remoteClock,
+                localUpdatedAt: localChat?.updatedAt,
+                remoteUpdatedAt: downloadedChat.updatedAt
             )
 
             if !remoteWins {

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -24,6 +24,14 @@ enum EditClockStore {
     private static let deviceIdKey = "tinfoil-sync-device-id"
     private static let counterKey = "tinfoil-sync-edit-clock"
 
+    /// Upper bound for the logical counter. Far above any value a
+    /// legitimate edit history could reach, yet with ample headroom
+    /// below Int.max so incrementing can never overflow and trap, even
+    /// when a corrupted or hostile remote blob carries an absurd clock.
+    /// Matches the webapp's JS safe-integer ceiling so both platforms
+    /// clamp identically.
+    static let maxCounter = 9_007_199_254_740_991  // 2^53 - 1
+
     private static var defaults: UserDefaults { .standard }
 
     /// Stable id for this installation. Generated once and persisted.
@@ -38,7 +46,10 @@ enum EditClockStore {
 
     private static func loadCounter() -> Int {
         let value = defaults.integer(forKey: counterKey)
-        return value > 0 ? value : 0
+        guard value > 0 else { return 0 }
+        // Clamp a previously-persisted value too, so a counter poisoned
+        // before this guard existed self-heals instead of trapping.
+        return min(value, maxCounter)
     }
 
     private static func persistCounter(_ value: Int) {
@@ -46,9 +57,12 @@ enum EditClockStore {
     }
 
     /// Advance the local counter past an observed remote value without
-    /// producing a new tick, so a later local edit outranks it.
+    /// producing a new tick, so a later local edit outranks it. Remote
+    /// values are untrusted input (decrypted blob), so a value above the
+    /// ceiling is treated as malformed and ignored rather than allowed
+    /// to poison the counter toward an overflow.
     static func observe(_ remoteV: Int?) {
-        guard let remoteV = remoteV, remoteV > 0 else { return }
+        guard let remoteV = remoteV, remoteV > 0, remoteV <= maxCounter else { return }
         if remoteV > loadCounter() {
             persistCounter(remoteV)
         }
@@ -56,10 +70,11 @@ enum EditClockStore {
 
     /// Produce the next clock for a local edit, advancing past
     /// `observedMax` (e.g. the unit's current clock) so a re-edit of an
-    /// already-high unit still moves forward.
+    /// already-high unit still moves forward. The base is clamped to the
+    /// ceiling so the increment can never overflow Int and trap.
     static func nextClock(observedMax: Int? = nil) -> EditClock {
-        let base = max(loadCounter(), observedMax ?? 0)
-        let next = base + 1
+        let base = min(max(loadCounter(), observedMax ?? 0), maxCounter)
+        let next = min(base + 1, maxCounter)
         persistCounter(next)
         return EditClock(v: next, w: deviceId())
     }

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -1,0 +1,66 @@
+//
+//  EditClock.swift
+//  TinfoilChat
+//
+//  A Lamport-style logical clock shared by mergeable sync units
+//  (profile fields, chat rows). Arbitration by `(v, w)` is a total
+//  order, making conflict resolution a convergent CRDT LWW-register
+//  that is immune to wall-clock skew between devices. Mirrors
+//  `services/cloud/edit-clock.ts` in the webapp.
+//
+
+import Foundation
+
+/// Per-unit logical edit clock: `v` is a Lamport counter, `w` the
+/// writing device id used as a deterministic tiebreak.
+struct EditClock: Codable, Equatable {
+    let v: Int
+    let w: String
+}
+
+/// Persisted Lamport counter and stable device id backing the edit
+/// clock. The device id is only a tiebreak label, never a secret.
+enum EditClockStore {
+    private static let deviceIdKey = "tinfoil-sync-device-id"
+    private static let counterKey = "tinfoil-sync-edit-clock"
+
+    private static var defaults: UserDefaults { .standard }
+
+    /// Stable id for this installation. Generated once and persisted.
+    static func deviceId() -> String {
+        if let existing = defaults.string(forKey: deviceIdKey), !existing.isEmpty {
+            return existing
+        }
+        let next = UUID().uuidString.lowercased()
+        defaults.set(next, forKey: deviceIdKey)
+        return next
+    }
+
+    private static func loadCounter() -> Int {
+        let value = defaults.integer(forKey: counterKey)
+        return value > 0 ? value : 0
+    }
+
+    private static func persistCounter(_ value: Int) {
+        defaults.set(value, forKey: counterKey)
+    }
+
+    /// Advance the local counter past an observed remote value without
+    /// producing a new tick, so a later local edit outranks it.
+    static func observe(_ remoteV: Int?) {
+        guard let remoteV = remoteV, remoteV > 0 else { return }
+        if remoteV > loadCounter() {
+            persistCounter(remoteV)
+        }
+    }
+
+    /// Produce the next clock for a local edit, advancing past
+    /// `observedMax` (e.g. the unit's current clock) so a re-edit of an
+    /// already-high unit still moves forward.
+    static func nextClock(observedMax: Int? = nil) -> EditClock {
+        let base = max(loadCounter(), observedMax ?? 0)
+        let next = base + 1
+        persistCounter(next)
+        return EditClock(v: next, w: deviceId())
+    }
+}

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -620,7 +620,7 @@ class ProfileManager: ObservableObject {
         // Avoid overlapping uploads
         guard !isPushing else { return }
         
-        let profile = createProfileData()
+        var profile = createProfileData()
 
         // Only push if there is a real change vs last synced baseline.
         // When nothing diverges, clear the pending flag so a phantom
@@ -629,7 +629,23 @@ class ProfileManager: ObservableObject {
             clearLocalProfileChanged()
             return
         }
-        
+
+        // Stamp a fresh edit clock on every field changed since the last
+        // sync, carrying forward the existing clocks for the rest. One
+        // tick covers this push because it is a single local write event;
+        // the deviceId tiebreak keeps it ordered against peers.
+        let baseClocks = profileSync.getCachedProfile()?.fieldClocks
+            ?? lastSyncedProfile?.fieldClocks ?? [:]
+        let changedFields = ProfileMerge.changedProfileFields(
+            local: profile, baseline: lastSyncedProfile
+        )
+        var fieldClocks = baseClocks
+        if !changedFields.isEmpty {
+            let tick = EditClockStore.nextClock()
+            for field in changedFields { fieldClocks[field] = tick }
+        }
+        profile.fieldClocks = fieldClocks
+
         isPushing = true
         updateSyncingState()
         

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -1,0 +1,176 @@
+//
+//  ProfileMerge.swift
+//  TinfoilChat
+//
+//  Field-level conflict resolution for profile sync. Mirrors
+//  `services/cloud/profile-merge.ts` in the webapp: each field is
+//  arbitrated by its edit clock when both sides are trusted (a
+//  convergent CRDT LWW-register, immune to clock skew), falling back to
+//  whole-blob updatedAt when a clock is absent or untrusted, and never
+//  letting an empty/default blob wipe a populated profile on fallback.
+//
+
+import Foundation
+
+enum ProfileMerge {
+    /// User-facing fields that participate in the merge. Metadata
+    /// (version, updatedAt, clocks) is handled separately.
+    static let mergeFields: [String] = [
+        "isDarkMode", "themeMode", "language", "nickname", "profession",
+        "traits", "additionalContext", "isUsingPersonalization",
+        "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
+        "favoritePromptPresetIds", "selectedModel", "reasoningEffort",
+        "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
+        "piiCheckEnabled", "genUIEnabled", "chatFont",
+        "projectUploadPreference",
+    ]
+
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static func parseDate(_ string: String?) -> Date? {
+        guard let string = string else { return nil }
+        if let date = isoFormatter.date(from: string) { return date }
+        let fallback = ISO8601DateFormatter()
+        fallback.formatOptions = [.withInternetDateTime]
+        return fallback.date(from: string)
+    }
+
+    // A blob's field clocks are trustworthy only when maintained at the
+    // row's current server version.
+    private static func clocksTrusted(_ p: ProfileData) -> Bool {
+        guard let clockVersion = p.clockVersion, let version = p.version else {
+            return false
+        }
+        return clockVersion == version
+    }
+
+    /// True when the profile carries user content worth protecting.
+    static func isProfilePopulated(_ p: ProfileData?) -> Bool {
+        guard let p = p else { return false }
+        func nonEmpty(_ s: String?) -> Bool {
+            guard let s = s else { return false }
+            return !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        if nonEmpty(p.nickname) || nonEmpty(p.profession)
+            || nonEmpty(p.additionalContext) || nonEmpty(p.customSystemPrompt) {
+            return true
+        }
+        if let traits = p.traits, !traits.isEmpty { return true }
+        if let presets = p.customPromptPresets, !presets.isEmpty { return true }
+        if let favs = p.favoritePromptPresetIds, !favs.isEmpty { return true }
+        return false
+    }
+
+    /// Field names whose local value differs from the last-synced
+    /// baseline, derived by diffing values rather than tracking events.
+    static func changedProfileFields(
+        local: ProfileData, baseline: ProfileData?
+    ) -> [String] {
+        guard let baseline = baseline else { return mergeFields }
+        let localDict = (try? dictionary(from: local)) ?? [:]
+        let baselineDict = (try? dictionary(from: baseline)) ?? [:]
+        var changed: [String] = []
+        for field in mergeFields {
+            let a = localDict[field]
+            let b = baselineDict[field]
+            if !valuesEqual(a, b) {
+                changed.append(field)
+            }
+        }
+        return changed
+    }
+
+    /// Merge a remote profile into the local one field by field.
+    static func mergeProfiles(
+        local: ProfileData, remote: ProfileData
+    ) -> (merged: ProfileData, adoptedRemote: Bool) {
+        let localTrusted = clocksTrusted(local)
+        let remoteTrusted = clocksTrusted(remote)
+        let fallback = !(localTrusted && remoteTrusted)
+
+        // On the fallback path there is no per-field signal to trust, so
+        // a single empty/default remote could clobber every populated
+        // local field at once (the data-loss incident). Refuse it.
+        if fallback && !isProfilePopulated(remote) && isProfilePopulated(local) {
+            return (local, false)
+        }
+
+        let localUpdatedAt = parseDate(local.updatedAt)
+        let remoteUpdatedAt = parseDate(remote.updatedAt)
+
+        guard
+            var mergedDict = try? dictionary(from: local),
+            let remoteDict = try? dictionary(from: remote)
+        else {
+            return (local, false)
+        }
+
+        var mergedClocks = local.fieldClocks ?? [:]
+        var adoptedRemote = false
+
+        for field in mergeFields {
+            guard remoteDict[field] != nil else { continue }
+            let lc = localTrusted ? local.fieldClocks?[field] : nil
+            let rc = remoteTrusted ? remote.fieldClocks?[field] : nil
+            let takeRemote = SyncConflictResolver.remoteWins(
+                localClock: lc,
+                remoteClock: rc,
+                localUpdatedAt: localUpdatedAt,
+                remoteUpdatedAt: remoteUpdatedAt
+            )
+            if takeRemote {
+                mergedDict[field] = remoteDict[field]
+                if let rc = rc { mergedClocks[field] = rc }
+                adoptedRemote = true
+            } else if let lc = lc {
+                mergedClocks[field] = lc
+            }
+        }
+
+        var merged = (try? profile(from: mergedDict)) ?? local
+        merged.fieldClocks = mergedClocks.isEmpty ? nil : mergedClocks
+        merged.updatedAt = laterTimestamp(local.updatedAt, remote.updatedAt)
+        return (merged, adoptedRemote)
+    }
+
+    // MARK: - Helpers
+
+    private static func laterTimestamp(_ a: String?, _ b: String?) -> String? {
+        let da = parseDate(a)
+        let db = parseDate(b)
+        guard let da = da else { return b ?? a }
+        guard let db = db else { return a }
+        return da >= db ? a : b
+    }
+
+    private static func dictionary(from profile: ProfileData) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(profile)
+        return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    private static func profile(from dict: [String: Any]) throws -> ProfileData {
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        return try JSONDecoder().decode(ProfileData.self, from: data)
+    }
+
+    private static func valuesEqual(_ a: Any?, _ b: Any?) -> Bool {
+        switch (a, b) {
+        case (nil, nil):
+            return true
+        case let (x?, y?):
+            return NSObject.isEqual(x, to: y)
+        default:
+            return false
+        }
+    }
+}
+
+private extension NSObject {
+    static func isEqual(_ a: Any, to b: Any) -> Bool {
+        (a as AnyObject).isEqual(b as AnyObject)
+    }
+}

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -109,12 +109,24 @@ enum ProfileMerge {
             return (local, false)
         }
 
-        var mergedClocks = local.fieldClocks ?? [:]
+        // Build the merged clocks from scratch, carrying only clocks we
+        // actually trust. Seeding from local.fieldClocks would smuggle
+        // untrusted/stale clocks into the output, which the next push
+        // re-stamps as trusted (clockVersion == version) and corrupts
+        // future conflict resolution.
+        var mergedClocks: [String: EditClock] = [:]
         var adoptedRemote = false
 
         for field in mergeFields {
-            guard remoteDict[field] != nil else { continue }
             let lc = localTrusted ? local.fieldClocks?[field] : nil
+
+            // Remote omits this field: keep the local value and its
+            // clock, but only when the local clock is trusted.
+            guard remoteDict[field] != nil else {
+                if let lc = lc { mergedClocks[field] = lc }
+                continue
+            }
+
             let rc = remoteTrusted ? remote.fieldClocks?[field] : nil
             let takeRemote = SyncConflictResolver.remoteWins(
                 localClock: lc,
@@ -124,6 +136,9 @@ enum ProfileMerge {
             )
             if takeRemote {
                 mergedDict[field] = remoteDict[field]
+                // Record a clock for the adopted value only if the remote
+                // clock is trusted; otherwise leave it absent so future
+                // reads fall back to updatedAt for this field.
                 if let rc = rc { mergedClocks[field] = rc }
                 adoptedRemote = true
             } else if let lc = lc {

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -40,7 +40,7 @@ class ProfileSyncService: ObservableObject {
         "favoritePromptPresetIds", "selectedModel", "reasoningEffort",
         "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont", "projectUploadPreference",
-        "version", "updatedAt",
+        "version", "updatedAt", "fieldClocks", "clockVersion",
     ]
 
     private static let iso8601Formatter: ISO8601DateFormatter = {
@@ -149,6 +149,13 @@ class ProfileSyncService: ObservableObject {
             if let etag = item.etag, let version = Int(etag) {
                 decoded.version = version
             }
+            // Advance the local logical clock past every remote field
+            // clock so a later local edit outranks what we observed.
+            if let fieldClocks = decoded.fieldClocks {
+                for clock in fieldClocks.values {
+                    EditClockStore.observe(clock.v)
+                }
+            }
             self.cachedProfile = decoded
             self.failedDecryptionData = nil
             return decoded
@@ -162,15 +169,23 @@ class ProfileSyncService: ObservableObject {
         guard await isAuthenticated() else { return (false, nil, nil) }
         let keyB64 = try CEKEncoding.requirePrimaryKeyB64()
 
+        // The working copy that gets pushed. On a conflict it is
+        // replaced by the field-level merge before re-push.
+        var working = profile
+
         // Push the local profile under a given base version. The
         // controlplane treats a missing/zero version as create-only and
         // any positive version as a CAS update gated on the row's etag.
         func pushAtVersion(_ baseVersion: Int) async throws -> (success: Bool, version: Int?) {
-            var profileWithMetadata = profile
+            var profileWithMetadata = working
             // Preserve the caller's edit time so other devices can
             // arbitrate last-write-wins; only stamp now when absent.
-            profileWithMetadata.updatedAt = profile.updatedAt ?? Self.iso8601Formatter.string(from: Date())
+            profileWithMetadata.updatedAt = working.updatedAt ?? Self.iso8601Formatter.string(from: Date())
             profileWithMetadata.version = baseVersion + 1
+            // The field clocks are current as of the version this push
+            // creates, so a remote reader trusts them (version ==
+            // clockVersion) instead of falling back to updatedAt.
+            profileWithMetadata.clockVersion = baseVersion + 1
 
             let plaintext = try self.encodeProfilePayload(profileWithMetadata)
             let ifMatch: String? = baseVersion > 0 ? String(baseVersion) : nil
@@ -201,27 +216,31 @@ class ProfileSyncService: ObservableObject {
             return (result.success, result.version, nil)
         } catch let error as SyncEnclaveError where Self.isStaleBlobConflict(error) {
             // Optimistic-concurrency conflict: the server holds a
-            // version our push was not based on. Re-read it and
-            // arbitrate last-write-wins by content modification time.
+            // version our push was not based on. Re-read it and merge
+            // field by field so neither device's edits are lost, then
+            // re-push the merged result onto the server's version.
             let remote = try await fetchProfile()
 
-            if let remote = remote,
-               SyncConflictResolver.remoteWins(
-                   local: Self.parseISODate(profile.updatedAt),
-                   remote: Self.parseISODate(remote.updatedAt)
-               ) {
-                // The remote is the strictly newer write. Adopt it
-                // instead of clobbering, and hand it back so the caller
-                // can apply it locally; both devices then converge.
-                self.cachedProfile = remote
-                return (true, remote.version, remote)
+            guard let remote = remote else {
+                // The remote vanished between the conflict and our
+                // re-read; re-push local as a fresh create.
+                let result = try await pushAtVersion(0)
+                return (result.success, result.version, nil)
             }
 
-            // Our local edit is the last write. Rebase onto the
-            // server's current version and re-push so local wins
-            // instead of looping on STALE_BLOB forever.
-            let result = try await pushAtVersion(remote?.version ?? 0)
-            return (result.success, result.version, nil)
+            let (merged, adoptedRemote) = ProfileMerge.mergeProfiles(
+                local: profile, remote: remote
+            )
+            working = merged
+
+            let result = try await pushAtVersion(remote.version ?? 0)
+            // Hand the merged profile back so the caller applies any
+            // fields adopted from the remote and both devices converge.
+            return (
+                result.success,
+                result.version,
+                adoptedRemote ? (self.cachedProfile ?? merged) : nil
+            )
         }
     }
 
@@ -239,19 +258,6 @@ class ProfileSyncService: ObservableObject {
             dict[key] = value
         }
         return try JSONSerialization.data(withJSONObject: dict)
-    }
-
-    /// Parse an ISO-8601 timestamp, tolerating values written with or
-    /// without fractional seconds so cross-device and cross-client
-    /// profiles compare correctly.
-    private static func parseISODate(_ string: String?) -> Date? {
-        guard let string = string else { return nil }
-        if let date = iso8601Formatter.date(from: string) {
-            return date
-        }
-        let fallback = ISO8601DateFormatter()
-        fallback.formatOptions = [.withInternetDateTime]
-        return fallback.date(from: string)
     }
 
     /// A STALE_BLOB (HTTP 412) push means our If-Match version no longer

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -90,6 +90,31 @@ struct ProfileMergeTests {
         #expect(result.adoptedRemote == false)
     }
 
+    @Test("does not carry untrusted local clocks into the merged output")
+    func dropsUntrustedLocalClocks() {
+        var local = ProfileData(nickname: "local", profession: "local-job")
+        local.version = 4
+        local.clockVersion = 2
+        local.fieldClocks = [
+            "nickname": EditClock(v: 99, w: "A"),
+            "profession": EditClock(v: 99, w: "A"),
+        ]
+        local.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        var remote = ProfileData(nickname: "remote")
+        remote.version = 5
+        remote.clockVersion = 2
+        remote.fieldClocks = ["nickname": EditClock(v: 1, w: "B")]
+        remote.updatedAt = "2024-01-01T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(local: local, remote: remote)
+
+        #expect(result.merged.nickname == "local")
+        #expect(result.merged.profession == "local-job")
+        // No trusted clock existed for either field, so none is carried.
+        #expect(result.merged.fieldClocks == nil)
+    }
+
     @Test("falls back to updatedAt when clocks are untrusted")
     func untrustedFallback() {
         var local = ProfileData(nickname: "local")
@@ -132,6 +157,25 @@ struct ProfileMergeTests {
 
 @Suite("Clock-aware conflict resolution")
 struct EditClockArbitrationTests {
+
+    // Reset the shared counter before each test so cases that push it to
+    // the ceiling don't bleed into the monotonicity assertions.
+    init() {
+        UserDefaults.standard.removeObject(forKey: "tinfoil-sync-edit-clock")
+    }
+
+    @Test("ignores remote clock values above the ceiling without trapping")
+    func ceilingGuard() {
+        // A hostile or corrupt remote clock must not poison the counter
+        // into an overflow trap on the next tick.
+        EditClockStore.observe(Int.max)
+        #expect(EditClockStore.nextClock().v == 1)
+
+        EditClockStore.observe(EditClockStore.maxCounter)
+        #expect(EditClockStore.nextClock().v == EditClockStore.maxCounter)
+        // A further tick stays pinned at the ceiling rather than trapping.
+        #expect(EditClockStore.nextClock().v == EditClockStore.maxCounter)
+    }
 
     @Test("prefers the higher clock counter over wall-clock time")
     func clockBeatsTime() {

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -1,0 +1,200 @@
+//  ProfileMergeTests.swift
+//  TinfoilChatTests
+//
+//  Field-level conflict resolution and clock arbitration for profile
+//  sync. Mirrors the webapp's profile-merge / sync-predicate tests.
+//
+
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Profile merge and clock arbitration")
+struct ProfileMergeTests {
+
+    private func trusted(_ p: ProfileData) -> ProfileData {
+        var copy = p
+        copy.version = 10
+        copy.clockVersion = 10
+        return copy
+    }
+
+    @Test("keeps each side's field with the higher clock")
+    func keepsHigherClockPerField() {
+        var local = ProfileData(
+            nickname: "local-name", customSystemPrompt: "old-prompt"
+        )
+        local.fieldClocks = [
+            "nickname": EditClock(v: 5, w: "A"),
+            "customSystemPrompt": EditClock(v: 1, w: "A"),
+        ]
+        local.updatedAt = "2024-01-01T00:00:00.000Z"
+
+        var remote = ProfileData(
+            nickname: "remote-name", customSystemPrompt: "new-prompt"
+        )
+        remote.fieldClocks = [
+            "nickname": EditClock(v: 2, w: "B"),
+            "customSystemPrompt": EditClock(v: 9, w: "B"),
+        ]
+        remote.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(
+            local: trusted(local), remote: trusted(remote)
+        )
+
+        #expect(result.merged.nickname == "local-name")
+        #expect(result.merged.customSystemPrompt == "new-prompt")
+        #expect(result.adoptedRemote == true)
+    }
+
+    @Test("converges regardless of merge direction")
+    func converges() {
+        var local = ProfileData(nickname: "local-name", profession: "old-job")
+        local.fieldClocks = [
+            "nickname": EditClock(v: 5, w: "A"),
+            "profession": EditClock(v: 1, w: "A"),
+        ]
+        var remote = ProfileData(nickname: "remote-name", profession: "new-job")
+        remote.fieldClocks = [
+            "nickname": EditClock(v: 2, w: "B"),
+            "profession": EditClock(v: 9, w: "B"),
+        ]
+
+        let a = ProfileMerge.mergeProfiles(
+            local: trusted(local), remote: trusted(remote)
+        ).merged
+        let b = ProfileMerge.mergeProfiles(
+            local: trusted(remote), remote: trusted(local)
+        ).merged
+
+        #expect(a.nickname == b.nickname)
+        #expect(a.profession == b.profession)
+        #expect(a.nickname == "local-name")
+        #expect(a.profession == "new-job")
+    }
+
+    @Test("refuses to let an empty remote wipe a populated local on fallback")
+    func emptyRemoteGuard() {
+        var local = ProfileData(
+            nickname: "real-user", traits: ["curious"], customSystemPrompt: "my prompt"
+        )
+        local.updatedAt = "2024-01-01T00:00:00.000Z"
+        var remote = ProfileData(nickname: "", traits: [], customSystemPrompt: "")
+        remote.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(local: local, remote: remote)
+
+        #expect(result.merged.nickname == "real-user")
+        #expect(result.merged.customSystemPrompt == "my prompt")
+        #expect(result.adoptedRemote == false)
+    }
+
+    @Test("falls back to updatedAt when clocks are untrusted")
+    func untrustedFallback() {
+        var local = ProfileData(nickname: "local")
+        local.version = 4
+        local.clockVersion = 2
+        local.fieldClocks = ["nickname": EditClock(v: 99, w: "A")]
+        local.updatedAt = "2024-01-01T00:00:00.000Z"
+
+        var remote = ProfileData(nickname: "remote")
+        remote.version = 5
+        remote.clockVersion = 2
+        remote.fieldClocks = ["nickname": EditClock(v: 1, w: "B")]
+        remote.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(local: local, remote: remote)
+
+        #expect(result.merged.nickname == "remote")
+    }
+
+    @Test("isProfilePopulated detects user content")
+    func populated() {
+        #expect(ProfileMerge.isProfilePopulated(ProfileData(nickname: "x")) == true)
+        #expect(ProfileMerge.isProfilePopulated(ProfileData(traits: ["a"])) == true)
+        #expect(ProfileMerge.isProfilePopulated(nil) == false)
+        #expect(
+            ProfileMerge.isProfilePopulated(
+                ProfileData(nickname: "", traits: [], thinkingEnabled: true)
+            ) == false
+        )
+    }
+
+    @Test("changedProfileFields diffs values")
+    func changedFields() {
+        let baseline = ProfileData(nickname: "a", traits: ["x"], thinkingEnabled: true)
+        let local = ProfileData(nickname: "b", traits: ["x", "y"], thinkingEnabled: true)
+        let fields = ProfileMerge.changedProfileFields(local: local, baseline: baseline)
+        #expect(Set(fields) == Set(["nickname", "traits"]))
+    }
+}
+
+@Suite("Clock-aware conflict resolution")
+struct EditClockArbitrationTests {
+
+    @Test("prefers the higher clock counter over wall-clock time")
+    func clockBeatsTime() {
+        let older = Date(timeIntervalSince1970: 1000)
+        let newer = Date(timeIntervalSince1970: 2000)
+        #expect(
+            SyncConflictResolver.remoteWins(
+                localClock: EditClock(v: 1, w: "a"),
+                remoteClock: EditClock(v: 2, w: "a"),
+                localUpdatedAt: newer,
+                remoteUpdatedAt: older
+            ) == true
+        )
+    }
+
+    @Test("breaks an equal counter by writer id deterministically")
+    func writerTiebreak() {
+        #expect(
+            SyncConflictResolver.remoteWins(
+                localClock: EditClock(v: 3, w: "aaa"),
+                remoteClock: EditClock(v: 3, w: "bbb"),
+                localUpdatedAt: nil, remoteUpdatedAt: nil
+            ) == true
+        )
+        #expect(
+            SyncConflictResolver.remoteWins(
+                localClock: EditClock(v: 3, w: "bbb"),
+                remoteClock: EditClock(v: 3, w: "aaa"),
+                localUpdatedAt: nil, remoteUpdatedAt: nil
+            ) == false
+        )
+    }
+
+    @Test("treats an identical clock as the same write")
+    func identicalClock() {
+        #expect(
+            SyncConflictResolver.remoteWins(
+                localClock: EditClock(v: 7, w: "a"),
+                remoteClock: EditClock(v: 7, w: "a"),
+                localUpdatedAt: nil, remoteUpdatedAt: nil
+            ) == false
+        )
+    }
+
+    @Test("falls back to updatedAt when a clock is missing")
+    func missingClockFallback() {
+        let older = Date(timeIntervalSince1970: 1000)
+        let newer = Date(timeIntervalSince1970: 2000)
+        #expect(
+            SyncConflictResolver.remoteWins(
+                localClock: EditClock(v: 9, w: "a"),
+                remoteClock: nil,
+                localUpdatedAt: older, remoteUpdatedAt: newer
+            ) == true
+        )
+    }
+
+    @Test("the edit clock counter is strictly increasing and observes remotes")
+    func counterMonotonic() {
+        let a = EditClockStore.nextClock()
+        let b = EditClockStore.nextClock()
+        #expect(b.v > a.v)
+        EditClockStore.observe(b.v + 1000)
+        #expect(EditClockStore.nextClock().v > b.v + 1000)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Lamport-style edit clocks and a field‑level profile merge so sync conflicts resolve deterministically without wall‑clock skew. Prevents data loss, safely ignores malformed remote clocks, and makes chats and profiles converge across devices.

- **New Features**
  - Introduced `EditClock` with a stable per-device id and monotonic counter; observes remote clocks and ticks on local edits.
  - Chats: added optional `clock`, `writer`, and `clockVersion` to models; `CloudSyncService` now arbitrates with clocks (falls back to timestamps when clocks aren’t trusted).
  - Profiles: added per-field `fieldClocks` and `clockVersion`; `ProfileManager` stamps a single tick across changed fields; on CAS conflicts `ProfileSyncService` merges field-by-field and blocks empty remotes from wiping populated locals; tests cover merge and clock arbitration.

- **Bug Fixes**
  - Hardened the clock store by clamping counters to 2^53−1 and ignoring out‑of‑range remote values to prevent overflow; added tests to cover ceiling and fallback behavior.

<sup>Written for commit 3ba2c89cc049ec5bc776bfe0fc8e298048fe8bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

