### PR TITLE
Fix various UX issues

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/textual";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.8;
+				minimumVersion = 0.0.9;
 			};
 		};
 		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "e765ae4da8c501e06c34d6059321d5e80e1759a3",
-        "version" : "0.0.8"
+        "revision" : "829dc540350fd6e635ab196aac26e13d385f4849",
+        "version" : "0.0.9"
       }
     },
     {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "829dc540350fd6e635ab196aac26e13d385f4849",
-        "version" : "0.0.9"
+        "revision" : "e6731067a510f6d45bdec8e090698c380a90144d",
+        "version" : "0.0.10"
       }
     },
     {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -362,6 +362,7 @@ enum Constants {
             static let encryptionKeySetUp = "tinfoil-secret-encryption-key-set-up"
             static let passkeyEnclaveKeyId = "tinfoil-secret-passkey-enclave-key-id"
             static let passkeyEnclaveCredentialId = "tinfoil-secret-passkey-enclave-credential-id"
+            static let passkeyRecoveryDismissedKeyId = "tinfoil-secret-passkey-recovery-dismissed-key-id"
 
             static func cloudKeyAuthorization(userId: String) -> String {
                 "tinfoil-secret-cloud-key-authorization-\(userId)"

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -82,7 +82,7 @@ struct ContentView: View {
                     await passkeyManager.startFreshWithNewKey()
                 },
                 onSkip: {
-                    passkeyManager.showPasskeyRecoveryChoice = false
+                    passkeyManager.dismissRecoveryChoice()
                 },
                 onManualKeyEntry: {
                     passkeyManager.showPasskeyRecoveryChoice = false

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -70,13 +70,41 @@ final class PasskeyManager: ObservableObject {
     /// captured so a "Skip for Now" can record exactly which keyId the
     /// user dismissed.
     private var pendingRecoveryKeyId: String?
-    /// Remote keyId the user explicitly skipped. The periodic sync
-    /// check must not re-surface the recovery sheet for this keyId,
-    /// otherwise Skip is overridden on the next tick. A genuinely new
-    /// keyId (another start_fresh) is not suppressed.
-    private var dismissedRecoveryKeyId: String?
 
-    private init() {}
+    /// True when the user skipped recovery for the current remote key
+    /// and has not since regained a usable key. Mirrors the webapp's
+    /// persistent recovery-dismissed flag and drives the Settings /
+    /// sidebar "unlock cloud sync" affordances.
+    @Published private(set) var recoverySkipped: Bool = false
+
+    private init() {
+        recoverySkipped = dismissedRecoveryKeyId != nil
+    }
+
+    /// Remote keyId the user explicitly skipped, persisted so the
+    /// recovery sheet stays dismissed across app launches (matching the
+    /// webapp). The periodic sync check must not re-surface the sheet
+    /// for this keyId; a genuinely new keyId (another start_fresh) is
+    /// not suppressed.
+    private var dismissedRecoveryKeyId: String? {
+        UserDefaults.standard.string(
+            forKey: Constants.StorageKeys.Secret.passkeyRecoveryDismissedKeyId
+        )
+    }
+
+    private func setDismissedRecoveryKeyId(_ keyId: String?) {
+        if let keyId {
+            UserDefaults.standard.set(
+                keyId,
+                forKey: Constants.StorageKeys.Secret.passkeyRecoveryDismissedKeyId
+            )
+        } else {
+            UserDefaults.standard.removeObject(
+                forKey: Constants.StorageKeys.Secret.passkeyRecoveryDismissedKeyId
+            )
+        }
+        recoverySkipped = keyId != nil
+    }
 
     // MARK: - Sign-Out Reset
 
@@ -86,7 +114,7 @@ final class PasskeyManager: ObservableObject {
         passkeyAddDeviceAvailable = false
         showPasskeyRecoveryChoice = false
         pendingRecoveryKeyId = nil
-        dismissedRecoveryKeyId = nil
+        setDismissedRecoveryKeyId(nil)
         onRecoveryComplete = nil
         onKeyRefreshedFromBackup = nil
         syncCheckTask?.cancel()
@@ -301,8 +329,24 @@ final class PasskeyManager: ObservableObject {
     /// Dismiss the recovery-choice sheet and remember which keyId the
     /// user skipped so the periodic sync check stops re-presenting it.
     func dismissRecoveryChoice() {
-        dismissedRecoveryKeyId = pendingRecoveryKeyId
+        setDismissedRecoveryKeyId(pendingRecoveryKeyId)
         showPasskeyRecoveryChoice = false
+    }
+
+    /// Clear a persisted recovery skip and re-run the recovery decision
+    /// tree. Backs the Settings and sidebar "unlock cloud sync"
+    /// affordances so a user who previously skipped can re-open
+    /// recovery. Mirrors the webapp's `showPasskeyRecoveryPrompt`.
+    /// Returns the recovery result so the caller can route the manual
+    /// setup / recovery cases to the onboarding sheet.
+    func reenableRecoveryPrompt() async -> PasskeyRecoveryResult {
+        pendingRecoveryKeyId = nil
+        setDismissedRecoveryKeyId(nil)
+        if EncryptionService.shared.hasEncryptionKey() {
+            await checkPasskeyStateForExistingKey()
+            return .success
+        }
+        return await attemptPasskeyKeyRecovery()
     }
 
     // MARK: - Recovery Choice Actions
@@ -366,6 +410,11 @@ final class PasskeyManager: ObservableObject {
         do {
             let state = try await SyncEnclaveAPI.keyCurrent()
             if let remoteKeyId = state.keyId, !state.bundles.isEmpty {
+                // A usable registered key with a local CEK means the
+                // user is no longer in a locked/skipped state, so drop
+                // any persisted recovery skip (e.g. left over from a
+                // manual unlock that bypassed the passkey flow).
+                setDismissedRecoveryKeyId(nil)
                 // Persist the keyId now so the periodic sync check has
                 // a baseline. Without this, a normal app launch (with
                 // a valid local CEK that matches the remote) would
@@ -595,7 +644,7 @@ final class PasskeyManager: ObservableObject {
         // A successful unlock clears any prior skip so a future genuine
         // mismatch can prompt again.
         pendingRecoveryKeyId = nil
-        dismissedRecoveryKeyId = nil
+        setDismissedRecoveryKeyId(nil)
     }
 
     private func cachedKeyIdHex() -> String? {

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -329,7 +329,12 @@ final class PasskeyManager: ObservableObject {
     /// Dismiss the recovery-choice sheet and remember which keyId the
     /// user skipped so the periodic sync check stops re-presenting it.
     func dismissRecoveryChoice() {
-        setDismissedRecoveryKeyId(pendingRecoveryKeyId)
+        // Only persist a concrete keyId. Skipping a sheet with no pending
+        // keyId must not clear an existing skip, or the periodic check
+        // would re-present recovery for a keyId the user already skipped.
+        if let keyId = pendingRecoveryKeyId {
+            setDismissedRecoveryKeyId(keyId)
+        }
         showPasskeyRecoveryChoice = false
     }
 

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -342,11 +342,22 @@ final class PasskeyManager: ObservableObject {
     func reenableRecoveryPrompt() async -> PasskeyRecoveryResult {
         pendingRecoveryKeyId = nil
         setDismissedRecoveryKeyId(nil)
-        if EncryptionService.shared.hasEncryptionKey() {
+        guard EncryptionService.shared.hasEncryptionKey() else {
+            return await attemptPasskeyKeyRecovery()
+        }
+        // A local key is present but it may be stale (rotated away by a
+        // `start_fresh` on another device). Re-run the mismatch resolver
+        // so a stale device re-enters recovery instead of being treated
+        // as already unlocked.
+        switch await resolveKeyMismatchAtLaunch() {
+        case .manualRecoveryRequired:
+            return .manualRecoveryRequired
+        case .noMismatch:
             await checkPasskeyStateForExistingKey()
             return .success
+        case .resolvedSilently, .passkeyPromptShown:
+            return .success
         }
-        return await attemptPasskeyKeyRecovery()
     }
 
     // MARK: - Recovery Choice Actions
@@ -410,24 +421,35 @@ final class PasskeyManager: ObservableObject {
         do {
             let state = try await SyncEnclaveAPI.keyCurrent()
             if let remoteKeyId = state.keyId, !state.bundles.isEmpty {
-                // A usable registered key with a local CEK means the
-                // user is no longer in a locked/skipped state, so drop
-                // any persisted recovery skip (e.g. left over from a
-                // manual unlock that bypassed the passkey flow).
-                setDismissedRecoveryKeyId(nil)
-                // Persist the keyId now so the periodic sync check has
-                // a baseline. Without this, a normal app launch (with
-                // a valid local CEK that matches the remote) would
-                // look like a `start_fresh` rotation on the next
-                // refresh tick and force the user through recovery.
-                if cachedKeyIdHex() == nil,
-                   let cek = try? EncryptionService.shared.getKeyBytesOrThrow(),
-                   let localKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek),
-                   localKeyId == remoteKeyId {
-                    UserDefaults.standard.set(
-                        remoteKeyId,
-                        forKey: Constants.StorageKeys.Secret.passkeyEnclaveKeyId
-                    )
+                // Derive the local key id so we can tell whether this
+                // device is actually on the current key or is holding a
+                // stale CEK that a `start_fresh` elsewhere rotated away.
+                let localKeyId: String? = {
+                    guard let cek = try? EncryptionService.shared.getKeyBytesOrThrow() else {
+                        return nil
+                    }
+                    return try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
+                }()
+                let isOnCurrentKey = localKeyId == remoteKeyId
+
+                if isOnCurrentKey {
+                    // The device is genuinely on the current key, so the
+                    // user is no longer in a locked/skipped state. Drop
+                    // any persisted recovery skip (e.g. left over from a
+                    // manual unlock that bypassed the passkey flow). A
+                    // stale device keeps its skip so it stays suppressed.
+                    setDismissedRecoveryKeyId(nil)
+                    // Persist the keyId now so the periodic sync check has
+                    // a baseline. Without this, a normal app launch (with
+                    // a valid local CEK that matches the remote) would
+                    // look like a `start_fresh` rotation on the next
+                    // refresh tick and force the user through recovery.
+                    if cachedKeyIdHex() == nil {
+                        UserDefaults.standard.set(
+                            remoteKeyId,
+                            forKey: Constants.StorageKeys.Secret.passkeyEnclaveKeyId
+                        )
+                    }
                 }
 
                 // The bundle map is keyed by credential id. If this

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -66,6 +66,16 @@ final class PasskeyManager: ObservableObject {
     private var syncCheckTask: Task<Void, Never>?
     private let passkeyService = PasskeyService.shared
 
+    /// Remote keyId currently surfaced in the recovery-choice sheet,
+    /// captured so a "Skip for Now" can record exactly which keyId the
+    /// user dismissed.
+    private var pendingRecoveryKeyId: String?
+    /// Remote keyId the user explicitly skipped. The periodic sync
+    /// check must not re-surface the recovery sheet for this keyId,
+    /// otherwise Skip is overridden on the next tick. A genuinely new
+    /// keyId (another start_fresh) is not suppressed.
+    private var dismissedRecoveryKeyId: String?
+
     private init() {}
 
     // MARK: - Sign-Out Reset
@@ -75,6 +85,8 @@ final class PasskeyManager: ObservableObject {
         passkeySetupAvailable = false
         passkeyAddDeviceAvailable = false
         showPasskeyRecoveryChoice = false
+        pendingRecoveryKeyId = nil
+        dismissedRecoveryKeyId = nil
         onRecoveryComplete = nil
         onKeyRefreshedFromBackup = nil
         syncCheckTask?.cancel()
@@ -92,7 +104,7 @@ final class PasskeyManager: ObservableObject {
         do {
             state = try await SyncEnclaveAPI.keyCurrent()
         } catch {
-            showPasskeyRecoveryChoice = true
+            surfaceRecoveryChoice(forKeyId: nil)
             return .recoveryFailed
         }
 
@@ -119,7 +131,7 @@ final class PasskeyManager: ObservableObject {
                     return await applyUnlockResult(legacyResult)
                 }
             }
-            showPasskeyRecoveryChoice = true
+            surfaceRecoveryChoice(forKeyId: state.keyId)
             return .recoveryFailed
         }
 
@@ -199,7 +211,7 @@ final class PasskeyManager: ObservableObject {
             do {
                 try await applyRecoveredCek(cek: recoveredCek)
             } catch {
-                showPasskeyRecoveryChoice = true
+                surfaceRecoveryChoice(forKeyId: remoteKeyId)
                 return .passkeyPromptShown
             }
             persistEnclaveKeyId(keyIdHex)
@@ -207,7 +219,7 @@ final class PasskeyManager: ObservableObject {
             onKeyRefreshedFromBackup?()
             return .resolvedSilently
         }
-        showPasskeyRecoveryChoice = true
+        surfaceRecoveryChoice(forKeyId: remoteKeyId)
         return .passkeyPromptShown
     }
 
@@ -222,14 +234,14 @@ final class PasskeyManager: ObservableObject {
             do {
                 try await applyRecoveredCek(cek: cek)
             } catch {
-                showPasskeyRecoveryChoice = true
+                surfaceRecoveryChoice(forKeyId: keyIdHex)
                 return .recoveryFailed
             }
             persistEnclaveKeyId(keyIdHex)
             activatePasskey()
             return .success
         case .failure:
-            showPasskeyRecoveryChoice = true
+            surfaceRecoveryChoice(forKeyId: nil)
             return .recoveryFailed
         }
     }
@@ -271,6 +283,26 @@ final class PasskeyManager: ObservableObject {
             #endif
             return false
         }
+    }
+
+    // MARK: - Recovery Choice Presentation
+
+    /// Surface the recovery-choice sheet for a given remote keyId,
+    /// unless the user already skipped recovery for that same keyId.
+    /// Records the keyId so a later Skip can suppress re-prompting.
+    private func surfaceRecoveryChoice(forKeyId keyId: String?) {
+        if let keyId, keyId == dismissedRecoveryKeyId {
+            return
+        }
+        pendingRecoveryKeyId = keyId
+        showPasskeyRecoveryChoice = true
+    }
+
+    /// Dismiss the recovery-choice sheet and remember which keyId the
+    /// user skipped so the periodic sync check stops re-presenting it.
+    func dismissRecoveryChoice() {
+        dismissedRecoveryKeyId = pendingRecoveryKeyId
+        showPasskeyRecoveryChoice = false
     }
 
     // MARK: - Recovery Choice Actions
@@ -560,6 +592,10 @@ final class PasskeyManager: ObservableObject {
     /// WebAuthn ceremony, gated on `.platform` attachment.
     private func persistEnclaveKeyId(_ keyIdHex: String) {
         UserDefaults.standard.set(keyIdHex, forKey: Constants.StorageKeys.Secret.passkeyEnclaveKeyId)
+        // A successful unlock clears any prior skip so a future genuine
+        // mismatch can prompt again.
+        pendingRecoveryKeyId = nil
+        dismissedRecoveryKeyId = nil
     }
 
     private func cachedKeyIdHex() -> String? {
@@ -602,7 +638,7 @@ final class PasskeyManager: ObservableObject {
                !state.bundles.values.contains(where: { $0.credentialId == credentialId }) {
                 // Our credential is gone too — the only path forward
                 // is a fresh recovery from another device.
-                showPasskeyRecoveryChoice = true
+                surfaceRecoveryChoice(forKeyId: remoteKeyId)
                 return
             }
 
@@ -619,7 +655,7 @@ final class PasskeyManager: ObservableObject {
                     persistEnclaveKeyId(keyIdHex)
                     onKeyRefreshedFromBackup?()
                 } catch {
-                    showPasskeyRecoveryChoice = true
+                    surfaceRecoveryChoice(forKeyId: remoteKeyId)
                 }
             case .failure(.enclaveUnavailable, _):
                 // Transient enclave/network failure — the keyId is
@@ -628,7 +664,7 @@ final class PasskeyManager: ObservableObject {
                 // recovery / start-fresh prompt.
                 break
             case .failure:
-                showPasskeyRecoveryChoice = true
+                surfaceRecoveryChoice(forKeyId: remoteKeyId)
             }
         } catch {
             // Non-fatal — try again on the next tick.

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -123,6 +123,7 @@ class ChatViewModel: ObservableObject {
     @Published var isFirstTimeUser: Bool = false
     @Published var showEncryptionSetup: Bool = false
     @Published var shouldShowKeyImport: Bool = false
+    @Published private(set) var isPasskeyRecoverySkipped: Bool = false
     private let passkeyManager = PasskeyManager.shared
     private let cloudSync = CloudSyncService.shared
     private let streamingTracker = StreamingTracker.shared
@@ -417,6 +418,12 @@ class ChatViewModel: ObservableObject {
 
         // Setup network status observer for automatic retry on reconnection
         setupNetworkStatusObserver()
+
+        // Mirror the passkey recovery-skipped state so views observe it through the
+        // view model rather than reaching into the passkey service directly.
+        passkeyManager.$recoverySkipped
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$isPasskeyRecoverySkipped)
 
         // Initial sync will be triggered when authManager is set (see authManager didSet)
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3403,6 +3403,12 @@ class ChatViewModel: ObservableObject {
         case .manualRecoveryRequired:
             cloudSyncOnboardingMode = .recovery
             showCloudSyncOnboarding = true
+        case .success:
+            // A silent re-unlock applied the key but, unlike the prompt-driven
+            // recovery paths, fires no completion callback. Resume loading and
+            // sync so the now-decryptable chats refresh immediately instead of
+            // waiting for a later sign-in or manual refresh.
+            handleSignIn()
         default:
             break
         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3390,6 +3390,24 @@ class ChatViewModel: ObservableObject {
         await Chat.deleteAllChatsFromStorage(userId: currentUserId)
     }
 
+    /// Clear a persisted passkey-recovery skip and re-open recovery.
+    /// Backs the Settings and sidebar "unlock cloud sync" affordances.
+    /// Routes the manual setup / recovery outcomes to the onboarding
+    /// sheet, matching the sign-in flow.
+    func reattemptPasskeyRecovery() async {
+        let result = await passkeyManager.reenableRecoveryPrompt()
+        switch result {
+        case .manualSetupRequired:
+            cloudSyncOnboardingMode = .setup
+            showCloudSyncOnboarding = true
+        case .manualRecoveryRequired:
+            cloudSyncOnboardingMode = .recovery
+            showCloudSyncOnboarding = true
+        default:
+            break
+        }
+    }
+
     /// Handle sign-in by loading user's saved chats and triggering sync
     func handleSignIn() {
         #if DEBUG

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -93,7 +93,7 @@ struct ChatListView: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
-                if messages.isEmpty && !isInputExpanded {
+                if messages.isEmpty && !isInputExpanded && !isKeyboardVisible {
                     PromptSuggestionsBar(
                         viewModel: viewModel,
                         onOpenLibrary: { showPromptLibrary = true }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -26,7 +26,6 @@ struct ChatSidebar: View {
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var cloudSync = CloudSyncService.shared
     @ObservedObject private var syncHealth = SyncHealthStore.shared
-    @ObservedObject private var passkeyManager = PasskeyManager.shared
 
     private var activeTab: ChatStorageTab {
         viewModel.activeStorageTab
@@ -142,7 +141,7 @@ struct ChatSidebar: View {
     
     @ViewBuilder
     private var recoveryBanner: some View {
-        if authManager.isAuthenticated && settings.isCloudSyncEnabled && passkeyManager.recoverySkipped {
+        if authManager.isAuthenticated && settings.isCloudSyncEnabled && viewModel.isPasskeyRecoverySkipped {
             Button {
                 withAnimation { isOpen = false }
                 Task { await viewModel.reattemptPasskeyRecovery() }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -142,7 +142,7 @@ struct ChatSidebar: View {
     
     @ViewBuilder
     private var recoveryBanner: some View {
-        if authManager.isAuthenticated && passkeyManager.recoverySkipped {
+        if authManager.isAuthenticated && settings.isCloudSyncEnabled && passkeyManager.recoverySkipped {
             Button {
                 withAnimation { isOpen = false }
                 Task { await viewModel.reattemptPasskeyRecovery() }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -142,9 +142,7 @@ struct ChatSidebar: View {
     
     @ViewBuilder
     private var recoveryBanner: some View {
-        if authManager.isAuthenticated
-            && passkeyManager.recoverySkipped
-            && !EncryptionService.shared.hasEncryptionKey() {
+        if authManager.isAuthenticated && passkeyManager.recoverySkipped {
             Button {
                 withAnimation { isOpen = false }
                 Task { await viewModel.reattemptPasskeyRecovery() }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -26,6 +26,7 @@ struct ChatSidebar: View {
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var cloudSync = CloudSyncService.shared
     @ObservedObject private var syncHealth = SyncHealthStore.shared
+    @ObservedObject private var passkeyManager = PasskeyManager.shared
 
     private var activeTab: ChatStorageTab {
         viewModel.activeStorageTab
@@ -139,8 +140,45 @@ struct ChatSidebar: View {
         }
     }
     
+    @ViewBuilder
+    private var recoveryBanner: some View {
+        if authManager.isAuthenticated
+            && passkeyManager.recoverySkipped
+            && !EncryptionService.shared.hasEncryptionKey() {
+            Button {
+                withAnimation { isOpen = false }
+                Task { await viewModel.reattemptPasskeyRecovery() }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "key.slash")
+                        .font(.subheadline)
+                        .foregroundColor(.orange)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Cloud sync is paused")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.primary)
+                        Text("Tap to unlock with your passkey")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.orange.opacity(0.12))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
     private var sidebarContent: some View {
         VStack(spacing: 0) {
+            recoveryBanner
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     if authManager.isAuthenticated && settings.isCloudSyncEnabled {

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -633,7 +633,6 @@ struct TabbedWelcomeView: View {
             }
             .padding(.horizontal, 32)
 
-            // Privacy explainer presented as a popup
             Button {
                 showPrivacySheet = true
             } label: {

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -603,79 +603,13 @@ struct WelcomeView: View {
     }
 }
 
-/// Typewriter text that reveals characters one by one
-private struct TypewriterText: View {
-    let fullText: String
-    let isActive: Bool
-    let font: Font
-    let color: Color
-    var charsPerTick: Int = 2
-    var tickInterval: TimeInterval = 0.015
-    var onFinished: (() -> Void)? = nil
-
-    @State private var visibleCount: Int = 0
-    @State private var timer: Timer?
-
-    var body: some View {
-        // Render full text invisibly for stable layout, overlay the revealed portion
-        Text(fullText)
-            .font(font)
-            .foregroundColor(.clear)
-            .multilineTextAlignment(.leading)
-            .fixedSize(horizontal: false, vertical: true)
-            .overlay(alignment: .topLeading) {
-                Text(String(fullText.prefix(visibleCount)))
-                    .font(font)
-                    .foregroundColor(color)
-                    .multilineTextAlignment(.leading)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .onAppear {
-                if isActive {
-                    startTyping()
-                }
-            }
-            .onChange(of: isActive) { _, active in
-                if active {
-                    startTyping()
-                } else {
-                    stopTyping()
-                    visibleCount = 0
-                }
-            }
-            .onDisappear {
-                stopTyping()
-            }
-    }
-
-    private func startTyping() {
-        visibleCount = 0
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { t in
-            if visibleCount < fullText.count {
-                visibleCount = min(visibleCount + charsPerTick, fullText.count)
-            } else {
-                t.invalidate()
-                timer = nil
-                onFinished?()
-            }
-        }
-    }
-
-    private func stopTyping() {
-        timer?.invalidate()
-        timer = nil
-    }
-}
-
 /// Welcome view shown when a chat has no messages
 struct TabbedWelcomeView: View {
     let isDarkMode: Bool
     @ObservedObject var authManager: AuthManager
     let onRequestSignIn: () -> Void
     @ObservedObject private var settings = SettingsManager.shared
-    @State private var isPrivacyExpanded = false
-    @State private var showLinks = false
+    @State private var showPrivacySheet = false
 
     private static let privacyText = "Your messages are encrypted directly to the AI models running inside secure hardware enclaves. These are hardware-isolated environments powered by confidential computing GPUs with verifiable confidentiality and integrity guarantees. Not even Tinfoil can access your data. This applies to all chats, images, documents, and voice input. Our open-source stack lets you verify this yourself by inspecting the hardware attestation."
 
@@ -699,89 +633,27 @@ struct TabbedWelcomeView: View {
             }
             .padding(.horizontal, 32)
 
-            // Collapsible privacy explainer
+            // Privacy explainer presented as a popup
             Button {
-                isPrivacyExpanded.toggle()
-                if !isPrivacyExpanded {
-                    showLinks = false
-                }
+                showPrivacySheet = true
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 13))
                     Text("Your chats are private by design")
                         .font(.system(size: 15, weight: .medium))
-                    Image(systemName: "chevron.down")
+                    Image(systemName: "chevron.right")
                         .font(.system(size: 10, weight: .semibold))
-                        .rotationEffect(.degrees(isPrivacyExpanded ? 180 : 0))
-                        .animation(.easeInOut(duration: 0.25), value: isPrivacyExpanded)
                 }
                 .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
-
-            VStack(spacing: 16) {
-                TypewriterText(
-                    fullText: Self.privacyText,
-                    isActive: isPrivacyExpanded,
-                    font: .system(size: 14),
-                    color: .primary.opacity(0.7),
-                    charsPerTick: 8,
-                    tickInterval: 0.012,
-                    onFinished: {
-                        withAnimation(.easeOut(duration: 0.3)) {
-                            showLinks = true
-                        }
-                    }
-                )
-
-                HStack(spacing: 10) {
-                    Button {
-                        UIApplication.shared.open(URL(string: "https://tinfoil.sh/technology")!)
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "cpu")
-                                .font(.system(size: 12))
-                            Text("Technology")
-                                .font(.system(size: 13, weight: .medium))
-                        }
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.secondary.opacity(0.12))
-                        )
-                    }
-                    .buttonStyle(.plain)
-                    Button {
-                        UIApplication.shared.open(URL(string: "https://github.com/tinfoilsh")!)
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "chevron.left.forwardslash.chevron.right")
-                                .font(.system(size: 12))
-                            Text("Source Code")
-                                .font(.system(size: 13, weight: .medium))
-                        }
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.secondary.opacity(0.12))
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-                .opacity(showLinks ? 1 : 0)
-                .allowsHitTesting(showLinks)
-            }
-            .padding(.horizontal, 12)
-            .opacity(isPrivacyExpanded ? 1 : 0)
-            .allowsHitTesting(isPrivacyExpanded)
         }
         .padding(.top, 24)
         .padding(.bottom, 4)
+        .sheet(isPresented: $showPrivacySheet) {
+            PrivacyExplainerSheet(privacyText: Self.privacyText, isDarkMode: isDarkMode)
+        }
     }
 
     /// Gets the display name for the user - prioritizes nickname from settings, falls back to first name from auth
@@ -797,6 +669,90 @@ struct TabbedWelcomeView: View {
         }
 
         return ""
+    }
+}
+
+/// Popup explaining how chats stay private, shown from the welcome screen
+struct PrivacyExplainerSheet: View {
+    let privacyText: String
+    let isDarkMode: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundColor(.green)
+                        Text("Your chats are private by design")
+                            .font(.system(size: 17, weight: .semibold))
+                    }
+
+                    Text(privacyText)
+                        .font(.system(size: 15))
+                        .foregroundColor(.primary.opacity(0.8))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: 10) {
+                        Button {
+                            UIApplication.shared.open(URL(string: "https://tinfoil.sh/technology")!)
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "cpu")
+                                    .font(.system(size: 12))
+                                Text("Technology")
+                                    .font(.system(size: 13, weight: .medium))
+                            }
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.secondary.opacity(0.12))
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        Button {
+                            UIApplication.shared.open(URL(string: "https://github.com/tinfoilsh")!)
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                                    .font(.system(size: 12))
+                                Text("Source Code")
+                                    .font(.system(size: 13, weight: .medium))
+                            }
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.secondary.opacity(0.12))
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(20)
+            }
+            .background(Color.sheetBackground(isDarkMode: isDarkMode).ignoresSafeArea())
+            .navigationTitle("Privacy")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 18, weight: .medium))
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+        .presentationDetents([.medium])
     }
 }
 

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -696,42 +696,8 @@ struct PrivacyExplainerSheet: View {
                         .fixedSize(horizontal: false, vertical: true)
 
                     HStack(spacing: 10) {
-                        Button {
-                            UIApplication.shared.open(URL(string: "https://tinfoil.sh/technology")!)
-                        } label: {
-                            HStack(spacing: 6) {
-                                Image(systemName: "cpu")
-                                    .font(.system(size: 12))
-                                Text("Technology")
-                                    .font(.system(size: 13, weight: .medium))
-                            }
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.secondary.opacity(0.12))
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        Button {
-                            UIApplication.shared.open(URL(string: "https://github.com/tinfoilsh")!)
-                        } label: {
-                            HStack(spacing: 6) {
-                                Image(systemName: "chevron.left.forwardslash.chevron.right")
-                                    .font(.system(size: 12))
-                                Text("Source Code")
-                                    .font(.system(size: 13, weight: .medium))
-                            }
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.secondary.opacity(0.12))
-                            )
-                        }
-                        .buttonStyle(.plain)
+                        linkButton(icon: "cpu", title: "Technology", urlString: "https://tinfoil.sh/technology")
+                        linkButton(icon: "chevron.left.forwardslash.chevron.right", title: "Source Code", urlString: "https://github.com/tinfoilsh")
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -753,6 +719,27 @@ struct PrivacyExplainerSheet: View {
             }
         }
         .presentationDetents([.medium])
+    }
+
+    private func linkButton(icon: String, title: String, urlString: String) -> some View {
+        Button {
+            UIApplication.shared.open(URL(string: urlString)!)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.secondary.opacity(0.12))
+            )
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -366,7 +366,15 @@ struct CloudSyncSettingsView: View {
                     passkeyBundleInventory
                 }
 
-                if passkeyManager.passkeyAddDeviceAvailable && EncryptionService.shared.hasEncryptionKey() {
+                if passkeyManager.recoverySkipped {
+                    passkeyActionButton(
+                        title: "Unlock Cloud Sync",
+                        subtitle: "Use your passkey to unlock and resume syncing chats across devices."
+                    ) {
+                        await MainActor.run { dismiss() }
+                        await viewModel.reattemptPasskeyRecovery()
+                    }
+                } else if passkeyManager.passkeyAddDeviceAvailable && EncryptionService.shared.hasEncryptionKey() {
                     passkeyActionButton(
                         title: "Set Up Passkey on This Device",
                         subtitle: "Your other devices use a passkey already. Add one here for one-tap access."
@@ -400,14 +408,6 @@ struct CloudSyncSettingsView: View {
                         default:
                             break
                         }
-                    }
-                } else if passkeyManager.recoverySkipped && !EncryptionService.shared.hasEncryptionKey() {
-                    passkeyActionButton(
-                        title: "Unlock Cloud Sync",
-                        subtitle: "Use your passkey to unlock and resume syncing chats across devices."
-                    ) {
-                        await MainActor.run { dismiss() }
-                        await viewModel.reattemptPasskeyRecovery()
                     }
                 }
             } header: {

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -332,7 +332,8 @@ struct CloudSyncSettingsView: View {
             || !passkeyBundles.isEmpty
             || passkeyBundleError != nil
             || passkeyManager.passkeyAddDeviceAvailable
-            || passkeyManager.passkeySetupAvailable {
+            || passkeyManager.passkeySetupAvailable
+            || passkeyManager.recoverySkipped {
             Section {
                 if passkeyManager.passkeyActive {
                     VStack(alignment: .leading, spacing: 6) {
@@ -399,6 +400,14 @@ struct CloudSyncSettingsView: View {
                         default:
                             break
                         }
+                    }
+                } else if passkeyManager.recoverySkipped && !EncryptionService.shared.hasEncryptionKey() {
+                    passkeyActionButton(
+                        title: "Unlock Cloud Sync",
+                        subtitle: "Use your passkey to unlock and resume syncing chats across devices."
+                    ) {
+                        await MainActor.run { dismiss() }
+                        await viewModel.reattemptPasskeyRecovery()
                     }
                 }
             } header: {

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -44,6 +44,7 @@ private struct SegmentView: View {
                 )
             StructuredText(markdown: strippedText)
                 .textual.highlighterTheme(isStreaming ? .plain : .default)
+                .textual.citations(isStreaming ? [] : (citationUrls ?? []))
                 .if(textSelectionEnabled) { view in
                     view.textual.textSelection(.enabled)
                 }
@@ -206,6 +207,7 @@ struct LaTeXMarkdownView: View, Equatable {
             )
         return StructuredText(markdown: strippedText)
             .textual.highlighterTheme(isStreaming ? .plain : .default)
+            .textual.citations(isStreaming ? [] : (citationUrls ?? []))
             .if(textSelectionEnabled) { view in
                 view.textual.textSelection(.enabled)
             }

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -17,6 +17,24 @@ private func citationFaviconData(for url: URL) async -> Data? {
     try? await LinkMetadataService.shared.metadata(for: url.absoluteString).faviconBytes
 }
 
+/// Renders markdown through `StructuredText` with the shared Tinfoil citation treatment, used by
+/// both the parsed-segment and fallback render paths.
+private func citationStructuredText(
+    _ markdown: String,
+    isStreaming: Bool,
+    citationUrls: Set<String>?,
+    textSelectionEnabled: Bool
+) -> some View {
+    StructuredText(markdown: markdown)
+        .textual.highlighterTheme(isStreaming ? .plain : .default)
+        .textual.citations(isStreaming ? [] : (citationUrls ?? []))
+        .textual.citationFaviconProvider(citationFaviconData)
+        .if(textSelectionEnabled) { view in
+            view.textual.textSelection(.enabled)
+        }
+        .fixedSize(horizontal: false, vertical: true)
+}
+
 private enum SegmentKind: Sendable {
     case markdown(String)
     case latex(String, isDisplay: Bool)
@@ -48,14 +66,12 @@ private struct SegmentView: View {
                     in: LaTeXMarkdownView.stripCitations(from: text),
                     citationUrls: citationUrls
                 )
-            StructuredText(markdown: strippedText)
-                .textual.highlighterTheme(isStreaming ? .plain : .default)
-                .textual.citations(isStreaming ? [] : (citationUrls ?? []))
-                .textual.citationFaviconProvider(citationFaviconData)
-                .if(textSelectionEnabled) { view in
-                    view.textual.textSelection(.enabled)
-                }
-                .fixedSize(horizontal: false, vertical: true)
+            citationStructuredText(
+                strippedText,
+                isStreaming: isStreaming,
+                citationUrls: citationUrls,
+                textSelectionEnabled: textSelectionEnabled
+            )
         case .latex(let latex, let isDisplay):
             LaTeXView(
                 latex: latex,
@@ -212,14 +228,12 @@ struct LaTeXMarkdownView: View, Equatable {
                 in: LaTeXMarkdownView.stripCitations(from: content),
                 citationUrls: citationUrls
             )
-        return StructuredText(markdown: strippedText)
-            .textual.highlighterTheme(isStreaming ? .plain : .default)
-            .textual.citations(isStreaming ? [] : (citationUrls ?? []))
-            .textual.citationFaviconProvider(citationFaviconData)
-            .if(textSelectionEnabled) { view in
-                view.textual.textSelection(.enabled)
-            }
-            .fixedSize(horizontal: false, vertical: true)
+        return citationStructuredText(
+            strippedText,
+            isStreaming: isStreaming,
+            citationUrls: citationUrls,
+            textSelectionEnabled: textSelectionEnabled
+        )
     }
 
     /// Rewrite standard markdown links whose URL matches an annotated web-search

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -11,6 +11,12 @@ import Textual
 import SwiftMath
 import UIKit
 
+/// Resolves a citation's favicon bytes from the attested metadata enclave so citation chips never
+/// reach an external icon host directly.
+private func citationFaviconData(for url: URL) async -> Data? {
+    try? await LinkMetadataService.shared.metadata(for: url.absoluteString).faviconBytes
+}
+
 private enum SegmentKind: Sendable {
     case markdown(String)
     case latex(String, isDisplay: Bool)
@@ -45,6 +51,7 @@ private struct SegmentView: View {
             StructuredText(markdown: strippedText)
                 .textual.highlighterTheme(isStreaming ? .plain : .default)
                 .textual.citations(isStreaming ? [] : (citationUrls ?? []))
+                .textual.citationFaviconProvider(citationFaviconData)
                 .if(textSelectionEnabled) { view in
                     view.textual.textSelection(.enabled)
                 }
@@ -208,6 +215,7 @@ struct LaTeXMarkdownView: View, Equatable {
         return StructuredText(markdown: strippedText)
             .textual.highlighterTheme(isStreaming ? .plain : .default)
             .textual.citations(isStreaming ? [] : (citationUrls ?? []))
+            .textual.citationFaviconProvider(citationFaviconData)
             .if(textSelectionEnabled) { view in
                 view.textual.textSelection(.enabled)
             }

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -248,7 +248,12 @@ struct MessageTableView: UIViewRepresentable {
                         context.coordinator.isCollapsingStreamingBuffer = false
                         context.coordinator.updateContentInset()
                         tableView.layoutIfNeeded()
-                        tableView.contentOffset.y = preservedOffset
+                        // Skip the offset restore if a newer scroll action (scroll-to-bottom or
+                        // scroll-to-user) cleared the preserved offset while this collapse was
+                        // pending, so the more recent scroll intent isn't overridden.
+                        if let preserved = context.coordinator.preservedOffsetAfterStreaming {
+                            tableView.contentOffset.y = preserved
+                        }
                     }
                 }
             }

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -47,6 +47,14 @@ struct MessageTableView: UIViewRepresentable {
         context.coordinator.tableView = tableView
         tableView.accessibilityCustomRotors = [context.coordinator.makeMessagesRotor()]
 
+        let tapGesture = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleBackgroundTap)
+        )
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delegate = context.coordinator
+        tableView.addGestureRecognizer(tapGesture)
+
         return tableView
     }
 
@@ -285,7 +293,7 @@ struct MessageTableView: UIViewRepresentable {
         Coordinator(self)
     }
 
-    class Coordinator: NSObject, UITableViewDelegate, UITableViewDataSource {
+    class Coordinator: NSObject, UITableViewDelegate, UITableViewDataSource, UIGestureRecognizerDelegate {
         var parent: MessageTableView
         weak var tableView: UITableView?
         var lastScrollTrigger: UUID?
@@ -328,6 +336,14 @@ struct MessageTableView: UIViewRepresentable {
                 messageWrappers[message.id] = wrapper
                 return wrapper
             }
+        }
+
+        @objc func handleBackgroundTap() {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            return true
         }
 
         func numberOfSections(in tableView: UITableView) -> Int {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -236,6 +236,10 @@ struct MessageTableView: UIViewRepresentable {
                 DispatchQueue.main.async {
                     guard context.coordinator.lastChatId == currentChatId else {
                         context.coordinator.isCollapsingStreamingBuffer = false
+                        // The user switched chats before the collapse ran. Recompute the inset for
+                        // the now-visible chat so the temporary streaming inset doesn't linger as
+                        // blank space in the reused table view.
+                        context.coordinator.updateContentInset()
                         return
                     }
                     UIView.performWithoutAnimation {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -91,6 +91,8 @@ struct MessageTableView: UIViewRepresentable {
 
         if chatIdChanged {
             context.coordinator.lastChatId = currentChatId
+            context.coordinator.preservedOffsetAfterStreaming = nil
+            context.coordinator.isCollapsingStreamingBuffer = false
 
             if !isIdConversion {
                 context.coordinator.messageWrappers.removeAll()
@@ -191,9 +193,24 @@ struct MessageTableView: UIViewRepresentable {
         context.coordinator.lastIsLoading = isLoading
 
         if isLoadingChanged && !isLoading {
+            let preservedOffset = tableView.contentOffset.y
+            context.coordinator.preservedOffsetAfterStreaming = preservedOffset
+            context.coordinator.isCollapsingStreamingBuffer = true
+            context.coordinator.shouldScrollToBottomAfterLayout = false
+
+            UIView.performWithoutAnimation {
+                let temporaryInset = max(tableView.contentInset.bottom, preservedOffset + tableView.bounds.height)
+                tableView.contentInset.bottom = temporaryInset
+                tableView.verticalScrollIndicatorInsets.bottom = temporaryInset
+                tableView.contentOffset.y = preservedOffset
+            }
+
+            var finishedWrapper: ObservableMessageWrapper?
+
             // Streaming just ended - update the last message wrapper to reflect final state (including any errors)
             if let lastMessage = messages.last,
                let wrapper = context.coordinator.messageWrappers[lastMessage.id] {
+                finishedWrapper = wrapper
                 let isArchived = messages.count - 1 < archivedMessagesStartIndex
                 let showArchiveSeparator = messages.count - 1 == archivedMessagesStartIndex && archivedMessagesStartIndex > 0
                 wrapper.update(
@@ -205,10 +222,6 @@ struct MessageTableView: UIViewRepresentable {
                     showArchiveSeparator: showArchiveSeparator,
                     messageIndex: messages.count - 1
                 )
-
-                DispatchQueue.main.async {
-                    wrapper.resetBuffer()
-                }
             }
 
             // Collapsing the streaming buffer changes contentSize dramatically.
@@ -219,22 +232,19 @@ struct MessageTableView: UIViewRepresentable {
             // and one already at the bottom stays at the bottom (the empty space
             // beneath them simply disappears) without an explicit jump.
             DispatchQueue.main.async {
-                UIView.performWithoutAnimation {
-                    // Temporarily inflate the bottom inset so the collapsing
-                    // streaming buffer cannot clamp the offset and snap the view
-                    // before the final inset is settled below.
-                    let currentOffset = tableView.contentOffset.y
-                    tableView.contentInset.bottom = tableView.bounds.height
-                    tableView.layoutIfNeeded()
-                    tableView.contentOffset.y = currentOffset
-                }
-
+                finishedWrapper?.resetBuffer()
                 DispatchQueue.main.async {
+                    guard context.coordinator.lastChatId == currentChatId else {
+                        context.coordinator.isCollapsingStreamingBuffer = false
+                        return
+                    }
                     UIView.performWithoutAnimation {
-                        let currentOffset = tableView.contentOffset.y
+                        tableView.beginUpdates()
+                        tableView.endUpdates()
+                        context.coordinator.isCollapsingStreamingBuffer = false
                         context.coordinator.updateContentInset()
                         tableView.layoutIfNeeded()
-                        tableView.contentOffset.y = currentOffset
+                        tableView.contentOffset.y = preservedOffset
                     }
                 }
             }
@@ -245,6 +255,7 @@ struct MessageTableView: UIViewRepresentable {
             context.coordinator.shouldScrollToUserMessageAfterLayout = true
             context.coordinator.shouldScrollToBottomAfterLayout = false
             context.coordinator.isUserMessageScrollMode = true
+            context.coordinator.preservedOffsetAfterStreaming = nil
 
             DispatchQueue.main.async {
                 context.coordinator.scrollToUserMessage(animated: false)
@@ -267,6 +278,7 @@ struct MessageTableView: UIViewRepresentable {
             context.coordinator.shouldScrollToBottomAfterLayout = true
             context.coordinator.shouldScrollToUserMessageAfterLayout = false
             context.coordinator.isUserMessageScrollMode = false
+            context.coordinator.preservedOffsetAfterStreaming = nil
 
             DispatchQueue.main.async {
                 context.coordinator.scrollToBottom(animated: false)
@@ -313,6 +325,8 @@ struct MessageTableView: UIViewRepresentable {
         /// Stays true while streaming after user sent a message, adjusting the
         /// bottom inset so the user message can be scrolled to the top of the screen.
         var isUserMessageScrollMode = false
+        var preservedOffsetAfterStreaming: CGFloat?
+        var isCollapsingStreamingBuffer = false
         var heightCache: [IndexPath: CGFloat] = [:]
         var messageHeightCache: [String: CGFloat] = [:]
         var contentEstimateCache: [String: CGFloat] = [:]
@@ -469,11 +483,9 @@ struct MessageTableView: UIViewRepresentable {
 
         func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
             // Skip the streaming last row: while it is loading its frame is
-            // inflated by the streaming buffer (many screens tall). Caching that
-            // value would make heightForRowAt later pin the finished row to the
-            // buffer height - a giant blank cell the user scrolls through without
-            // ever seeing the response. didEndDisplaying guards this the same way.
-            let isStreamingLastRow = parent.isLoading && indexPath.row == parent.messages.count - 1
+            // inflated by the streaming buffer. Caching that value would poison
+            // future estimates after the buffer collapses.
+            let isStreamingLastRow = isStreamingRow(at: indexPath)
             let height = cell.frame.size.height
             if height > 0 && !isStreamingLastRow {
                 heightCache[indexPath] = height
@@ -512,50 +524,22 @@ struct MessageTableView: UIViewRepresentable {
         }
 
         func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-            // Cache the settled height once a row leaves the screen. By this
-            // point any asynchronously rendered content (LaTeX, generative-UI
-            // cards) has laid out, so this is the most accurate height to pin
-            // the row to on its next appearance.
+            // Cache measured heights for future estimates only. Rows still use
+            // automatic sizing so late SwiftUI layout cannot overflow a pinned
+            // cell height.
             guard indexPath.row < parent.messages.count else { return }
-            let isLastMessage = indexPath.row == parent.messages.count - 1
-            if parent.isLoading && isLastMessage { return }
+            if isStreamingRow(at: indexPath) { return }
             let height = cell.frame.size.height
             guard height > 0 else { return }
             messageHeightCache[parent.messages[indexPath.row].id] = height
             heightCache[indexPath] = height
         }
 
-        func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-            // While the user is actively scrolling, pin already-measured rows to
-            // their cached height. Re-measuring self-sizing rows mid-scroll makes
-            // contentSize oscillate (a row reports a slightly different height
-            // each time it re-enters), and UIKit answers every change by shifting
-            // contentOffset - the feedback loop that snaps the view back and makes
-            // scrolling up impossible. When stationary, rows resize normally so
-            // reasoning toggles and late-rendering content settle correctly.
-            guard tableView.isDragging || tableView.isDecelerating else {
-                return UITableView.automaticDimension
-            }
-            guard indexPath.row < parent.messages.count else {
-                return UITableView.automaticDimension
-            }
-            let isLastMessage = indexPath.row == parent.messages.count - 1
-            if parent.isLoading && isLastMessage {
-                return UITableView.automaticDimension
-            }
+        private func isStreamingRow(at indexPath: IndexPath) -> Bool {
+            guard indexPath.row < parent.messages.count else { return false }
+            guard indexPath.row == parent.messages.count - 1 else { return false }
             let message = parent.messages[indexPath.row]
-            // Messages with generative-UI widgets render asynchronously and can
-            // grow after their height was first cached. Pinning them to that
-            // stale height makes the taller content overflow onto adjacent rows
-            // (the table has clipsToBounds off), which stacks cells on top of
-            // each other. Always let these rows self-size.
-            if !message.toolCalls.isEmpty {
-                return UITableView.automaticDimension
-            }
-            if let cached = messageHeightCache[message.id] {
-                return cached
-            }
-            return UITableView.automaticDimension
+            return parent.isLoading || messageWrappers[message.id]?.isLoading == true
         }
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -565,6 +549,7 @@ struct MessageTableView: UIViewRepresentable {
 
         func updateContentInset() {
             guard !isUpdatingContentInset else { return }
+            guard !isCollapsingStreamingBuffer else { return }
             guard let tableView = tableView else { return }
             isUpdatingContentInset = true
             defer { isUpdatingContentInset = false }
@@ -591,7 +576,9 @@ struct MessageTableView: UIViewRepresentable {
                 // Streaming has ended but the user is still reading with their
                 // message near the top; keep enough bottom inset to hold that
                 // position instead of snapping to the bottom of the response.
-                targetInset = max(0, insetForUserMessageAtTop(tableView))
+                targetInset = max(0, insetForUserMessageAtTop(tableView), insetForPreservedOffset(tableView))
+            } else if preservedOffsetAfterStreaming != nil {
+                targetInset = max(0, insetForPreservedOffset(tableView))
             } else {
                 targetInset = 0
             }
@@ -612,6 +599,11 @@ struct MessageTableView: UIViewRepresentable {
             let userMessageIndexPath = IndexPath(row: numberOfRows - 2, section: 0)
             let userMessageY = tableView.rectForRow(at: userMessageIndexPath).origin.y
             return userMessageY + tableView.bounds.height - tableView.contentSize.height
+        }
+
+        private func insetForPreservedOffset(_ tableView: UITableView) -> CGFloat {
+            guard let preservedOffsetAfterStreaming else { return 0 }
+            return preservedOffsetAfterStreaming + tableView.bounds.height - tableView.contentSize.height
         }
 
         func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -369,6 +369,22 @@ struct MessageTableView: UIViewRepresentable {
             return true
         }
 
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+            // Only treat taps on non-interactive areas as background taps. Taps on buttons,
+            // editable text fields, and the inline message editor must not dismiss the keyboard.
+            var view = touch.view
+            while let current = view {
+                if current is UIControl || current is UITextField {
+                    return false
+                }
+                if let textView = current as? UITextView, textView.isEditable {
+                    return false
+                }
+                view = current.superview
+            }
+            return true
+        }
+
         func numberOfSections(in tableView: UITableView) -> Int {
             return 1
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves passkey recovery and chat UX: users can skip and later resume cloud sync unlock, scrolling stays stable (and respects newer scrolls) when responses finish or when switching chats, and the privacy explainer is now a simple popup.

- **New Features**
  - Skippable passkey recovery with per-keyId persistence. Add “Unlock Cloud Sync” in the sidebar and Settings to re-open recovery. Clears after unlock or when the local key matches the remote; hides the banner when cloud sync is off.
  - Privacy explainer moved to a sheet from the welcome screen.
  - Tap the chat background to dismiss the keyboard; hide prompt suggestions while typing.
  - Show citations when not streaming, now with source favicons; bump `tinfoilsh/textual` to `0.0.10`.

- **Bug Fixes**
  - Keep scroll position stable when a response finishes and when switching chats; preserve newer user scroll if it changes during finalize, and avoid caching inflated streaming row heights.
  - Keep the keyboard open when tapping message actions.

<sup>Written for commit ae9d03727fd0ca0ceef086c24a97f6170f5e4a9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

