### PR TITLE
Voiceover accessibility improvements

### DIFF
--- a/TinfoilChat/Views/AnimatedConfidentialTitle.swift
+++ b/TinfoilChat/Views/AnimatedConfidentialTitle.swift
@@ -16,6 +16,7 @@ struct AnimatedConfidentialTitle: View {
     @State private var showLock = false
     @State private var animationTimer: Timer?
     @ObservedObject private var settings = SettingsManager.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     
     private let fullText = "Private Chat"
     private let typingSpeed = 0.05 // seconds per character
@@ -38,7 +39,13 @@ struct AnimatedConfidentialTitle: View {
         }
         .onAppear {
             hapticGenerator.prepare()
-            startTypingAnimation()
+            if reduceMotion {
+                displayedText = fullText
+                showLock = true
+                isLocked = true
+            } else {
+                startTypingAnimation()
+            }
         }
         .onDisappear {
             animationTimer?.invalidate()

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -605,6 +605,7 @@ struct ChatListItem: View {
                                 Circle()
                                     .fill(Color.blue)
                                     .frame(width: 8, height: 8)
+                                    .accessibilityHidden(true)
                             }
                             
                             Spacer()

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -262,7 +262,7 @@ struct ChatSidebar: View {
                 Task { await viewModel.loadMoreChats() }
             } label: {
                 Text("Load More")
-                    .font(.system(size: 16, weight: .regular))
+                    .font(.system(.callout, weight: .regular))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
             }
@@ -274,7 +274,7 @@ struct ChatSidebar: View {
             } label: {
                 Text("Load More")
                     .foregroundColor(.primary)
-                    .font(.system(size: 16, weight: .regular))
+                    .font(.system(.callout, weight: .regular))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
                     .background(

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -367,6 +367,7 @@ struct ChatSidebar: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Projects")
+            .accessibilityAddTraits(.isHeader)
             .accessibilityValue(isProjectsExpanded ? "Expanded" : "Collapsed")
             .accessibilityHint(isProjectsExpanded ? "Collapses the projects list" : "Expands the projects list")
 

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -458,6 +458,7 @@ struct ChatSidebar: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Chats")
+        .accessibilityAddTraits(.isHeader)
         .accessibilityValue(isChatsExpanded ? "Expanded" : "Collapsed")
         .accessibilityHint(isChatsExpanded ? "Collapses the chat list" : "Expands the chat list")
     }

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -320,7 +320,7 @@ struct ChatContainer: View {
                             Image(systemName: preset.iconName)
                                 .font(.system(size: 9, weight: .semibold))
                             Text(preset.name)
-                                .font(.system(size: 10, weight: .medium))
+                                .font(.system(.caption2, weight: .medium))
                                 .lineLimit(1)
                         }
                         .foregroundColor(toolbarContentColor.opacity(0.7))
@@ -553,12 +553,12 @@ struct ChatContainer: View {
                     Image(systemName: "internaldrive")
                         .font(.system(size: 9))
                     Text("Local")
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.system(.caption2, weight: .medium))
                 } else {
                     Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90.icloud")
                         .font(.system(size: 9))
                     Text("Cloud")
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.system(.caption2, weight: .medium))
                 }
             }
             .foregroundColor(.secondary)

