### PR TITLE
Add auto model selection that routes to the best model

### DIFF
--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -45,6 +45,19 @@ struct ReasoningConfig: Codable, Equatable {
     let params: [String: ReasoningEndpointParams]?
 }
 
+/// Synthetic "Auto" model selection that lets the router pick the best
+/// available model for a capability tier. The client never sends these ids
+/// as the request model; it sends `AutoModel.requestModel` plus an ordered
+/// candidate list under `AutoModel.optionsField`, mirroring the webapp.
+enum AutoModel {
+    static let smartId = "auto-smart"
+    static let fastId = "auto-fast"
+    static let smartTier = "smart"
+    static let fastTier = "fast"
+    static let requestModel = "auto"
+    static let optionsField = "auto_model_options"
+}
+
 /// Model configuration from the new /api/app/models endpoint
 struct AppModelConfig: Codable {
     let modelName: String
@@ -59,6 +72,8 @@ struct AppModelConfig: Codable {
     let chat: Bool?
     let paid: Bool
     let multimodal: Bool
+    let toolCalling: Bool?
+    let attributes: [String]?
     let reasoningConfig: ReasoningConfig?
 }
 
@@ -149,6 +164,52 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
         appConfig.reasoningConfig?.supportsToggle == true
     }
 
+    // MARK: - Auto routing
+
+    /// Capability tags advertised by the controlplane (e.g. `smart`, `fast`).
+    var attributes: [String] { appConfig.attributes ?? [] }
+
+    /// True iff the model can be picked as an auto candidate for tool use.
+    var supportsToolCalling: Bool { appConfig.toolCalling ?? false }
+
+    /// True iff this is one of the synthetic Auto picker entries.
+    var isAuto: Bool { id == AutoModel.smartId || id == AutoModel.fastId }
+
+    /// The capability tier this Auto entry routes within, or nil for real models.
+    var autoTier: String? {
+        switch id {
+        case AutoModel.smartId: return AutoModel.smartTier
+        case AutoModel.fastId: return AutoModel.fastTier
+        default: return nil
+        }
+    }
+
+    /// Build a synthetic Auto model for a capability tier. Multimodal and
+    /// tool-calling flags are unions of the tier members so the UI and
+    /// message builder behave sensibly before resolution.
+    static func auto(tier: String, members: [ModelType]) -> ModelType {
+        let isSmart = tier == AutoModel.smartTier
+        let config = AppModelConfig(
+            modelName: isSmart ? AutoModel.smartId : AutoModel.fastId,
+            image: "",
+            name: isSmart ? "Auto" : "Auto",
+            nameShort: isSmart ? "Auto · Smart" : "Auto · Fast",
+            description: isSmart
+                ? "Routes to the best available high-capability model"
+                : "Routes to the fastest available model",
+            details: "",
+            parameters: "",
+            contextWindow: "",
+            type: "chat",
+            chat: true,
+            paid: true,
+            multimodal: members.contains { $0.isMultimodal },
+            toolCalling: members.contains { $0.supportsToolCalling },
+            attributes: [tier],
+            reasoningConfig: nil
+        )
+        return ModelType(from: config)
+    }
 
     // For Hashable conformance
     func hash(into hasher: inout Hasher) {
@@ -159,6 +220,14 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
     static func == (lhs: ModelType, rhs: ModelType) -> Bool {
         lhs.id == rhs.id
     }
+}
+
+/// Result of resolving a (possibly Auto) selection into a concrete
+/// representative model plus, when Auto, the ordered candidate list the
+/// router should try in order.
+struct ModelSelection {
+    let representative: ModelType
+    let autoCandidates: [ModelType]?
 }
 
 /// Application-wide configuration settings
