### PR TITLE
Fix streaming message blank cell

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.3;
+				MARKETING_VERSION = 2.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.3;
+				MARKETING_VERSION = 2.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -329,6 +329,11 @@ struct MessageInputView: View {
             VStack(spacing: 4) {
                 rateLimitLabel
 
+                // Host both interactive glass effects (the input container and
+                // the send button) in one container so their gravity-well anchor
+                // views attach here instead of directly under the hosting
+                // controller's view, which UIKit warns against for hosted cells.
+                GlassEffectContainer {
                 VStack(spacing: 0) {
                 // Attachment preview bar
                 if !viewModel.pendingAttachments.isEmpty {
@@ -420,6 +425,7 @@ struct MessageInputView: View {
                 .padding(.vertical, 8)
             }
             .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 26))
+            }
             }
             .padding(.horizontal, 12)
             .padding(.bottom, inputBottomPadding)

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -455,8 +455,14 @@ struct MessageTableView: UIViewRepresentable {
         }
 
         func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+            // Skip the streaming last row: while it is loading its frame is
+            // inflated by the streaming buffer (many screens tall). Caching that
+            // value would make heightForRowAt later pin the finished row to the
+            // buffer height - a giant blank cell the user scrolls through without
+            // ever seeing the response. didEndDisplaying guards this the same way.
+            let isStreamingLastRow = parent.isLoading && indexPath.row == parent.messages.count - 1
             let height = cell.frame.size.height
-            if height > 0 {
+            if height > 0 && !isStreamingLastRow {
                 heightCache[indexPath] = height
                 if indexPath.row < parent.messages.count {
                     messageHeightCache[parent.messages[indexPath.row].id] = height

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -204,11 +204,16 @@ struct MessageTableView: UIViewRepresentable {
             }
 
             // Capture the user's intent before any layout change. Follow down to
-            // the end only when the user was passively watching from the bottom.
-            // When their sent message is pinned to the top (the normal send
-            // flow), keep that reading position instead of snapping to the
-            // bottom of the finished response.
-            let wasFollowing = !userHasScrolled && !context.coordinator.isUserMessageScrollMode
+            // the end when the user is at the bottom watching the response, or
+            // when they never scrolled and their message isn't pinned to the top.
+            // isUserMessageScrollMode is sticky (it isn't cleared when the user
+            // scrolls back down), so the actual bottom state has to be consulted
+            // too; otherwise a user who returned to the bottom stays stuck in the
+            // top-reading position instead of ending at the bottom. A tall
+            // response still being read from the top has isAtBottom == false, so
+            // it keeps its position rather than snapping to the bottom.
+            let wasFollowing = isAtBottom ||
+                (!userHasScrolled && !context.coordinator.isUserMessageScrollMode)
 
             DispatchQueue.main.async {
                 UIView.performWithoutAnimation {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -532,7 +532,16 @@ struct MessageTableView: UIViewRepresentable {
             if parent.isLoading && isLastMessage {
                 return UITableView.automaticDimension
             }
-            if let cached = messageHeightCache[parent.messages[indexPath.row].id] {
+            let message = parent.messages[indexPath.row]
+            // Messages with generative-UI widgets render asynchronously and can
+            // grow after their height was first cached. Pinning them to that
+            // stale height makes the taller content overflow onto adjacent rows
+            // (the table has clipsToBounds off), which stacks cells on top of
+            // each other. Always let these rows self-size.
+            if !message.toolCalls.isEmpty {
+                return UITableView.automaticDimension
+            }
+            if let cached = messageHeightCache[message.id] {
                 return cached
             }
             return UITableView.automaticDimension

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -203,10 +203,12 @@ struct MessageTableView: UIViewRepresentable {
                 }
             }
 
-            // Capture the user's intent before any layout change. If they were
-            // actively scrolling through the response, keep their reading
-            // position; otherwise follow down to the end of the finished message.
-            let wasFollowing = !userHasScrolled
+            // Capture the user's intent before any layout change. Follow down to
+            // the end only when the user was passively watching from the bottom.
+            // When their sent message is pinned to the top (the normal send
+            // flow), keep that reading position instead of snapping to the
+            // bottom of the finished response.
+            let wasFollowing = !userHasScrolled && !context.coordinator.isUserMessageScrollMode
 
             DispatchQueue.main.async {
                 UIView.performWithoutAnimation {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -203,23 +203,18 @@ struct MessageTableView: UIViewRepresentable {
                 }
             }
 
-            // Capture the user's intent before any layout change. Follow down to
-            // the end when the user is at the bottom watching the response, or
-            // when they never scrolled and their message isn't pinned to the top.
-            // isUserMessageScrollMode is sticky (it isn't cleared when the user
-            // scrolls back down), so the actual bottom state has to be consulted
-            // too; otherwise a user who returned to the bottom stays stuck in the
-            // top-reading position instead of ending at the bottom. A tall
-            // response still being read from the top has isAtBottom == false, so
-            // it keeps its position rather than snapping to the bottom.
-            let wasFollowing = isAtBottom ||
-                (!userHasScrolled && !context.coordinator.isUserMessageScrollMode)
-
+            // Collapsing the streaming buffer changes contentSize dramatically.
+            // Preserve the user's exact reading position through that resize
+            // rather than scrolling to the end. The buffer being removed sits
+            // below the visible content, so holding the offset keeps whatever the
+            // user is looking at stationary: a reader at the top stays at the top,
+            // and one already at the bottom stays at the bottom (the empty space
+            // beneath them simply disappears) without an explicit jump.
             DispatchQueue.main.async {
                 UIView.performWithoutAnimation {
                     // Temporarily inflate the bottom inset so the collapsing
                     // streaming buffer cannot clamp the offset and snap the view
-                    // to the bottom before the final inset is settled below.
+                    // before the final inset is settled below.
                     let currentOffset = tableView.contentOffset.y
                     tableView.contentInset.bottom = tableView.bounds.height
                     tableView.layoutIfNeeded()
@@ -227,16 +222,11 @@ struct MessageTableView: UIViewRepresentable {
                 }
 
                 DispatchQueue.main.async {
-                    if wasFollowing {
-                        context.coordinator.isUserMessageScrollMode = false
-                        context.coordinator.scrollToBottom(animated: false)
-                    } else {
-                        UIView.performWithoutAnimation {
-                            let currentOffset = tableView.contentOffset.y
-                            context.coordinator.updateContentInset()
-                            tableView.layoutIfNeeded()
-                            tableView.contentOffset.y = currentOffset
-                        }
+                    UIView.performWithoutAnimation {
+                        let currentOffset = tableView.contentOffset.y
+                        context.coordinator.updateContentInset()
+                        tableView.layoutIfNeeded()
+                        tableView.contentOffset.y = currentOffset
                     }
                 }
             }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1515,6 +1515,7 @@ struct TextPulseAnimation: ViewModifier {
                         offset = 1.0
                     }
                 }
+        }
     }
 }
 

--- a/TinfoilChat/Views/OnboardingView.swift
+++ b/TinfoilChat/Views/OnboardingView.swift
@@ -569,7 +569,7 @@ private struct OnboardingModelsPage: View {
                             .onTapGesture(perform: selectModel)
                             .accessibilityElement(children: .combine)
                             .accessibilityAddTraits(index == selectedModelIndex ? [.isButton, .isSelected] : .isButton)
-                            .accessibilityAction(action: selectModel)
+                            .accessibilityAction(.default, selectModel)
                     }
                 }
                 .padding(.horizontal, 24)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes streaming message layout and scrolling: skips height caching for the streaming last row to avoid a giant blank cell, preserves your reading position when the streaming buffer collapses, lets generated‑UI rows self‑size to prevent overlap, and keeps your place when a response finishes. If you’re at the bottom (or never scrolled) you stay at the bottom on completion; also wraps input‑bar effects in a GlassEffectContainer to silence view‑hierarchy warnings and updates the onboarding model picker to use the .default accessibility action.

<sup>Written for commit 7ae402b813a92ddc677023975f2d5eb47e85b21b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

