### PR TITLE
Misc UI and UX improvements

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -312,8 +312,7 @@ class AppConfig: ObservableObject {
             // Confirm current model is still valid
             if let currentModel = currentModel,
                !selectableModels.contains(currentModel) {
-                // Fall back to first available model
-                self.currentModel = availableModels.first
+                self.currentModel = defaultModel
             }
 
             // Clear any previous error
@@ -340,9 +339,14 @@ class AppConfig: ObservableObject {
            let model = findSelectableModel(id: savedModelId) {
             currentModel = model
         } else {
-            // Fall back to first available model
-            currentModel = availableModels.first
+            currentModel = defaultModel
         }
+    }
+
+    // Default selection: prefer Auto Fast, fall back to the first available
+    // model if no fast-tier models exist in the config.
+    private var defaultModel: ModelType? {
+        findSelectableModel(id: AutoModel.fastId) ?? availableModels.first
     }
     
     // MARK: - Public interface

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -446,7 +446,6 @@ struct ProfileData: Codable {
     var favoritePromptPresetIds: [String]?
 
     // Shared chat defaults
-    var selectedModel: String?
     var reasoningEffort: String?
     var thinkingEnabled: Bool?
     var webSearchEnabled: Bool?

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -175,8 +175,6 @@ class ProfileManager: ObservableObject {
     
     /// Create ProfileData from current settings
     private func createProfileData() -> ProfileData {
-        let selectedModel = AppConfig.shared.currentModel?.id
-            ?? UserDefaults.standard.string(forKey: Constants.StorageKeys.Settings.selectedModel)
         let reasoningEffort = UserDefaults.standard.string(
             forKey: Constants.StorageKeys.Settings.reasoningEffort
         ) ?? ReasoningEffort.medium.rawValue
@@ -199,7 +197,6 @@ class ProfileManager: ObservableObject {
             customSystemPrompt: customSystemPrompt,
             customPromptPresets: customPromptPresets,
             favoritePromptPresetIds: favoritePromptPresetIds,
-            selectedModel: selectedModel,
             reasoningEffort: reasoningEffort,
             thinkingEnabled: thinkingEnabled,
             webSearchEnabled: SettingsManager.shared.webSearchEnabled,
@@ -254,10 +251,6 @@ class ProfileManager: ObservableObject {
         if let favoritePromptPresetIds = profile.favoritePromptPresetIds {
             self.favoritePromptPresetIds = favoritePromptPresetIds
         }
-        if let selectedModel = profile.selectedModel {
-            UserDefaults.standard.set(selectedModel, forKey: Constants.StorageKeys.Settings.selectedModel)
-            applySelectedModel(selectedModel)
-        }
         if let reasoningEffort = profile.reasoningEffort,
            ReasoningEffort(rawValue: reasoningEffort) != nil {
             UserDefaults.standard.set(reasoningEffort, forKey: Constants.StorageKeys.Settings.reasoningEffort)
@@ -296,13 +289,6 @@ class ProfileManager: ObservableObject {
         isApplyingProfile = false  // Re-enable observers
     }
 
-    private func applySelectedModel(_ modelId: String) {
-        guard let model = AppConfig.shared.findSelectableModel(id: modelId) else {
-            return
-        }
-        AppConfig.shared.currentModel = model
-    }
-    
     // MARK: - Change Observers
     
     private func setupChangeObservers() {
@@ -753,7 +739,6 @@ class ProfileManager: ObservableObject {
                p1.customSystemPrompt != p2.customSystemPrompt ||
                p1.customPromptPresets != p2.customPromptPresets ||
                p1.favoritePromptPresetIds != p2.favoritePromptPresetIds ||
-               p1.selectedModel != p2.selectedModel ||
                p1.reasoningEffort != p2.reasoningEffort ||
                p1.thinkingEnabled != p2.thinkingEnabled ||
                p1.webSearchEnabled != p2.webSearchEnabled ||

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -19,7 +19,7 @@ enum ProfileMerge {
         "isDarkMode", "themeMode", "language", "nickname", "profession",
         "traits", "additionalContext", "isUsingPersonalization",
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
-        "favoritePromptPresetIds", "selectedModel", "reasoningEffort",
+        "favoritePromptPresetIds", "reasoningEffort",
         "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont",
         "projectUploadPreference",

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -37,7 +37,7 @@ class ProfileSyncService: ObservableObject {
         "isDarkMode", "themeMode", "language", "nickname", "profession",
         "traits", "additionalContext", "isUsingPersonalization",
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
-        "favoritePromptPresetIds", "selectedModel", "reasoningEffort",
+        "favoritePromptPresetIds", "reasoningEffort",
         "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont", "projectUploadPreference",
         "version", "updatedAt", "fieldClocks", "clockVersion",

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -478,10 +478,6 @@ class ChatViewModel: ObservableObject {
     }
 
     private func applySharedSettings(_ profile: ProfileData) {
-        if let selectedModel = profile.selectedModel,
-           let model = AppConfig.shared.availableModels.first(where: { $0.id == selectedModel }) {
-            currentModel = model
-        }
         if let effort = profile.reasoningEffort,
            let parsedEffort = ReasoningEffort(rawValue: effort) {
             reasoningEffort = parsedEffort
@@ -3264,7 +3260,6 @@ class ChatViewModel: ObservableObject {
         self.currentModel = modelType
         // This will trigger the didSet in AppConfig which persists to UserDefaults
         AppConfig.shared.currentModel = modelType
-        ProfileManager.shared.sharedSettingsDidChange()
         
         // Update the current chat's model if requested
         if shouldUpdateChat, var chat = currentChat {

--- a/TinfoilChat/ViewModels/RevenueCatManager.swift
+++ b/TinfoilChat/ViewModels/RevenueCatManager.swift
@@ -82,18 +82,20 @@ class RevenueCatManager: ObservableObject {
     /// produce webhooks without a user identifier that the backend rejects,
     /// so callers must block the paywall until this returns true.
     func ensureLoggedIn(_ userId: String) async -> Bool {
-        if Purchases.shared.appUserID == userId {
-            setClerkUserId(userId)
-            return true
-        }
         do {
+            // logIn also refreshes customerInfo when already identified,
+            // so always call it rather than short-circuiting on appUserID.
             let (customerInfo, _) = try await Purchases.shared.logIn(userId)
             self.customerInfo = customerInfo
             // Also set clerk_user_id as attribute
             setClerkUserId(userId)
             return true
         } catch {
-            return false
+            // A transient failure must not block the paywall if the SDK is
+            // already identified as this user from a previous session.
+            guard Purchases.shared.appUserID == userId else { return false }
+            setClerkUserId(userId)
+            return true
         }
     }
     

--- a/TinfoilChat/ViewModels/RevenueCatManager.swift
+++ b/TinfoilChat/ViewModels/RevenueCatManager.swift
@@ -74,14 +74,26 @@ class RevenueCatManager: ObservableObject {
     
     /// Log in user to RevenueCat
     func loginUser(_ userId: String) async {
+        _ = await ensureLoggedIn(userId)
+    }
+
+    /// Make sure RevenueCat is identified as the given Clerk user before a
+    /// purchase can happen. Purchases made while RevenueCat is still anonymous
+    /// produce webhooks without a user identifier that the backend rejects,
+    /// so callers must block the paywall until this returns true.
+    func ensureLoggedIn(_ userId: String) async -> Bool {
+        if Purchases.shared.appUserID == userId {
+            setClerkUserId(userId)
+            return true
+        }
         do {
             let (customerInfo, _) = try await Purchases.shared.logIn(userId)
-            await MainActor.run {
-                self.customerInfo = customerInfo
-            }
+            self.customerInfo = customerInfo
             // Also set clerk_user_id as attribute
             setClerkUserId(userId)
+            return true
         } catch {
+            return false
         }
     }
     

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -132,11 +132,10 @@ struct ChatContainer: View {
                 .environmentObject(viewModel)
         }
         .sheet(isPresented: $showPremiumModal) {
-            PaywallView(displayCloseButton: true)
-                .onPurchaseCompleted { _ in
-                    showPremiumModal = false
-                    shouldCreateNewChatAfterSubscription = true
-                }
+            GatedPaywallView {
+                showPremiumModal = false
+                shouldCreateNewChatAfterSubscription = true
+            }
                 .onDisappear {
                     // Quick check when paywall is dismissed
                     Task {

--- a/TinfoilChat/Views/GatedPaywallView.swift
+++ b/TinfoilChat/Views/GatedPaywallView.swift
@@ -1,0 +1,59 @@
+//
+//  GatedPaywallView.swift
+//  TinfoilChat
+//
+//  Created on 07/07/26.
+//  Copyright © 2026 Tinfoil. All rights reserved.
+
+import SwiftUI
+import RevenueCatUI
+
+/// Wraps the RevenueCat paywall and blocks it until the current Clerk user
+/// is logged in to RevenueCat. Purchases made while the SDK is still
+/// anonymous produce webhooks without a user identifier that the backend
+/// rejects, so the paywall must never be reachable in that state.
+struct GatedPaywallView: View {
+    let onPurchaseCompleted: () -> Void
+
+    @EnvironmentObject private var authManager: AuthManager
+    @Environment(\.dismiss) private var dismiss
+    @State private var gateState: GateState = .preparing
+
+    private enum GateState {
+        case preparing
+        case ready
+        case failed
+    }
+
+    var body: some View {
+        switch gateState {
+        case .preparing:
+            ProgressView()
+                .controlSize(.large)
+                .task { await prepare() }
+        case .ready:
+            PaywallView(displayCloseButton: true)
+                .onPurchaseCompleted { _ in onPurchaseCompleted() }
+        case .failed:
+            VStack(spacing: 16) {
+                Text("Unable to load subscription options. Please check your connection and try again.")
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                Button("Retry") { gateState = .preparing }
+                    .buttonStyle(.borderedProminent)
+                Button("Close") { dismiss() }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.secondary)
+            }
+            .padding(32)
+        }
+    }
+
+    private func prepare() async {
+        guard let clerkUserId = authManager.localUserData?["id"] as? String else {
+            gateState = .failed
+            return
+        }
+        gateState = await RevenueCatManager.shared.ensureLoggedIn(clerkUserId) ? .ready : .failed
+    }
+}

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -161,10 +161,9 @@ struct MessageInputView: View {
                 .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
             }
             .sheet(isPresented: $viewModel.showRateLimitPaywall) {
-                PaywallView(displayCloseButton: true)
-                    .onPurchaseCompleted { _ in
-                        viewModel.showRateLimitPaywall = false
-                    }
+                GatedPaywallView {
+                    viewModel.showRateLimitPaywall = false
+                }
                     .onDisappear {
                         Task {
                             await authManager.fetchSubscriptionStatus()

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -822,13 +822,6 @@ struct SettingsView: View {
                 }
             } else {
                 Button(action: {
-                    guard authManager.isAuthenticated else {
-                        showAuthView = true
-                        return
-                    }
-                    if let clerkUserId = authManager.localUserData?["id"] as? String {
-                        Purchases.shared.attribution.setAttributes(["clerk_user_id": clerkUserId])
-                    }
                     showPremiumModal = true
                 }) {
                     HStack(spacing: 8) {
@@ -907,7 +900,9 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 accountSection
-                subscriptionSection
+                if authManager.isAuthenticated {
+                    subscriptionSection
+                }
                 chatSettingsSection
                 preferencesSection
                 contactSection

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -993,11 +993,10 @@ struct SettingsView: View {
                 .environmentObject(authManager)
         }
         .sheet(isPresented: $showPremiumModal) {
-            PaywallView(displayCloseButton: true)
-                .onPurchaseCompleted { _ in
-                    showPremiumModal = false
-                    // The subscription status will update automatically via webhook
-                }
+            GatedPaywallView {
+                showPremiumModal = false
+                // The subscription status will update automatically via webhook
+            }
                 .onDisappear {
                     // Check subscription status when paywall is dismissed
                     Task {

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -343,12 +343,19 @@ private struct WebSearchQueryRow: View {
         instance.sources ?? []
     }
 
+    private var displayQuery: String {
+        if let query = instance.query, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return query
+        }
+        return "Web search"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 10) {
                 statusIcon
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(instance.query ?? "Web search")
+                    Text(displayQuery)
                         .font(.system(size: 15, weight: .medium))
                         .foregroundColor(isDarkMode ? .white : .black.opacity(0.85))
                         .multilineTextAlignment(.leading)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gate the subscription paywall behind a verified `RevenueCat` login using a new GatedPaywallView, and hide the subscription section when signed out. Default the model to auto-fast with a safe fallback.

- **Bug Fixes**
  - Show “Web search” when a query is empty or whitespace.
  - Refresh `RevenueCat` customer info while verifying the account link before showing the paywall.
  - Keep model selection local to this device (removed from profile sync).

<sup>Written for commit 7823b5c7f8e39ef308875f76016f9f19380462e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