--- a/TinfoilChat/Views/CloudSyncOnboardingView.swift
+++ b/TinfoilChat/Views/CloudSyncOnboardingView.swift
@@ -215,6 +215,7 @@ struct CloudSyncOnboardingView: View {
                 Text("Enable Cloud Sync?")
                     .font(.title)
                     .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
 
                 // Description
                 Text("Cloud sync enables encrypted syncing of chats across your devices.")
@@ -309,6 +310,7 @@ struct CloudSyncOnboardingView: View {
                 Text("Encryption Key")
                     .font(.title)
                     .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
 
                 // Description
                 Text(
@@ -392,6 +394,7 @@ struct CloudSyncOnboardingView: View {
                 Text("Success!")
                     .font(.title)
                     .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
 
                 // Description
                 Text(
@@ -476,6 +479,7 @@ struct CloudSyncOnboardingView: View {
                 Text("Restore Encryption Key")
                     .font(.title)
                     .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
 
                 // Description
                 Text("Enter or upload your personal encryption key.")

--- a/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
@@ -114,7 +114,7 @@ private struct ArtifactPreviewView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Code artifact preview")
+        .accessibilityLabel(args.title ?? sourceLabel)
         .accessibilityHint("Opens preview")
         .sheet(isPresented: $showSheet) {
             ArtifactDetailSheet(args: args, isDarkMode: isDarkMode)

--- a/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ArtifactPreviewWidget.swift
@@ -114,6 +114,7 @@ private struct ArtifactPreviewView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
+        .accessibilityLabel("Code artifact preview")
         .accessibilityHint("Opens preview")
         .sheet(isPresented: $showSheet) {
             ArtifactDetailSheet(args: args, isDarkMode: isDarkMode)

--- a/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
@@ -133,6 +133,21 @@ private struct ClockFaceView: View {
         }
         .frame(maxWidth: .infinity)
         .genUICard(isDarkMode: isDarkMode, padding: 16)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(clockAccessibilityLabel)
+        .accessibilityAddTraits(.updatesFrequently)
+    }
+
+    private var clockAccessibilityLabel: String {
+        var parts: [String] = []
+        if let label = args.label, !label.isEmpty {
+            parts.append(label)
+        }
+        parts.append("Clock")
+        if let tz = args.timeZone {
+            parts.append(tz)
+        }
+        return parts.joined(separator: ", ")
     }
 
     private func timeString(for date: Date) -> String {
@@ -515,6 +530,21 @@ private struct CountdownView: View {
         .genUICard(isDarkMode: isDarkMode, padding: 0)
         .onAppear(perform: configure)
         .onDisappear { alarm.stop() }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(timerAccessibilityLabel)
+    }
+
+    private var timerAccessibilityLabel: String {
+        var parts: [String] = []
+        if let title = args.title ?? args.label, !title.isEmpty {
+            parts.append(title)
+        } else {
+            parts.append("Timer")
+        }
+        if let duration = args.durationSeconds, duration > 0 {
+            parts.append("\(Int(duration)) seconds")
+        }
+        return parts.joined(separator: ", ")
     }
 
     private func configure() {

--- a/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ClockWidget.swift
@@ -117,6 +117,7 @@ private struct ClockFaceView: View {
                 ClockDial(date: date, timeZone: timeZone, showSeconds: showSeconds, isDarkMode: isDarkMode)
                     .frame(width: 160, height: 160)
             }
+            .accessibilityHidden(true)
 
             TimelineView(.periodic(from: .now, by: 1.0)) { context in
                 VStack(spacing: 2) {
@@ -129,25 +130,31 @@ private struct ClockFaceView: View {
                             .foregroundColor(GenUIStyle.mutedText(isDarkMode))
                     }
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(clockAccessibilityLabel(for: context.date))
+                .accessibilityAddTraits(.updatesFrequently)
             }
         }
         .frame(maxWidth: .infinity)
         .genUICard(isDarkMode: isDarkMode, padding: 16)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(clockAccessibilityLabel)
-        .accessibilityAddTraits(.updatesFrequently)
+        .accessibilityElement(children: .contain)
     }
 
-    private var clockAccessibilityLabel: String {
-        var parts: [String] = []
-        if let label = args.label, !label.isEmpty {
-            parts.append(label)
-        }
-        parts.append("Clock")
-        if let tz = args.timeZone {
+    private func clockAccessibilityLabel(for date: Date) -> String {
+        var parts: [String] = [spokenTimeString(for: date)]
+        if showDate {
+            parts.append(dateString(for: date))
+        } else if let tz = args.timeZone {
             parts.append(tz)
         }
         return parts.joined(separator: ", ")
+    }
+
+    private func spokenTimeString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.timeStyle = showSeconds ? .medium : .short
+        return formatter.string(from: date)
     }
 
     private func timeString(for date: Date) -> String {
@@ -472,6 +479,9 @@ private struct CountdownView: View {
                     Text(formatRemaining(max(0, remaining)))
                         .font(.system(size: 36, weight: .light, design: .monospaced))
                         .foregroundColor(GenUIStyle.primaryText(isDarkMode))
+                        .accessibilityElement()
+                        .accessibilityLabel(spokenRemaining(max(0, remaining)))
+                        .accessibilityAddTraits(.updatesFrequently)
                 }
                 .frame(width: 200, height: 200)
                 .opacity(finishedNow && alarmMode == .flash && !flashOn ? 0.4 : 1.0)
@@ -531,20 +541,15 @@ private struct CountdownView: View {
         .onAppear(perform: configure)
         .onDisappear { alarm.stop() }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(timerAccessibilityLabel)
     }
 
-    private var timerAccessibilityLabel: String {
-        var parts: [String] = []
-        if let title = args.title ?? args.label, !title.isEmpty {
-            parts.append(title)
-        } else {
-            parts.append("Timer")
-        }
-        if let duration = args.durationSeconds, duration > 0 {
-            parts.append("\(Int(duration)) seconds")
-        }
-        return parts.joined(separator: ", ")
+    private func spokenRemaining(_ remaining: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .full
+        formatter.zeroFormattingBehavior = .dropLeading
+        let value = formatter.string(from: max(0, remaining)) ?? "0 seconds"
+        return "\(value) remaining"
     }
 
     private func configure() {

--- a/TinfoilChat/Views/GenUI/Widgets/ImageWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/ImageWidget.swift
@@ -107,8 +107,12 @@ private struct SingleImageView: View {
                     .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
             )
             .contentShape(Rectangle())
+            .accessibilityElement()
             .accessibilityLabel(accessibilityText(for: image))
+            .accessibilityAddTraits(.isButton)
+            .accessibilityHint(image.link?.isEmpty == false ? "Opens link" : "Opens full screen")
             .onTapGesture { handleTap() }
+            .accessibilityAction { handleTap() }
 
             if let caption = image.caption, !caption.isEmpty {
                 Text(caption)
@@ -229,8 +233,12 @@ private struct ImageGridView: View {
                         .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
                 )
                 .contentShape(Rectangle())
+                .accessibilityElement()
                 .accessibilityLabel(accessibilityText(for: image))
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint(image.link?.isEmpty == false ? "Opens link" : "Opens full screen")
                 .onTapGesture { handleTap(index: index, image: image) }
+                .accessibilityAction { handleTap(index: index, image: image) }
 
             if let caption = image.caption, !caption.isEmpty {
                 Text(caption)

--- a/TinfoilChat/Views/GenUI/Widgets/MapWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/MapWidget.swift
@@ -213,6 +213,9 @@ private struct MapWidgetView: View {
                     RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius)
                         .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
                 )
+                .accessibilityElement()
+                .accessibilityLabel(mapAccessibilityLabel)
+                .accessibilityAddTraits(.isImage)
 
             if args.locations.count > 1 {
                 locationList
@@ -234,8 +237,6 @@ private struct MapWidgetView: View {
             await resolvePins()
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(mapAccessibilityLabel)
-        .accessibilityAddTraits(.isImage)
     }
 
     private var mapAccessibilityLabel: String {

--- a/TinfoilChat/Views/GenUI/Widgets/MapWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/MapWidget.swift
@@ -233,6 +233,21 @@ private struct MapWidgetView: View {
         .task(id: locationsKey) {
             await resolvePins()
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(mapAccessibilityLabel)
+        .accessibilityAddTraits(.isImage)
+    }
+
+    private var mapAccessibilityLabel: String {
+        var parts: [String] = []
+        if let title = args.title, !title.isEmpty {
+            parts.append(title)
+        }
+        parts.append("Map with \(args.locations.count) location\(args.locations.count == 1 ? "" : "s")")
+        if let first = args.locations.first {
+            parts.append(first.name)
+        }
+        return parts.joined(separator: ", ")
     }
 
     private var locationsKey: String {

--- a/TinfoilChat/Views/GenUI/Widgets/MessageComposeWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/MessageComposeWidget.swift
@@ -107,6 +107,7 @@ private struct MessageComposeView: View {
                 .stroke(GenUIStyle.borderColor(isDarkMode), lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: GenUIStyle.cornerRadius))
+        .accessibilityElement(children: .contain)
     }
 
     @ViewBuilder
@@ -117,6 +118,7 @@ private struct MessageComposeView: View {
                 Circle().fill(Color(red: 1.0, green: 0.74, blue: 0.18)).frame(width: 10, height: 10)
                 Circle().fill(Color(red: 0.16, green: 0.78, blue: 0.25)).frame(width: 10, height: 10)
             }
+            .accessibilityHidden(true)
             Spacer()
             Text(args.title ?? "New Message")
                 .font(.caption.weight(.medium))

--- a/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
@@ -295,6 +295,7 @@ private struct RecipeCardView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .accessibilityAddTraits(scale == recipeScale ? .isSelected : [])
             }
         }
         .padding(4)

--- a/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
@@ -127,6 +127,29 @@ private struct SportsDataView: View {
             footer
         }
         .genUICard(isDarkMode: isDarkMode)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(sportsAccessibilityLabel)
+    }
+
+    private var sportsAccessibilityLabel: String {
+        var parts: [String] = []
+        if let sport = args.sport, !sport.isEmpty {
+            parts.append(sport)
+        }
+        if let title = titleText {
+            parts.append(title)
+        }
+        if args.kind == "fixture" {
+            if let home = args.home, let away = args.away {
+                parts.append("\(home.name) vs \(away.name)")
+            }
+            if let status = args.status, !status.isEmpty {
+                parts.append(status)
+            }
+        } else if args.kind == "standings" {
+            parts.append("Standings")
+        }
+        return parts.isEmpty ? "Sports data" : parts.joined(separator: ", ")
     }
 
     @ViewBuilder

--- a/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/SportsDataWidget.swift
@@ -127,7 +127,7 @@ private struct SportsDataView: View {
             footer
         }
         .genUICard(isDarkMode: isDarkMode)
-        .accessibilityElement(children: .contain)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel(sportsAccessibilityLabel)
     }
 
@@ -141,7 +141,12 @@ private struct SportsDataView: View {
         }
         if args.kind == "fixture" {
             if let home = args.home, let away = args.away {
-                parts.append("\(home.name) vs \(away.name)")
+                if let homeScore = home.score?.stringValue, !homeScore.isEmpty,
+                   let awayScore = away.score?.stringValue, !awayScore.isEmpty {
+                    parts.append("\(home.name) \(homeScore), \(away.name) \(awayScore)")
+                } else {
+                    parts.append("\(home.name) vs \(away.name)")
+                }
             }
             if let status = args.status, !status.isEmpty {
                 parts.append(status)

--- a/TinfoilChat/Views/GenUI/Widgets/TimelineWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/TimelineWidget.swift
@@ -78,6 +78,7 @@ private struct TimelineEventsView: View {
                                 .padding(.top, 4)
                         }
                         .frame(width: 14)
+                        .accessibilityHidden(true)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(event.date.uppercased())
@@ -95,6 +96,8 @@ private struct TimelineEventsView: View {
                             }
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(event.date), \(event.title)\(event.description.map { ", \($0)" } ?? "")")
                     }
                     // Hug the text's ideal height so the greedy connector
                     // line cannot stretch the row when a large height is
@@ -103,5 +106,6 @@ private struct TimelineEventsView: View {
                 }
             }
         }
+        .accessibilityElement(children: .contain)
     }
 }

--- a/TinfoilChat/Views/InitializationFailedView.swift
+++ b/TinfoilChat/Views/InitializationFailedView.swift
@@ -21,6 +21,7 @@ struct InitializationFailedView: View {
                 Image(systemName: "exclamationmark.triangle")
                     .font(.system(size: Constants.UI.initFailedIconSize))
                     .foregroundColor(.primary)
+                    .accessibilityHidden(true)
 
                 VStack(spacing: 12) {
                     Text("Failed to Initialize")

--- a/TinfoilChat/Views/InitializationFailedView.swift
+++ b/TinfoilChat/Views/InitializationFailedView.swift
@@ -25,12 +25,12 @@ struct InitializationFailedView: View {
 
                 VStack(spacing: 12) {
                     Text("Failed to Initialize")
-                        .font(.system(size: 28, weight: .medium))
+                        .font(.system(.title, weight: .medium))
                         .foregroundColor(.primary)
                         .multilineTextAlignment(.center)
 
                     Text(errorMessage)
-                        .font(.system(size: 17))
+                        .font(.body)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
@@ -42,9 +42,9 @@ struct InitializationFailedView: View {
                 Button(action: retryAction) {
                     HStack(spacing: 8) {
                         Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 16, weight: .medium))
+                            .font(.system(.callout, weight: .medium))
                         Text("Try Again")
-                            .font(.system(size: 17, weight: .semibold))
+                            .font(.system(.body, weight: .semibold))
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -16,6 +16,7 @@ struct MessageInputView: View {
     @Binding var messageText: String
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
     @EnvironmentObject private var authManager: AuthManager
     @State private var textHeight: CGFloat = Layout.defaultHeight
     /// Reflects whether the editor has grown beyond a single line, so callers
@@ -362,9 +363,9 @@ struct MessageInputView: View {
                                     Circle()
                                         .fill(Color.red.opacity(0.2))
                                         .frame(width: 44, height: 44)
-                                        .scaleEffect(isPulsing ? 1.1 : 0.9)
+                                        .scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 1.1 : 0.9))
                                         .animation(
-                                            .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                                            reduceMotion ? nil : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
                                             value: isPulsing
                                         )
                                 }
@@ -461,9 +462,9 @@ struct MessageInputView: View {
                                     Circle()
                                         .fill(Color.red.opacity(0.2))
                                         .frame(width: 44, height: 44)
-                                        .scaleEffect(isPulsing ? 1.1 : 0.9)
+                                        .scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 1.1 : 0.9))
                                         .animation(
-                                            .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                                            reduceMotion ? nil : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
                                             value: isPulsing
                                         )
                                 }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -193,23 +193,31 @@ struct MessageInputView: View {
                 )
                 .transition(.opacity)
         } else if let rl = viewModel.rateLimit, rl.remaining <= Constants.RateLimit.warningThreshold {
-            Text(rl.remaining <= 0
+            let isOutOfRequests = rl.remaining <= 0
+            Text(isOutOfRequests
                  ? "No requests left"
                  : "\(rl.remaining) request\(rl.remaining == 1 ? "" : "s") left")
                 .font(.system(size: 11, weight: .medium))
-                .foregroundColor(rl.remaining <= 0 ? .orange : .secondary)
+                .foregroundColor(isOutOfRequests ? .orange : .secondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)
                 .background(
                     Capsule()
-                        .fill(rl.remaining <= 0
+                        .fill(isOutOfRequests
                               ? Color.orange.opacity(0.15)
                               : Color.secondary.opacity(0.12))
                 )
                 .transition(.opacity)
                 .animation(.easeInOut(duration: 0.25), value: rl.remaining)
                 .onTapGesture {
-                    if rl.remaining <= 0 {
+                    if isOutOfRequests {
+                        viewModel.showRateLimitPaywall = true
+                    }
+                }
+                .accessibilityAddTraits(isOutOfRequests ? .isButton : [])
+                .accessibilityHint(isOutOfRequests ? "Opens upgrade options" : "")
+                .accessibilityAction {
+                    if isOutOfRequests {
                         viewModel.showRateLimitPaywall = true
                     }
                 }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -667,7 +667,7 @@ struct MessageView: View {
                     // AI disclaimer - only on the last assistant message
                     if isLastMessage {
                         Text("AI can make mistakes. Verify important information.")
-                            .font(.system(size: 11))
+                            .font(.caption2)
                             .foregroundColor(isDarkMode ? .white.opacity(0.35) : .black.opacity(0.35))
                     }
                 }
@@ -942,15 +942,15 @@ private struct LongMessageAttachmentView: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Long Message")
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.system(.callout, weight: .semibold))
                     .foregroundColor(Color.userMessageForeground(isDarkMode: isDarkMode))
 
                 Text(wordCountText)
-                    .font(.system(size: 12))
+                    .font(.caption)
                     .foregroundColor(Color.userMessageForeground(isDarkMode: isDarkMode).opacity(0.6))
 
                 Text(previewText)
-                    .font(.system(size: 14))
+                    .font(.footnote)
                     .foregroundColor(Color.userMessageForeground(isDarkMode: isDarkMode).opacity(0.85))
                     .lineLimit(3)
                     .multilineTextAlignment(.leading)
@@ -1323,7 +1323,7 @@ struct CollapsibleThinkingBox: View {
                     } else {
                         HStack(spacing: 4) {
                             Text("Thinking")
-                                .font(.system(size: 16))
+                                .font(.callout)
                                 .foregroundColor(isDarkMode ? .white : Color.black.opacity(0.8))
                             InlineLoadingDotsView(isDarkMode: isDarkMode)
                         }
@@ -1820,7 +1820,7 @@ struct UserMessageEditView: View {
 
                 Button(action: onCancel) {
                     Text("Cancel")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(.caption, weight: .medium))
                         .foregroundColor(secondaryTextColor)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
@@ -1835,7 +1835,7 @@ struct UserMessageEditView: View {
                     }
                 }) {
                     Text("Save")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(.caption, weight: .medium))
                         .foregroundColor(.white)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
@@ -1882,7 +1882,7 @@ private struct SourcesButton: View {
         Button(action: action) {
             HStack(spacing: 4) {
                 Text("Sources")
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.system(.footnote, weight: .medium))
 
                 // Overlapping favicons
                 HStack(spacing: -6) {
@@ -1948,13 +1948,13 @@ private struct SourcesSheetView: View {
 
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(source.title)
-                                        .font(.system(size: 15, weight: .medium))
+                                        .font(.system(.subheadline, weight: .medium))
                                         .foregroundColor(isDarkMode ? .white : .black)
                                         .lineLimit(2)
                                         .multilineTextAlignment(.leading)
 
                                     Text(getDomain(from: source.url))
-                                        .font(.system(size: 13))
+                                        .font(.footnote)
                                         .foregroundColor(.secondary)
                                         .lineLimit(1)
                                 }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -961,11 +961,14 @@ private struct LongMessageAttachmentView: View {
             Image(systemName: "chevron.right")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(Color.userMessageForeground(isDarkMode: isDarkMode).opacity(0.5))
+                .accessibilityHidden(true)
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
         .onTapGesture(perform: openAction)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Shows the full message")
     }
 }
 

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1338,11 +1338,13 @@ struct CollapsibleThinkingBox: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(isDarkMode ? .white.opacity(0.4) : .black.opacity(0.4))
+                    .accessibilityHidden(true)
             }
             .padding(.vertical, 8)
             .contentShape(Rectangle())
         }
         .buttonStyle(NoHighlightButtonStyle())
+        .accessibilityLabel("Thinking")
         .accessibilityHint("Shows the full reasoning")
     }
 }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1456,56 +1456,65 @@ struct NoHighlightButtonStyle: ButtonStyle {
 struct PulsingAnimation: ViewModifier {
     let delay: Double
     @State private var isPulsing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func body(content: Content) -> some View {
-        content
-            .scaleEffect(isPulsing ? 1.0 : 0.6)
-            .opacity(isPulsing ? 1.0 : 0.3)
-            .animation(
-                Animation.easeInOut(duration: 0.6)
-                    .repeatForever(autoreverses: true)
-                    .delay(delay),
-                value: isPulsing
-            )
-            .onAppear {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    isPulsing = true
+        if reduceMotion {
+            content
+        } else {
+            content
+                .scaleEffect(isPulsing ? 1.0 : 0.6)
+                .opacity(isPulsing ? 1.0 : 0.3)
+                .animation(
+                    Animation.easeInOut(duration: 0.6)
+                        .repeatForever(autoreverses: true)
+                        .delay(delay),
+                    value: isPulsing
+                )
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isPulsing = true
+                    }
                 }
-            }
+        }
     }
 }
 
 struct TextPulseAnimation: ViewModifier {
     @State private var offset: CGFloat = -1.0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func body(content: Content) -> some View {
-        content
-            .overlay(
-                GeometryReader { geometry in
-                    let shimmerWidth = geometry.size.width * 0.4
-                    LinearGradient(
-                        colors: [
-                            .clear,
-                            .white.opacity(0.35),
-                            .clear
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                    .frame(width: shimmerWidth)
-                    .offset(x: offset * (geometry.size.width + shimmerWidth))
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        if reduceMotion {
+            content
+        } else {
+            content
+                .overlay(
+                    GeometryReader { geometry in
+                        let shimmerWidth = geometry.size.width * 0.4
+                        LinearGradient(
+                            colors: [
+                                .clear,
+                                .white.opacity(0.35),
+                                .clear
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(width: shimmerWidth)
+                        .offset(x: offset * (geometry.size.width + shimmerWidth))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .mask(content)
+                )
+                .onAppear {
+                    withAnimation(
+                        .easeInOut(duration: 2.0)
+                        .repeatForever(autoreverses: false)
+                    ) {
+                        offset = 1.0
+                    }
                 }
-                .mask(content)
-            )
-            .onAppear {
-                withAnimation(
-                    .easeInOut(duration: 2.0)
-                    .repeatForever(autoreverses: false)
-                ) {
-                    offset = 1.0
-                }
-            }
     }
 }
 

--- a/TinfoilChat/Views/NoInternetView.swift
+++ b/TinfoilChat/Views/NoInternetView.swift
@@ -16,6 +16,7 @@ struct NoInternetView: View {
                 Image(systemName: "wifi.slash")
                     .font(.system(size: Constants.UI.initFailedIconSize))
                     .foregroundColor(.primary)
+                    .accessibilityHidden(true)
 
                 VStack(spacing: 12) {
                     Text("No Internet Connection")

--- a/TinfoilChat/Views/NoInternetView.swift
+++ b/TinfoilChat/Views/NoInternetView.swift
@@ -20,12 +20,12 @@ struct NoInternetView: View {
 
                 VStack(spacing: 12) {
                     Text("No Internet Connection")
-                        .font(.system(size: 28, weight: .medium))
+                        .font(.system(.title, weight: .medium))
                         .foregroundColor(.primary)
                         .multilineTextAlignment(.center)
 
                     Text("Please check your internet connection and try again.")
-                        .font(.system(size: 17))
+                        .font(.body)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
@@ -37,9 +37,9 @@ struct NoInternetView: View {
                 Button(action: retryAction) {
                     HStack(spacing: 8) {
                         Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 16, weight: .medium))
+                            .font(.system(.callout, weight: .medium))
                         Text("Try Again")
-                            .font(.system(size: 17, weight: .semibold))
+                            .font(.system(.body, weight: .semibold))
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -568,6 +568,11 @@ private struct OnboardingModelsPage: View {
                             }
                             .accessibilityElement(children: .combine)
                             .accessibilityAddTraits(index == selectedModelIndex ? [.isButton, .isSelected] : .isButton)
+                            .accessibilityAction {
+                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                    selectedModelIndex = index
+                                }
+                            }
                     }
                 }
                 .padding(.horizontal, 24)

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -133,6 +133,7 @@ struct OnboardingView: View {
 
 private struct OnboardingPrivacyPage: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Binding var isPrivacyEnabled: Bool
     @State private var isPrivateOn = false
     @State private var showExplanation = false
@@ -285,8 +286,10 @@ private struct OnboardingPrivacyPage: View {
                             lineWidth: 1
                         )
                         .onAppear {
-                            withAnimation(.linear(duration: 4.0).repeatForever(autoreverses: false)) {
-                                borderRotation = 360
+                            if !reduceMotion {
+                                withAnimation(.linear(duration: 4.0).repeatForever(autoreverses: false)) {
+                                    borderRotation = 360
+                                }
                             }
                         }
                 }

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -560,19 +560,16 @@ private struct OnboardingModelsPage: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {
                     ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
-                        modelCard(model: model, isSelected: index == selectedModelIndex)
-                            .onTapGesture {
-                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                    selectedModelIndex = index
-                                }
+                        let selectModel = {
+                            withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                selectedModelIndex = index
                             }
+                        }
+                        modelCard(model: model, isSelected: index == selectedModelIndex)
+                            .onTapGesture(perform: selectModel)
                             .accessibilityElement(children: .combine)
                             .accessibilityAddTraits(index == selectedModelIndex ? [.isButton, .isSelected] : .isButton)
-                            .accessibilityAction {
-                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                    selectedModelIndex = index
-                                }
-                            }
+                            .accessibilityAction(action: selectModel)
                     }
                 }
                 .padding(.horizontal, 24)

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -65,6 +65,7 @@ struct OnboardingView: View {
                                 .animation(.spring(response: 0.3, dampingFraction: 0.7), value: currentPage)
                         }
                     }
+                    .accessibilityHidden(true)
 
                     // Continue / Get Started button
                     let canContinue = currentPage != 0 || privacyEnabled

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -154,6 +154,7 @@ private struct OnboardingPrivacyPage: View {
                     Text("Privacy First")
                         .font(.title)
                         .fontWeight(.bold)
+                        .accessibilityAddTraits(.isHeader)
                 }
 
                 Text("Tinfoil is built for people who believe their conversations are nobody else's business.")
@@ -410,6 +411,7 @@ private struct OnboardingEncryptionPage: View {
                     Text("Your Key, Your Data")
                         .font(.title)
                         .fontWeight(.bold)
+                        .accessibilityAddTraits(.isHeader)
 
                     Text("Every chat is encrypted with a key that only exists on your device. Nobody but you can read your conversations.")
                         .font(.subheadline)
@@ -504,6 +506,7 @@ private struct OnboardingModelsPage: View {
                     Text("Powerful Models")
                         .font(.title)
                         .fontWeight(.bold)
+                        .accessibilityAddTraits(.isHeader)
 
                     Text("Access leading AI models, all running inside secure hardware with verified privacy.")
                         .font(.subheadline)

--- a/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
+++ b/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
@@ -44,6 +44,7 @@ struct PasskeyRecoveryChoiceView: View {
             Text("Passkey Not Found")
                 .font(.title2)
                 .fontWeight(.bold)
+                .accessibilityAddTraits(.isHeader)
 
             Text("We couldn't find a matching passkey on this device. Your passkey might be in iCloud Keychain or a password manager that hasn't synced yet.")
                 .font(.subheadline)

--- a/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
+++ b/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
@@ -40,6 +40,7 @@ struct PasskeyRecoveryChoiceView: View {
                     .font(.system(size: 28))
                     .foregroundColor(.primary)
             }
+            .accessibilityHidden(true)
 
             Text("Passkey Not Found")
                 .font(.title2)

--- a/TinfoilChat/Views/PromptLibraryView.swift
+++ b/TinfoilChat/Views/PromptLibraryView.swift
@@ -90,7 +90,7 @@ struct PromptSuggestionsBar: View {
             Image(systemName: iconName)
                 .font(.system(size: 13))
             Text(title)
-                .font(.system(size: 13, weight: .medium))
+                .font(.system(.footnote, weight: .medium))
                 .lineLimit(1)
         }
         .foregroundColor(isActive ? Color.adaptiveAccent : .secondary)

--- a/TinfoilChat/Views/QRCodeScannerView.swift
+++ b/TinfoilChat/Views/QRCodeScannerView.swift
@@ -84,6 +84,7 @@ class QRScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsD
         cancelButton.layer.cornerRadius = 8
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        cancelButton.accessibilityLabel = "Cancel QR scan"
 
         view.addSubview(cancelButton)
 
@@ -104,6 +105,7 @@ class QRScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsD
         overlayView.translatesAutoresizingMaskIntoConstraints = false
         // Ensure overlay does not intercept touches intended for buttons beneath
         overlayView.isUserInteractionEnabled = false
+        overlayView.isAccessibilityElement = false
         view.addSubview(overlayView)
         
         NSLayoutConstraint.activate([
@@ -165,6 +167,14 @@ class QRScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsD
             DispatchQueue.global(qos: .background).async {
                 self.captureSession.startRunning()
             }
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .announcement, argument: "QR code scanner active. Point your camera at a QR code containing an encryption key.")
         }
     }
     

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -425,6 +425,7 @@ struct SettingsView: View {
                         Image(systemName: "chevron.right")
                             .font(.caption2)
                             .foregroundColor(Color(UIColor.quaternaryLabel))
+                            .accessibilityHidden(true)
                     }
                 }
 
@@ -816,6 +817,7 @@ struct SettingsView: View {
                         Image(systemName: "arrow.up.forward.square")
                             .font(.footnote)
                             .foregroundColor(Color(UIColor.tertiaryLabel))
+                            .accessibilityHidden(true)
                     }
                 }
             } else {
@@ -878,6 +880,7 @@ struct SettingsView: View {
                     Image(systemName: "arrow.up.forward.square")
                         .font(.footnote)
                         .foregroundColor(Color(UIColor.tertiaryLabel))
+                        .accessibilityHidden(true)
                 }
             }
 
@@ -891,6 +894,7 @@ struct SettingsView: View {
                     Image(systemName: "arrow.up.forward.square")
                         .font(.footnote)
                         .foregroundColor(Color(UIColor.tertiaryLabel))
+                        .accessibilityHidden(true)
                 }
             }
         } header: {

--- a/TinfoilChat/Views/ShareChatView.swift
+++ b/TinfoilChat/Views/ShareChatView.swift
@@ -67,6 +67,7 @@ struct ShareChatView: View {
             Spacer()
             Image(systemName: "bubble.left.fill")
                 .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
         }
         .padding(14)
         .background(cardColor)

--- a/TinfoilChat/Views/ShareChatView.swift
+++ b/TinfoilChat/Views/ShareChatView.swift
@@ -81,6 +81,7 @@ struct ShareChatView: View {
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
                 .padding(.leading, 4)
+                .accessibilityAddTraits(.isHeader)
 
             accessOptions
             actionButton

--- a/TinfoilChat/Views/ShareChatView.swift
+++ b/TinfoilChat/Views/ShareChatView.swift
@@ -62,7 +62,7 @@ struct ShareChatView: View {
     private var titleCard: some View {
         HStack {
             Text(chatTitle ?? "Untitled")
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(.callout, weight: .semibold))
                 .lineLimit(2)
             Spacer()
             Image(systemName: "bubble.left.fill")
@@ -79,7 +79,7 @@ struct ShareChatView: View {
     private var accessCard: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Who has access")
-                .font(.system(size: 13))
+                .font(.system(.footnote))
                 .foregroundStyle(.secondary)
                 .padding(.leading, 4)
                 .accessibilityAddTraits(.isHeader)

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -41,6 +41,7 @@ struct WebSearchBox: View {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(isDarkMode ? .white.opacity(0.4) : .black.opacity(0.4))
+                        .accessibilityHidden(true)
                 }
             }
             .padding(.vertical, 8)
@@ -103,6 +104,7 @@ struct WebSearchBox: View {
                         .foregroundColor(isDarkMode ? .white.opacity(0.7) : .black.opacity(0.6))
                         .font(.system(size: 14))
                         .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 5 }
+                        .accessibilityHidden(true)
 
                     Text("Searched the web on \(groupSize) quer\(groupSize == 1 ? "y" : "ies")")
                         .font(.subheadline)
@@ -121,6 +123,7 @@ struct WebSearchBox: View {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundColor(.red)
                     .font(.system(size: 14))
+                    .accessibilityHidden(true)
                 Text("Search failed")
                     .font(.subheadline)
                     .foregroundColor(.red.opacity(0.8))
@@ -131,6 +134,7 @@ struct WebSearchBox: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundColor(.orange)
                     .font(.system(size: 14))
+                    .accessibilityHidden(true)
                 Text(webSearchState.reason ?? "Search blocked")
                     .font(.subheadline)
                     .foregroundColor(.orange.opacity(0.8))
@@ -154,6 +158,7 @@ struct WebSearchBox: View {
                     .padding(.leading, 6)
             }
         }
+        .accessibilityHidden(true)
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve VoiceOver support across the app for faster, clearer navigation and interaction. Adds descriptive labels, header roles, better grouping, Dynamic Type text, and respects Reduce Motion to cut unnecessary animations.

- **New Features**
  - Added VoiceOver labels, hints, and actions across widgets and controls (images, long messages, artifact previews, model cards, rate‑limit badge, sources, share access, thinking, web search); simplified model carousel selection with an explicit accessibility action.
  - Spoke dynamic content with concise summaries and marked frequent updates where needed (clock/timezone/date, countdown “X remaining”, sports scores, timeline events, maps).
  - Marked key titles as headers for easier navigation (Sidebar sections, Onboarding steps, Cloud Sync, Passkey recovery, Share screen).
  - QR scanner now announces when active and exposes a clearly labeled Cancel; improved grouping/reading order in composite views.

- **Bug Fixes**
  - Hid decorative icons/indicators from VoiceOver and made generated image tiles fully operable via actions.
  - Respected Reduce Motion by disabling pulsing/shimmer/typing effects and using static states where appropriate.
  - Replaced fixed font sizes with Dynamic Type styles in key screens for better scaling and readability.

<sup>Written for commit f36ad705fa8d047e0038a074d523c33c202fe8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