@@ -242,7 +311,7 @@ class AppConfig: ObservableObject {
 
             // Confirm current model is still valid
             if let currentModel = currentModel,
-               !availableModels.contains(currentModel) {
+               !selectableModels.contains(currentModel) {
                 // Fall back to first available model
                 self.currentModel = availableModels.first
             }
@@ -268,8 +337,8 @@ class AppConfig: ObservableObject {
     // Load the last selected model from UserDefaults
     private func loadLastSelectedModel() {
         if let savedModelId = UserDefaults.standard.string(forKey: Constants.StorageKeys.Settings.selectedModel),
-           let appModel = appModels.first(where: { $0.modelName == savedModelId }) {
-            currentModel = ModelType(from: appModel)
+           let model = findSelectableModel(id: savedModelId) {
+            currentModel = model
         } else {
             // Fall back to first available model
             currentModel = availableModels.first
@@ -367,6 +436,66 @@ class AppConfig: ObservableObject {
     /// Get all model types available for selection (all models accessible to all users)
     func filteredModelTypes(isAuthenticated: Bool = false, hasActiveSubscription: Bool = false) -> [ModelType] {
         return availableModels
+    }
+
+    // MARK: - Auto routing
+
+    /// Real chat models advertising the given capability tier.
+    func tierModels(_ tier: String) -> [ModelType] {
+        availableModels.filter { $0.isChat && $0.attributes.contains(tier) }
+    }
+
+    /// Synthetic Auto entries for tiers that currently have at least one member.
+    var autoModels: [ModelType] {
+        var models: [ModelType] = []
+        let smart = tierModels(AutoModel.smartTier)
+        if !smart.isEmpty {
+            models.append(ModelType.auto(tier: AutoModel.smartTier, members: smart))
+        }
+        let fast = tierModels(AutoModel.fastTier)
+        if !fast.isEmpty {
+            models.append(ModelType.auto(tier: AutoModel.fastTier, members: fast))
+        }
+        return models
+    }
+
+    /// Models shown in the picker: Auto entries first, then real models.
+    var selectableModels: [ModelType] {
+        autoModels + availableModels
+    }
+
+    /// Resolve a selectable id (Auto or real) back to a ModelType.
+    func findSelectableModel(id: String) -> ModelType? {
+        if id == AutoModel.smartId || id == AutoModel.fastId {
+            return autoModels.first { $0.id == id }
+        }
+        return availableModels.first { $0.id == id }
+    }
+
+    /// Resolve a (possibly Auto) selection into a representative model plus an
+    /// ordered candidate list. Progressive narrowing keeps a preference only
+    /// when at least one candidate satisfies it, mirroring the webapp.
+    func resolveModelSelection(
+        _ selected: ModelType,
+        preferMultimodal: Bool,
+        preferToolCalling: Bool
+    ) -> ModelSelection {
+        guard selected.isAuto, let tier = selected.autoTier else {
+            return ModelSelection(representative: selected, autoCandidates: nil)
+        }
+
+        var candidates = tierModels(tier)
+        if preferMultimodal {
+            let capable = candidates.filter { $0.isMultimodal }
+            if !capable.isEmpty { candidates = capable }
+        }
+        if preferToolCalling {
+            let capable = candidates.filter { $0.supportsToolCalling }
+            if !capable.isEmpty { candidates = capable }
+        }
+
+        let representative = candidates.first ?? selected
+        return ModelSelection(representative: representative, autoCandidates: candidates)
     }
 
     /// Get the title model for generating titles and thinking summaries

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -297,7 +297,7 @@ class ProfileManager: ObservableObject {
     }
 
     private func applySelectedModel(_ modelId: String) {
-        guard let model = AppConfig.shared.availableModels.first(where: { $0.id == modelId }) else {
+        guard let model = AppConfig.shared.findSelectableModel(id: modelId) else {
             return
         }
         AppConfig.shared.currentModel = model

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -44,6 +44,10 @@ struct ChatQueryBuilder {
     ///     graded effort. Ignored for models that do not.
     ///   - thinkingEnabled: Whether thinking is on for models that support a
     ///     toggle. Ignored for models that do not.
+    ///   - autoCandidates: When set, the request is sent as an Auto selection:
+    ///     `model` becomes `AutoModel.requestModel` and the ordered candidates
+    ///     (with per-candidate reasoning params) are attached under
+    ///     `AutoModel.optionsField` for the router to resolve.
     /// - Returns: A configured ChatQuery
     @MainActor
     static func buildQuery(
@@ -58,13 +62,18 @@ struct ChatQueryBuilder {
         reasoningConfig: ReasoningConfig? = nil,
         reasoningEffort: ReasoningEffort = .medium,
         thinkingEnabled: Bool = true,
-        genUIEnabled: Bool = true
+        genUIEnabled: Bool = true,
+        autoCandidates: [ModelType]? = nil
     ) -> ChatQuery {
 
         var messages: [ChatQuery.ChatCompletionMessageParam] = []
 
-        // Most models support system role; DeepSeek is the known exception
-        let useSystemRole = !modelId.hasPrefix("deepseek")
+        // Most models support system role; DeepSeek is the known exception.
+        // For Auto requests the representative `modelId` drives this, but if
+        // any candidate needs the synthetic `<system>` message we prepend for
+        // all so a DeepSeek resolution never loses its instructions.
+        let candidatesNeedPrepend = autoCandidates?.contains { $0.modelName.hasPrefix("deepseek") } ?? false
+        let useSystemRole = !modelId.hasPrefix("deepseek") && !candidatesNeedPrepend
 
         // Append the GenUI prompt hint so the model knows it can call
         // render_* tools instead of replying with markdown for structured
@@ -197,15 +206,37 @@ struct ChatQueryBuilder {
             (tools?.isEmpty == false) ? .auto : nil
         let parallelToolCalls: Bool? = (tools?.isEmpty == false) ? true : nil
 
-        let extraBody = makeReasoningExtraBody(
-            reasoningConfig: reasoningConfig,
-            reasoningEffort: reasoningEffort,
-            thinkingEnabled: thinkingEnabled
-        )
+        let requestModel: String
+        let extraBody: [String: OpenAIJSON]?
+        if let autoCandidates, !autoCandidates.isEmpty {
+            // Send `model: "auto"` with an ordered candidate list. Each option
+            // carries its own pre-built reasoning params so the router can
+            // splice the resolved candidate's body without re-deriving them.
+            requestModel = AutoModel.requestModel
+            let options: [OpenAIJSON] = autoCandidates.map { candidate in
+                let params = makeReasoningExtraBody(
+                    reasoningConfig: candidate.reasoningConfig,
+                    reasoningEffort: reasoningEffort,
+                    thinkingEnabled: thinkingEnabled
+                ) ?? [:]
+                return .object([
+                    "model": .string(candidate.modelName),
+                    "params": .object(params)
+                ])
+            }
+            extraBody = [AutoModel.optionsField: .array(options)]
+        } else {
+            requestModel = modelId
+            extraBody = makeReasoningExtraBody(
+                reasoningConfig: reasoningConfig,
+                reasoningEffort: reasoningEffort,
+                thinkingEnabled: thinkingEnabled
+            )
+        }
 
         return ChatQuery(
             messages: messages,
-            model: modelId,
+            model: requestModel,
             parallelToolCalls: parallelToolCalls,
             toolChoice: toolChoice,
             tools: tools,

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1699,8 +1699,22 @@ class ChatViewModel: ObservableObject {
                     forceRefresh: hasRetriedWithFreshKey
                 )
 
+                // Resolve the (possibly Auto) selection into a representative
+                // model plus an ordered candidate list. Preferences narrow the
+                // Auto candidates: multimodal when the turn carries images, and
+                // tool-calling when web search or GenUI tools may be used.
+                let turnHasImages = self.messages.contains { message in
+                    message.attachments.contains { $0.type == .image }
+                }
+                let modelSelection = AppConfig.shared.resolveModelSelection(
+                    currentModel,
+                    preferMultimodal: turnHasImages,
+                    preferToolCalling: self.isWebSearchEnabled || SettingsManager.shared.genUIEnabled
+                )
+                let representativeModel = modelSelection.representative
+
                 // Create the stream with proper parameters
-                let modelId = currentModel.modelName
+                let modelId = representativeModel.modelName
                 
                 // Add system message first with language preference
                 let settingsManager = SettingsManager.shared
@@ -1722,7 +1736,7 @@ class ChatViewModel: ObservableObject {
                 }
                 
                 // Replace MODEL_NAME placeholder with current model name
-                systemPrompt = systemPrompt.replacingOccurrences(of: "{MODEL_NAME}", with: currentModel.fullName)
+                systemPrompt = systemPrompt.replacingOccurrences(of: "{MODEL_NAME}", with: representativeModel.fullName)
                 
                 // Replace language placeholder - use ProfileManager language first, then settings preference
                 let languageToUse: String
@@ -1774,7 +1788,7 @@ class ChatViewModel: ObservableObject {
                 // Process rules with same replacements
                 var processedRules = suppressDefaultRules ? "" : AppConfig.shared.rules
                 if !processedRules.isEmpty {
-                    processedRules = processedRules.replacingOccurrences(of: "{MODEL_NAME}", with: currentModel.fullName)
+                    processedRules = processedRules.replacingOccurrences(of: "{MODEL_NAME}", with: representativeModel.fullName)
                     processedRules = processedRules.replacingOccurrences(of: "{LANGUAGE}", with: languageToUse)
 
                     if !personalizationXML.isEmpty {
@@ -1793,13 +1807,14 @@ class ChatViewModel: ObservableObject {
                     systemPrompt: systemPrompt,
                     rules: processedRules,
                     conversationMessages: self.messages,
-                    contextWindow: self.currentModel.contextWindow,
+                    contextWindow: representativeModel.contextWindow,
                     webSearchEnabled: self.isWebSearchEnabled,
-                    isMultimodal: self.currentModel.isMultimodal,
-                    reasoningConfig: self.currentModel.reasoningConfig,
+                    isMultimodal: representativeModel.isMultimodal,
+                    reasoningConfig: representativeModel.reasoningConfig,
                     reasoningEffort: self.reasoningEffort,
                     thinkingEnabled: self.thinkingEnabled,
-                    genUIEnabled: SettingsManager.shared.genUIEnabled
+                    genUIEnabled: SettingsManager.shared.genUIEnabled,
+                    autoCandidates: modelSelection.autoCandidates
                 )
 
                 // Web search state tracking
@@ -3272,9 +3287,10 @@ class ChatViewModel: ObservableObject {
             setupTinfoilClient()
         }
 
-        // If current model is no longer in the available list, switch to first available model
-        let availableModels = AppConfig.shared.filteredModelTypes()
-        if !availableModels.contains(where: { $0.id == currentModel.id }), let firstModel = availableModels.first {
+        // If current model is no longer selectable, switch to first available model
+        let selectableModels = AppConfig.shared.selectableModels
+        if !selectableModels.contains(where: { $0.id == currentModel.id }),
+           let firstModel = AppConfig.shared.filteredModelTypes().first {
             changeModel(to: firstModel)
         }
         

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -1093,31 +1093,41 @@ struct ModelPicker: View {
 
     var body: some View {
         Menu {
-            let availableModels = AppConfig.shared.filteredModelTypes()
+            let selectableModels = AppConfig.shared.selectableModels
 
-            ForEach(availableModels) { model in
+            ForEach(selectableModels) { model in
                 Button(action: {
                     viewModel.changeModel(to: model)
                 }) {
                     Label {
                         Text(model.displayName)
                     } icon: {
-                        Image(model.iconName)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 20, height: 20)
+                        modelIcon(for: model, size: 20)
                     }
                 }
                 .disabled(viewModel.currentModel == model)
             }
         } label: {
-            Image(viewModel.currentModel.iconName)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 22, height: 22)
+            modelIcon(for: viewModel.currentModel, size: 22)
         }
         .accessibilityLabel("Select model")
         .accessibilityValue(viewModel.currentModel.displayName)
+    }
+
+    /// Auto entries have no asset icon; show a routing glyph instead.
+    @ViewBuilder
+    private func modelIcon(for model: ModelType, size: CGFloat) -> some View {
+        if model.isAuto {
+            Image(systemName: "shuffle")
+                .resizable()
+                .scaledToFit()
+                .frame(width: size, height: size)
+        } else {
+            Image(model.iconName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: size, height: size)
+        }
     }
 }
 

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -737,7 +737,23 @@ struct ModelSelectorSheetView: View {
     @Environment(\.dismiss) private var dismiss
 
     private var availableModels: [ModelType] {
-        AppConfig.shared.filteredModelTypes()
+        AppConfig.shared.selectableModels
+    }
+
+    /// Auto entries have no asset icon; show a routing glyph instead.
+    @ViewBuilder
+    private func modelIcon(for model: ModelType) -> some View {
+        if model.isAuto {
+            Image(systemName: "shuffle")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
+        } else {
+            Image(model.iconName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
+        }
     }
 
     var body: some View {
@@ -749,10 +765,7 @@ struct ModelSelectorSheetView: View {
                     dismiss()
                 } label: {
                     HStack(spacing: 12) {
-                        Image(model.iconName)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 28, height: 28)
+                        modelIcon(for: model)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(model.displayName)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds “Auto” model selection for Smart and Fast tiers that picks the best model at send time. The picker shows Auto options, and chat requests route using an ordered candidate list for the right capabilities.

- **New Features**
  - Added synthetic Auto entries (`auto-smart`, `auto-fast`) to the model picker; shown first with a shuffle icon.
  - Per-turn resolution picks a representative model and builds an ordered candidate list, preferring multimodal for image turns and tool-calling when web search or GenUI is enabled.
  - Requests now support auto routing: send `model: "auto"` with `auto_model_options` (each option includes its own reasoning params); system-role handling accounts for DeepSeek candidates.
  - App config and selection flow updated to include Auto entries, with persistence, validation, and fallbacks; Profile and UI pickers use the new selectable model list.

<sup>Written for commit 96ab4a784598391be9002fa407e7267ee49d8810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

