### PR TITLE
Fix bugs, performance issues, and UI issues 

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		99AB00012FABC00100ABC001 /* TinfoilShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 99AB00032FABC00300ABC003 /* TinfoilShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		99DDBFA42F6869250038A729 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 99DDBFA32F6869250038A729 /* Textual */; };
 		99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */ = {isa = PBXBuildFile; productRef = 99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */; };
 		99F154692F4F60C500E9174E /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154682F4F60C500E9174E /* ClerkKit */; };
@@ -19,6 +20,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		99AB00022FABC00200ABC002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 99F153BA2F4F5F0200E9174E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 99AB00082FABC00800ABC008;
+			remoteInfo = TinfoilShareExtension;
+		};
 		992FC2992F532EA800699029 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 99F153BA2F4F5F0200E9174E /* Project object */;
@@ -30,10 +38,19 @@
 
 /* Begin PBXFileReference section */
 		992FC2952F532EA800699029 /* TinfoilChatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinfoilChatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		99AB00032FABC00300ABC003 /* TinfoilShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TinfoilShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		99F153C22F4F5F0200E9174E /* TinfoilChat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TinfoilChat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		99AB00042FABC00400ABC004 /* Exceptions for "TinfoilShareExtension" folder in "TinfoilShareExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+				TinfoilShareExtension.entitlements,
+			);
+			target = 99AB00082FABC00800ABC008 /* TinfoilShareExtension */;
+		};
 		99F1547E2F4F622400E9174E /* Exceptions for "TinfoilChat" folder in "TinfoilChat" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -49,6 +66,19 @@
 			path = TinfoilChatTests;
 			sourceTree = "<group>";
 		};
+		99AB00052FABC00500ABC005 /* TinfoilShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				99AB00042FABC00400ABC004 /* Exceptions for "TinfoilShareExtension" folder in "TinfoilShareExtension" target */,
+			);
+			path = TinfoilShareExtension;
+			sourceTree = "<group>";
+		};
+		99AB00062FABC00600ABC006 /* TinfoilShared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TinfoilShared;
+			sourceTree = "<group>";
+		};
 		99F153C42F4F5F0200E9174E /* TinfoilChat */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -61,6 +91,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		992FC2922F532EA800699029 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		99AB00072FABC00700ABC007 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -90,6 +127,8 @@
 			isa = PBXGroup;
 			children = (
 				99F153C42F4F5F0200E9174E /* TinfoilChat */,
+				99AB00062FABC00600ABC006 /* TinfoilShared */,
+				99AB00052FABC00500ABC005 /* TinfoilShareExtension */,
 				992FC2962F532EA800699029 /* TinfoilChatTests */,
 				99F154802F4F632500E9174E /* Frameworks */,
 				99F153C32F4F5F0200E9174E /* Products */,
@@ -100,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				99F153C22F4F5F0200E9174E /* TinfoilChat.app */,
+				99AB00032FABC00300ABC003 /* TinfoilShareExtension.appex */,
 				992FC2952F532EA800699029 /* TinfoilChatTests.xctest */,
 			);
 			name = Products;
@@ -138,6 +178,29 @@
 			productReference = 992FC2952F532EA800699029 /* TinfoilChatTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		99AB00082FABC00800ABC008 /* TinfoilShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 99AB000F2FABC00F00ABC00F /* Build configuration list for PBXNativeTarget "TinfoilShareExtension" */;
+			buildPhases = (
+				99AB000A2FABC00A00ABC00A /* Sources */,
+				99AB00072FABC00700ABC007 /* Frameworks */,
+				99AB00092FABC00900ABC009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				99AB00052FABC00500ABC005 /* TinfoilShareExtension */,
+				99AB00062FABC00600ABC006 /* TinfoilShared */,
+			);
+			name = TinfoilShareExtension;
+			packageProductDependencies = (
+			);
+			productName = TinfoilShareExtension;
+			productReference = 99AB00032FABC00300ABC003 /* TinfoilShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		99F153C12F4F5F0200E9174E /* TinfoilChat */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 99F153CD2F4F5F0300E9174E /* Build configuration list for PBXNativeTarget "TinfoilChat" */;
@@ -145,14 +208,17 @@
 				99F153BE2F4F5F0200E9174E /* Sources */,
 				99F153BF2F4F5F0200E9174E /* Frameworks */,
 				99F153C02F4F5F0200E9174E /* Resources */,
+				99AB000C2FABC00C00ABC00C /* Embed Foundation Extensions */,
 				99F1547D2F4F615600E9174E /* ShellScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				99AB000B2FABC00B00ABC00B /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				99F153C42F4F5F0200E9174E /* TinfoilChat */,
+				99AB00062FABC00600ABC006 /* TinfoilShared */,
 			);
 			name = TinfoilChat;
 			packageProductDependencies = (
@@ -184,6 +250,9 @@
 						CreatedOnToolsVersion = 26.2;
 						TestTargetID = 99F153C12F4F5F0200E9174E;
 					};
+					99AB00082FABC00800ABC008 = {
+						CreatedOnToolsVersion = 26.2;
+					};
 					99F153C12F4F5F0200E9174E = {
 						CreatedOnToolsVersion = 26.2;
 					};
@@ -213,6 +282,7 @@
 			projectRoot = "";
 			targets = (
 				99F153C12F4F5F0200E9174E /* TinfoilChat */,
+				99AB00082FABC00800ABC008 /* TinfoilShareExtension */,
 				992FC2942F532EA800699029 /* TinfoilChatTests */,
 			);
 		};
@@ -220,6 +290,13 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		992FC2932F532EA800699029 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		99AB00092FABC00900ABC009 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -234,6 +311,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		99AB000C2FABC00C00ABC00C /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				99AB00012FABC00100ABC001 /* TinfoilShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		99F1547D2F4F615600E9174E /* ShellScript */ = {
@@ -265,6 +356,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		99AB000A2FABC00A00ABC00A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		99F153BE2F4F5F0200E9174E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -279,6 +377,11 @@
 			isa = PBXTargetDependency;
 			target = 99F153C12F4F5F0200E9174E /* TinfoilChat */;
 			targetProxy = 992FC2992F532EA800699029 /* PBXContainerItemProxy */;
+		};
+		99AB000B2FABC00B00ABC00B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 99AB00082FABC00800ABC008 /* TinfoilShareExtension */;
+			targetProxy = 99AB00022FABC00200ABC002 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -326,6 +429,67 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TinfoilChat.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TinfoilChat";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		99AB000D2FABC00D00ABC00D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = TinfoilShareExtension/TinfoilShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8KSH668LZT;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TinfoilShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 2.4.6;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		99AB000E2FABC00E00ABC00E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = TinfoilShareExtension/TinfoilShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8KSH668LZT;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TinfoilShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 2.4.6;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -544,6 +708,15 @@
 			buildConfigurations = (
 				992FC29C2F532EA800699029 /* Debug */,
 				992FC29D2F532EA800699029 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		99AB000F2FABC00F00ABC00F /* Build configuration list for PBXNativeTarget "TinfoilShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				99AB000D2FABC00D00ABC00D /* Debug */,
+				99AB000E2FABC00E00ABC00E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "4c140fd40148a91fdf50d3b23aa986f3f9996767",
-        "version" : "0.6.0"
+        "revision" : "796b0610993a6577a8ea8580f7dce4ee6da14801",
+        "version" : "0.6.3"
       }
     }
   ],

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -334,9 +334,10 @@ enum Constants {
         enum Sync {
             static let chatStatus = "tinfoil-sync-chat-status"
             static let allChatsStatus = "tinfoil-sync-all-chats-status"
+            static let projectChatStatusPrefix = "tinfoil-sync-project-chat-status-"
 
             static func projectChatStatus(projectId: String) -> String {
-                "tinfoil-sync-project-chat-status-\(projectId)"
+                "\(projectChatStatusPrefix)\(projectId)"
             }
             static func lastSyncDate(userId: String) -> String {
                 "tinfoil-sync-last-sync-date-\(userId)"

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -409,14 +409,14 @@ enum Constants {
     enum Attachments {
         static let maxImageDimension: CGFloat = 768
         static let imageCompressionQuality: CGFloat = 0.85
-        static let maxFileSizeBytes: Int64 = 20 * 1024 * 1024      // 20 MB
-        static let maxImageSizeBytes: Int64 = 10 * 1024 * 1024     // 10 MB
+        static let maxFileSizeBytes = SharedImportConfiguration.maximumDocumentSizeBytes
+        static let maxImageSizeBytes = SharedImportConfiguration.maximumImageSizeBytes
         static let previewThumbnailSize: CGFloat = 60
         static let thumbnailMaxDimension: CGFloat = 300
         static let previewMaxWidth: CGFloat = 200
         static let messageThumbnailSize: CGFloat = 80
         static let messageThumbnailColumns: Int = 3
-        static let supportedDocumentExtensions: Set<String> = ["pdf", "docx", "pptx", "xlsx", "txt", "md", "csv", "html", "json", "xml"]
+        static let supportedDocumentExtensions = SharedImportConfiguration.supportedDocumentExtensions
         static let supportedImageExtensions: Set<String> = ["jpg", "jpeg", "png", "gif", "webp", "heic"]
         static let defaultImageMimeType = "image/jpeg"
     }

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -196,6 +196,7 @@ enum Constants {
     enum Sync {
         static let chatSyncIntervalSeconds: TimeInterval = 20.0
         static let profileSyncIntervalSeconds: TimeInterval = 60.0  // 1 minute
+        static let profileSyncProtocolVersion = 2
         static let clientInitTimeoutSeconds: TimeInterval = 60.0
         static let backgroundTaskName = "CompleteStreamingResponse"
         static let maxReverseTimestamp: Int = 9999999999999

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -77,6 +77,9 @@ enum Constants {
         /// content; users can still select large messages via the full-text
         /// selection sheet.
         static let maxInlineSelectionCharacters = 10_000
+        /// Thinking/reasoning chunks larger than this are hard-split so no
+        /// single Text view forces an unbounded CoreText layout pass.
+        static let maxThinkingChunkCharacters = 8_000
     }
 
     enum StreamingBuffer {

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -45,6 +45,7 @@ struct ContentView: View {
             chatViewModel.authManager = authManager
             authManager.setChatViewModel(chatViewModel)
             requestAppReviewIfEligible()
+            importSharedAttachmentsIfReady()
 
             // Initialize encryption with existing key only (no auto-creation)
             Task {
@@ -124,6 +125,10 @@ struct ContentView: View {
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                importSharedAttachmentsIfReady()
+            }
+
             if newPhase == .active && authManager.isAuthenticated {
                 // Sync when app becomes active if authenticated
                 // Only sync if it's been more than 30 seconds since last sync
@@ -151,8 +156,11 @@ struct ContentView: View {
             }
         }
         .onChange(of: authManager.isLoading) { _, isLoading in
-            if !isLoading && authManager.isAuthenticated {
-                chatViewModel.handleSignIn()
+            if !isLoading {
+                importSharedAttachmentsIfReady()
+                if authManager.isAuthenticated {
+                    chatViewModel.handleSignIn()
+                }
             }
         }
         .onChange(of: authManager.hasActiveSubscription) { _, hasSubscription in
@@ -195,6 +203,11 @@ struct ContentView: View {
 
         defaults.set(true, forKey: Constants.StorageKeys.Settings.hasSeenReviewPrompt)
         requestReview()
+    }
+
+    private func importSharedAttachmentsIfReady() {
+        guard !authManager.isLoading else { return }
+        SharedImportCoordinator.shared.importPendingAttachments(into: chatViewModel)
     }
 }
 

--- a/TinfoilChat/Models/AttachmentModels.swift
+++ b/TinfoilChat/Models/AttachmentModels.swift
@@ -19,6 +19,10 @@ enum AttachmentProcessingState: String, Codable, Equatable {
     case failed
 }
 
+func attachmentsAreReadyToSend(_ attachments: [Attachment]) -> Bool {
+    attachments.allSatisfy { $0.processingState == .completed }
+}
+
 struct Attachment: Identifiable, Equatable {
     var id: String
     let type: AttachmentType
@@ -29,6 +33,7 @@ struct Attachment: Identifiable, Equatable {
     var textContent: String?
     var description: String?
     var fileSize: Int64
+    var sharedImportRequestID: UUID?
     // Per-attachment AES-256 key as standard base64 (32 raw bytes → 44 chars).
     // Cross-platform contract: iOS uses Data.base64EncodedString(), React uses btoa().
     // v2 attachments live in buckets and are addressed through the sync enclave
@@ -48,6 +53,7 @@ struct Attachment: Identifiable, Equatable {
         textContent: String? = nil,
         description: String? = nil,
         fileSize: Int64 = 0,
+        sharedImportRequestID: UUID? = nil,
         encryptionKey: String? = nil,
         processingState: AttachmentProcessingState = .pending
     ) {
@@ -60,6 +66,7 @@ struct Attachment: Identifiable, Equatable {
         self.textContent = textContent
         self.description = description
         self.fileSize = fileSize
+        self.sharedImportRequestID = sharedImportRequestID
         self.encryptionKey = encryptionKey
         self.processingState = processingState
     }
@@ -88,6 +95,7 @@ extension Attachment: Codable {
         textContent = try container.decodeIfPresent(String.self, forKey: .textContent)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         fileSize = try container.decodeIfPresent(Int64.self, forKey: .fileSize) ?? 0
+        sharedImportRequestID = nil
         let modernKey = try container.decodeIfPresent(String.self, forKey: .encryptionKey)
         let legacyKey = try container.decodeIfPresent(String.self, forKey: .key)
         encryptionKey = modernKey ?? legacyKey

--- a/TinfoilChat/Models/AttachmentModels.swift
+++ b/TinfoilChat/Models/AttachmentModels.swift
@@ -95,6 +95,8 @@ extension Attachment: Codable {
         textContent = try container.decodeIfPresent(String.self, forKey: .textContent)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         fileSize = try container.decodeIfPresent(Int64.self, forKey: .fileSize) ?? 0
+        // sharedImportRequestID is transient share-inbox bookkeeping —
+        // never persisted, always reset on decode
         sharedImportRequestID = nil
         let modernKey = try container.decodeIfPresent(String.self, forKey: .encryptionKey)
         let legacyKey = try container.decodeIfPresent(String.self, forKey: .key)

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -225,7 +225,9 @@ class CloudStorageService: ObservableObject {
     /// the legacy placeholder behavior so the rest of the app can
     /// still display the chat row.
     func downloadChat(_ chatId: String) async throws -> StoredChat? {
-        guard let keys = CEKEncoding.pullKeysIfAvailable() else { return nil }
+        guard let keys = CEKEncoding.pullKeysIfAvailable() else {
+            return encryptedPlaceholder(chatId: chatId)
+        }
         let response = try await SyncEnclaveAPI.pull(
             EnclavePullRequest(
                 scope: .chat,
@@ -236,7 +238,9 @@ class CloudStorageService: ObservableObject {
                 keys: keys
             )
         )
-        guard let item = response.items.first else { return nil }
+        guard let item = response.items.first else {
+            throw CloudStorageError.invalidResponse
+        }
 
         if !item.ok {
             if item.code == WireCodes.notFound { return nil }
@@ -245,7 +249,7 @@ class CloudStorageService: ObservableObject {
 
         guard let plaintextB64 = item.plaintext,
               let plaintext = Data(base64Encoded: plaintextB64) else {
-            return nil
+            return encryptedPlaceholder(chatId: chatId)
         }
 
         do {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -686,7 +686,26 @@ class CloudSyncService: ObservableObject {
     }
 
     // MARK: - Bulk Sync Operations
-    
+
+    /// Load full chat objects for every locally-modified or never-synced,
+    /// non-local-only chat. Returns nil when the account generation moved
+    /// on while loading.
+    private func loadUnsyncedChats(userId: String, generation: Int) async -> [Chat]? {
+        let index = (try? await EncryptedFileStorage.cloud.loadIndex(
+            userId: userId
+        )) ?? []
+        guard generation == accountGeneration else { return nil }
+        let unsyncedIds = index.filter {
+            ($0.locallyModified || $0.syncedAt == nil) && !$0.isLocalOnly
+        }.map(\.id)
+        let unsyncedChats = (try? await EncryptedFileStorage.cloud.loadChats(
+            chatIds: unsyncedIds,
+            userId: userId
+        )) ?? []
+        guard generation == accountGeneration else { return nil }
+        return unsyncedChats
+    }
+
     /// Backup all unsynced chats
     func backupUnsyncedChats() async -> SyncResult {
         let generation = accountGeneration
@@ -700,18 +719,9 @@ class CloudSyncService: ObservableObject {
             return result
         }
 
-        let index = (try? await EncryptedFileStorage.cloud.loadIndex(
-            userId: userId
-        )) ?? []
-        guard generation == accountGeneration else { return result }
-        let unsyncedIds = index.filter {
-            ($0.locallyModified || $0.syncedAt == nil) && !$0.isLocalOnly
-        }.map(\.id)
-        let unsyncedChats = (try? await EncryptedFileStorage.cloud.loadChats(
-            chatIds: unsyncedIds,
-            userId: userId
-        )) ?? []
-        guard generation == accountGeneration else { return result }
+        guard let unsyncedChats = await loadUnsyncedChats(
+            userId: userId, generation: generation
+        ) else { return result }
         
         
         // Filter out blank, empty, decryption failure, and streaming chats
@@ -1860,18 +1870,9 @@ class CloudSyncService: ObservableObject {
         }
         guard generation == accountGeneration else { return result }
 
-        let index = (try? await EncryptedFileStorage.cloud.loadIndex(
-            userId: userId
-        )) ?? []
-        guard generation == accountGeneration else { return result }
-        let unsyncedIds = index.filter {
-            ($0.locallyModified || $0.syncedAt == nil) && !$0.isLocalOnly
-        }.map(\.id)
-        let unsyncedChats = (try? await EncryptedFileStorage.cloud.loadChats(
-            chatIds: unsyncedIds,
-            userId: userId
-        )) ?? []
-        guard generation == accountGeneration else { return result }
+        guard let unsyncedChats = await loadUnsyncedChats(
+            userId: userId, generation: generation
+        ) else { return result }
         let unsyncedProjectChats = unsyncedChats.filter { $0.projectId == projectId }
 
         for chat in unsyncedProjectChats {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -49,6 +49,7 @@ private actor UploadCoalescer {
     }
 
     private var states: [String: ChatUploadState] = [:]
+    private var generation = 0
     private let uploadFn: @Sendable (String, String) async throws -> Void
 
     init(uploadFn: @escaping @Sendable (String, String) async throws -> Void) {
@@ -88,9 +89,10 @@ private actor UploadCoalescer {
     }
 
     private func runWorker(_ chatId: String) async {
+        let workerGeneration = generation
         var terminalError: Error?
 
-        while states[chatId]?.dirty == true {
+        while states[chatId]?.dirty == true && workerGeneration == generation {
             states[chatId]?.dirty = false
 
             // Mint one idempotency key per logical write. All HTTP
@@ -99,8 +101,13 @@ private actor UploadCoalescer {
             // committed effect, even when a previous attempt
             // already committed and we lost the response.
             let idempotencyKey = newSyncEnclaveIdempotencyKey()
-            terminalError = await uploadWithRetry(chatId, idempotencyKey: idempotencyKey)
+            terminalError = await uploadWithRetry(
+                chatId,
+                idempotencyKey: idempotencyKey,
+                generation: workerGeneration
+            )
         }
+        guard workerGeneration == generation else { return }
 
         // Notify waiters and clean up in a single access
         let waiters = states[chatId]?.waiters ?? []
@@ -127,15 +134,25 @@ private actor UploadCoalescer {
         }
     }
 
-    private func uploadWithRetry(_ chatId: String, idempotencyKey: String) async -> Error? {
+    private func uploadWithRetry(
+        _ chatId: String,
+        idempotencyKey: String,
+        generation workerGeneration: Int
+    ) async -> Error? {
         var lastError: Error?
 
         for attempt in 0...Constants.Sync.uploadMaxRetries {
             do {
                 try await uploadFn(chatId, idempotencyKey)
+                guard workerGeneration == generation else {
+                    return CancellationError()
+                }
                 states[chatId]?.failureCount = 0
                 return nil
             } catch {
+                guard workerGeneration == generation else {
+                    return CancellationError()
+                }
                 lastError = error
                 let currentCount = states[chatId]?.failureCount ?? 0
                 states[chatId]?.failureCount = currentCount + 1
@@ -149,6 +166,9 @@ private actor UploadCoalescer {
                     Constants.Sync.uploadMaxDelaySeconds
                 )
                 try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard workerGeneration == generation else {
+                    return CancellationError()
+                }
 
                 // If dirty was set during backoff, return early to upload fresh data
                 let isDirty = states[chatId]?.dirty ?? false
@@ -159,6 +179,15 @@ private actor UploadCoalescer {
         }
 
         return lastError
+    }
+
+    func clear() {
+        generation += 1
+        let waiters = states.values.flatMap(\.waiters)
+        let throwingWaiters = states.values.flatMap(\.throwingWaiters)
+        states.removeAll()
+        waiters.forEach { $0.resume() }
+        throwingWaiters.forEach { $0.resume(throwing: CancellationError()) }
     }
 }
 
@@ -188,6 +217,7 @@ class CloudSyncService: ObservableObject {
         }
     }()
     private var streamingCallbacks: Set<String> = []
+    private var accountGeneration = 0
     private let cloudStorage = CloudStorageService.shared
     private let encryptionService = EncryptionService.shared
     private let deletedChatsTracker = DeletedChatsTracker.shared
@@ -372,6 +402,7 @@ class CloudSyncService: ObservableObject {
     
     /// Backup a single chat to the cloud, coalescing rapid successive calls
     func backupChat(_ chatId: String, ensureLatestUpload: Bool = false) async {
+        let generation = accountGeneration
         // Don't attempt backup if not authenticated
         guard await cloudStorage.isAuthenticated() else {
             return
@@ -380,12 +411,13 @@ class CloudSyncService: ObservableObject {
         guard await canWriteToCloud() else {
             return
         }
+        guard generation == accountGeneration else { return }
 
         beginPendingUpload(chatId)
         await uploadCoalescer.enqueue(chatId)
         Task { [weak self] in
             await self?.uploadCoalescer.waitForUpload(chatId)
-            self?.endPendingUpload(chatId)
+            self?.endPendingUpload(chatId, generation: generation)
         }
 
         if ensureLatestUpload {
@@ -398,7 +430,8 @@ class CloudSyncService: ObservableObject {
         pendingUploadChatIds.insert(chatId)
     }
 
-    private func endPendingUpload(_ chatId: String) {
+    private func endPendingUpload(_ chatId: String, generation: Int) {
+        guard generation == accountGeneration else { return }
         let remaining = (pendingUploadCounts[chatId] ?? 1) - 1
         if remaining <= 0 {
             pendingUploadCounts.removeValue(forKey: chatId)
@@ -409,7 +442,10 @@ class CloudSyncService: ObservableObject {
     }
 
     private func doBackupChat(_ chatId: String, idempotencyKey: String) async throws {
+        let generation = accountGeneration
+        guard let userId = await getCurrentUserId() else { return }
         guard await canWriteToCloud() else { return }
+        guard generation == accountGeneration else { return }
 
         // Check if chat is currently streaming
         if streamingTracker.isStreaming(chatId) {
@@ -425,6 +461,7 @@ class CloudSyncService: ObservableObject {
             // Register to sync once streaming ends
             streamingTracker.onStreamEnd(chatId) { [weak self] in
                 Task { @MainActor in
+                    guard self?.accountGeneration == generation else { return }
                     // Remove from tracking set
                     self?.streamingCallbacks.remove(chatId)
                     
@@ -438,9 +475,13 @@ class CloudSyncService: ObservableObject {
         }
         
         // Load chat from storage
-        guard let chat = await loadChatFromStorage(chatId) else {
+        guard let chat = try? await EncryptedFileStorage.cloud.loadChat(
+            chatId: chatId,
+            userId: userId
+        ) else {
             return // Chat might have been deleted
         }
+        guard generation == accountGeneration else { return }
         
         
         // Don't sync blank, empty, decryption-failure, or local-only chats.
@@ -456,9 +497,20 @@ class CloudSyncService: ObservableObject {
         }
         
         do {
-            try await uploadAndMarkSynced(chat, idempotencyKey: idempotencyKey)
+            try await uploadAndMarkSynced(
+                chat,
+                idempotencyKey: idempotencyKey,
+                generation: generation,
+                userId: userId
+            )
         } catch {
-            try await handleUploadFailure(chatId: chatId, error: error)
+            guard generation == accountGeneration else { return }
+            try await handleUploadFailure(
+                chatId: chatId,
+                error: error,
+                generation: generation,
+                userId: userId
+            )
         }
     }
 
@@ -470,7 +522,12 @@ class CloudSyncService: ObservableObject {
     /// render) so the chat stays locallyModified and is picked up
     /// on the next natural sync cycle without burning the retry
     /// budget.
-    private func handleUploadFailure(chatId: String, error: Error) async throws {
+    private func handleUploadFailure(
+        chatId: String,
+        error: Error,
+        generation: Int,
+        userId: String
+    ) async throws {
         let decision = EnclaveErrorRecovery.decide(error)
         #if DEBUG
         print("[CloudSync] upload recovery decision chat=\(chatId) action=\(decision.action) code=\(decision.classification.code?.rawValue ?? "nil")")
@@ -488,7 +545,11 @@ class CloudSyncService: ObservableObject {
             SyncHealthStore.shared.reportKeyActionRequired(.keyMismatch)
             throw error
         case .surfaceConflict:
-            await resolveConflictByPullingRemote(chatId)
+            await resolveConflictByPullingRemote(
+                chatId,
+                generation: generation,
+                userId: userId
+            )
         case .surfaceExistingDataUnderOtherKey:
             SyncHealthStore.shared.reportKeyActionRequired(.keyConflict)
         case .surfaceNotFound:
@@ -537,16 +598,24 @@ class CloudSyncService: ObservableObject {
     ///
     /// If the pull itself fails the chat stays locallyModified and the
     /// next sync cycle retries.
-    private func resolveConflictByPullingRemote(_ chatId: String) async {
+    private func resolveConflictByPullingRemote(
+        _ chatId: String,
+        generation: Int,
+        userId: String
+    ) async {
         do {
             guard var downloadedChat = try await cloudStorage.downloadChat(chatId) else {
                 return
             }
+            guard generation == accountGeneration else { return }
             if downloadedChat.modelType == nil {
                 downloadedChat.modelType = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first
             }
 
-            let localChat = await loadChatFromStorage(chatId)
+            let localChat = try? await EncryptedFileStorage.cloud.loadChat(
+                chatId: chatId,
+                userId: userId
+            )
 
             // A chat's edit clock is trusted only when it was maintained
             // at the row's current synced version; otherwise a
@@ -581,7 +650,14 @@ class CloudSyncService: ObservableObject {
             )
 
             if !remoteWins {
-                await rebaseSyncVersion(chatId, version: downloadedChat.syncVersion)
+                guard generation == accountGeneration else { return }
+                await rebaseSyncVersion(
+                    chatId,
+                    version: downloadedChat.syncVersion,
+                    generation: generation,
+                    userId: userId
+                )
+                guard generation == accountGeneration else { return }
                 // Re-enqueue rather than wait: the coalescer worker will
                 // pick up the dirty flag and re-run the upload with the
                 // rebased version.
@@ -589,8 +665,19 @@ class CloudSyncService: ObservableObject {
                 return
             }
 
-            await saveChatToStorage(downloadedChat)
-            await markChatAsSynced(downloadedChat.id, version: downloadedChat.syncVersion)
+            guard generation == accountGeneration else { return }
+            downloadedChat.syncedAt = Date()
+            downloadedChat.locallyModified = false
+            let applied = await applyRemoteChatToStorage(
+                downloadedChat,
+                generation: generation,
+                userId: userId,
+                expectedLocalUpdatedAt: localChat?.updatedAt,
+                allowLocallyModified: true
+            )
+            if applied {
+                SyncHealthStore.shared.reportChatSynced(downloadedChat.id)
+            }
         } catch {
             #if DEBUG
             print("[CloudSync] resolveConflictByPullingRemote failed for \(chatId): \(error)")
@@ -602,13 +689,29 @@ class CloudSyncService: ObservableObject {
     
     /// Backup all unsynced chats
     func backupUnsyncedChats() async -> SyncResult {
+        let generation = accountGeneration
         var result = SyncResult()
 
         guard await canWriteToCloud() else {
             return result
         }
-        
-        let unsyncedChats = await getUnsyncedChats()
+        guard let userId = await getCurrentUserId(),
+              generation == accountGeneration else {
+            return result
+        }
+
+        let index = (try? await EncryptedFileStorage.cloud.loadIndex(
+            userId: userId
+        )) ?? []
+        guard generation == accountGeneration else { return result }
+        let unsyncedIds = index.filter {
+            ($0.locallyModified || $0.syncedAt == nil) && !$0.isLocalOnly
+        }.map(\.id)
+        let unsyncedChats = (try? await EncryptedFileStorage.cloud.loadChats(
+            chatIds: unsyncedIds,
+            userId: userId
+        )) ?? []
+        guard generation == accountGeneration else { return result }
         
         
         // Filter out blank, empty, decryption failure, and streaming chats
@@ -625,6 +728,7 @@ class CloudSyncService: ObservableObject {
         
         // Upload chats sequentially to avoid connection exhaustion
         for chat in chatsToSync {
+            guard generation == accountGeneration else { return result }
             // Skip if chat started streaming
             if streamingTracker.isStreaming(chat.id) {
                 continue
@@ -632,12 +736,14 @@ class CloudSyncService: ObservableObject {
 
             do {
                 try await uploadCoalescer.enqueueAndWait(chat.id)
+                guard generation == accountGeneration else { return result }
                 result = SyncResult(
                     uploaded: result.uploaded + 1,
                     downloaded: result.downloaded,
                     errors: result.errors
                 )
             } catch {
+                guard generation == accountGeneration else { return result }
                 SyncHealthStore.shared.reportChatSyncFailed(
                     chat.id,
                     message: "This chat couldn't be synced"
@@ -661,15 +767,23 @@ class CloudSyncService: ObservableObject {
         continuationToken: String? = nil,
         loadLocal: Bool = true
     ) async -> PaginatedChatsResult {
+        let generation = accountGeneration
         let pageLimit = limit ?? Constants.Pagination.chatsPerPage
         // If not authenticated, fall back to local-only pagination
         guard await cloudStorage.isAuthenticated() else {
             if loadLocal {
-                return await loadLocalChatsWithPagination(
+                let result = await loadLocalChatsWithPagination(
                     limit: pageLimit,
                     continuationToken: continuationToken
                 )
+                guard generation == accountGeneration else {
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                }
+                return result
             }
+            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+        }
+        guard generation == accountGeneration else {
             return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
         }
         
@@ -681,6 +795,9 @@ class CloudSyncService: ObservableObject {
                 continuationToken: continuationToken,
                 includeContent: true
             )
+            guard generation == accountGeneration else {
+                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+            }
             
             // Process remote chats in parallel
             var downloadedChats: [StoredChat] = []
@@ -689,9 +806,15 @@ class CloudSyncService: ObservableObject {
             // Initialize encryption if available; continue even without a key so we can at least
             // fetch metadata and store encrypted placeholders. Decryption will be attempted per-chat.
             _ = try? await encryptionService.initialize()
+            guard generation == accountGeneration else {
+                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+            }
 
             // Process chats sequentially to avoid connection exhaustion
             for remoteChat in chatsToProcess {
+                guard generation == accountGeneration else {
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                }
                 // Skip recently deleted chats
                 if deletedChatsTracker.isDeleted(remoteChat.id) {
                     continue
@@ -707,8 +830,14 @@ class CloudSyncService: ObservableObject {
                 }
 
                 if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
+                    guard generation == accountGeneration else {
+                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                    }
                     downloadedChats.append(decrypted.chat)
                 } else {
+                    guard generation == accountGeneration else {
+                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                    }
                     let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
                     downloadedChats.append(placeholder)
                 }
@@ -727,10 +856,14 @@ class CloudSyncService: ObservableObject {
         } catch {
             // On error, fall back to local if enabled
             if loadLocal {
-                return await loadLocalChatsWithPagination(
+                let result = await loadLocalChatsWithPagination(
                     limit: pageLimit,
                     continuationToken: continuationToken
                 )
+                guard generation == accountGeneration else {
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                }
+                return result
             }
             return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
         }
@@ -835,17 +968,27 @@ class CloudSyncService: ObservableObject {
     
     /// Download a remote chat by ID, apply metadata dates, and save locally.
     /// Returns `true` if the chat was downloaded and saved, `false` on failure.
-    private func downloadAndSaveRemoteChat(_ remoteChat: RemoteChat, projectId: String? = nil) async throws {
+    private func downloadAndSaveRemoteChat(
+        _ remoteChat: RemoteChat,
+        projectId: String? = nil,
+        generation: Int,
+        userId: String,
+        expectedLocalUpdatedAt: Date?
+    ) async throws {
         guard var downloadedChat = try await cloudStorage.downloadChat(remoteChat.id) else {
             return
         }
+        guard generation == accountGeneration else { return }
         if let projectId = projectId ?? remoteChat.projectId {
             downloadedChat.projectId = projectId
         }
 
         // If decryption failed, don't overwrite a valid local copy.
         if downloadedChat.decryptionFailed == true {
-            if let localChat = await loadChatFromStorage(remoteChat.id),
+            if let localChat = try? await EncryptedFileStorage.cloud.loadChat(
+                chatId: remoteChat.id,
+                userId: userId
+            ),
                !localChat.messages.isEmpty,
                !localChat.decryptionFailed {
                 return
@@ -867,12 +1010,19 @@ class CloudSyncService: ObservableObject {
             downloadedChat.modelType = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first
         }
 
-        await saveChatToStorage(downloadedChat)
-        await markChatAsSynced(downloadedChat.id, version: downloadedChat.syncVersion)
+        downloadedChat.syncedAt = Date()
+        downloadedChat.locallyModified = false
+        _ = await applyRemoteChatToStorage(
+            downloadedChat,
+            generation: generation,
+            userId: userId,
+            expectedLocalUpdatedAt: expectedLocalUpdatedAt
+        )
     }
 
     /// Sync all chats (upload local changes, download remote changes)
     func syncAllChats() async -> SyncResult {
+        let generation = accountGeneration
         guard !isSyncing else {
             return SyncResult()
         }
@@ -880,28 +1030,39 @@ class CloudSyncService: ObservableObject {
         isSyncing = true
         syncStatus = "Syncing..."
         defer {
-            isSyncing = false
-            syncStatus = ""
-            lastSyncDate = Date()
+            if generation == accountGeneration {
+                isSyncing = false
+                syncStatus = ""
+                lastSyncDate = Date()
+            }
         }
 
         let result = await doSyncAllChats()
+        guard generation == accountGeneration else { return SyncResult() }
         syncErrors = result.errors
         return result
     }
 
     private func doSyncAllChats() async -> SyncResult {
+        let generation = accountGeneration
+        guard let userId = await getCurrentUserId() else { return SyncResult() }
         var result = SyncResult()
 
         // Delete local chats that were deleted on another device
         var deletedCount = 0
         if let cachedStatus = getCachedSyncStatus(),
            let lastUpdated = cachedStatus.lastUpdated {
-            deletedCount = await deleteRemotelyDeletedChats(since: lastUpdated)
+            deletedCount = await deleteRemotelyDeletedChats(
+                since: lastUpdated,
+                generation: generation,
+                userId: userId
+            )
         }
+        guard generation == accountGeneration else { return SyncResult() }
 
         // First, backup any unsynced local changes
         let backupResult = await backupUnsyncedChats()
+        guard generation == accountGeneration else { return SyncResult() }
         result = SyncResult(
             uploaded: backupResult.uploaded,
             downloaded: 0,
@@ -911,7 +1072,9 @@ class CloudSyncService: ObservableObject {
 
         // Then, get list of remote chats with content
         do {
-            let localChats = await getAllChatsFromStorage()
+            let localChats = (try? await EncryptedFileStorage.cloud.loadAllChats(
+                userId: userId
+            )) ?? []
 
             // Initialize encryption if available; continue even without a key so we can at least
             // fetch metadata and store encrypted placeholders. Decryption will be attempted per-chat.
@@ -931,6 +1094,7 @@ class CloudSyncService: ObservableObject {
                 continuationToken: nil,
                 includeContent: false
             )
+            guard generation == accountGeneration else { return result }
             let remoteConversations = remoteList.conversations
 
             // First pass: decide which chats need processing.
@@ -978,6 +1142,7 @@ class CloudSyncService: ObservableObject {
 
             // Process sequentially to avoid connection exhaustion
             for remoteChat in chatsToProcess {
+                guard generation == accountGeneration else { return result }
                 let localChat = localChatMap[remoteChat.id]
 
                 if let content = remoteChat.content {
@@ -988,8 +1153,16 @@ class CloudSyncService: ObservableObject {
                             continue
                         }
 
-                        await saveChatToStorage(decrypted.chat)
-                        await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                        var remoteChatToApply = decrypted.chat
+                        remoteChatToApply.syncedAt = Date()
+                        remoteChatToApply.locallyModified = false
+                        let applied = await applyRemoteChatToStorage(
+                            remoteChatToApply,
+                            generation: generation,
+                            userId: userId,
+                            expectedLocalUpdatedAt: localChat?.updatedAt
+                        )
+                        guard applied else { continue }
                         result = SyncResult(
                             uploaded: result.uploaded,
                             downloaded: result.downloaded + 1,
@@ -1004,8 +1177,16 @@ class CloudSyncService: ObservableObject {
                         // the remote was re-encrypted with a key we don't have yet).
                         let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
                         if !hasValidLocal {
-                            let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
-                            await saveChatToStorage(placeholder)
+                            var placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
+                            placeholder.syncedAt = Date()
+                            placeholder.locallyModified = false
+                            let applied = await applyRemoteChatToStorage(
+                                placeholder,
+                                generation: generation,
+                                userId: userId,
+                                expectedLocalUpdatedAt: localChat?.updatedAt
+                            )
+                            guard applied else { continue }
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
@@ -1017,7 +1198,12 @@ class CloudSyncService: ObservableObject {
                 } else {
                     // No inline content - fetch via downloadChat (handles its own decryption)
                     do {
-                        try await downloadAndSaveRemoteChat(remoteChat)
+                        try await downloadAndSaveRemoteChat(
+                            remoteChat,
+                            generation: generation,
+                            userId: userId,
+                            expectedLocalUpdatedAt: localChat?.updatedAt
+                        )
                         result = SyncResult(
                             uploaded: result.uploaded,
                             downloaded: result.downloaded + 1,
@@ -1036,10 +1222,10 @@ class CloudSyncService: ObservableObject {
             }
 
             // Refresh cached sync status so subsequent smart-syncs have up-to-date info
-            await refreshSyncStatusCache()
+            await refreshSyncStatusCache(generation: generation, userId: userId)
 
             // Detect cross-scope moves (chats moving between projects)
-            await syncCrossScope()
+            await syncCrossScope(generation: generation, userId: userId)
 
         } catch {
             result = SyncResult(
@@ -1150,13 +1336,21 @@ class CloudSyncService: ObservableObject {
 
     /// Sync only chats that changed since last sync
     private func syncChangedChats(since: String) async -> SyncResult {
+        let generation = accountGeneration
+        guard let userId = await getCurrentUserId() else { return SyncResult() }
         var result = SyncResult()
 
         // Delete local chats that were deleted on another device
-        let deletedCount = await deleteRemotelyDeletedChats(since: since)
+        let deletedCount = await deleteRemotelyDeletedChats(
+            since: since,
+            generation: generation,
+            userId: userId
+        )
+        guard generation == accountGeneration else { return SyncResult() }
 
         // Backup any unsynced local changes first (matches doSyncAllChats behavior)
         let backupResult = await backupUnsyncedChats()
+        guard generation == accountGeneration else { return SyncResult() }
         result = SyncResult(
             uploaded: backupResult.uploaded,
             downloaded: 0,
@@ -1167,7 +1361,9 @@ class CloudSyncService: ObservableObject {
         do {
             _ = try? await encryptionService.initialize()
 
-            let localChats = await getAllChatsFromStorage()
+            let localChats = (try? await EncryptedFileStorage.cloud.loadAllChats(
+                userId: userId
+            )) ?? []
             let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
 
             // Paginate through all changed chats
@@ -1180,6 +1376,7 @@ class CloudSyncService: ObservableObject {
                     includeContent: true,
                     continuationToken: continuationToken
                 )
+                guard generation == accountGeneration else { return result }
 
                 for remoteChat in changedChats.conversations {
                     if deletedChatsTracker.isDeleted(remoteChat.id) {
@@ -1203,8 +1400,17 @@ class CloudSyncService: ObservableObject {
 
                     if let content = remoteChat.content {
                         if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
-                            await saveChatToStorage(decrypted.chat)
-                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                            let localChat = localChatMap[remoteChat.id]
+                            var remoteChatToApply = decrypted.chat
+                            remoteChatToApply.syncedAt = Date()
+                            remoteChatToApply.locallyModified = false
+                            let applied = await applyRemoteChatToStorage(
+                                remoteChatToApply,
+                                generation: generation,
+                                userId: userId,
+                                expectedLocalUpdatedAt: localChat?.updatedAt
+                            )
+                            guard applied else { continue }
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
@@ -1216,8 +1422,16 @@ class CloudSyncService: ObservableObject {
                             let localChat = localChatMap[remoteChat.id]
                             let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
                             if !hasValidLocal {
-                                let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
-                                await saveChatToStorage(placeholder)
+                                var placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
+                                placeholder.syncedAt = Date()
+                                placeholder.locallyModified = false
+                                let applied = await applyRemoteChatToStorage(
+                                    placeholder,
+                                    generation: generation,
+                                    userId: userId,
+                                    expectedLocalUpdatedAt: localChat?.updatedAt
+                                )
+                                guard applied else { continue }
                                 result = SyncResult(
                                     uploaded: result.uploaded,
                                     downloaded: result.downloaded + 1,
@@ -1229,7 +1443,12 @@ class CloudSyncService: ObservableObject {
                     } else {
                         // No inline content - fetch via downloadChat (handles its own decryption)
                         do {
-                            try await downloadAndSaveRemoteChat(remoteChat)
+                            try await downloadAndSaveRemoteChat(
+                                remoteChat,
+                                generation: generation,
+                                userId: userId,
+                                expectedLocalUpdatedAt: localChatMap[remoteChat.id]?.updatedAt
+                            )
                             result = SyncResult(
                                 uploaded: result.uploaded,
                                 downloaded: result.downloaded + 1,
@@ -1253,10 +1472,10 @@ class CloudSyncService: ObservableObject {
             }
 
             // Refresh cached sync status so subsequent smart-syncs have up-to-date info
-            await refreshSyncStatusCache()
+            await refreshSyncStatusCache(generation: generation, userId: userId)
 
             // Detect cross-scope moves (chats moving between projects)
-            await syncCrossScope()
+            await syncCrossScope(generation: generation, userId: userId)
         } catch {
             result = SyncResult(
                 uploaded: result.uploaded,
@@ -1271,6 +1490,7 @@ class CloudSyncService: ObservableObject {
 
     /// Smart sync - only sync if changes detected
     func smartSync() async -> SyncResult {
+        let generation = accountGeneration
         guard !isSyncing else {
             return SyncResult()
         }
@@ -1278,8 +1498,15 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated() else {
             return SyncResult()
         }
+        guard let userId = await getCurrentUserId(),
+              generation == accountGeneration else {
+            return SyncResult()
+        }
 
         let statusCheck = await checkSyncStatus()
+        guard generation == accountGeneration else {
+            return SyncResult()
+        }
 
         if !statusCheck.needsSync {
             // A deletion from another device can be absorbed into the status
@@ -1291,7 +1518,11 @@ class CloudSyncService: ObservableObject {
             // removed locally, so it triggers a UI reload only when needed.
             if let cachedStatus = getCachedSyncStatus(),
                let lastUpdated = cachedStatus.lastUpdated {
-                let reconciled = await deleteRemotelyDeletedChats(since: lastUpdated)
+                let reconciled = await deleteRemotelyDeletedChats(
+                    since: lastUpdated,
+                    generation: generation,
+                    userId: userId
+                )
                 if reconciled > 0 {
                     return SyncResult(deleted: reconciled)
                 }
@@ -1302,9 +1533,11 @@ class CloudSyncService: ObservableObject {
         isSyncing = true
         syncStatus = "Syncing..."
         defer {
-            isSyncing = false
-            syncStatus = ""
-            lastSyncDate = Date()
+            if generation == accountGeneration {
+                isSyncing = false
+                syncStatus = ""
+                lastSyncDate = Date()
+            }
         }
 
         var result = SyncResult()
@@ -1342,6 +1575,7 @@ class CloudSyncService: ObservableObject {
             )
         }
 
+        guard generation == accountGeneration else { return SyncResult() }
         syncErrors = result.errors
         return result
     }
@@ -1354,6 +1588,7 @@ class CloudSyncService: ObservableObject {
     }
 
     func syncProjectChats(_ projectId: String) async -> SyncResult {
+        let generation = accountGeneration
         guard !isSyncing else {
             return SyncResult()
         }
@@ -1361,21 +1596,26 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated() else {
             return SyncResult()
         }
+        guard generation == accountGeneration else { return SyncResult() }
 
         isSyncing = true
         syncStatus = "Syncing project..."
         defer {
-            isSyncing = false
-            syncStatus = ""
-            lastSyncDate = Date()
+            if generation == accountGeneration {
+                isSyncing = false
+                syncStatus = ""
+                lastSyncDate = Date()
+            }
         }
 
         let result = await doSyncProjectChats(projectId)
+        guard generation == accountGeneration else { return SyncResult() }
         syncErrors = result.errors
         return result
     }
 
     private func smartSyncProjectChats(_ projectId: String) async -> SyncResult {
+        let generation = accountGeneration
         guard !isSyncing else {
             return SyncResult()
         }
@@ -1383,14 +1623,17 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated() else {
             return SyncResult()
         }
+        guard generation == accountGeneration else { return SyncResult() }
 
         let unsyncedChats = await getUnsyncedChats()
+        guard generation == accountGeneration else { return SyncResult() }
         let localProjectChanges = unsyncedChats.contains {
             $0.projectId == projectId && !$0.isBlankChat && !$0.messages.isEmpty
         }
 
         do {
             let remoteStatus = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
+            guard generation == accountGeneration else { return SyncResult() }
             let cachedStatus = getCachedProjectChatSyncStatus(projectId)
 
             if !localProjectChanges,
@@ -1403,15 +1646,18 @@ class CloudSyncService: ObservableObject {
             isSyncing = true
             syncStatus = "Syncing project..."
             defer {
-                isSyncing = false
-                syncStatus = ""
-                lastSyncDate = Date()
+                if generation == accountGeneration {
+                    isSyncing = false
+                    syncStatus = ""
+                    lastSyncDate = Date()
+                }
             }
 
             if !localProjectChanges,
                let cachedLastUpdated = cachedStatus?.lastUpdated,
                remoteStatus.count == cachedStatus?.count {
                 let result = await syncProjectChatsChanged(projectId, since: cachedLastUpdated)
+                guard generation == accountGeneration else { return SyncResult() }
                 if result.errors.isEmpty {
                     saveProjectChatSyncStatus(projectId, remoteStatus)
                     return result
@@ -1419,9 +1665,11 @@ class CloudSyncService: ObservableObject {
             }
 
             let result = await doSyncProjectChats(projectId)
+            guard generation == accountGeneration else { return SyncResult() }
             syncErrors = result.errors
             return result
         } catch {
+            guard generation == accountGeneration else { return SyncResult() }
             return await syncProjectChats(projectId)
         }
     }
@@ -1464,9 +1712,16 @@ class CloudSyncService: ObservableObject {
         applyShouldProcessFilter: Bool,
         fetchPage: (String?) async throws -> (chats: [RemoteChat], nextToken: String?, hasMore: Bool)
     ) async -> SyncResult {
+        let generation = accountGeneration
+        guard let userId = await getCurrentUserId() else { return SyncResult() }
         var result = SyncResult()
 
-        let backupResult = await backupUnsyncedProjectChats(projectId)
+        let backupResult = await backupUnsyncedProjectChats(
+            projectId,
+            generation: generation,
+            userId: userId
+        )
+        guard generation == accountGeneration else { return SyncResult() }
         result = SyncResult(
             uploaded: backupResult.uploaded,
             downloaded: 0,
@@ -1477,12 +1732,15 @@ class CloudSyncService: ObservableObject {
         do {
             _ = try? await encryptionService.initialize()
 
-            let localChats = await getAllChatsFromStorage()
+            let localChats = (try? await EncryptedFileStorage.cloud.loadAllChats(
+                userId: userId
+            )) ?? []
             let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
             var continuationToken: String? = nil
 
             repeat {
                 let page = try await fetchPage(continuationToken)
+                guard generation == accountGeneration else { return result }
 
                 for remoteChat in page.chats {
                     if deletedChatsTracker.isDeleted(remoteChat.id) {
@@ -1502,7 +1760,9 @@ class CloudSyncService: ObservableObject {
                         remoteChat,
                         projectId: projectId,
                         localChatMap: localChatMap,
-                        errorPrefix: errorPrefix
+                        errorPrefix: errorPrefix,
+                        generation: generation,
+                        userId: userId
                     )
                     result = SyncResult(
                         uploaded: result.uploaded,
@@ -1517,8 +1777,10 @@ class CloudSyncService: ObservableObject {
             } while continuationToken != nil
 
             let status = try await cloudStorage.getProjectChatsSyncStatus(projectId: projectId)
-            saveProjectChatSyncStatus(projectId, status)
-            await syncCrossScope()
+            if generation == accountGeneration {
+                saveProjectChatSyncStatus(projectId, status)
+                await syncCrossScope(generation: generation, userId: userId)
+            }
         } catch {
             result = SyncResult(
                 uploaded: result.uploaded,
@@ -1535,46 +1797,85 @@ class CloudSyncService: ObservableObject {
         _ remoteChat: RemoteChat,
         projectId: String,
         localChatMap: [String: Chat],
-        errorPrefix: String
+        errorPrefix: String,
+        generation: Int,
+        userId: String
     ) async -> (downloaded: Int, errors: [String]) {
+        guard generation == accountGeneration else { return (0, []) }
+        let localChat = localChatMap[remoteChat.id]
         if let content = remoteChat.content {
             if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
                 decrypted.chat.projectId = projectId
-                await saveChatToStorage(decrypted.chat)
-                await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
-                return (1, [])
+                decrypted.chat.syncedAt = Date()
+                decrypted.chat.locallyModified = false
+                let applied = await applyRemoteChatToStorage(
+                    decrypted.chat,
+                    generation: generation,
+                    userId: userId,
+                    expectedLocalUpdatedAt: localChat?.updatedAt
+                )
+                return (applied ? 1 : 0, [])
             } else {
-                let localChat = localChatMap[remoteChat.id]
                 let hasValidLocal = localChat.map { !$0.messages.isEmpty && !$0.decryptionFailed } ?? false
                 if !hasValidLocal {
                     var placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
                     placeholder.projectId = projectId
-                    await saveChatToStorage(placeholder)
-                    return (1, [])
+                    placeholder.syncedAt = Date()
+                    placeholder.locallyModified = false
+                    let applied = await applyRemoteChatToStorage(
+                        placeholder,
+                        generation: generation,
+                        userId: userId,
+                        expectedLocalUpdatedAt: localChat?.updatedAt
+                    )
+                    return (applied ? 1 : 0, [])
                 }
                 return (0, [])
             }
         }
 
         do {
-            try await downloadAndSaveRemoteChat(remoteChat, projectId: projectId)
+            try await downloadAndSaveRemoteChat(
+                remoteChat,
+                projectId: projectId,
+                generation: generation,
+                userId: userId,
+                expectedLocalUpdatedAt: localChat?.updatedAt
+            )
             return (1, [])
         } catch {
             return (0, ["\(errorPrefix) (\(remoteChat.id)): \(error.localizedDescription)"])
         }
     }
 
-    private func backupUnsyncedProjectChats(_ projectId: String) async -> SyncResult {
+    private func backupUnsyncedProjectChats(
+        _ projectId: String,
+        generation: Int,
+        userId: String
+    ) async -> SyncResult {
         var result = SyncResult()
 
         guard await canWriteToCloud() else {
             return result
         }
+        guard generation == accountGeneration else { return result }
 
-        let unsyncedChats = await getUnsyncedChats()
+        let index = (try? await EncryptedFileStorage.cloud.loadIndex(
+            userId: userId
+        )) ?? []
+        guard generation == accountGeneration else { return result }
+        let unsyncedIds = index.filter {
+            ($0.locallyModified || $0.syncedAt == nil) && !$0.isLocalOnly
+        }.map(\.id)
+        let unsyncedChats = (try? await EncryptedFileStorage.cloud.loadChats(
+            chatIds: unsyncedIds,
+            userId: userId
+        )) ?? []
+        guard generation == accountGeneration else { return result }
         let unsyncedProjectChats = unsyncedChats.filter { $0.projectId == projectId }
 
         for chat in unsyncedProjectChats {
+            guard generation == accountGeneration else { return result }
             guard !chat.isBlankChat,
                   !chat.messages.isEmpty,
                   !chat.decryptionFailed,
@@ -1584,6 +1885,7 @@ class CloudSyncService: ObservableObject {
 
             do {
                 try await uploadCoalescer.enqueueAndWait(chat.id)
+                guard generation == accountGeneration else { return result }
                 result = SyncResult(
                     uploaded: result.uploaded + 1,
                     downloaded: result.downloaded,
@@ -1591,6 +1893,7 @@ class CloudSyncService: ObservableObject {
                     errors: result.errors
                 )
             } catch {
+                guard generation == accountGeneration else { return result }
                 result = SyncResult(
                     uploaded: result.uploaded,
                     downloaded: result.downloaded,
@@ -1604,9 +1907,21 @@ class CloudSyncService: ObservableObject {
     }
 
     /// Clear cached sync status (call on logout)
-    func clearSyncStatus() {
+    func clearSyncStatus() async {
+        accountGeneration += 1
+        isSyncing = false
+        syncStatus = ""
+        lastSyncDate = nil
+        streamingCallbacks.removeAll()
+        pendingUploadCounts.removeAll()
+        pendingUploadChatIds.removeAll()
+        await uploadCoalescer.clear()
         UserDefaults.standard.removeObject(forKey: syncStatusKey)
         UserDefaults.standard.removeObject(forKey: allChatsSyncStatusKey)
+        for key in UserDefaults.standard.dictionaryRepresentation().keys
+            where key.hasPrefix(Constants.StorageKeys.Sync.projectChatStatusPrefix) {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
         // Drop any in-flight key registration so the next signed-in user
         // never awaits a task started under the previous user's key.
         emptyRemoteRegistration?.cancel()
@@ -1665,10 +1980,13 @@ class CloudSyncService: ObservableObject {
         }
     }
 
-    private func refreshSyncStatusCache() async {
+    private func refreshSyncStatusCache(generation: Int, userId: String) async {
         if let remoteStatus = try? await cloudStorage.getChatSyncStatus(),
-           let lastUpdated = remoteStatus.lastUpdated {
-            let localCount = await safeReadLocalChatCount()
+           let lastUpdated = remoteStatus.lastUpdated,
+           generation == accountGeneration {
+            let index = try? await EncryptedFileStorage.cloud.loadIndex(userId: userId)
+            let localCount = index?.filter { !$0.isLocalOnly }.count
+            guard generation == accountGeneration else { return }
             saveSyncStatus(
                 count: remoteStatus.count,
                 lastUpdated: lastUpdated,
@@ -1694,11 +2012,12 @@ class CloudSyncService: ObservableObject {
 
     /// Detect and apply cross-scope changes (chats moving between projects or becoming unassigned).
     /// Uses the unscoped all-updated-since endpoint to find chats whose projectId changed.
-    private func syncCrossScope() async {
+    private func syncCrossScope(generation: Int, userId: String) async {
         do {
             let cachedAllStatus = getCachedAllChatsSyncStatus()
 
             let remoteAllStatus = try await cloudStorage.getAllChatsSyncStatus()
+            guard generation == accountGeneration else { return }
 
             // If nothing changed globally, skip
             if let cached = cachedAllStatus,
@@ -1714,7 +2033,9 @@ class CloudSyncService: ObservableObject {
                 return
             }
 
-            let localChats = await getAllChatsFromStorage()
+            let localChats = (try? await EncryptedFileStorage.cloud.loadAllChats(
+                userId: userId
+            )) ?? []
             let localChatMap = Dictionary(uniqueKeysWithValues: localChats.map { ($0.id, $0) })
 
             var continuationToken: String? = nil
@@ -1725,6 +2046,7 @@ class CloudSyncService: ObservableObject {
                     since: cachedLastUpdated,
                     continuationToken: continuationToken
                 )
+                guard generation == accountGeneration else { return }
 
                 let remoteChats = allUpdated.conversations
                 if remoteChats.isEmpty { break }
@@ -1732,28 +2054,43 @@ class CloudSyncService: ObservableObject {
                 totalProcessed += remoteChats.count
 
                 for remoteChat in remoteChats {
+                    guard generation == accountGeneration else { return }
                     let localChat = localChatMap[remoteChat.id]
                     let remoteProjectId = remoteChat.projectId
                     let localProjectId = localChat?.projectId
 
-                    if localChat != nil && remoteProjectId != localProjectId {
+                    if var localChat, remoteProjectId != localProjectId {
                         // Project assignment changed — update local cloud state
-                        let userId = await getCurrentUserId()
-                        if let userId = userId,
-                           var chat = try? await EncryptedFileStorage.cloud.loadChat(chatId: remoteChat.id, userId: userId) {
-                            chat.projectId = remoteProjectId
-                            try? await EncryptedFileStorage.cloud.saveChat(chat, userId: userId)
-                        }
+                        let expectedUpdatedAt = localChat.updatedAt
+                        localChat.projectId = remoteProjectId
+                        _ = try? await EncryptedFileStorage.cloud.applyRemoteChatIfFresh(
+                            localChat,
+                            userId: userId,
+                            expectedLocalUpdatedAt: expectedUpdatedAt
+                        )
                     } else if localChat == nil, !deletedChatsTracker.isDeleted(remoteChat.id), let content = remoteChat.content {
                         // New chat we don't have locally — decrypt and save it
                         if var decrypted = await decryptRemoteChat(remoteChat, content: content) {
                             decrypted.chat.projectId = remoteProjectId
-                            await saveChatToStorage(decrypted.chat)
-                            await markChatAsSynced(decrypted.chat.id, version: decrypted.chat.syncVersion)
+                            decrypted.chat.syncedAt = Date()
+                            decrypted.chat.locallyModified = false
+                            _ = await applyRemoteChatToStorage(
+                                decrypted.chat,
+                                generation: generation,
+                                userId: userId,
+                                expectedLocalUpdatedAt: nil
+                            )
                         } else {
                             var placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
                             placeholder.projectId = remoteProjectId
-                            await saveChatToStorage(placeholder)
+                            placeholder.syncedAt = Date()
+                            placeholder.locallyModified = false
+                            _ = await applyRemoteChatToStorage(
+                                placeholder,
+                                generation: generation,
+                                userId: userId,
+                                expectedLocalUpdatedAt: nil
+                            )
                         }
                     }
                 }
@@ -1768,7 +2105,9 @@ class CloudSyncService: ObservableObject {
             }
             #endif
 
-            saveAllChatsSyncStatus(remoteAllStatus)
+            if generation == accountGeneration {
+                saveAllChatsSyncStatus(remoteAllStatus)
+            }
         } catch {
             #if DEBUG
             print("[CloudSync] Failed to sync cross-scope changes: \(error)")
@@ -1815,11 +2154,6 @@ class CloudSyncService: ObservableObject {
     
     // MARK: - Storage Helpers
     
-    private func loadChatFromStorage(_ chatId: String) async -> Chat? {
-        guard let userId = await getCurrentUserId() else { return nil }
-        return try? await EncryptedFileStorage.cloud.loadChat(chatId: chatId, userId: userId)
-    }
-
     private func getAllChatsFromStorage() async -> [Chat] {
         let userId = await getCurrentUserId()
         guard let userId = userId else { return [] }
@@ -1836,9 +2170,7 @@ class CloudSyncService: ObservableObject {
         return (try? await EncryptedFileStorage.cloud.loadChats(chatIds: unsyncedIds, userId: userId)) ?? []
     }
 
-    private func saveChatToStorage(_ storedChat: StoredChat) async {
-        let userId = await getCurrentUserId()
-
+    private func convertStoredChat(_ storedChat: StoredChat) async -> Chat? {
         // For R2 data without modelType, set it from current config
         var chatToConvert = storedChat
         if chatToConvert.modelType == nil {
@@ -1848,108 +2180,85 @@ class CloudSyncService: ObservableObject {
         }
 
         // Convert to Chat - may return nil if models aren't available
-        guard let chatToSave = chatToConvert.toChat() else {
+        guard let chat = chatToConvert.toChat() else {
             #if DEBUG
             print("Warning: Could not convert StoredChat to Chat - no models available. Skipping chat \(chatToConvert.id)")
             #endif
-            return
+            return nil
         }
+        return chat
+    }
 
-        await Chat.saveChat(chatToSave, userId: userId)
+    private func applyRemoteChatToStorage(
+        _ storedChat: StoredChat,
+        generation: Int,
+        userId: String,
+        expectedLocalUpdatedAt: Date?,
+        allowLocallyModified: Bool = false
+    ) async -> Bool {
+        guard generation == accountGeneration else { return false }
+        guard let chat = await convertStoredChat(storedChat) else { return false }
+        guard generation == accountGeneration else { return false }
+        return (try? await EncryptedFileStorage.cloud.applyRemoteChatIfFresh(
+            chat,
+            userId: userId,
+            expectedLocalUpdatedAt: expectedLocalUpdatedAt,
+            allowLocallyModified: allowLocallyModified
+        )) ?? false
     }
 
     /// Upload a chat to cloud and mark it as synced with the enclave's
     /// authoritative version (the new etag), or `chat.syncVersion + 1`
     /// when the enclave didn't return a parseable etag.
-    private func uploadAndMarkSynced(_ chat: Chat, idempotencyKey: String) async throws {
+    private func uploadAndMarkSynced(
+        _ chat: Chat,
+        idempotencyKey: String,
+        generation: Int,
+        userId: String
+    ) async throws {
         guard !streamingTracker.isStreaming(chat.id) else { return }
 
         let storedChat = StoredChat(from: chat, syncVersion: chat.syncVersion)
         let result = try await cloudStorage.uploadChat(storedChat, idempotencyKey: idempotencyKey)
+        guard generation == accountGeneration else { return }
         let newVersion = result.syncVersion ?? chat.syncVersion + 1
-        if !result.rewrites.isEmpty {
-            // Persist the enclave-minted attachment ids before marking
-            // the chat synced. If the local rewrite fails we want the
-            // next sync pass to retry the upload (so the cloud copy and
-            // the on-disk copy converge on the same ids) rather than
-            // record success while the local chat still points at
-            // pre-upload client ids.
-            try await applyAttachmentRewrites(chatId: chat.id, rewrites: result.rewrites)
-        }
-        // Guard against clobbering an edit made while this upload was in
-        // flight. We uploaded the snapshot captured before the request;
-        // if the on-disk copy has advanced past it, the freshest content
-        // was never sent. Clearing locallyModified here would mark that
-        // edit synced and it would never upload. Adopt the new etag as
-        // the CAS base but keep the dirty flag set so the next cycle
-        // re-uploads the newer content.
-        let current = await loadChatFromStorage(chat.id)
-        let editedDuringUpload = current.map { $0.updatedAt > chat.updatedAt } ?? false
-        if editedDuringUpload {
-            await rebaseSyncVersion(chat.id, version: newVersion)
-        } else {
-            await markChatAsSynced(chat.id, version: newVersion)
+        let fullySynced = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
+            chatId: chat.id,
+            userId: userId,
+            expectedUpdatedAt: chat.updatedAt,
+            syncVersion: newVersion,
+            attachmentRewrites: result.rewrites.map {
+                (
+                    clientId: $0.clientId,
+                    serverId: $0.serverId,
+                    encryptionKey: $0.encryptionKey
+                )
+            }
+        )
+        if fullySynced {
             SyncHealthStore.shared.reportChatSynced(chat.id)
         }
-    }
-
-    /// Apply enclave-minted attachment ids/keys to the freshest local
-    /// copy of the chat, matching by the stable client-side id that
-    /// the upload captured. The chat object we uploaded is a private
-    /// snapshot, so without this step the persistent chat keeps the
-    /// pre-upload local ids and the next sync would either re-upload
-    /// the same bytes or fail to fetch the cloud copy on another
-    /// device.
-    private func applyAttachmentRewrites(
-        chatId: String,
-        rewrites: [CloudStorageService.AttachmentRewrite]
-    ) async throws {
-        guard let userId = await getCurrentUserId() else { return }
-        guard var chat = try await EncryptedFileStorage.cloud.loadChat(
-            chatId: chatId,
-            userId: userId
-        ) else { return }
-
-        let rewriteByClientId = Dictionary(
-            uniqueKeysWithValues: rewrites.map { ($0.clientId, $0) }
-        )
-
-        var didChange = false
-        for msgIdx in chat.messages.indices {
-            for attIdx in chat.messages[msgIdx].attachments.indices {
-                let clientId = chat.messages[msgIdx].attachments[attIdx].id
-                guard let rewrite = rewriteByClientId[clientId] else { continue }
-                chat.messages[msgIdx].attachments[attIdx].id = rewrite.serverId
-                chat.messages[msgIdx].attachments[attIdx].encryptionKey =
-                    rewrite.encryptionKey
-                didChange = true
-            }
-        }
-
-        guard didChange else { return }
-        try await EncryptedFileStorage.cloud.saveChat(chat, userId: userId)
-    }
-
-    private func markChatAsSynced(_ chatId: String, version: Int) async {
-        guard let userId = await getCurrentUserId() else { return }
-        try? await EncryptedFileStorage.cloud.updateSyncMetadata(
-            chatId: chatId,
-            userId: userId,
-            syncVersion: version,
-            syncedAt: Date(),
-            locallyModified: false
-        )
     }
 
     /// Rebase the local chat's sync version onto the server's current
     /// version while keeping it locallyModified, so the next upload's
     /// CAS base matches the enclave and the fresher local copy wins the
-    /// last-write-wins race instead of looping on STALE_BLOB. Unlike
-    /// markChatAsSynced this never clears the dirty flag, so the chat is
-    /// still uploaded; the existing syncedAt is preserved.
-    private func rebaseSyncVersion(_ chatId: String, version: Int) async {
-        guard let userId = await getCurrentUserId() else { return }
-        let existingSyncedAt = await loadChatFromStorage(chatId)?.syncedAt
+    /// last-write-wins race instead of looping on STALE_BLOB. This never
+    /// clears the dirty flag, so the chat is still uploaded; the existing
+    /// syncedAt is preserved.
+    private func rebaseSyncVersion(
+        _ chatId: String,
+        version: Int,
+        generation: Int,
+        userId: String
+    ) async {
+        guard generation == accountGeneration else { return }
+        let existing = try? await EncryptedFileStorage.cloud.loadChat(
+            chatId: chatId,
+            userId: userId
+        )
+        guard generation == accountGeneration else { return }
+        let existingSyncedAt = existing?.syncedAt
         try? await EncryptedFileStorage.cloud.updateSyncMetadata(
             chatId: chatId,
             userId: userId,
@@ -1962,15 +2271,20 @@ class CloudSyncService: ObservableObject {
     /// Delete local chats that were deleted on another device since `since` timestamp.
     /// Returns the number of chats deleted locally.
     @discardableResult
-    private func deleteRemotelyDeletedChats(since: String) async -> Int {
+    private func deleteRemotelyDeletedChats(
+        since: String,
+        generation: Int,
+        userId: String
+    ) async -> Int {
         do {
             let deleted = try await cloudStorage.getDeletedChatsSince(since: since)
-            guard !deleted.deletedIds.isEmpty,
-                  let userId = await getCurrentUserId() else {
+            guard generation == accountGeneration,
+                  !deleted.deletedIds.isEmpty else {
                 return 0
             }
             var removedCount = 0
             for id in deleted.deletedIds {
+                guard generation == accountGeneration else { break }
                 // Skip chats already absent locally (a prior reconciliation
                 // pass handled them, or they were never stored here). This
                 // keeps repeated passes idempotent so they never report a
@@ -1981,10 +2295,18 @@ class CloudSyncService: ObservableObject {
                     chatId: id,
                     userId: userId
                 )
-                guard existing != nil else { continue }
-                deletedChatsTracker.markAsDeleted(id)
-                await deleteChatFromStorage(id)
-                removedCount += 1
+                guard let expectedUpdatedAt = existing?.updatedAt else { continue }
+                let removed = (try? await EncryptedFileStorage.cloud.deleteChatIfEvictable(
+                    chatId: id,
+                    userId: userId,
+                    shouldEvict: { $0.updatedAt == expectedUpdatedAt },
+                    shouldEvictOnLoadError: { _ in false }
+                )) ?? false
+                guard generation == accountGeneration else { break }
+                if removed {
+                    deletedChatsTracker.markAsDeleted(id)
+                    removedCount += 1
+                }
             }
             return removedCount
         } catch {
@@ -1993,11 +2315,6 @@ class CloudSyncService: ObservableObject {
         }
     }
 
-    private func deleteChatFromStorage(_ chatId: String) async {
-        guard let userId = await getCurrentUserId() else { return }
-        try? await EncryptedFileStorage.cloud.deleteChat(chatId: chatId, userId: userId)
-    }
-    
     private func getCurrentUserId() async -> String? {
         // Get from Clerk
         if let user = Clerk.shared.user {
@@ -2045,6 +2362,7 @@ class CloudSyncService: ObservableObject {
         onProgress: ((Int, Int) -> Void)? = nil,
         batchSize: Int = 5
     ) async -> Int {
+        let generation = accountGeneration
         guard let userId = await getCurrentUserId() else { return 0 }
         // The index alone knows which chats are placeholders; loading
         // and decrypting every chat file just to read the flag would
@@ -2060,6 +2378,7 @@ class CloudSyncService: ObservableObject {
 
         var recovered = 0
         for (offset, chatId) in failedChatIds.enumerated() {
+            guard generation == accountGeneration else { break }
             // Re-pull each failed chat by id and replace the local
             // placeholder only once the enclave hands back plaintext.
             // A transient failure leaves the placeholder in place, so
@@ -2069,13 +2388,42 @@ class CloudSyncService: ObservableObject {
             // reported as "recovered".
             do {
                 if let fresh = try await cloudStorage.downloadChat(chatId) {
-                    if fresh.decryptionFailed != true {
-                        await saveChatToStorage(fresh)
-                        await markChatAsSynced(fresh.id, version: fresh.syncVersion)
-                        recovered += 1
+                    if fresh.decryptionFailed != true,
+                       generation == accountGeneration {
+                        var remoteChat = fresh
+                        remoteChat.syncedAt = Date()
+                        remoteChat.locallyModified = false
+                        let expectedUpdatedAt = index.first {
+                            $0.id == chatId
+                        }?.updatedAt
+                        let applied = await applyRemoteChatToStorage(
+                            remoteChat,
+                            generation: generation,
+                            userId: userId,
+                            expectedLocalUpdatedAt: expectedUpdatedAt
+                        )
+                        if applied {
+                            recovered += 1
+                        }
                     }
-                } else {
-                    await deleteChatFromStorage(chatId)
+                } else if generation == accountGeneration {
+                    guard let expectedUpdatedAt = index.first(where: {
+                        $0.id == chatId
+                    })?.updatedAt else {
+                        continue
+                    }
+                    let removed = (try? await EncryptedFileStorage.cloud.deleteChatIfEvictable(
+                        chatId: chatId,
+                        userId: userId,
+                        shouldEvict: {
+                            $0.updatedAt == expectedUpdatedAt && $0.decryptionFailed
+                        },
+                        shouldEvictOnLoadError: { _ in false }
+                    )) ?? false
+                    guard generation == accountGeneration else { break }
+                    if removed {
+                        deletedChatsTracker.markAsDeleted(chatId)
+                    }
                 }
             } catch {
                 // Keep the placeholder; a later pass retries.
@@ -2092,14 +2440,18 @@ class CloudSyncService: ObservableObject {
     
     /// Re-encrypt all local chats with new key and upload to cloud
     func reencryptAndUploadChats() async -> (reencrypted: Int, uploaded: Int, errors: [String]) {
+        let generation = accountGeneration
         var result = (reencrypted: 0, uploaded: 0, errors: [String]())
+        guard let userId = await getCurrentUserId() else { return result }
 
         guard await canWriteToCloud() else {
             return result
         }
         
         // Get all local chats
-        let allChats = await getAllChatsFromStorage()
+        let allChats = (try? await EncryptedFileStorage.cloud.loadAllChats(
+            userId: userId
+        )) ?? []
         
         
         // Initialize encryption with new key
@@ -2111,6 +2463,7 @@ class CloudSyncService: ObservableObject {
         }
         
         for chat in allChats {
+            guard generation == accountGeneration else { break }
             // Skip blank and empty chats
             if chat.isBlankChat || chat.messages.isEmpty { continue }
 
@@ -2122,7 +2475,11 @@ class CloudSyncService: ObservableObject {
                 chatToReencrypt.locallyModified = true
                 
                 // Save locally then upload (will be encrypted with new key)
-                await saveChatToStorage(StoredChat(from: chatToReencrypt))
+                try await EncryptedFileStorage.cloud.saveChat(
+                    chatToReencrypt,
+                    userId: userId
+                )
+                guard generation == accountGeneration else { break }
                 try await uploadCoalescer.enqueueAndWait(chatToReencrypt.id)
                 
                 result.uploaded += 1

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -215,6 +215,95 @@ actor EncryptedFileStorage {
         try await performSaveChat(chat, userId: userId)
     }
 
+    func applyRemoteChatIfFresh(
+        _ chat: Chat,
+        userId: String,
+        expectedLocalUpdatedAt: Date?,
+        allowLocallyModified: Bool = false
+    ) async throws -> Bool {
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+
+        let entries = (try? await loadIndex(userId: userId)) ?? []
+        let existing = entries.first { $0.id == chat.id }
+        guard existing?.updatedAt == expectedLocalUpdatedAt else { return false }
+        if existing?.locallyModified == true && !allowLocallyModified {
+            return false
+        }
+        try await performSaveChat(chat, userId: userId)
+        return true
+    }
+
+    func finalizeUploadIfFresh(
+        chatId: String,
+        userId: String,
+        expectedUpdatedAt: Date,
+        syncVersion: Int,
+        attachmentRewrites: [
+            (clientId: String, serverId: String, encryptionKey: String)
+        ]
+    ) async throws -> Bool {
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+
+        let entries = (try? await loadIndex(userId: userId)) ?? []
+        guard let existing = entries.first(where: { $0.id == chatId }) else {
+            return false
+        }
+        let editedDuringUpload = existing.updatedAt != expectedUpdatedAt
+        if !attachmentRewrites.isEmpty {
+            let encPath = try chatFilePath(
+                chatId: chatId,
+                userId: userId,
+                isCorrupted: false
+            )
+            let rawPath = try chatFilePath(
+                chatId: chatId,
+                userId: userId,
+                isCorrupted: true
+            )
+            let hasEncryptedFile = fileManager.fileExists(atPath: encPath.path)
+            let filePath = hasEncryptedFile ? encPath : rawPath
+            guard fileManager.fileExists(atPath: filePath.path),
+                  var chat = try await loadChatFromFile(
+                      filePath,
+                      isRaw: !hasEncryptedFile
+                  ) else {
+                return false
+            }
+            await overlaySyncSidecar(&chat, userId: userId)
+
+            let rewritesByClientId = Dictionary(
+                uniqueKeysWithValues: attachmentRewrites.map {
+                    ($0.clientId, (serverId: $0.serverId, encryptionKey: $0.encryptionKey))
+                }
+            )
+            var didRewriteAttachment = false
+            for messageIndex in chat.messages.indices {
+                for attachmentIndex in chat.messages[messageIndex].attachments.indices {
+                    let clientId = chat.messages[messageIndex].attachments[attachmentIndex].id
+                    guard let rewrite = rewritesByClientId[clientId] else { continue }
+                    chat.messages[messageIndex].attachments[attachmentIndex].id =
+                        rewrite.serverId
+                    chat.messages[messageIndex].attachments[attachmentIndex].encryptionKey =
+                        rewrite.encryptionKey
+                    didRewriteAttachment = true
+                }
+            }
+            if didRewriteAttachment {
+                try await performSaveChat(chat, userId: userId)
+            }
+        }
+        try await performUpdateSyncMetadata(
+            chatId: chatId,
+            userId: userId,
+            syncVersion: syncVersion,
+            syncedAt: editedDuringUpload ? (existing.syncedAt ?? Date()) : Date(),
+            locallyModified: editedDuringUpload
+        )
+        return !editedDuringUpload
+    }
+
     private func performSaveChat(_ chat: Chat, userId: String) async throws {
         let isCorrupted = chat.decryptionFailed || chat.dataCorrupted
 

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -273,10 +273,13 @@ actor EncryptedFileStorage {
             }
             await overlaySyncSidecar(&chat, userId: userId)
 
+            // The rewrites come from a server response, so tolerate
+            // duplicate client ids instead of trapping on them.
             let rewritesByClientId = Dictionary(
-                uniqueKeysWithValues: attachmentRewrites.map {
+                attachmentRewrites.map {
                     ($0.clientId, (serverId: $0.serverId, encryptionKey: $0.encryptionKey))
-                }
+                },
+                uniquingKeysWith: { first, _ in first }
             )
             var didRewriteAttachment = false
             for messageIndex in chat.messages.indices {

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -945,8 +945,20 @@ class ProfileManager: ObservableObject {
         piiCheckEnabled = nil
         chatFont = nil
         projectUploadPreference = nil
-        keychainHelper.delete(for: keychainKey, service: keychainService)
-        keychainHelper.delete(for: profileBaselineKey, service: keychainService)
+        // Delete on the same serial queue the persist helpers write on and
+        // wait for it, so a queued save from before removal can never land
+        // after the delete and resurrect the previous account's profile.
+        let helper = keychainHelper
+        let profileKey = keychainKey
+        let baselineKey = profileBaselineKey
+        let service = keychainService
+        await withCheckedContinuation { continuation in
+            keychainQueue.async {
+                helper.delete(for: profileKey, service: service)
+                helper.delete(for: baselineKey, service: service)
+                continuation.resume()
+            }
+        }
         lastSyncedVersion = 0
         lastSyncedProfile = nil
         syncError = nil

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -191,7 +191,12 @@ class ProfileManager: ObservableObject {
             return
         }
 
-        keychainHelper.save(data, for: profileBaselineKey, service: keychainService)
+        let helper = keychainHelper
+        let key = profileBaselineKey
+        let service = keychainService
+        keychainQueue.async {
+            helper.save(data, for: key, service: service)
+        }
     }
     
     /// Create ProfileData from current settings
@@ -775,11 +780,12 @@ class ProfileManager: ObservableObject {
 
     /// Record `snapshot` as the synced baseline at `version`: stamp the
     /// version, persist it to the keychain (without triggering local
-    /// change observers), and set it as the in-memory baseline. Callers
-    /// pass the round-tripped local snapshot (createProfileData()) rather
-    /// than the raw remote so fields this client always emits but a peer
-    /// omits never read back as a phantom local change that would wedge
-    /// sync behind a never-clearing dirty flag.
+    /// change observers), and set it as the in-memory baseline. The
+    /// baseline is the last server state this client observed — the
+    /// common ancestor for three-way merges — so callers pass the
+    /// fetched remote, or the exact snapshot they just pushed. Passing a
+    /// local working copy instead would make its pending edits look
+    /// already-synced and let a later pull silently revert them.
     private func commitSyncedBaseline(_ snapshot: ProfileData, version: Int) {
         var baseline = snapshot
         baseline.version = version
@@ -930,6 +936,15 @@ class ProfileManager: ObservableObject {
             }
         }
         applyDefaultProfile()
+        // Reset non-published profile state too, so fields and CRDT
+        // clocks from the previous account never ride along into the
+        // next account's first sync.
+        localFieldClocks = nil
+        localClockVersion = nil
+        codeExecutionEnabled = nil
+        piiCheckEnabled = nil
+        chatFont = nil
+        projectUploadPreference = nil
         keychainHelper.delete(for: keychainKey, service: keychainService)
         keychainHelper.delete(for: profileBaselineKey, service: keychainService)
         lastSyncedVersion = 0

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -56,6 +56,12 @@ class ProfileManager: ObservableObject {
     private var isApplyingProfile: Bool = false  // Flag to prevent observer loops
     private var isPulling: Bool = false
     private var isPushing: Bool = false
+    private var isFullSyncInProgress: Bool = false
+    private var fullSyncWaiters: [CheckedContinuation<Void, Never>] = []
+    private var accountGeneration: Int = 0
+    private var themeMode: String?
+    private var localFieldClocks: [String: EditClock]?
+    private var localClockVersion: Int?
     private var codeExecutionEnabled: Bool?
     private var piiCheckEnabled: Bool?
     private var chatFont: String?
@@ -63,6 +69,7 @@ class ProfileManager: ObservableObject {
     
     // Keychain keys
     private let keychainKey = "userProfile"
+    private let profileBaselineKey = "userProfileSyncBaseline"
     private let keychainService = "com.tinfoil.chat.profile"
     private let profileDirtyKey = "com.tinfoil.chat.profile.dirty"
     // Content modification time of the pending local profile edit, used
@@ -95,9 +102,15 @@ class ProfileManager: ObservableObject {
         if let version = profile.version {
             lastSyncedVersion = version
         }
-        // Treat the loaded profile as the last synced baseline
-        if !hasPendingLocalProfileChanges {
+        if let baselineData = keychainHelper.load(
+            for: profileBaselineKey,
+            service: keychainService
+        ), let baseline = try? JSONDecoder().decode(ProfileData.self, from: baselineData) {
+            lastSyncedProfile = baseline
+            lastSyncedVersion = baseline.version ?? lastSyncedVersion
+        } else if !hasPendingLocalProfileChanges {
             lastSyncedProfile = profile
+            persistBaselineToKeychain(profile)
         }
     }
     
@@ -172,6 +185,14 @@ class ProfileManager: ObservableObject {
             helper.save(data, for: key, service: service)
         }
     }
+
+    private func persistBaselineToKeychain(_ profile: ProfileData) {
+        guard let data = try? JSONEncoder().encode(profile) else {
+            return
+        }
+
+        keychainHelper.save(data, for: profileBaselineKey, service: keychainService)
+    }
     
     /// Create ProfileData from current settings
     private func createProfileData() -> ProfileData {
@@ -187,6 +208,7 @@ class ProfileManager: ObservableObject {
 
         return ProfileData(
             isDarkMode: isDarkMode,
+            themeMode: themeMode,
             language: language,
             nickname: nickname,
             profession: profession,
@@ -206,7 +228,9 @@ class ProfileManager: ObservableObject {
             chatFont: chatFont,
             projectUploadPreference: projectUploadPreference,
             version: lastSyncedVersion,  // Will be incremented by ProfileSyncService
-            updatedAt: localProfileChangedAt()
+            updatedAt: localProfileChangedAt(),
+            fieldClocks: localFieldClocks,
+            clockVersion: localClockVersion
         )
     }
     
@@ -220,6 +244,9 @@ class ProfileManager: ObservableObject {
         
         if let isDarkMode = profile.isDarkMode {
             self.isDarkMode = isDarkMode
+        }
+        if let themeMode = profile.themeMode {
+            self.themeMode = themeMode
         }
         if let language = profile.language {
             self.language = language
@@ -279,6 +306,8 @@ class ProfileManager: ObservableObject {
         if let version = profile.version {
             self.lastSyncedVersion = version
         }
+        self.localFieldClocks = profile.fieldClocks
+        self.localClockVersion = profile.clockVersion
 
         NotificationCenter.default.post(
             name: .profileSharedSettingsDidChange,
@@ -510,7 +539,7 @@ class ProfileManager: ObservableObject {
         syncDebounceTimer?.invalidate()
         let timer = Timer(timeInterval: 2.0, repeats: false) { [weak self] _ in
             Task { @MainActor in
-                await self?.syncToCloud()
+                await self?.performFullSync()
             }
         }
         syncDebounceTimer = timer
@@ -520,69 +549,109 @@ class ProfileManager: ObservableObject {
     private func updateSyncingState() {
         isSyncing = isPulling || isPushing
     }
+
+    private func prepareLocalProfileForSync() -> ProfileData {
+        var profile = createProfileData()
+        let changedFields = ProfileMerge.changedProfileFields(
+            local: profile,
+            baseline: lastSyncedProfile
+        )
+        var clocks = profile.fieldClocks ?? lastSyncedProfile?.fieldClocks ?? [:]
+        let unstampedFields = changedFields.filter {
+            clocks[$0] == lastSyncedProfile?.fieldClocks?[$0]
+        }
+        if !unstampedFields.isEmpty {
+            let tick = EditClockStore.nextClock()
+            for field in unstampedFields {
+                clocks[field] = tick
+            }
+        }
+        profile.fieldClocks = clocks.isEmpty ? nil : clocks
+        profile.clockVersion = lastSyncedVersion
+        localFieldClocks = profile.fieldClocks
+        localClockVersion = profile.clockVersion
+        if !unstampedFields.isEmpty {
+            persistProfileToKeychain(profile)
+        }
+        return profile
+    }
     
     /// Sync profile from cloud
     func syncFromCloud() async {
+        await performFullSync()
+    }
+
+    private func syncFromCloud(generation: Int) async -> Bool {
         // Skip if not authenticated
         guard await profileSync.isAuthenticated() else {
-            return
+            return false
         }
 
         // Skip if no encryption key is set
         guard EncryptionService.shared.hasEncryptionKey() else {
-            return
+            return false
         }
 
-        // Prevent overlapping pulls
-        guard !isPulling else { return }
-        // A pending local edit must not be overwritten by the remote, but
-        // we still pull so we can learn the server's current version.
-        // Otherwise a client left "dirty" never establishes a base version
-        // and keeps trying to create the profile at version zero, which
-        // loops forever on STALE_BLOB and blocks all future pulls.
-        let hasPendingEdit = hasPendingLocalProfileChanges
         isPulling = true
         updateSyncingState()
-        
+        defer {
+            isPulling = false
+            updateSyncingState()
+        }
+
         do {
+            guard generation == accountGeneration else { return false }
             if let cloudProfile = try await profileSync.fetchProfile() {
+                guard generation == accountGeneration else { return false }
                 let cloudVersion = cloudProfile.version ?? 0
+                let localProfile = hasPendingLocalProfileChanges
+                    ? prepareLocalProfileForSync()
+                    : createProfileData()
 
-                if hasPendingEdit {
-                    // Record the server version so the pending push rebases
-                    // onto it as a CAS update instead of a create; the
-                    // last-write-wins arbitration on push decides the winner.
-                    if cloudVersion > lastSyncedVersion {
-                        lastSyncedVersion = cloudVersion
+                if let baseline = lastSyncedProfile {
+                    let merge = ProfileMerge.mergeProfiles(
+                        baseline: baseline,
+                        local: localProfile,
+                        remote: cloudProfile
+                    )
+                    guard merge.conflicts.isEmpty else {
+                        throw ProfileSyncError.unresolvedConflicts(merge.conflicts)
                     }
-                } else if cloudVersion > lastSyncedVersion || hasProfileChanged(cloudProfile, lastSyncedProfile) {
-                    // Apply if cloud is newer by version OR content differs from our last-synced snapshot
+                    applyProfile(merge.merged)
+                    persistProfileToKeychain(createProfileData())
+                    commitSyncedBaseline(cloudProfile, version: cloudVersion)
+                    if hasProfileChanged(merge.merged, cloudProfile) {
+                        markLocalProfileChanged()
+                    } else {
+                        clearLocalProfileChanged()
+                    }
+                } else if hasPendingLocalProfileChanges {
+                    throw ProfileSyncError.unresolvedConflicts(
+                        ProfileMerge.changedProfileFields(local: localProfile, baseline: nil)
+                    )
+                } else {
                     applyProfile(cloudProfile)
-
-                    // Use the round-tripped local snapshot as the baseline
-                    // rather than the raw remote: the remote may omit fields
-                    // this client always emits (e.g. defaulted reasoning or
-                    // thinking values), which would otherwise read back as a
-                    // phantom local change and wedge sync behind a
-                    // never-clearing dirty flag while looping STALE_BLOB pushes.
-                    commitSyncedBaseline(createProfileData(), version: cloudVersion)
-
-                    lastSyncedVersion = cloudVersion
+                    persistProfileToKeychain(createProfileData())
+                    commitSyncedBaseline(cloudProfile, version: cloudVersion)
                     clearLocalProfileChanged()
-                    lastSyncDate = Date()
-                    syncError = nil
                 }
             }
+            lastSyncDate = Date()
+            syncError = nil
+            return true
         } catch {
+            guard generation == accountGeneration else { return false }
             syncError = error.localizedDescription
+            return false
         }
-        
-        isPulling = false
-        updateSyncingState()
     }
     
     /// Sync profile to cloud
     func syncToCloud() async {
+        await performFullSync()
+    }
+
+    private func syncToCloud(generation: Int) async {
         // Skip if not authenticated but keep pending flag so we can retry later
         guard await profileSync.isAuthenticated() else {
             return
@@ -603,10 +672,8 @@ class ProfileManager: ObservableObject {
             return
         }
 
-        // Avoid overlapping uploads
-        guard !isPushing else { return }
-        
-        var profile = createProfileData()
+        guard generation == accountGeneration else { return }
+        var profile = prepareLocalProfileForSync()
 
         // Only push if there is a real change vs last synced baseline.
         // When nothing diverges, clear the pending flag so a phantom
@@ -616,27 +683,19 @@ class ProfileManager: ObservableObject {
             return
         }
 
-        // Stamp a fresh edit clock on every field changed since the last
-        // sync, carrying forward the existing clocks for the rest. One
-        // tick covers this push because it is a single local write event;
-        // the deviceId tiebreak keeps it ordered against peers.
-        let baseClocks = profileSync.getCachedProfile()?.fieldClocks
-            ?? lastSyncedProfile?.fieldClocks ?? [:]
-        let changedFields = ProfileMerge.changedProfileFields(
-            local: profile, baseline: lastSyncedProfile
-        )
-        var fieldClocks = baseClocks
-        if !changedFields.isEmpty {
-            let tick = EditClockStore.nextClock()
-            for field in changedFields { fieldClocks[field] = tick }
-        }
-        profile.fieldClocks = fieldClocks
-
         isPushing = true
         updateSyncingState()
-        
+        defer {
+            isPushing = false
+            updateSyncingState()
+        }
+
         do {
-            let result = try await profileSync.saveProfile(profile)
+            let result = try await profileSync.saveProfile(
+                profile,
+                baseline: lastSyncedProfile
+            )
+            guard generation == accountGeneration else { return }
             if result.success {
                 // Server returns the authoritative version; always adopt it
                 if let version = result.version {
@@ -650,60 +709,66 @@ class ProfileManager: ObservableObject {
                     // A concurrently-updated device won the last-write
                     // race; adopt its settings locally so both devices
                     // converge instead of keeping our now-stale edit.
-                    applyProfile(remoteProfile)
-                    // Baseline mirrors what we would re-serialize, not the
-                    // raw remote, so fields we emit but the peer omits don't
-                    // read back as a phantom change and re-arm the push loop.
-                    commitSyncedBaseline(createProfileData(), version: lastSyncedVersion)
+                    let postSaveMerge = ProfileMerge.mergeProfiles(
+                        baseline: profile,
+                        local: createProfileData(),
+                        remote: remoteProfile
+                    )
+                    applyProfile(postSaveMerge.merged)
+                    persistProfileToKeychain(createProfileData())
+                    commitSyncedBaseline(remoteProfile, version: lastSyncedVersion)
                 } else {
+                    profile.version = lastSyncedVersion
+                    profile.clockVersion = lastSyncedVersion
+                    localFieldClocks = profile.fieldClocks
+                    localClockVersion = profile.clockVersion
+                    persistProfileToKeychain(createProfileData())
                     commitSyncedBaseline(profile, version: lastSyncedVersion)
                 }
-                clearLocalProfileChanged()
-                lastSyncDate = Date()
-                syncError = nil
-                
-                // If local state changed during the sync, schedule another upload
                 let currentAfter = createProfileData()
                 if hasProfileChanged(currentAfter, lastSyncedProfile) {
+                    markLocalProfileChanged()
                     debounceCloudSync()
+                } else {
+                    clearLocalProfileChanged()
                 }
+                lastSyncDate = Date()
+                syncError = nil
             }
         } catch {
+            guard generation == accountGeneration else { return }
             syncError = error.localizedDescription
             // On error, allow future changes to trigger another attempt via debounce
         }
-        
-        isPushing = false
-        updateSyncingState()
     }
     
     /// Perform immediate sync (both directions)
     func performFullSync() async {
+        if isFullSyncInProgress {
+            await withCheckedContinuation { continuation in
+                fullSyncWaiters.append(continuation)
+            }
+            return
+        }
+        isFullSyncInProgress = true
+        defer {
+            isFullSyncInProgress = false
+            let waiters = fullSyncWaiters
+            fullSyncWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        let generation = accountGeneration
         // First pull from cloud
-        await syncFromCloud()
+        guard await syncFromCloud(generation: generation) else { return }
         
         // Then push any local changes (method will no-op if nothing changed)
-        await syncToCloud()
+        await syncToCloud(generation: generation)
     }
     
     /// Retry decryption with new encryption key
     func retryDecryptionWithNewKey() async {
-        do {
-            if let decryptedProfile = try await profileSync.retryDecryptionWithNewKey() {
-                applyProfile(decryptedProfile)
-                if let version = decryptedProfile.version {
-                    lastSyncedVersion = version
-                }
-                // Baseline mirrors what we would re-serialize, not the raw
-                // remote, so peer-omitted fields don't read back as a
-                // phantom local change after decryption recovery.
-                commitSyncedBaseline(createProfileData(), version: lastSyncedVersion)
-                clearLocalProfileChanged()
-                syncError = nil
-            }
-        } catch {
-            syncError = error.localizedDescription
-        }
+        await performFullSync()
     }
     
     // MARK: - Helpers
@@ -718,8 +783,10 @@ class ProfileManager: ObservableObject {
     private func commitSyncedBaseline(_ snapshot: ProfileData, version: Int) {
         var baseline = snapshot
         baseline.version = version
-        persistProfileToKeychain(baseline)
+        baseline.clockVersion = version
+        persistBaselineToKeychain(baseline)
         lastSyncedProfile = baseline
+        lastSyncedVersion = version
     }
 
     /// Check if two profiles are different (excluding metadata)
@@ -729,6 +796,7 @@ class ProfileManager: ObservableObject {
         }
         
         return p1.isDarkMode != p2.isDarkMode ||
+               p1.themeMode != p2.themeMode ||
                p1.language != p2.language ||
                p1.nickname != p2.nickname ||
                p1.profession != p2.profession ||
@@ -829,10 +897,10 @@ class ProfileManager: ObservableObject {
         return !result.isEmpty
     }
     
-    /// Clear all profile data
-    func clearProfile() {
-        // Reset to defaults
+    private func applyDefaultProfile() {
+        isApplyingProfile = true
         isDarkMode = true
+        themeMode = nil
         language = "English"
         nickname = ""
         profession = ""
@@ -843,17 +911,31 @@ class ProfileManager: ObservableObject {
         customSystemPrompt = ""
         customPromptPresets = []
         favoritePromptPresetIds = []
-        
-        // Clear from keychain
+        isApplyingProfile = false
+    }
+
+    func resetProfile() {
+        applyDefaultProfile()
+        persistProfileToKeychain(createProfileData())
+        markLocalProfileChanged()
+        debounceCloudSync()
+    }
+
+    func clearLocalProfileForAccountRemoval() async {
+        accountGeneration += 1
+        syncDebounceTimer?.invalidate()
+        if isFullSyncInProgress {
+            await withCheckedContinuation { continuation in
+                fullSyncWaiters.append(continuation)
+            }
+        }
+        applyDefaultProfile()
         keychainHelper.delete(for: keychainKey, service: keychainService)
-        
-        // Reset sync state
+        keychainHelper.delete(for: profileBaselineKey, service: keychainService)
         lastSyncedVersion = 0
         lastSyncedProfile = nil
         syncError = nil
         clearLocalProfileChanged()
-        
-        // Clear cloud cache
         profileSync.clearCache()
     }
 }

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -121,15 +121,42 @@ enum ProfileMerge {
         for field in mergeFields {
             let baselineValue = baselineDict[field]
             let localValue = localDict[field]
-            let remoteValue = remoteDict[field]
             let localClock = localTrusted ? local.fieldClocks?[field] : nil
+
+            // Remote omits this field: keep the local value and its
+            // clock, mirroring the two-way merge. Omission means the
+            // peer does not model the field (resets are expressed as
+            // empty values, never as a missing key), so treating it as
+            // a deletion would wipe settings owned by this client.
+            guard remoteDict[field] != nil else {
+                if let localClock { mergedClocks[field] = localClock }
+                continue
+            }
+
+            let remoteValue = remoteDict[field]
             let remoteClock = remoteTrusted ? remote.fieldClocks?[field] : nil
 
             if valuesEqual(localValue, baselineValue) {
                 assign(remoteValue, field: field)
                 if let remoteClock { mergedClocks[field] = remoteClock }
                 adoptedRemote = adoptedRemote || !valuesEqual(localValue, remoteValue)
-            } else if valuesEqual(remoteValue, baselineValue) || valuesEqual(localValue, remoteValue) {
+            } else if valuesEqual(localValue, remoteValue) {
+                // Both sides converged on the same value. Keep the
+                // higher trusted clock so the CRDT ordering survives
+                // for future merges instead of silently rewinding to
+                // the local stamp.
+                if let localClock, let remoteClock {
+                    let remoteHigher = SyncConflictResolver.remoteWins(
+                        localClock: localClock,
+                        remoteClock: remoteClock,
+                        localUpdatedAt: nil,
+                        remoteUpdatedAt: nil
+                    )
+                    mergedClocks[field] = remoteHigher ? remoteClock : localClock
+                } else if let clock = localClock ?? remoteClock {
+                    mergedClocks[field] = clock
+                }
+            } else if valuesEqual(remoteValue, baselineValue) {
                 if let localClock { mergedClocks[field] = localClock }
             } else if let localClock, let remoteClock {
                 if SyncConflictResolver.remoteWins(

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -13,6 +13,12 @@
 import Foundation
 
 enum ProfileMerge {
+    struct ThreeWayResult {
+        let merged: ProfileData
+        let conflicts: [String]
+        let adoptedRemote: Bool
+    }
+
     /// User-facing fields that participate in the merge. Metadata
     /// (version, updatedAt, clocks) is handled separately.
     static let mergeFields: [String] = [
@@ -82,6 +88,78 @@ enum ProfileMerge {
             }
         }
         return changed
+    }
+
+    static func mergeProfiles(
+        baseline: ProfileData,
+        local: ProfileData,
+        remote: ProfileData
+    ) -> ThreeWayResult {
+        guard
+            let baselineDict = try? dictionary(from: baseline),
+            let localDict = try? dictionary(from: local),
+            let remoteDict = try? dictionary(from: remote)
+        else {
+            return ThreeWayResult(merged: local, conflicts: mergeFields, adoptedRemote: false)
+        }
+
+        let localTrusted = clocksTrusted(local)
+        let remoteTrusted = clocksTrusted(remote)
+        var mergedDict = localDict
+        var mergedClocks: [String: EditClock] = [:]
+        var conflicts: [String] = []
+        var adoptedRemote = false
+
+        func assign(_ value: Any?, field: String) {
+            if let value {
+                mergedDict[field] = value
+            } else {
+                mergedDict.removeValue(forKey: field)
+            }
+        }
+
+        for field in mergeFields {
+            let baselineValue = baselineDict[field]
+            let localValue = localDict[field]
+            let remoteValue = remoteDict[field]
+            let localClock = localTrusted ? local.fieldClocks?[field] : nil
+            let remoteClock = remoteTrusted ? remote.fieldClocks?[field] : nil
+
+            if valuesEqual(localValue, baselineValue) {
+                assign(remoteValue, field: field)
+                if let remoteClock { mergedClocks[field] = remoteClock }
+                adoptedRemote = adoptedRemote || !valuesEqual(localValue, remoteValue)
+            } else if valuesEqual(remoteValue, baselineValue) || valuesEqual(localValue, remoteValue) {
+                if let localClock { mergedClocks[field] = localClock }
+            } else if let localClock, let remoteClock {
+                if SyncConflictResolver.remoteWins(
+                    localClock: localClock,
+                    remoteClock: remoteClock,
+                    localUpdatedAt: nil,
+                    remoteUpdatedAt: nil
+                ) {
+                    assign(remoteValue, field: field)
+                    mergedClocks[field] = remoteClock
+                    adoptedRemote = true
+                } else {
+                    mergedClocks[field] = localClock
+                }
+            } else {
+                conflicts.append(field)
+                if let localClock { mergedClocks[field] = localClock }
+            }
+        }
+
+        var merged = (try? profile(from: mergedDict)) ?? local
+        merged.version = remote.version
+        merged.clockVersion = remote.version
+        merged.fieldClocks = mergedClocks.isEmpty ? nil : mergedClocks
+        merged.updatedAt = laterTimestamp(local.updatedAt, remote.updatedAt)
+        return ThreeWayResult(
+            merged: merged,
+            conflicts: conflicts,
+            adoptedRemote: adoptedRemote
+        )
     }
 
     /// Merge a remote profile into the local one field by field.

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -137,6 +137,7 @@ class ProfileSyncService: ObservableObject {
                 self.failedDecryptionData = nil
                 self.cachedProfile = nil
                 self.unknownRemoteFields = [:]
+                self.persistUnknownRemoteFields()
                 return nil
             }
             if !item.ok {
@@ -148,6 +149,7 @@ class ProfileSyncService: ObservableObject {
                     self.failedDecryptionData = nil
                     self.cachedProfile = nil
                     self.unknownRemoteFields = [:]
+                    self.persistUnknownRemoteFields()
                     return nil
                 }
                 self.failedDecryptionData = "code:\(item.code ?? "UNKNOWN")"
@@ -268,12 +270,13 @@ class ProfileSyncService: ObservableObject {
             working = merge.merged
 
             let result = try await pushAtVersion(remote.version ?? 0)
-            // Hand the merged profile back so the caller applies any
-            // fields adopted from the remote and both devices converge.
+            // Hand the pushed snapshot back so the caller applies the
+            // exact uploaded profile — values adopted from the remote
+            // and the merged field clocks — and both devices converge.
             return (
                 result.success,
                 result.version,
-                merge.adoptedRemote ? (self.cachedProfile ?? merge.merged) : nil
+                self.cachedProfile ?? merge.merged
             )
         }
     }

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -11,6 +11,17 @@
 import ClerkKit
 import Foundation
 
+enum ProfileSyncError: LocalizedError {
+    case unresolvedConflicts([String])
+
+    var errorDescription: String? {
+        switch self {
+        case .unresolvedConflicts:
+            return "Profile changes conflict with changes from another device."
+        }
+    }
+}
+
 /// Service for managing profile synchronization with cloud.
 @MainActor
 class ProfileSyncService: ObservableObject {
@@ -18,6 +29,8 @@ class ProfileSyncService: ObservableObject {
 
     private let profileScope: SyncScope = .profile
     private let profileRowId = "profile"
+    private let unknownFieldsKey = "profileUnknownFields"
+    private let unknownFieldsService = "com.tinfoil.chat.profile"
 
     private var getToken: (() async -> String?)? = nil
     private var cachedProfile: ProfileData? = nil
@@ -49,7 +62,14 @@ class ProfileSyncService: ObservableObject {
         return formatter
     }()
 
-    private init() {}
+    private init() {
+        if let data = KeychainHelper.shared.load(
+            for: unknownFieldsKey,
+            service: unknownFieldsService
+        ), let fields = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            unknownRemoteFields = fields
+        }
+    }
 
     // MARK: - Configuration
 
@@ -143,8 +163,10 @@ class ProfileSyncService: ObservableObject {
             // them forward instead of wiping them.
             if let raw = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any] {
                 self.unknownRemoteFields = raw.filter { !Self.knownProfileKeys.contains($0.key) }
+                self.persistUnknownRemoteFields()
             } else {
                 self.unknownRemoteFields = [:]
+                self.persistUnknownRemoteFields()
             }
             if let etag = item.etag, let version = Int(etag) {
                 decoded.version = version
@@ -165,7 +187,10 @@ class ProfileSyncService: ObservableObject {
     }
 
     /// Save profile to cloud through the enclave.
-    func saveProfile(_ profile: ProfileData) async throws -> (success: Bool, version: Int?, remoteProfile: ProfileData?) {
+    func saveProfile(
+        _ profile: ProfileData,
+        baseline: ProfileData?
+    ) async throws -> (success: Bool, version: Int?, remoteProfile: ProfileData?) {
         guard await isAuthenticated() else { return (false, nil, nil) }
         let keyB64 = try CEKEncoding.requirePrimaryKeyB64()
 
@@ -191,7 +216,8 @@ class ProfileSyncService: ObservableObject {
             let ifMatch: String? = baseVersion > 0 ? String(baseVersion) : nil
 
             let metadata: [String: AnyCodable] = [
-                "version": AnyCodable(profileWithMetadata.version ?? 1)
+                "version": AnyCodable(profileWithMetadata.version ?? 1),
+                "profile_sync_protocol": AnyCodable(Constants.Sync.profileSyncProtocolVersion)
             ]
             let response = try await SyncEnclaveAPI.push(
                 EnclavePushRequest(
@@ -228,10 +254,18 @@ class ProfileSyncService: ObservableObject {
                 return (result.success, result.version, nil)
             }
 
-            let (merged, adoptedRemote) = ProfileMerge.mergeProfiles(
-                local: profile, remote: remote
+            guard let baseline else {
+                throw error
+            }
+            let merge = ProfileMerge.mergeProfiles(
+                baseline: baseline,
+                local: profile,
+                remote: remote
             )
-            working = merged
+            guard merge.conflicts.isEmpty else {
+                throw ProfileSyncError.unresolvedConflicts(merge.conflicts)
+            }
+            working = merge.merged
 
             let result = try await pushAtVersion(remote.version ?? 0)
             // Hand the merged profile back so the caller applies any
@@ -239,7 +273,7 @@ class ProfileSyncService: ObservableObject {
             return (
                 result.success,
                 result.version,
-                adoptedRemote ? (self.cachedProfile ?? merged) : nil
+                merge.adoptedRemote ? (self.cachedProfile ?? merge.merged) : nil
             )
         }
     }
@@ -260,11 +294,30 @@ class ProfileSyncService: ObservableObject {
         return try JSONSerialization.data(withJSONObject: dict)
     }
 
+    private func persistUnknownRemoteFields() {
+        guard !unknownRemoteFields.isEmpty,
+              let data = try? JSONSerialization.data(withJSONObject: unknownRemoteFields)
+        else {
+            KeychainHelper.shared.delete(
+                for: unknownFieldsKey,
+                service: unknownFieldsService
+            )
+            return
+        }
+        KeychainHelper.shared.save(
+            data,
+            for: unknownFieldsKey,
+            service: unknownFieldsService
+        )
+    }
+
     /// A STALE_BLOB (HTTP 412) push means our If-Match version no longer
     /// matches the server: either the row advanced under another writer
     /// or we tried to create a profile that already exists.
     private static func isStaleBlobConflict(_ error: SyncEnclaveError) -> Bool {
-        error.code == WireCodes.staleBlob || error.status == 412
+        error.code == WireCodes.staleBlob
+            || error.status == 412
+            || (error.status == 409 && error.code == WireCodes.syncConflict)
     }
 
     /// Re-attempt a profile fetch after a key change. The enclave
@@ -283,6 +336,7 @@ class ProfileSyncService: ObservableObject {
         cachedProfile = nil
         failedDecryptionData = nil
         unknownRemoteFields = [:]
+        persistUnknownRemoteFields()
     }
 
     // MARK: - Sync status

--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@MainActor
+final class SharedImportCoordinator {
+    static let shared = SharedImportCoordinator()
+
+    private init() {}
+
+    func importPendingAttachments(into viewModel: ChatViewModel) {
+        guard let store = try? SharedImportStore() else { return }
+
+        let importedRequestIDs = Set(
+            viewModel.pendingAttachments.compactMap(\.sharedImportRequestID)
+        )
+        for request in store.pendingRequests() where !importedRequestIDs.contains(request.id) {
+            do {
+                let payloadURL = try store.payloadURL(for: request)
+                switch request.item.kind {
+                case .image:
+                    let data = try Data(contentsOf: payloadURL, options: .mappedIfSafe)
+                    viewModel.addImageAttachment(
+                        data: data,
+                        fileName: request.item.originalFileName,
+                        sharedImportRequestID: request.id
+                    )
+                case .document:
+                    viewModel.addDocumentAttachment(
+                        url: payloadURL,
+                        fileName: request.item.originalFileName,
+                        sharedImportRequestID: request.id
+                    )
+                }
+            } catch {
+                viewModel.attachmentError = error.localizedDescription
+            }
+        }
+    }
+
+    func acknowledge(requestID: UUID) {
+        guard let store = try? SharedImportStore() else { return }
+        store.removeRequest(id: requestID)
+    }
+}

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -1,0 +1,591 @@
+//
+//  StreamingResponseProcessor.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+
+import Foundation
+import OpenAI
+
+/// Owns all per-chunk parsing state for one streaming response (event
+/// markers, thinking state machine, chunkers, tool calls, web search
+/// bookkeeping) so the stream can be consumed off the main actor. The main
+/// actor only receives immutable snapshots and per-chunk outcomes.
+///
+/// Thread-safety contract (`@unchecked Sendable`): the stream task is the
+/// single consumer. The main actor touches the processor only through the
+/// event-application accessors, and only while the stream task is suspended
+/// awaiting that main-actor hop, so all access is serialized even though the
+/// class is not internally synchronized.
+final class StreamingResponseProcessor: @unchecked Sendable {
+
+    /// Everything the UI writes onto the streaming message. Captured as a
+    /// value so the main actor never reads live processor state.
+    struct Snapshot {
+        var responseContent: String
+        var thoughts: String?
+        var thinkingChunks: [ThinkingChunk]
+        var contentChunks: [ContentChunk]
+        var isThinking: Bool
+        var generationTimeSeconds: TimeInterval?
+        var segments: [MessageSegment]
+        var webSearches: [WebSearchInstance]
+        var toolCalls: [GenUIToolCall]
+        var timelineBlocks: [JSONValue]
+        var collectedSources: [WebSearchSource]
+        var collectedAnnotations: [Annotation]
+        var webSearchBeforeThinking: Bool?
+    }
+
+    /// Main-actor side effects produced while processing one chunk.
+    struct ChunkOutcome {
+        var didMutateState = false
+        var shouldTickHaptic = false
+        var summaryActions: [SummaryAction] = []
+    }
+
+    enum SummaryAction {
+        case beginThinkingSession
+        case endThinkingSession
+        case generate(String)
+    }
+
+    /// One chunk with its `<tinfoil-event>` markers stripped and decoded.
+    struct ParsedChunk {
+        let chunk: ChatStreamResult
+        let content: String
+        let events: [TinfoilWebSearchCallEvent]
+    }
+
+    // Stateful parser for `<tinfoil-event>` markers embedded
+    // in the content stream. When the router isn't asked to
+    // emit markers it sends none, so the parser is a pure
+    // pass-through.
+    private var tinfoilEventParser = TinfoilEventParser()
+    private let chunker = StreamingMarkdownChunker()
+    private let thinkingChunker = ThinkingTextChunker()
+
+    // Ordered content segments (text + inline event refs) that preserve
+    // the exact order in which events arrived relative to streamed text.
+    private var segments: [MessageSegment] = []
+    private var webSearches: [WebSearchInstance] = []
+    private var nextSearchId = 0
+    // Track whether web search started before thinking (shared across the
+    // event application and the streaming state machine).
+    private var webSearchStarted = false
+
+    // GenUI tool-call accumulator. The OpenAI streaming
+    // protocol sends a sequence of partial deltas keyed by
+    // `index`; each delta may carry an `id`, a `name`, and
+    // an `arguments` fragment. We coalesce them by index
+    // and write both:
+    //   - the flat `Message.toolCalls` array (mirrored from
+    //     webapp `MessageAssembler.toMessage`), and
+    //   - the canonical `Message.timeline` tool_call blocks
+    //     that the webapp uses to track resolution state.
+    private var streamingToolCalls: [Int: GenUIToolCall] = [:]
+    private var timelineBlocks: [JSONValue] = []
+
+    // Web search state tracking
+    private var collectedSources: [WebSearchSource] = []
+    private var collectedAnnotations: [Annotation] = []
+
+    private var thinkStartTime: Date? = nil
+    private var hasThinkTag = false
+    private var thoughtsBuffer = ""
+    private var isInThinkingMode: Bool
+    private var isUsingReasoningFormat = false
+    // True while thinking was closed by answer content (not by
+    // a tool boundary). Reasoning arriving in that state is the
+    // late tail of the previous thought — upstreams race the
+    // think-close boundary so the final reasoning fragment can
+    // land after content started — and is merged into the
+    // existing thoughts without re-entering thinking mode.
+    private var thinkingClosedByContent = false
+    private var didRecordWebSearchBeforeThinking = false
+    private var webSearchBeforeThinking: Bool? = nil
+    private var initialContentBuffer = ""
+    private var isFirstChunk = true
+    private var responseContent: String
+    private var currentThoughts: String?
+    private var generationTimeSeconds: TimeInterval?
+
+    private let isWebSearchEnabled: Bool
+    private let hapticEnabled: Bool
+    private var hapticChunkCount = 0
+    private var lastHapticTime = Date.distantPast
+    private let minHapticInterval: TimeInterval = 0.1
+    private var hasStartedResponse = false
+
+    init(
+        isWebSearchEnabled: Bool,
+        hapticEnabled: Bool,
+        responseContent: String = "",
+        currentThoughts: String? = nil,
+        generationTimeSeconds: TimeInterval? = nil,
+        isInThinkingMode: Bool = false
+    ) {
+        self.isWebSearchEnabled = isWebSearchEnabled
+        self.hapticEnabled = hapticEnabled
+        self.responseContent = responseContent
+        self.currentThoughts = currentThoughts
+        self.generationTimeSeconds = generationTimeSeconds
+        self.isInThinkingMode = isInThinkingMode
+    }
+
+    // MARK: - Event application accessors (main actor, serialized)
+
+    var currentSegments: [MessageSegment] { segments }
+    var currentWebSearches: [WebSearchInstance] { webSearches }
+
+    func markWebSearchStarted() {
+        webSearchStarted = true
+    }
+
+    func allocateSearchId() -> String {
+        defer { nextSearchId += 1 }
+        return "ws-\(nextSearchId)"
+    }
+
+    func appendURLFetchSegment(_ fetchId: String) {
+        segments.append(.urlFetch(fetchId: fetchId))
+    }
+
+    func upsertWebSearch(_ instance: WebSearchInstance) {
+        if let idx = webSearches.firstIndex(where: { $0.id == instance.id }) {
+            webSearches[idx] = instance
+        } else {
+            webSearches.append(instance)
+            segments.append(.webSearch(searchId: instance.id))
+        }
+    }
+
+    func findSearchInstance(matching eventId: String?) -> WebSearchInstance? {
+        if let eventId = eventId,
+           let hit = webSearches.first(where: { $0.id == eventId }) {
+            return hit
+        }
+        return webSearches.last
+    }
+
+    // MARK: - Chunk processing (stream task)
+
+    /// Strip router-emitted `<tinfoil-event>` markers from the delta before
+    /// any downstream logic sees it. The decoded events must be applied on
+    /// the main actor before `process` runs so segment ordering matches the
+    /// order in which markers arrived relative to the surrounding text.
+    func parse(_ chunk: ChatStreamResult) -> ParsedChunk {
+        var content = chunk.choices.first?.delta.content ?? ""
+        var events: [TinfoilWebSearchCallEvent] = []
+        if !content.isEmpty {
+            let parsed = tinfoilEventParser.consume(content)
+            events = parsed.events
+            if !parsed.events.isEmpty {
+                thinkingClosedByContent = false
+            }
+            content = parsed.text
+        }
+        return ParsedChunk(chunk: chunk, content: content, events: events)
+    }
+
+    func process(_ parsed: ParsedChunk) -> ChunkOutcome {
+        var outcome = ChunkOutcome()
+        outcome.shouldTickHaptic = evaluateHapticTick()
+
+        let chunk = parsed.chunk
+        let content = parsed.content
+        let hasReasoningContent = chunk.choices.first?.delta.reasoning != nil
+        let reasoningContent = chunk.choices.first?.delta.reasoning ?? ""
+
+        // Accumulate GenUI tool-call deltas. Mirrors the
+        // webapp's normalizer: deltas may carry only
+        // partial fragments and we merge them by index.
+        // Each merged tool call is also reflected on the
+        // canonical `timeline` so the wire format matches
+        // `TimelineToolCallBlock` exactly.
+        if let deltas = chunk.choices.first?.delta.toolCalls {
+            thinkingClosedByContent = false
+            for delta in deltas {
+                let index = delta.index
+                let existing = streamingToolCalls[index]
+                let mergedId = delta.id ?? existing?.id ?? ""
+                let mergedName = delta.function?.name ?? existing?.name ?? ""
+                let mergedArgs = (existing?.arguments ?? "") + (delta.function?.arguments ?? "")
+                let updated = GenUIToolCall(
+                    id: mergedId,
+                    name: mergedName,
+                    arguments: mergedArgs
+                )
+                streamingToolCalls[index] = updated
+                if !mergedId.isEmpty {
+                    appendToolCallSegment(mergedId)
+                    TimelineToolCalls.upsertStreamingBlock(
+                        in: &timelineBlocks,
+                        toolCallId: mergedId,
+                        name: mergedName,
+                        arguments: mergedArgs
+                    )
+                }
+                outcome.didMutateState = true
+            }
+        }
+
+        // Collect sources from annotations (no deduplication to preserve citation index mapping)
+        if isWebSearchEnabled, let annotations = chunk.choices.first?.delta.annotations {
+            var didCollectNewSource = false
+            for annotation in annotations where annotation.type == "url_citation" {
+                if let citation = annotation.urlCitation {
+                    let source = WebSearchSource(
+                        title: citation.title ?? citation.url,
+                        url: citation.url
+                    )
+                    collectedSources.append(source)
+                    collectedAnnotations.append(
+                        Annotation(
+                            type: "url_citation",
+                            url_citation: URLCitation(
+                                title: citation.title ?? citation.url,
+                                url: citation.url,
+                                start_index: nil,
+                                end_index: nil
+                            )
+                        )
+                    )
+                    didCollectNewSource = true
+                    outcome.didMutateState = true
+                }
+            }
+            // Mirror the running sources onto the most recent WebSearchInstance.
+            // When the router sent `.completed` before any sources, we held the
+            // instance at `.searching` to avoid a zero-source completed pill;
+            // promote it now that a source has arrived.
+            if didCollectNewSource, let idx = webSearches.indices.last {
+                let lastSearch = webSearches[idx]
+                let promotedStatus: WebSearchStatus = lastSearch.status == .searching
+                    ? .completed
+                    : lastSearch.status
+                webSearches[idx] = WebSearchInstance(
+                    id: lastSearch.id,
+                    query: lastSearch.query,
+                    status: promotedStatus,
+                    sources: collectedSources,
+                    reason: lastSearch.reason
+                )
+            }
+        }
+
+        if hasReasoningContent && !isUsingReasoningFormat && !isInThinkingMode {
+            isUsingReasoningFormat = true
+            isInThinkingMode = true
+            isFirstChunk = false
+            thinkingClosedByContent = false
+            thinkStartTime = Date()
+            if !didRecordWebSearchBeforeThinking {
+                didRecordWebSearchBeforeThinking = true
+                webSearchBeforeThinking = webSearchStarted
+            }
+            thoughtsBuffer = reasoningContent
+            thinkingChunker.appendToken(reasoningContent)
+            currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+            outcome.didMutateState = true
+            // Reset summary service for new thinking session
+            outcome.summaryActions.append(.beginThinkingSession)
+            // Some routers attach content to the same chunk as
+            // the first reasoning delta; close the thinking
+            // session and emit it so the text isn't dropped.
+            if !content.isEmpty {
+                if let startTime = thinkStartTime {
+                    generationTimeSeconds = Date().timeIntervalSince(startTime)
+                }
+                isInThinkingMode = false
+                thinkingClosedByContent = true
+                thinkStartTime = nil
+                thinkingChunker.finalize()
+                if responseContent.isEmpty {
+                    responseContent = content
+                } else {
+                    responseContent += content
+                }
+                chunker.appendToken(content)
+                appendText(content)
+            }
+        } else if isUsingReasoningFormat {
+            if !reasoningContent.isEmpty {
+                if isInThinkingMode {
+                    thoughtsBuffer += reasoningContent
+                    thinkingChunker.appendToken(reasoningContent)
+                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    outcome.didMutateState = true
+                    // Generate thinking summary (reuse existing client)
+                    outcome.summaryActions.append(.generate(thoughtsBuffer))
+                } else if thinkingClosedByContent {
+                    // Late tail of the thought that content
+                    // already closed. Merge it into the existing
+                    // thoughts without re-entering thinking mode,
+                    // so the answer isn't split around a phantom
+                    // thought.
+                    thoughtsBuffer += reasoningContent
+                    thinkingChunker.appendTail(reasoningContent)
+                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    outcome.didMutateState = true
+                } else {
+                    // Reasoning resumed after a tool boundary —
+                    // a new thinking phase of the next model turn.
+                    isInThinkingMode = true
+                    thoughtsBuffer += reasoningContent
+                    thinkingChunker.appendToken(reasoningContent)
+                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    outcome.didMutateState = true
+                    outcome.summaryActions.append(.generate(thoughtsBuffer))
+                }
+            }
+
+            if !content.isEmpty && isInThinkingMode {
+                if let startTime = thinkStartTime {
+                    generationTimeSeconds = Date().timeIntervalSince(startTime)
+                }
+                isInThinkingMode = false
+                thinkingClosedByContent = true
+                thinkStartTime = nil
+                thinkingChunker.finalize()
+                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                // Clear thinking summary and cancel any in-flight summary generation
+                outcome.summaryActions.append(.endThinkingSession)
+                // Inline appendToResponse
+                if responseContent.isEmpty {
+                    responseContent = content
+                } else {
+                    responseContent += content
+                }
+                chunker.appendToken(content)
+                appendText(content)
+                outcome.didMutateState = true
+            } else if !content.isEmpty {
+                if responseContent.isEmpty {
+                    responseContent = content
+                } else {
+                    responseContent += content
+                }
+                chunker.appendToken(content)
+                appendText(content)
+                isInThinkingMode = false
+                outcome.didMutateState = true
+            }
+        } else if !isUsingReasoningFormat && !content.isEmpty {
+            if isFirstChunk {
+                initialContentBuffer += content
+
+                if initialContentBuffer.contains("<think>") || initialContentBuffer.count > 5 {
+                    isFirstChunk = false
+                    let processContent = initialContentBuffer
+                    initialContentBuffer = ""
+
+                    if let thinkRange = processContent.range(of: "<think>") {
+                        isInThinkingMode = true
+                        hasThinkTag = true
+                        thinkStartTime = Date()
+                        if !didRecordWebSearchBeforeThinking {
+                            didRecordWebSearchBeforeThinking = true
+                            webSearchBeforeThinking = webSearchStarted
+                        }
+                        let afterThink = String(processContent[thinkRange.upperBound...])
+                        thoughtsBuffer = afterThink
+                        thinkingChunker.appendToken(afterThink)
+                        currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                        outcome.didMutateState = true
+                        // Reset summary service for new thinking session
+                        outcome.summaryActions.append(.beginThinkingSession)
+                    } else {
+                        if responseContent.isEmpty {
+                            responseContent = processContent
+                        } else {
+                            responseContent += processContent
+                        }
+                        chunker.appendToken(processContent)
+                        appendText(processContent)
+                        outcome.didMutateState = true
+                    }
+                }
+            } else if hasThinkTag {
+                if let endRange = content.range(of: "</think>") {
+                    let beforeEnd = String(content[..<endRange.lowerBound])
+                    thoughtsBuffer += beforeEnd
+                    thinkingChunker.appendToken(beforeEnd)
+                    thinkingChunker.finalize()
+                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    isInThinkingMode = false
+                    // Clear thinking summary and cancel any in-flight summary generation
+                    outcome.summaryActions.append(.endThinkingSession)
+
+                    let afterEnd = String(content[endRange.upperBound...])
+                    if responseContent.isEmpty {
+                        responseContent = afterEnd
+                    } else {
+                        responseContent += afterEnd
+                    }
+                    chunker.appendToken(afterEnd)
+                    appendText(afterEnd)
+
+                    if let startTime = thinkStartTime {
+                        generationTimeSeconds = Date().timeIntervalSince(startTime)
+                    }
+
+                    hasThinkTag = false
+                    thinkStartTime = nil
+                    thoughtsBuffer = ""
+                    outcome.didMutateState = true
+                } else {
+                    thoughtsBuffer += content
+                    thinkingChunker.appendToken(content)
+                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    isInThinkingMode = true
+                    outcome.didMutateState = true
+                    // Generate thinking summary (reuse existing client)
+                    outcome.summaryActions.append(.generate(thoughtsBuffer))
+                }
+            } else {
+                if responseContent.isEmpty {
+                    responseContent = content
+                } else {
+                    responseContent += content
+                }
+                chunker.appendToken(content)
+                appendText(content)
+                outcome.didMutateState = true
+            }
+        }
+
+        return outcome
+    }
+
+    /// Runs once after the stream ends (completed or cancelled, not thrown):
+    /// drains parser tails, closes any open thinking state, and finalizes the
+    /// chunkers so `snapshot()` reflects the completed response.
+    func finishStream() {
+        // Drain any bytes the tinfoil-event parser is still
+        // holding back at the stream boundary. Anything in the
+        // tail is either an unterminated marker body (router
+        // bug) or a trailing open-tag prefix; surface it as
+        // plain assistant content minus any stray tag bytes so
+        // no characters the model emitted are silently lost.
+        let tinfoilEventTail = tinfoilEventParser.flush()
+        if !tinfoilEventTail.isEmpty {
+            let sanitizedTail = tinfoilEventTail
+                .replacingOccurrences(of: "<tinfoil-event>", with: "")
+                .replacingOccurrences(of: "</tinfoil-event>", with: "")
+            if !sanitizedTail.isEmpty {
+                if responseContent.isEmpty {
+                    responseContent = sanitizedTail
+                } else {
+                    responseContent += sanitizedTail
+                }
+                _ = chunker.appendToken(sanitizedTail)
+                appendText(sanitizedTail)
+            }
+        }
+
+        // Handle any remaining content when stream ends
+        if isInThinkingMode && !thoughtsBuffer.isEmpty {
+            if isUsingReasoningFormat {
+                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+            } else {
+                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                if responseContent.isEmpty {
+                    responseContent = thoughtsBuffer
+                    currentThoughts = nil
+                    appendText(thoughtsBuffer)
+                }
+            }
+            if let startTime = thinkStartTime {
+                generationTimeSeconds = Date().timeIntervalSince(startTime)
+            }
+            isInThinkingMode = false
+        } else if isFirstChunk && !initialContentBuffer.isEmpty {
+            if responseContent.isEmpty {
+                responseContent = initialContentBuffer
+            } else {
+                responseContent += initialContentBuffer
+            }
+            _ = chunker.appendToken(initialContentBuffer)
+            appendText(initialContentBuffer)
+            isInThinkingMode = false
+            currentThoughts = nil
+        }
+
+        chunker.finalize()
+        thinkingChunker.finalize()
+
+        // Mirror the final sources onto the most recent WebSearchInstance,
+        // promoting it out of the `.searching` holding state if the router
+        // sent `.completed` before any sources landed.
+        if !collectedSources.isEmpty,
+           let idx = webSearches.indices.last {
+            let lastSearch = webSearches[idx]
+            let finalStatus: WebSearchStatus = lastSearch.status == .searching
+                ? .completed
+                : lastSearch.status
+            webSearches[idx] = WebSearchInstance(
+                id: lastSearch.id,
+                query: lastSearch.query,
+                status: finalStatus,
+                sources: collectedSources,
+                reason: lastSearch.reason
+            )
+        }
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            responseContent: responseContent,
+            thoughts: currentThoughts,
+            thinkingChunks: thinkingChunker.getAllChunks(),
+            contentChunks: chunker.getAllChunks(),
+            isThinking: isInThinkingMode,
+            generationTimeSeconds: generationTimeSeconds,
+            segments: segments,
+            webSearches: webSearches,
+            toolCalls: streamingToolCalls
+                .sorted(by: { $0.key < $1.key })
+                .map { $0.value }
+                .filter { !$0.id.isEmpty },
+            timelineBlocks: timelineBlocks,
+            collectedSources: collectedSources,
+            collectedAnnotations: collectedAnnotations,
+            webSearchBeforeThinking: webSearchBeforeThinking
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func appendText(_ text: String) {
+        guard !text.isEmpty else { return }
+        if case .text(let existing) = segments.last {
+            segments[segments.count - 1] = .text(existing + text)
+        } else {
+            segments.append(.text(text))
+        }
+    }
+
+    private func appendToolCallSegment(_ toolCallId: String) {
+        if !segments.contains(where: {
+            if case .toolCall(let id) = $0, id == toolCallId { return true }
+            return false
+        }) {
+            segments.append(.toolCall(toolCallId: toolCallId))
+        }
+    }
+
+    private func evaluateHapticTick() -> Bool {
+        guard hapticEnabled else { return false }
+        if !isInThinkingMode && !hasStartedResponse {
+            hasStartedResponse = true
+            hapticChunkCount = 0
+        }
+        guard hapticChunkCount < 5 else { return false }
+        let now = Date()
+        guard now.timeIntervalSince(lastHapticTime) >= minHapticInterval else { return false }
+        lastHapticTime = now
+        hapticChunkCount += 1
+        return true
+    }
+}

--- a/TinfoilChat/Services/ThinkingTextChunker.swift
+++ b/TinfoilChat/Services/ThinkingTextChunker.swift
@@ -60,12 +60,20 @@ class ThinkingTextChunker {
     /// new one.
     func appendTail(_ token: String) {
         if workingBuffer.isEmpty, !completedChunks.isEmpty {
-            let last = completedChunks[completedChunks.count - 1]
-            completedChunks[completedChunks.count - 1] = ThinkingChunk(
+            let last = completedChunks.removeLast()
+            // Re-split the grown chunk so a long late tail can never
+            // push it past the per-chunk layout cap. The first piece
+            // keeps its id so the existing view identity is stable.
+            var pieces = Self.hardSplit(last.content + token)
+            let first = pieces.removeFirst()
+            completedChunks.append(ThinkingChunk(
                 id: last.id,
-                content: last.content + token,
+                content: first,
                 isComplete: true
-            )
+            ))
+            for piece in pieces {
+                appendCompletedChunk(piece)
+            }
         } else {
             appendToken(token)
         }
@@ -110,8 +118,11 @@ class ThinkingTextChunker {
 
         var pieces: [String] = []
         var remainder = Substring(text)
-        while remainder.count > cap {
-            let capIndex = remainder.index(remainder.startIndex, offsetBy: cap)
+        // `limitedBy:` keeps each split O(cap) instead of rescanning the
+        // whole remaining suffix with `count` on every iteration.
+        while let capIndex = remainder.index(
+            remainder.startIndex, offsetBy: cap, limitedBy: remainder.endIndex
+        ), capIndex != remainder.endIndex {
             let window = remainder[..<capIndex]
             let splitIndex = window.lastIndex(of: "\n").map { remainder.index(after: $0) } ?? capIndex
             pieces.append(String(remainder[..<splitIndex]))

--- a/TinfoilChat/Services/ThinkingTextChunker.swift
+++ b/TinfoilChat/Services/ThinkingTextChunker.swift
@@ -39,14 +39,19 @@ class ThinkingTextChunker {
         while let range = workingBuffer.range(of: "\n\n") {
             let paragraph = String(workingBuffer[..<range.lowerBound])
             if !paragraph.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                let chunkId = "thinking_\(completedChunks.count)"
-                completedChunks.append(ThinkingChunk(
-                    id: chunkId,
-                    content: paragraph,
-                    isComplete: true
-                ))
+                appendCompletedChunk(paragraph)
             }
             workingBuffer = String(workingBuffer[range.upperBound...])
+        }
+
+        // A single paragraph with no blank lines can grow without bound;
+        // flush completed pieces so the working chunk stays capped.
+        if workingBuffer.count > Constants.Rendering.maxThinkingChunkCharacters {
+            var pieces = Self.hardSplit(workingBuffer)
+            workingBuffer = pieces.removeLast()
+            for piece in pieces {
+                appendCompletedChunk(piece)
+            }
         }
     }
 
@@ -68,12 +73,7 @@ class ThinkingTextChunker {
 
     func finalize() {
         if !workingBuffer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let chunkId = "thinking_\(completedChunks.count)"
-            completedChunks.append(ThinkingChunk(
-                id: chunkId,
-                content: workingBuffer,
-                isComplete: true
-            ))
+            appendCompletedChunk(workingBuffer)
         }
         workingBuffer = ""
     }
@@ -81,5 +81,45 @@ class ThinkingTextChunker {
     func reset() {
         completedChunks.removeAll()
         workingBuffer = ""
+    }
+
+    /// One-shot chunking for already-complete thinking text, e.g. thoughts
+    /// loaded from storage where the streaming chunks were not persisted.
+    static func chunk(_ text: String) -> [ThinkingChunk] {
+        let chunker = ThinkingTextChunker()
+        chunker.appendToken(text)
+        chunker.finalize()
+        return chunker.getAllChunks()
+    }
+
+    private func appendCompletedChunk(_ content: String) {
+        for piece in Self.hardSplit(content) {
+            completedChunks.append(ThinkingChunk(
+                id: "thinking_\(completedChunks.count)",
+                content: piece,
+                isComplete: true
+            ))
+        }
+    }
+
+    /// Splits text into pieces no longer than the chunk cap, preferring the
+    /// last newline before the cap so lines stay intact.
+    private static func hardSplit(_ text: String) -> [String] {
+        let cap = Constants.Rendering.maxThinkingChunkCharacters
+        guard text.count > cap else { return [text] }
+
+        var pieces: [String] = []
+        var remainder = Substring(text)
+        while remainder.count > cap {
+            let capIndex = remainder.index(remainder.startIndex, offsetBy: cap)
+            let window = remainder[..<capIndex]
+            let splitIndex = window.lastIndex(of: "\n").map { remainder.index(after: $0) } ?? capIndex
+            pieces.append(String(remainder[..<splitIndex]))
+            remainder = remainder[splitIndex...]
+        }
+        if !remainder.isEmpty {
+            pieces.append(String(remainder))
+        }
+        return pieces
     }
 }

--- a/TinfoilChat/TinfoilChatRelease.entitlements
+++ b/TinfoilChat/TinfoilChatRelease.entitlements
@@ -10,5 +10,9 @@
 	<array>
 		<string>webcredentials:tinfoil.sh</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.sh.tinfoil.TinfoilChat</string>
+	</array>
 </dict>
 </plist>

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -208,6 +208,7 @@ class AuthManager: ObservableObject {
         // keys, or personalization bleed into the next account on a shared
         // device. This runs before isAuthenticated is cleared below so the
         // view model can still resolve the signing-out user's id for the wipe.
+        await ProfileManager.shared.clearLocalProfileForAccountRemoval()
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()
         if let chatViewModel {
@@ -219,7 +220,6 @@ class AuthManager: ObservableObject {
             await Chat.deleteAllChatsFromStorage(userId: localUserData?["id"] as? String)
         }
         SettingsManager.shared.clearAllSettings()
-        ProfileManager.shared.clearProfile()
 
         localUserData = nil
         isAuthenticated = false

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -104,10 +104,15 @@ class AuthManager: ObservableObject {
                     guard let self else { return }
                     await self.clearAuthState()
                     await RevenueCatManager.shared.logoutUser()
+                    // A sign-out may have completed while the cleanup
+                    // above was suspended; only restore auth state when
+                    // Clerk still reports the captured user.
+                    guard self.clerk?.user?.id == user.id else { return }
                     self.updateUserData(from: user)
                     self.isAuthenticated = true
                     self.saveAuthState()
                     await RevenueCatManager.shared.loginUser(user.id)
+                    guard self.clerk?.user?.id == user.id else { return }
                     if !self.hasTriggeredSignIn,
                        let chatVM = self.chatViewModel {
                         self.hasTriggeredSignIn = true

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -20,6 +20,7 @@ class AuthManager: ObservableObject {
     private var timer: Timer?
     private var clerk: Clerk?
     private var hasTriggeredSignIn = false
+    private var accountSwitchTask: Task<Void, Never>?
     
     // UserDefaults keys
     private let authStateKey = Constants.StorageKeys.Auth.state
@@ -96,6 +97,25 @@ class AuthManager: ObservableObject {
         self.clerk = clerk
         // Check if clerk is already loaded and has a user
         if let user = clerk.user {
+            if let cachedUserId = localUserData?["id"] as? String,
+               cachedUserId != user.id {
+                hasTriggeredSignIn = true
+                accountSwitchTask = Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    await self.clearAuthState()
+                    await RevenueCatManager.shared.logoutUser()
+                    self.updateUserData(from: user)
+                    self.isAuthenticated = true
+                    self.saveAuthState()
+                    await RevenueCatManager.shared.loginUser(user.id)
+                    if !self.hasTriggeredSignIn,
+                       let chatVM = self.chatViewModel {
+                        self.hasTriggeredSignIn = true
+                        chatVM.handleSignIn()
+                    }
+                }
+                return
+            }
             // Update user data BEFORE setting isAuthenticated
             updateUserData(from: user)
             
@@ -176,10 +196,20 @@ class AuthManager: ObservableObject {
             return
         }
 
+        if let accountSwitchTask {
+            await accountSwitchTask.value
+            self.accountSwitchTask = nil
+        }
+
         // Clerk loaded successfully - now we can trust clerk.user state
         let wasAuthenticated = isAuthenticated
 
         if let user = clerk.user {
+            if let cachedUserId = localUserData?["id"] as? String,
+               cachedUserId != user.id {
+                await clearAuthState()
+                await RevenueCatManager.shared.logoutUser()
+            }
             isAuthenticated = true
             updateUserData(from: user)
             await RevenueCatManager.shared.loginUser(user.id)
@@ -202,7 +232,7 @@ class AuthManager: ObservableObject {
     private func clearAuthState() async {
         // Handle chat state BEFORE clearing auth so the view model can still
         // save the current chat (hasChatAccess depends on isAuthenticated).
-        chatViewModel?.handleSignOut()
+        await chatViewModel?.handleSignOut()
 
         // Sign-out performs a full local wipe so that no content, encryption
         // keys, or personalization bleed into the next account on a shared

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1893,6 +1893,11 @@ class ChatViewModel: ObservableObject {
                     var chat = self.chat(at: location)
                     guard !chat.messages.isEmpty,
                           let lastIndex = chat.messages.indices.last else { return }
+                    // webSearchSummary drives the status line of whichever
+                    // chat is on screen, so only surface new search progress
+                    // while the user is still viewing the streaming chat
+                    // (clearing it is always safe).
+                    let isViewingStreamChat = self.currentChat?.id == sid
 
                     if event.action?.type == "open_page", let url = event.action?.url {
                         let fetchId = event.itemId ?? url
@@ -1941,7 +1946,9 @@ class ChatViewModel: ObservableObject {
                             status: .searching,
                             sources: existingSources
                         )
-                        self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
+                        if isViewingStreamChat {
+                            self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
+                        }
                     case .completed:
                         let eventSources = event.sources?.compactMap { source -> WebSearchSource? in
                             guard let url = source.url, !url.isEmpty else { return nil }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -195,9 +195,11 @@ class ChatViewModel: ObservableObject {
 
     // Attachment properties
     @Published var pendingAttachments: [Attachment] = []
-    @Published var isProcessingAttachment: Bool = false
     @Published var attachmentError: String? = nil
     @Published var pendingImageThumbnails: [String: String] = [:]
+    var isProcessingAttachment: Bool {
+        pendingAttachments.contains { $0.processingState == .processing }
+    }
 
     // Project properties
     @Published var projects: [Project] = []
@@ -1472,6 +1474,7 @@ class ChatViewModel: ObservableObject {
         let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasAttachments = !pendingAttachments.isEmpty
         guard hasText || hasAttachments else { return }
+        guard attachmentsAreReadyToSend(pendingAttachments) else { return }
 
         // Block send when free-tier requests are exhausted
         #if DEBUG
@@ -1499,7 +1502,7 @@ class ChatViewModel: ObservableObject {
         isLoading = true
 
         let messageAttachments = pendingAttachments
-        clearPendingAttachments()
+        clearPendingAttachments(acknowledgeSharedImports: false)
 
         // Create and add user message — attachments carry all data
         let userMessage = Message(
@@ -1508,6 +1511,9 @@ class ChatViewModel: ObservableObject {
             attachments: messageAttachments
         )
         addMessage(userMessage)
+        for requestID in messageAttachments.compactMap(\.sharedImportRequestID) {
+            SharedImportCoordinator.shared.acknowledge(requestID: requestID)
+        }
 
         // If this is the first message, mark as modified (title will be generated after assistant reply)
         if var chat = currentChat, chat.messages.count == 1 {
@@ -1521,8 +1527,11 @@ class ChatViewModel: ObservableObject {
 
     // MARK: - Attachment Management
 
-    func addDocumentAttachment(url: URL, fileName: String) {
-        isProcessingAttachment = true
+    func addDocumentAttachment(
+        url: URL,
+        fileName: String,
+        sharedImportRequestID: UUID? = nil
+    ) {
         attachmentError = nil
 
         let attachmentId = UUID().uuidString.lowercased()
@@ -1530,6 +1539,7 @@ class ChatViewModel: ObservableObject {
             id: attachmentId,
             type: .document,
             fileName: fileName,
+            sharedImportRequestID: sharedImportRequestID,
             processingState: .processing
         )
         pendingAttachments.append(attachment)
@@ -1553,12 +1563,14 @@ class ChatViewModel: ObservableObject {
                 }
                 attachmentError = error.localizedDescription
             }
-            isProcessingAttachment = false
         }
     }
 
-    func addImageAttachment(data: Data, fileName: String) {
-        isProcessingAttachment = true
+    func addImageAttachment(
+        data: Data,
+        fileName: String,
+        sharedImportRequestID: UUID? = nil
+    ) {
         attachmentError = nil
 
         let attachmentId = UUID().uuidString.lowercased()
@@ -1567,6 +1579,7 @@ class ChatViewModel: ObservableObject {
             type: .image,
             fileName: fileName,
             fileSize: Int64(data.count),
+            sharedImportRequestID: sharedImportRequestID,
             processingState: .processing
         )
         pendingAttachments.append(attachment)
@@ -1596,23 +1609,33 @@ class ChatViewModel: ObservableObject {
                 }
                 attachmentError = error.localizedDescription
             }
-            isProcessingAttachment = false
         }
     }
 
     func removePendingAttachment(id: String) {
+        let sharedImportRequestID = pendingAttachments
+            .first(where: { $0.id == id })?
+            .sharedImportRequestID
         pendingAttachments.removeAll { $0.id == id }
         pendingImageThumbnails.removeValue(forKey: id)
+        if let sharedImportRequestID {
+            SharedImportCoordinator.shared.acknowledge(requestID: sharedImportRequestID)
+        }
         if pendingAttachments.isEmpty {
             attachmentError = nil
         }
     }
 
-    func clearPendingAttachments() {
+    func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
+        let sharedImportRequestIDs = pendingAttachments.compactMap(\.sharedImportRequestID)
         pendingAttachments.removeAll()
         pendingImageThumbnails.removeAll()
         attachmentError = nil
-        isProcessingAttachment = false
+        if acknowledgeSharedImports {
+            for requestID in sharedImportRequestIDs {
+                SharedImportCoordinator.shared.acknowledge(requestID: requestID)
+            }
+        }
     }
 
     /// Generates an assistant response for the current conversation (expects user message to already be in chat)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1885,8 +1885,13 @@ class ChatViewModel: ObservableObject {
                 // progress without a second SSE channel.
                 let applyWebSearchCallEvent: @MainActor (TinfoilWebSearchCallEvent) -> Void = { [weak self] event in
                     guard let self = self else { return }
-                    guard var chat = self.currentChat,
-                          !chat.messages.isEmpty,
+                    // Look up the streaming chat by ID, not self.currentChat,
+                    // so an event landing after the user switched chats never
+                    // writes search state into the newly selected chat.
+                    guard let sid = streamChatId,
+                          let location = self.findChatLocation(sid) else { return }
+                    var chat = self.chat(at: location)
+                    guard !chat.messages.isEmpty,
                           let lastIndex = chat.messages.indices.last else { return }
 
                     if event.action?.type == "open_page", let url = event.action?.url {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @preconcurrency import TinfoilAI
 import OpenAI
 import AVFoundation
-import os
 
 enum ChatStorageTab: String {
     case cloud
@@ -1836,51 +1835,39 @@ class ChatViewModel: ObservableObject {
                     autoCandidates: modelSelection.autoCandidates
                 )
 
-                // Web search state tracking
-                var collectedSources: [WebSearchSource] = []
-                var collectedAnnotations: [Annotation] = []
-                let isWebSearchEnabled = self.isWebSearchEnabled
-                // Track whether web search started before thinking (shared across callback and streaming loop)
-                let webSearchStartedFlag = OSAllocatedUnfairLock(initialState: false)
+                let hapticEnabled = SettingsManager.shared.hapticFeedbackEnabled
+                let hapticGenerator: UIImpactFeedbackGenerator? = hapticEnabled
+                    ? UIImpactFeedbackGenerator(style: .light)
+                    : nil
+                hapticGenerator?.prepare()
 
-                // Ordered content segments (text + inline event refs) that preserve
-                // the exact order in which events arrived relative to streamed text.
-                // Accessed only on the main actor (this Task and the
-                // applyWebSearchCallEvent closure both run MainActor-isolated).
-                var segments: [MessageSegment] = []
-                var webSearches: [WebSearchInstance] = []
-                var nextSearchId = 0
-
-                let allocateSearchId = { () -> String in
-                    defer { nextSearchId += 1 }
-                    return "ws-\(nextSearchId)"
+                // Carry over any partial message state (a retry after a
+                // mid-stream auth refresh resumes into the same message).
+                var initialResponseContent = ""
+                var initialThoughts: String? = nil
+                var initialGenerationTime: TimeInterval? = nil
+                var initialIsThinking = false
+                if let chat = self.currentChat,
+                   !chat.messages.isEmpty,
+                   let lastIndex = chat.messages.indices.last {
+                    initialResponseContent = chat.messages[lastIndex].content
+                    initialThoughts = chat.messages[lastIndex].thoughts
+                    initialGenerationTime = chat.messages[lastIndex].generationTimeSeconds
+                    initialIsThinking = chat.messages[lastIndex].isThinking
                 }
 
-                let appendText: (String) -> Void = { text in
-                    guard !text.isEmpty else { return }
-                    if case .text(let existing) = segments.last {
-                        segments[segments.count - 1] = .text(existing + text)
-                    } else {
-                        segments.append(.text(text))
-                    }
-                }
-
-                let upsertWebSearch: (WebSearchInstance) -> Void = { instance in
-                    if let idx = webSearches.firstIndex(where: { $0.id == instance.id }) {
-                        webSearches[idx] = instance
-                    } else {
-                        webSearches.append(instance)
-                        segments.append(.webSearch(searchId: instance.id))
-                    }
-                }
-
-                let findLatestSearchInstance = { (eventId: String?) -> WebSearchInstance? in
-                    if let eventId = eventId,
-                       let hit = webSearches.first(where: { $0.id == eventId }) {
-                        return hit
-                    }
-                    return webSearches.last
-                }
+                // All per-chunk parsing state (event markers, chunkers, the
+                // thinking state machine, tool calls, web search bookkeeping)
+                // lives in the processor so the stream can be consumed off
+                // the main actor.
+                let processor = StreamingResponseProcessor(
+                    isWebSearchEnabled: self.isWebSearchEnabled,
+                    hapticEnabled: hapticEnabled,
+                    responseContent: initialResponseContent,
+                    currentThoughts: initialThoughts,
+                    generationTimeSeconds: initialGenerationTime,
+                    isInThinkingMode: initialIsThinking
+                )
 
                 // Web search progress now rides inline with the model's
                 // content as `<tinfoil-event>` markers (opted into via
@@ -1910,7 +1897,7 @@ class ChatViewModel: ObservableObject {
                                 chat.messages[lastIndex].urlFetches.append(
                                     URLFetchState(id: fetchId, url: url, status: .fetching)
                                 )
-                                segments.append(.urlFetch(fetchId: fetchId))
+                                processor.appendURLFetchSegment(fetchId)
                             }
                         case .completed:
                             if let idx = chat.messages[lastIndex].urlFetches.firstIndex(where: { $0.id == fetchId }) {
@@ -1925,7 +1912,7 @@ class ChatViewModel: ObservableObject {
                                 chat.messages[lastIndex].urlFetches[idx].status = .blocked
                             }
                         }
-                        chat.messages[lastIndex].segments = segments
+                        chat.messages[lastIndex].segments = processor.currentSegments
                         self.updateChat(chat, throttleForStreaming: true)
                         return
                     }
@@ -1933,9 +1920,9 @@ class ChatViewModel: ObservableObject {
                     let existingSources = chat.messages[lastIndex].webSearchState?.sources ?? []
                     switch event.status {
                     case .inProgress, .searching:
-                        webSearchStartedFlag.withLock { $0 = true }
-                        let id = event.itemId ?? allocateSearchId()
-                        upsertWebSearch(
+                        processor.markWebSearchStarted()
+                        let id = event.itemId ?? processor.allocateSearchId()
+                        processor.upsertWebSearch(
                             WebSearchInstance(
                                 id: id,
                                 query: event.action?.query,
@@ -1955,7 +1942,7 @@ class ChatViewModel: ObservableObject {
                             guard let url = source.url, !url.isEmpty else { return nil }
                             return WebSearchSource(title: source.title ?? url, url: url)
                         }
-                        if let existing = findLatestSearchInstance(event.itemId) {
+                        if let existing = processor.findSearchInstance(matching: event.itemId) {
                             // Preserve any sources already collected for this
                             // instance when the completion payload doesn't
                             // carry a non-empty sources list of its own.
@@ -1965,7 +1952,7 @@ class ChatViewModel: ObservableObject {
                             } else {
                                 mergedSources = existing.sources
                             }
-                            upsertWebSearch(
+                            processor.upsertWebSearch(
                                 WebSearchInstance(
                                     id: existing.id,
                                     query: existing.query,
@@ -1990,8 +1977,8 @@ class ChatViewModel: ObservableObject {
                             guard let url = source.url, !url.isEmpty else { return nil }
                             return WebSearchSource(title: source.title ?? url, url: url)
                         } ?? []
-                        if let existing = findLatestSearchInstance(event.itemId) {
-                            upsertWebSearch(
+                        if let existing = processor.findSearchInstance(matching: event.itemId) {
+                            processor.upsertWebSearch(
                                 WebSearchInstance(
                                     id: existing.id,
                                     query: existing.query,
@@ -2004,9 +1991,9 @@ class ChatViewModel: ObservableObject {
                         chat.messages[lastIndex].webSearchState?.status = .failed
                         self.webSearchSummary = ""
                     case .blocked:
-                        let existing = findLatestSearchInstance(event.itemId)
-                        let id = existing?.id ?? event.itemId ?? allocateSearchId()
-                        upsertWebSearch(
+                        let existing = processor.findSearchInstance(matching: event.itemId)
+                        let id = existing?.id ?? event.itemId ?? processor.allocateSearchId()
+                        processor.upsertWebSearch(
                             WebSearchInstance(
                                 id: id,
                                 query: event.action?.query ?? existing?.query,
@@ -2022,513 +2009,94 @@ class ChatViewModel: ObservableObject {
                         )
                         self.webSearchSummary = ""
                     }
-                    chat.messages[lastIndex].segments = segments
-                    chat.messages[lastIndex].webSearches = webSearches
+                    chat.messages[lastIndex].segments = processor.currentSegments
+                    chat.messages[lastIndex].webSearches = processor.currentWebSearches
                     self.updateChat(chat, throttleForStreaming: true)
                 }
 
-                // Stateful parser for `<tinfoil-event>` markers embedded
-                // in the content stream. `isWebSearchEnabled` has no
-                // effect on parsing: when the router isn't asked to
-                // emit markers it sends none, so the parser is a pure
-                // pass-through.
-                var tinfoilEventParser = TinfoilEventParser()
+                // Consume the stream off the main actor: all per-chunk parsing
+                // happens in the processor on this detached task, and the main
+                // actor is only hopped to for rare event application, haptics,
+                // and the throttled snapshot updates.
+                let consumeTask = Task.detached(priority: .userInitiated) { [weak self] in
+                    var lastUIUpdateTime = Date.distantPast
+                    let uiUpdateInterval: TimeInterval = Constants.Streaming.uiUpdateInterval
+                    // Latest thoughts awaiting a summary request; forwarded with
+                    // the next throttled snapshot so summary generation does not
+                    // force a main-actor hop per reasoning chunk.
+                    var pendingSummaryThoughts: String? = nil
 
-                // GenUI tool-call accumulator. The OpenAI streaming
-                // protocol sends a sequence of partial deltas keyed by
-                // `index`; each delta may carry an `id`, a `name`, and
-                // an `arguments` fragment. We coalesce them by index
-                // and write both:
-                //   - the flat `Message.toolCalls` array (mirrored from
-                //     webapp `MessageAssembler.toMessage`), and
-                //   - the canonical `Message.timeline` tool_call blocks
-                //     that the webapp uses to track resolution state.
-                var streamingToolCalls: [Int: GenUIToolCall] = [:]
-                var timelineBlocks: [JSONValue] = []
-                let appendToolCallSegment: (String) -> Void = { toolCallId in
-                    if !segments.contains(where: {
-                        if case .toolCall(let id) = $0, id == toolCallId { return true }
-                        return false
-                    }) {
-                        segments.append(.toolCall(toolCallId: toolCallId))
-                    }
-                }
+                    for try await chunk in stream {
+                        if Task.isCancelled { break }
 
-                var thinkStartTime: Date? = nil
-                var hasThinkTag = false
-                var thoughtsBuffer = ""
-                var isInThinkingMode = false
-                var isUsingReasoningFormat = false
-                // True while thinking was closed by answer content (not by
-                // a tool boundary). Reasoning arriving in that state is the
-                // late tail of the previous thought — upstreams race the
-                // think-close boundary so the final reasoning fragment can
-                // land after content started — and is merged into the
-                // existing thoughts without re-entering thinking mode.
-                var thinkingClosedByContent = false
-                var didRecordWebSearchBeforeThinking = false
-                var webSearchBeforeThinking: Bool? = nil
-                var initialContentBuffer = ""
-                var isFirstChunk = true
-                var responseContent = ""
-                var currentThoughts: String? = nil
-                var generationTimeSeconds: TimeInterval? = nil
-                let hapticEnabled = SettingsManager.shared.hapticFeedbackEnabled
-                var hapticGenerator: UIImpactFeedbackGenerator?
-                var lastHapticTime = Date.distantPast
-                let minHapticInterval: TimeInterval = 0.1
-                let chunker = StreamingMarkdownChunker()
-                let thinkingChunker = ThinkingTextChunker()
-                var hapticChunkCount = 0
-                var hasStartedResponse = false
-                var lastUIUpdateTime = Date.distantPast
-                let uiUpdateInterval: TimeInterval = Constants.Streaming.uiUpdateInterval
+                        let parsed = processor.parse(chunk)
 
-                await MainActor.run {
-                    if let chat = self.currentChat,
-                       !chat.messages.isEmpty,
-                       let lastIndex = chat.messages.indices.last {
-                        responseContent = chat.messages[lastIndex].content
-                        currentThoughts = chat.messages[lastIndex].thoughts
-                        generationTimeSeconds = chat.messages[lastIndex].generationTimeSeconds
-                        isInThinkingMode = chat.messages[lastIndex].isThinking
-                    }
-                    if hapticEnabled {
-                        hapticGenerator = UIImpactFeedbackGenerator(style: .light)
-                        hapticGenerator?.prepare()
-                    }
-                }
-
-                for try await chunk in stream {
-                    if Task.isCancelled { break }
-
-                    // Inline haptic feedback
-                    if hapticEnabled, let generator = hapticGenerator {
-                        if isInThinkingMode {
-                            if hapticChunkCount < 5 {
-                                let now = Date()
-                                if now.timeIntervalSince(lastHapticTime) >= minHapticInterval {
-                                    generator.impactOccurred(intensity: 0.5)
-                                    lastHapticTime = now
-                                    hapticChunkCount += 1
-                                }
-                            }
-                        } else {
-                            if !hasStartedResponse {
-                                hasStartedResponse = true
-                                hapticChunkCount = 0
-                            }
-                            if hapticChunkCount < 5 {
-                                let now = Date()
-                                if now.timeIntervalSince(lastHapticTime) >= minHapticInterval {
-                                    generator.impactOccurred(intensity: 0.5)
-                                    lastHapticTime = now
-                                    hapticChunkCount += 1
-                                }
-                            }
-                        }
-                    }
-
-                    var content = chunk.choices.first?.delta.content ?? ""
-                    // Strip router-emitted `<tinfoil-event>` markers
-                    // from the delta before any downstream logic sees
-                    // it, and dispatch the decoded events so the same
-                    // UI surfaces the legacy callback populated. The
-                    // enclosing class is @MainActor and Task inherits
-                    // that isolation, so applyWebSearchCallEvent runs
-                    // synchronously on the main actor here.
-                    if !content.isEmpty {
-                        let parsed = tinfoilEventParser.consume(content)
+                        // Apply decoded marker events on the main actor before
+                        // processing the chunk's text. The loop suspends until
+                        // each event lands, so event handling stays ordered
+                        // relative to the streamed text around it and the
+                        // processor is never touched concurrently.
                         for event in parsed.events {
-                            applyWebSearchCallEvent(event)
+                            await applyWebSearchCallEvent(event)
                         }
-                        if !parsed.events.isEmpty {
-                            thinkingClosedByContent = false
-                        }
-                        content = parsed.text
-                    }
-                    let hasReasoningContent = chunk.choices.first?.delta.reasoning != nil
-                    let reasoningContent = chunk.choices.first?.delta.reasoning ?? ""
-                    var didMutateState = false
 
-                    // Accumulate GenUI tool-call deltas. Mirrors the
-                    // webapp's normalizer: deltas may carry only
-                    // partial fragments and we merge them by index.
-                    // Each merged tool call is also reflected on the
-                    // canonical `timeline` so the wire format matches
-                    // `TimelineToolCallBlock` exactly.
-                    if let deltas = chunk.choices.first?.delta.toolCalls {
-                        thinkingClosedByContent = false
-                        for delta in deltas {
-                            let index = delta.index
-                            let existing = streamingToolCalls[index]
-                            let mergedId = delta.id ?? existing?.id ?? ""
-                            let mergedName = delta.function?.name ?? existing?.name ?? ""
-                            let mergedArgs = (existing?.arguments ?? "") + (delta.function?.arguments ?? "")
-                            let updated = GenUIToolCall(
-                                id: mergedId,
-                                name: mergedName,
-                                arguments: mergedArgs
-                            )
-                            streamingToolCalls[index] = updated
-                            if !mergedId.isEmpty {
-                                appendToolCallSegment(mergedId)
-                                TimelineToolCalls.upsertStreamingBlock(
-                                    in: &timelineBlocks,
-                                    toolCallId: mergedId,
-                                    name: mergedName,
-                                    arguments: mergedArgs
-                                )
-                            }
-                            didMutateState = true
-                        }
-                    }
+                        let outcome = processor.process(parsed)
 
-                    // Collect sources from annotations (no deduplication to preserve citation index mapping)
-                    if isWebSearchEnabled, let annotations = chunk.choices.first?.delta.annotations {
-                        var didCollectNewSource = false
-                        for annotation in annotations where annotation.type == "url_citation" {
-                            if let citation = annotation.urlCitation {
-                                let source = WebSearchSource(
-                                    title: citation.title ?? citation.url,
-                                    url: citation.url
-                                )
-                                collectedSources.append(source)
-                                collectedAnnotations.append(
-                                    Annotation(
-                                        type: "url_citation",
-                                        url_citation: URLCitation(
-                                            title: citation.title ?? citation.url,
-                                            url: citation.url,
-                                            start_index: nil,
-                                            end_index: nil
-                                        )
-                                    )
-                                )
-                                didCollectNewSource = true
-                                didMutateState = true
+                        if outcome.shouldTickHaptic {
+                            await MainActor.run {
+                                hapticGenerator?.impactOccurred(intensity: 0.5)
                             }
                         }
-                        // Mirror the running sources onto the most recent WebSearchInstance.
-                        // When the router sent `.completed` before any sources, we held the
-                        // instance at `.searching` to avoid a zero-source completed pill;
-                        // promote it now that a source has arrived.
-                        if didCollectNewSource, let idx = webSearches.indices.last {
-                            let lastSearch = webSearches[idx]
-                            let promotedStatus: WebSearchStatus = lastSearch.status == .searching
-                                ? .completed
-                                : lastSearch.status
-                            webSearches[idx] = WebSearchInstance(
-                                id: lastSearch.id,
-                                query: lastSearch.query,
-                                status: promotedStatus,
-                                sources: collectedSources,
-                                reason: lastSearch.reason
-                            )
-                        }
-                    }
 
-                    if hasReasoningContent && !isUsingReasoningFormat && !isInThinkingMode {
-                        isUsingReasoningFormat = true
-                        isInThinkingMode = true
-                        isFirstChunk = false
-                        thinkingClosedByContent = false
-                        thinkStartTime = Date()
-                        if !didRecordWebSearchBeforeThinking {
-                            didRecordWebSearchBeforeThinking = true
-                            webSearchBeforeThinking = webSearchStartedFlag.withLock { $0 }
-                        }
-                        thoughtsBuffer = reasoningContent
-                        thinkingChunker.appendToken(reasoningContent)
-                        currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                        didMutateState = true
-                        // Reset summary service for new thinking session
-                        Task { @MainActor in
-                            ThinkingSummaryService.shared.reset()
-                        }
-                        // Some routers attach content to the same chunk as
-                        // the first reasoning delta; close the thinking
-                        // session and emit it so the text isn't dropped.
-                        if !content.isEmpty {
-                            if let startTime = thinkStartTime {
-                                generationTimeSeconds = Date().timeIntervalSince(startTime)
-                            }
-                            isInThinkingMode = false
-                            thinkingClosedByContent = true
-                            thinkStartTime = nil
-                            thinkingChunker.finalize()
-                            if responseContent.isEmpty {
-                                responseContent = content
-                            } else {
-                                responseContent += content
-                            }
-                            chunker.appendToken(content)
-                            appendText(content)
-                        }
-                    } else if isUsingReasoningFormat {
-                        if !reasoningContent.isEmpty {
-                            if isInThinkingMode {
-                                thoughtsBuffer += reasoningContent
-                                thinkingChunker.appendToken(reasoningContent)
-                                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                                didMutateState = true
-                                // Generate thinking summary (reuse existing client)
-                                let currentThoughtsForSummary = thoughtsBuffer
-                                Task { @MainActor [weak self] in
-                                    ThinkingSummaryService.shared.generateSummary(thoughts: currentThoughtsForSummary) { summary in
-                                        self?.thinkingSummary = summary
-                                    }
+                        for action in outcome.summaryActions {
+                            switch action {
+                            case .beginThinkingSession:
+                                pendingSummaryThoughts = nil
+                                await MainActor.run {
+                                    ThinkingSummaryService.shared.reset()
                                 }
-                            } else if thinkingClosedByContent {
-                                // Late tail of the thought that content
-                                // already closed. Merge it into the existing
-                                // thoughts without re-entering thinking mode,
-                                // so the answer isn't split around a phantom
-                                // thought.
-                                thoughtsBuffer += reasoningContent
-                                thinkingChunker.appendTail(reasoningContent)
-                                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                                didMutateState = true
-                            } else {
-                                // Reasoning resumed after a tool boundary —
-                                // a new thinking phase of the next model turn.
-                                isInThinkingMode = true
-                                thoughtsBuffer += reasoningContent
-                                thinkingChunker.appendToken(reasoningContent)
-                                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                                didMutateState = true
-                                let currentThoughtsForSummary = thoughtsBuffer
-                                Task { @MainActor [weak self] in
-                                    ThinkingSummaryService.shared.generateSummary(thoughts: currentThoughtsForSummary) { summary in
-                                        self?.thinkingSummary = summary
-                                    }
-                                }
-                            }
-                        }
-
-                        if !content.isEmpty && isInThinkingMode {
-                            if let startTime = thinkStartTime {
-                                generationTimeSeconds = Date().timeIntervalSince(startTime)
-                            }
-                            isInThinkingMode = false
-                            thinkingClosedByContent = true
-                            thinkStartTime = nil
-                            thinkingChunker.finalize()
-                            currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                            // Clear thinking summary and cancel any in-flight summary generation
-                            Task { @MainActor [weak self] in
-                                ThinkingSummaryService.shared.reset()
-                                self?.thinkingSummary = ""
-                            }
-                            // Inline appendToResponse
-                            if responseContent.isEmpty {
-                                responseContent = content
-                            } else {
-                                responseContent += content
-                            }
-                            chunker.appendToken(content)
-                            appendText(content)
-                            didMutateState = true
-                        } else if !content.isEmpty {
-                            if responseContent.isEmpty {
-                                responseContent = content
-                            } else {
-                                responseContent += content
-                            }
-                            chunker.appendToken(content)
-                            appendText(content)
-                            isInThinkingMode = false
-                            didMutateState = true
-                        }
-                    } else if !isUsingReasoningFormat && !content.isEmpty {
-                        if isFirstChunk {
-                            initialContentBuffer += content
-
-                            if initialContentBuffer.contains("<think>") || initialContentBuffer.count > 5 {
-                                isFirstChunk = false
-                                let processContent = initialContentBuffer
-                                initialContentBuffer = ""
-
-                                if let thinkRange = processContent.range(of: "<think>") {
-                                    isInThinkingMode = true
-                                    hasThinkTag = true
-                                    thinkStartTime = Date()
-                                    if !didRecordWebSearchBeforeThinking {
-                                        didRecordWebSearchBeforeThinking = true
-                                        webSearchBeforeThinking = webSearchStartedFlag.withLock { $0 }
-                                    }
-                                    let afterThink = String(processContent[thinkRange.upperBound...])
-                                    thoughtsBuffer = afterThink
-                                    thinkingChunker.appendToken(afterThink)
-                                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                                    didMutateState = true
-                                    // Reset summary service for new thinking session
-                                    Task { @MainActor in
-                                        ThinkingSummaryService.shared.reset()
-                                    }
-                                } else {
-                                    if responseContent.isEmpty {
-                                        responseContent = processContent
-                                    } else {
-                                        responseContent += processContent
-                                    }
-                                    chunker.appendToken(processContent)
-                                    appendText(processContent)
-                                    didMutateState = true
-                                }
-                            }
-                        } else if hasThinkTag {
-                            if let endRange = content.range(of: "</think>") {
-                                let beforeEnd = String(content[..<endRange.lowerBound])
-                                thoughtsBuffer += beforeEnd
-                                thinkingChunker.appendToken(beforeEnd)
-                                thinkingChunker.finalize()
-                                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                                isInThinkingMode = false
-                                // Clear thinking summary and cancel any in-flight summary generation
-                                Task { @MainActor [weak self] in
+                            case .endThinkingSession:
+                                pendingSummaryThoughts = nil
+                                await MainActor.run {
                                     ThinkingSummaryService.shared.reset()
                                     self?.thinkingSummary = ""
                                 }
+                            case .generate(let thoughts):
+                                pendingSummaryThoughts = thoughts
+                            }
+                        }
 
-                                let afterEnd = String(content[endRange.upperBound...])
-                                if responseContent.isEmpty {
-                                    responseContent = afterEnd
-                                } else {
-                                    responseContent += afterEnd
-                                }
-                                chunker.appendToken(afterEnd)
-                                appendText(afterEnd)
-
-                                if let startTime = thinkStartTime {
-                                    generationTimeSeconds = Date().timeIntervalSince(startTime)
-                                }
-
-                                hasThinkTag = false
-                                thinkStartTime = nil
-                                thoughtsBuffer = ""
-                                didMutateState = true
-                            } else {
-                                thoughtsBuffer += content
-                                thinkingChunker.appendToken(content)
-                                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                                isInThinkingMode = true
-                                didMutateState = true
-                                // Generate thinking summary (reuse existing client)
-                                let currentThoughtsForSummary = thoughtsBuffer
-                                Task { @MainActor [weak self] in
-                                    ThinkingSummaryService.shared.generateSummary(thoughts: currentThoughtsForSummary) { summary in
+                        // Update UI at a throttled rate to avoid overwhelming SwiftUI with diffs
+                        let now = Date()
+                        if outcome.didMutateState && now.timeIntervalSince(lastUIUpdateTime) >= uiUpdateInterval {
+                            lastUIUpdateTime = now
+                            let snapshot = processor.snapshot()
+                            let thoughtsForSummary = pendingSummaryThoughts
+                            pendingSummaryThoughts = nil
+                            await MainActor.run {
+                                guard let self else { return }
+                                self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
+                                if let thoughtsForSummary {
+                                    ThinkingSummaryService.shared.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
                                         self?.thinkingSummary = summary
                                     }
                                 }
                             }
-                        } else {
-                            if responseContent.isEmpty {
-                                responseContent = content
-                            } else {
-                                responseContent += content
-                            }
-                            chunker.appendToken(content)
-                            appendText(content)
-                            didMutateState = true
                         }
                     }
 
-                    // Update UI at a throttled rate to avoid overwhelming SwiftUI with diffs
-                    let now = Date()
-                    if didMutateState && now.timeIntervalSince(lastUIUpdateTime) >= uiUpdateInterval {
-                        lastUIUpdateTime = now
-                        // The streaming loop and `applyWebSearchCallEvent` both run on
-                        // MainActor, so this block executes synchronously with respect to
-                        // event dispatch; reading `segments` / `webSearches` directly here
-                        // is safe and gives the latest values (no stale snapshot race).
-                        guard self.currentChat?.id == streamChatId else { continue }
-                        guard var chat = self.currentChat,
-                              chat.hasActiveStream,
-                              !chat.messages.isEmpty,
-                              let lastIndex = chat.messages.indices.last else {
-                            continue
-                        }
-
-                        chat.messages[lastIndex].content = responseContent
-                        chat.messages[lastIndex].thoughts = currentThoughts
-                        chat.messages[lastIndex].thinkingChunks = thinkingChunker.getAllChunks()
-                        chat.messages[lastIndex].isThinking = isInThinkingMode
-                        chat.messages[lastIndex].generationTimeSeconds = generationTimeSeconds
-                        chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
-                        chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
-                        chat.messages[lastIndex].webSearches = webSearches.isEmpty ? nil : webSearches
-                        chat.messages[lastIndex].toolCalls = streamingToolCalls
-                            .sorted(by: { $0.key < $1.key })
-                            .map { $0.value }
-                            .filter { !$0.id.isEmpty }
-                        if !timelineBlocks.isEmpty {
-                            chat.messages[lastIndex].timeline = timelineBlocks
-                        }
-
-                        // Merge collected sources into the message's current webSearchState.
-                        if !collectedSources.isEmpty {
-                            var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
-                            searchState.sources = collectedSources
-                            chat.messages[lastIndex].webSearchState = searchState
-                        }
-                        if !collectedAnnotations.isEmpty {
-                            chat.messages[lastIndex].annotations = collectedAnnotations
-                        }
-
-                        self.updateChat(chat, throttleForStreaming: true)
-                    }
+                    processor.finishStream()
                 }
 
-                // Drain any bytes the tinfoil-event parser is still
-                // holding back at the stream boundary. Anything in the
-                // tail is either an unterminated marker body (router
-                // bug) or a trailing open-tag prefix; surface it as
-                // plain assistant content minus any stray tag bytes so
-                // no characters the model emitted are silently lost.
-                let tinfoilEventTail = tinfoilEventParser.flush()
-                if !tinfoilEventTail.isEmpty {
-                    let sanitizedTail = tinfoilEventTail
-                        .replacingOccurrences(of: "<tinfoil-event>", with: "")
-                        .replacingOccurrences(of: "</tinfoil-event>", with: "")
-                    if !sanitizedTail.isEmpty {
-                        if responseContent.isEmpty {
-                            responseContent = sanitizedTail
-                        } else {
-                            responseContent += sanitizedTail
-                        }
-                        _ = chunker.appendToken(sanitizedTail)
-                        appendText(sanitizedTail)
-                    }
+                // Propagate cancellation from cancelGeneration (which cancels
+                // the outer task) into the detached stream consumer.
+                try await withTaskCancellationHandler {
+                    try await consumeTask.value
+                } onCancel: {
+                    consumeTask.cancel()
                 }
 
-                // Handle any remaining content when stream ends
-                if isInThinkingMode && !thoughtsBuffer.isEmpty {
-                    if isUsingReasoningFormat {
-                        currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                    } else {
-                        currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                        if responseContent.isEmpty {
-                            responseContent = thoughtsBuffer
-                            currentThoughts = nil
-                            appendText(thoughtsBuffer)
-                        }
-                    }
-                    if let startTime = thinkStartTime {
-                        generationTimeSeconds = Date().timeIntervalSince(startTime)
-                    }
-                    isInThinkingMode = false
-                } else if isFirstChunk && !initialContentBuffer.isEmpty {
-                    if responseContent.isEmpty {
-                        responseContent = initialContentBuffer
-                    } else {
-                        responseContent += initialContentBuffer
-                    }
-                    _ = chunker.appendToken(initialContentBuffer)
-                    appendText(initialContentBuffer)
-                    isInThinkingMode = false
-                    currentThoughts = nil
-                }
+                let finalSnapshot = processor.snapshot()
 
                 // Finalize message content and prepare chat for save
                 // Look up the streaming chat by ID, not self.currentChat, because
@@ -2556,54 +2124,32 @@ class ChatViewModel: ObservableObject {
                     self.thinkingSummary = ""
                     self.webSearchSummary = ""
                     if !chat.messages.isEmpty, let lastIndex = chat.messages.indices.last {
-                        chunker.finalize()
-                        thinkingChunker.finalize()
-                        chat.messages[lastIndex].content = responseContent
-                        chat.messages[lastIndex].thoughts = currentThoughts
-                        chat.messages[lastIndex].thinkingChunks = thinkingChunker.getAllChunks()
+                        chat.messages[lastIndex].content = finalSnapshot.responseContent
+                        chat.messages[lastIndex].thoughts = finalSnapshot.thoughts
+                        chat.messages[lastIndex].thinkingChunks = finalSnapshot.thinkingChunks
                         chat.messages[lastIndex].isThinking = false
-                        chat.messages[lastIndex].generationTimeSeconds = generationTimeSeconds
-                        chat.messages[lastIndex].thinkingDuration = generationTimeSeconds
-                        chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
-                        chat.messages[lastIndex].contentChunks = chunker.getAllChunks()
-                        chat.messages[lastIndex].segments = segments.isEmpty ? nil : segments
-                        chat.messages[lastIndex].toolCalls = streamingToolCalls
-                            .sorted(by: { $0.key < $1.key })
-                            .map { $0.value }
-                            .filter { !$0.id.isEmpty }
-                        if !timelineBlocks.isEmpty {
-                            chat.messages[lastIndex].timeline = timelineBlocks
+                        chat.messages[lastIndex].generationTimeSeconds = finalSnapshot.generationTimeSeconds
+                        chat.messages[lastIndex].thinkingDuration = finalSnapshot.generationTimeSeconds
+                        chat.messages[lastIndex].webSearchBeforeThinking = finalSnapshot.webSearchBeforeThinking
+                        chat.messages[lastIndex].contentChunks = finalSnapshot.contentChunks
+                        chat.messages[lastIndex].segments = finalSnapshot.segments.isEmpty ? nil : finalSnapshot.segments
+                        chat.messages[lastIndex].toolCalls = finalSnapshot.toolCalls
+                        if !finalSnapshot.timelineBlocks.isEmpty {
+                            chat.messages[lastIndex].timeline = finalSnapshot.timelineBlocks
                         }
-                        // Mirror the final sources onto the most recent WebSearchInstance,
-                        // promoting it out of the `.searching` holding state if the router
-                        // sent `.completed` before any sources landed.
-                        if !collectedSources.isEmpty,
-                           let idx = webSearches.indices.last {
-                            let lastSearch = webSearches[idx]
-                            let finalStatus: WebSearchStatus = lastSearch.status == .searching
-                                ? .completed
-                                : lastSearch.status
-                            webSearches[idx] = WebSearchInstance(
-                                id: lastSearch.id,
-                                query: lastSearch.query,
-                                status: finalStatus,
-                                sources: collectedSources,
-                                reason: lastSearch.reason
-                            )
-                        }
-                        chat.messages[lastIndex].webSearches = webSearches.isEmpty ? nil : webSearches
+                        chat.messages[lastIndex].webSearches = finalSnapshot.webSearches.isEmpty ? nil : finalSnapshot.webSearches
                         // Merge final collected sources into the aggregate webSearchState,
                         // promoting the same way.
-                        if !collectedSources.isEmpty {
+                        if !finalSnapshot.collectedSources.isEmpty {
                             var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
-                            searchState.sources = collectedSources
+                            searchState.sources = finalSnapshot.collectedSources
                             if searchState.status == .searching {
                                 searchState.status = .completed
                             }
                             chat.messages[lastIndex].webSearchState = searchState
                         }
-                        if !collectedAnnotations.isEmpty {
-                            chat.messages[lastIndex].annotations = collectedAnnotations
+                        if !finalSnapshot.collectedAnnotations.isEmpty {
+                            chat.messages[lastIndex].annotations = finalSnapshot.collectedAnnotations
                         }
                     }
 
@@ -2736,6 +2282,44 @@ class ChatViewModel: ObservableObject {
         }
     }
     
+    /// Applies one throttled streaming snapshot to the streaming chat's last
+    /// message. Snapshots are immutable values produced by the stream task's
+    /// processor, so this never reads live parsing state.
+    private func applyStreamSnapshot(_ snapshot: StreamingResponseProcessor.Snapshot, streamChatId: String?) {
+        guard self.currentChat?.id == streamChatId else { return }
+        guard var chat = self.currentChat,
+              chat.hasActiveStream,
+              !chat.messages.isEmpty,
+              let lastIndex = chat.messages.indices.last else {
+            return
+        }
+
+        chat.messages[lastIndex].content = snapshot.responseContent
+        chat.messages[lastIndex].thoughts = snapshot.thoughts
+        chat.messages[lastIndex].thinkingChunks = snapshot.thinkingChunks
+        chat.messages[lastIndex].isThinking = snapshot.isThinking
+        chat.messages[lastIndex].generationTimeSeconds = snapshot.generationTimeSeconds
+        chat.messages[lastIndex].contentChunks = snapshot.contentChunks
+        chat.messages[lastIndex].segments = snapshot.segments.isEmpty ? nil : snapshot.segments
+        chat.messages[lastIndex].webSearches = snapshot.webSearches.isEmpty ? nil : snapshot.webSearches
+        chat.messages[lastIndex].toolCalls = snapshot.toolCalls
+        if !snapshot.timelineBlocks.isEmpty {
+            chat.messages[lastIndex].timeline = snapshot.timelineBlocks
+        }
+
+        // Merge collected sources into the message's current webSearchState.
+        if !snapshot.collectedSources.isEmpty {
+            var searchState = chat.messages[lastIndex].webSearchState ?? WebSearchState(status: .searching)
+            searchState.sources = snapshot.collectedSources
+            chat.messages[lastIndex].webSearchState = searchState
+        }
+        if !snapshot.collectedAnnotations.isEmpty {
+            chat.messages[lastIndex].annotations = snapshot.collectedAnnotations
+        }
+
+        self.updateChat(chat, throttleForStreaming: true)
+    }
+
     /// Formats a user-friendly error message from the caught error
     private func formatUserFriendlyError(_ error: Error) -> String {
         let nsError = error as NSError

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3243,7 +3243,7 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Saves a single chat to per-chat file storage and triggers cloud backup
-    private func saveChat(_ chat: Chat) {
+    private func saveChat(_ chat: Chat, shouldBackup: Bool = true) {
         guard !chat.isTemporary else { return }
         guard hasChatAccess else { return }
         guard !chat.messages.isEmpty || chat.decryptionFailed else { return }
@@ -3257,7 +3257,7 @@ class ChatViewModel: ObservableObject {
 
         // Trigger cloud backup if cloud sync is enabled, the chat is not local-only,
         // has messages, and no active stream.
-        if SettingsManager.shared.isCloudSyncEnabled && !chat.isLocalOnly && !chat.messages.isEmpty && !chat.hasActiveStream {
+        if shouldBackup && SettingsManager.shared.isCloudSyncEnabled && !chat.isLocalOnly && !chat.messages.isEmpty && !chat.hasActiveStream {
             let saveTask = pendingSaveTask
             Task {
                 await saveTask?.value
@@ -3335,7 +3335,7 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Handle sign-out by clearing current chats but preserving them in storage
-    func handleSignOut() {
+    func handleSignOut() async {
         // Allow a new sign-in flow after sign-out
         isSignInInProgress = false
         hasPerformedInitialSync = false
@@ -3349,15 +3349,15 @@ class ChatViewModel: ObservableObject {
         // so that hasChatAccess/currentUserId are available for the save.
         if hasChatAccess {
             for chat in localChats where !chat.messages.isEmpty {
-                saveChat(chat)
+                saveChat(chat, shouldBackup: false)
             }
             if let chat = currentChat, !chat.messages.isEmpty {
-                saveChat(chat)
+                saveChat(chat, shouldBackup: false)
             }
         }
 
         // Clear sync caches so stale state doesn't leak into the next session
-        cloudSync.clearSyncStatus()
+        await cloudSync.clearSyncStatus()
         DeletedChatsTracker.shared.clear()
         CloudKeyAuthorizationStore.shared.clearAuthorization(userId: currentUserId)
 

--- a/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
@@ -52,14 +52,25 @@ private struct StatCardsView: View {
     let stats: [StatCardsWidget.Stat]
     let isDarkMode: Bool
 
+    private enum Layout {
+        static let gridSpacing: CGFloat = 8
+        static let contentSpacing: CGFloat = 6
+        static let cardPadding: CGFloat = 12
+    }
+
+    @State private var maximumCardContentHeight: CGFloat = 0
+
     private var columns: [GridItem] {
-        [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)]
+        [
+            GridItem(.flexible(), spacing: Layout.gridSpacing),
+            GridItem(.flexible(), spacing: Layout.gridSpacing),
+        ]
     }
 
     var body: some View {
-        LazyVGrid(columns: columns, spacing: 8) {
+        LazyVGrid(columns: columns, spacing: Layout.gridSpacing) {
             ForEach(Array(stats.enumerated()), id: \.offset) { _, stat in
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: Layout.contentSpacing) {
                     Text(stat.label)
                         .font(.caption.weight(.medium))
                         .foregroundColor(GenUIStyle.mutedText(isDarkMode))
@@ -80,11 +91,26 @@ private struct StatCardsView: View {
                         }
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .genUICard(isDarkMode: isDarkMode, padding: 12)
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: StatCardHeightPreferenceKey.self,
+                            value: proxy.size.height
+                        )
+                    }
+                )
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: maximumCardContentHeight,
+                    alignment: .topLeading
+                )
+                .genUICard(isDarkMode: isDarkMode, padding: Layout.cardPadding)
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(statAccessibilityLabel(stat))
             }
+        }
+        .onPreferenceChange(StatCardHeightPreferenceKey.self) { height in
+            maximumCardContentHeight = height
         }
     }
 
@@ -96,5 +122,13 @@ private struct StatCardsView: View {
             label += ", trending down"
         }
         return label
+    }
+}
+
+struct StatCardHeightPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -589,16 +589,17 @@ struct LaTeXMarkdownView: View, Equatable {
     /// Segments content that exceeds the full-parsing cap. LaTeX and table
     /// parsing is still skipped, but the text is split at paragraph
     /// boundaries so no single segment forces an unbounded CoreText
-    /// measurement pass. Fenced code blocks are kept whole so splitting
-    /// never breaks a fence open.
+    /// measurement pass. Fenced code blocks never have a fence split
+    /// open; oversized ones are re-fenced per chunk.
     private nonisolated static func splitLargeContent(_ content: String) -> [ContentSegment] {
         splitFencePreservingSegment(content, baseId: "md")
     }
 
-    /// Splits oversized markdown while keeping every fenced code block in
-    /// its own whole segment, so a split can never leave an opening and
+    /// Splits oversized markdown without ever leaving an opening and
     /// closing fence in different `StructuredText` segments (which would
-    /// render the surrounding text as malformed Markdown).
+    /// render the surrounding text as malformed Markdown): prose is split
+    /// at paragraph boundaries and each fenced code block gets its own
+    /// segment, re-fenced per chunk when the block itself exceeds the cap.
     private nonisolated static func splitFencePreservingSegment(
         _ content: String, baseId: String
     ) -> [ContentSegment] {
@@ -624,9 +625,9 @@ struct LaTeXMarkdownView: View, Equatable {
             if lastIndex < swiftRange.lowerBound {
                 appendMarkdown(String(content[lastIndex..<swiftRange.lowerBound]), at: match.range.location)
             }
-            segments.append(ContentSegment(
-                id: "\(baseId)_code_\(match.range.location)",
-                kind: .markdown(String(content[swiftRange]))
+            segments.append(contentsOf: splitOversizedCodeBlock(
+                String(content[swiftRange]),
+                baseId: "\(baseId)_code_\(match.range.location)"
             ))
             lastIndex = swiftRange.upperBound
         }
@@ -635,6 +636,52 @@ struct LaTeXMarkdownView: View, Equatable {
         }
 
         return segments
+    }
+
+    /// Rewrites a fenced code block that exceeds the segment cap into
+    /// several smaller fenced blocks, repeating the opening fence (with
+    /// its language info) and the closing fence around each chunk. Every
+    /// chunk stays valid Markdown while no single segment forces an
+    /// unbounded CoreText measurement pass.
+    private nonisolated static func splitOversizedCodeBlock(
+        _ block: String, baseId: String
+    ) -> [ContentSegment] {
+        let cap = Constants.Rendering.maxMarkdownSegmentCharacters
+        guard block.count > cap,
+              block.hasSuffix("```"),
+              let headerEnd = block.firstIndex(of: "\n") else {
+            return [ContentSegment(id: baseId, kind: .markdown(block))]
+        }
+        let openingFence = String(block[..<headerEnd])
+        let bodyStart = block.index(after: headerEnd)
+        let bodyEnd = block.index(block.endIndex, offsetBy: -3)
+        guard bodyStart < bodyEnd else {
+            return [ContentSegment(id: baseId, kind: .markdown(block))]
+        }
+
+        var pieces: [Substring] = []
+        var remainder = block[bodyStart..<bodyEnd]
+        while let capIndex = remainder.index(
+            remainder.startIndex, offsetBy: cap, limitedBy: remainder.endIndex
+        ), capIndex != remainder.endIndex {
+            // Prefer splitting after the last newline inside the window so
+            // chunks break between lines instead of mid-line.
+            let window = remainder[..<capIndex]
+            let splitIndex = window.lastIndex(of: "\n").map { remainder.index(after: $0) } ?? capIndex
+            pieces.append(remainder[..<splitIndex])
+            remainder = remainder[splitIndex...]
+        }
+        if !remainder.isEmpty {
+            pieces.append(remainder)
+        }
+
+        return pieces.enumerated().map { index, piece in
+            let body = piece.hasSuffix("\n") ? String(piece) : String(piece) + "\n"
+            return ContentSegment(
+                id: "\(baseId)_part_\(index)",
+                kind: .markdown("\(openingFence)\n\(body)```")
+            )
+        }
     }
 
     private nonisolated static func splitMarkdownSegment(_ text: String, baseId: String) -> [ContentSegment] {

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -448,7 +448,7 @@ struct LaTeXMarkdownView: View, Equatable {
     /// Parse content into segments of markdown and LaTeX
     private nonisolated static func parseContent(_ content: String) -> [ContentSegment] {
         if content.count > Constants.Rendering.maxFullParsingCharacters {
-            return [ContentSegment(id: "md_full_\(content.hashValue)", kind: .markdown(content))]
+            return splitLargeContent(content)
         }
 
         let nsContent = content as NSString
@@ -586,6 +586,47 @@ struct LaTeXMarkdownView: View, Equatable {
         return segments
     }
 
+    /// Segments content that exceeds the full-parsing cap. LaTeX and table
+    /// parsing is still skipped, but the text is split at paragraph
+    /// boundaries so no single segment forces an unbounded CoreText
+    /// measurement pass. Fenced code blocks are kept whole so splitting
+    /// never breaks a fence open.
+    private nonisolated static func splitLargeContent(_ content: String) -> [ContentSegment] {
+        var segments: [ContentSegment] = []
+
+        func appendMarkdown(_ text: String, at location: Int) {
+            guard !text.isEmpty else { return }
+            let baseId = "md_\(location)_\(text.hashValue)"
+            if text.count > Constants.Rendering.maxMarkdownSegmentCharacters {
+                segments.append(contentsOf: splitMarkdownSegment(text, baseId: baseId))
+            } else {
+                segments.append(ContentSegment(id: baseId, kind: .markdown(text)))
+            }
+        }
+
+        let nsContent = content as NSString
+        let fullRange = NSRange(location: 0, length: nsContent.length)
+        let codeMatches = Self.codeBlockRegex?.matches(in: content, options: [], range: fullRange) ?? []
+
+        var lastIndex = content.startIndex
+        for match in codeMatches {
+            guard let swiftRange = Range(match.range, in: content) else { continue }
+            if lastIndex < swiftRange.lowerBound {
+                appendMarkdown(String(content[lastIndex..<swiftRange.lowerBound]), at: match.range.location)
+            }
+            segments.append(ContentSegment(
+                id: "md_code_\(match.range.location)",
+                kind: .markdown(String(content[swiftRange]))
+            ))
+            lastIndex = swiftRange.upperBound
+        }
+        if lastIndex < content.endIndex {
+            appendMarkdown(String(content[lastIndex...]), at: nsContent.length)
+        }
+
+        return segments
+    }
+
     private nonisolated static func splitMarkdownSegment(_ text: String, baseId: String) -> [ContentSegment] {
         let paragraphs = text.components(separatedBy: "\n\n")
         var result: [ContentSegment] = []
@@ -613,7 +654,43 @@ struct LaTeXMarkdownView: View, Equatable {
             ))
         }
 
-        return result
+        // A single paragraph with no blank lines can still exceed the cap;
+        // hard-split it so no segment stays unbounded.
+        return result.flatMap { segment -> [ContentSegment] in
+            guard case .markdown(let text) = segment.kind,
+                  text.count > Constants.Rendering.maxMarkdownSegmentCharacters else {
+                return [segment]
+            }
+            return hardSplitMarkdown(text, baseId: segment.id)
+        }
+    }
+
+    /// Splits markdown into pieces no longer than the segment cap, preferring
+    /// the last newline before the cap so lines stay intact.
+    private nonisolated static func hardSplitMarkdown(_ text: String, baseId: String) -> [ContentSegment] {
+        let cap = Constants.Rendering.maxMarkdownSegmentCharacters
+        var pieces: [ContentSegment] = []
+        var remainder = Substring(text)
+        var subIndex = 0
+
+        while remainder.count > cap {
+            let capIndex = remainder.index(remainder.startIndex, offsetBy: cap)
+            let window = remainder[..<capIndex]
+            let splitIndex = window.lastIndex(of: "\n").map { remainder.index(after: $0) } ?? capIndex
+            pieces.append(ContentSegment(
+                id: "\(baseId)_hard_\(subIndex)",
+                kind: .markdown(String(remainder[..<splitIndex]))
+            ))
+            subIndex += 1
+            remainder = remainder[splitIndex...]
+        }
+        if !remainder.isEmpty {
+            pieces.append(ContentSegment(
+                id: "\(baseId)_hard_\(subIndex)",
+                kind: .markdown(String(remainder))
+            ))
+        }
+        return pieces
     }
 
     private nonisolated static func sanitizeLatex(_ latex: String) -> String {

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -580,7 +580,7 @@ struct LaTeXMarkdownView: View, Equatable {
                   text.count > Constants.Rendering.maxMarkdownSegmentCharacters else {
                 return [segment]
             }
-            return splitMarkdownSegment(text, baseId: segment.id)
+            return splitFencePreservingSegment(text, baseId: segment.id)
         }
 
         return segments
@@ -592,15 +592,25 @@ struct LaTeXMarkdownView: View, Equatable {
     /// measurement pass. Fenced code blocks are kept whole so splitting
     /// never breaks a fence open.
     private nonisolated static func splitLargeContent(_ content: String) -> [ContentSegment] {
+        splitFencePreservingSegment(content, baseId: "md")
+    }
+
+    /// Splits oversized markdown while keeping every fenced code block in
+    /// its own whole segment, so a split can never leave an opening and
+    /// closing fence in different `StructuredText` segments (which would
+    /// render the surrounding text as malformed Markdown).
+    private nonisolated static func splitFencePreservingSegment(
+        _ content: String, baseId: String
+    ) -> [ContentSegment] {
         var segments: [ContentSegment] = []
 
         func appendMarkdown(_ text: String, at location: Int) {
             guard !text.isEmpty else { return }
-            let baseId = "md_\(location)_\(text.hashValue)"
+            let segmentId = "\(baseId)_\(location)_\(text.hashValue)"
             if text.count > Constants.Rendering.maxMarkdownSegmentCharacters {
-                segments.append(contentsOf: splitMarkdownSegment(text, baseId: baseId))
+                segments.append(contentsOf: splitMarkdownSegment(text, baseId: segmentId))
             } else {
-                segments.append(ContentSegment(id: baseId, kind: .markdown(text)))
+                segments.append(ContentSegment(id: segmentId, kind: .markdown(text)))
             }
         }
 
@@ -615,7 +625,7 @@ struct LaTeXMarkdownView: View, Equatable {
                 appendMarkdown(String(content[lastIndex..<swiftRange.lowerBound]), at: match.range.location)
             }
             segments.append(ContentSegment(
-                id: "md_code_\(match.range.location)",
+                id: "\(baseId)_code_\(match.range.location)",
                 kind: .markdown(String(content[swiftRange]))
             ))
             lastIndex = swiftRange.upperBound

--- a/TinfoilChat/Views/MessageAttachmentIndicator.swift
+++ b/TinfoilChat/Views/MessageAttachmentIndicator.swift
@@ -209,6 +209,7 @@ struct ImageViewerOverlay: View {
     @State private var currentIndex: Int
     @State private var dragOffset: CGFloat = 0
     @State private var isDraggingVertically = false
+    @State private var isImageZoomed = false
 
     init(images: [Attachment], initialIndex: Int, onDismiss: @escaping () -> Void) {
         self.images = images
@@ -227,16 +228,24 @@ struct ImageViewerOverlay: View {
 
             TabView(selection: $currentIndex) {
                 ForEach(Array(images.enumerated()), id: \.element.id) { index, attachment in
-                    ZoomableImagePage(attachment: attachment)
-                        .tag(index)
+                    ZoomableImagePage(
+                        attachment: attachment,
+                        isZoomed: $isImageZoomed,
+                        isActive: index == currentIndex
+                    )
+                    .tag(index)
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: images.count > 1 ? .automatic : .never))
             .ignoresSafeArea()
+            .onChange(of: currentIndex) { _, _ in
+                isImageZoomed = false
+            }
             .offset(y: dragOffset)
             .simultaneousGesture(
                 DragGesture(minimumDistance: 20)
                     .onChanged { value in
+                        guard !isImageZoomed else { return }
                         if !isDraggingVertically {
                             isDraggingVertically = abs(value.translation.height) > abs(value.translation.width)
                         }
@@ -332,8 +341,12 @@ private extension Array {
 
 struct ZoomableImagePage: View {
     let attachment: Attachment
+    @Binding var isZoomed: Bool
+    let isActive: Bool
     @State private var scale: CGFloat = 1.0
     @State private var lastScale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
     @State private var decodedImage: UIImage?
 
     private var fullSizeBase64: String? {
@@ -352,6 +365,7 @@ struct ZoomableImagePage: View {
                     .aspectRatio(contentMode: .fit)
                     .accessibilityLabel("Image")
                     .scaleEffect(scale)
+                    .offset(offset)
                     .gesture(
                         MagnifyGesture()
                             .onChanged { value in
@@ -360,12 +374,22 @@ struct ZoomableImagePage: View {
                             .onEnded { _ in
                                 lastScale = max(1.0, scale)
                                 scale = lastScale
+                                if lastScale == 1.0 {
+                                    resetPan()
+                                }
+                                isZoomed = lastScale > 1.0
                             }
                     )
+                    // Pan only while zoomed, so an un-zoomed image never
+                    // steals the TabView's horizontal page gesture or the
+                    // overlay's swipe-down-to-dismiss.
+                    .highPriorityGesture(isZoomed ? panWhenZoomed : nil)
                     .onTapGesture(count: 2) {
                         withAnimation {
                             scale = 1.0
                             lastScale = 1.0
+                            resetPan()
+                            isZoomed = false
                         }
                     }
             } else {
@@ -377,6 +401,13 @@ struct ZoomableImagePage: View {
                         .foregroundStyle(.white.opacity(0.5))
                         .font(.caption)
                 }
+            }
+        }
+        .onChange(of: isActive) { _, active in
+            if !active {
+                scale = 1.0
+                lastScale = 1.0
+                resetPan()
             }
         }
         .task(id: cacheKey) {
@@ -393,5 +424,23 @@ struct ZoomableImagePage: View {
             guard !Task.isCancelled else { return }
             decodedImage = await Base64ImageDecoder.decode(base64: fullSizeBase64, cacheKey: cacheKey)
         }
+    }
+
+    private var panWhenZoomed: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                offset = CGSize(
+                    width: lastOffset.width + value.translation.width,
+                    height: lastOffset.height + value.translation.height
+                )
+            }
+            .onEnded { _ in
+                lastOffset = offset
+            }
+    }
+
+    private func resetPan() {
+        offset = .zero
+        lastOffset = .zero
     }
 }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -31,6 +31,12 @@ struct MessageInputView: View {
         static let defaultHeight: CGFloat = 72
         static let minimumHeight: CGFloat = 72
         static let maximumHeight: CGFloat = 180
+        /// Drafts at or beyond these bounds cannot fit within `maximumHeight`
+        /// at any supported text size, so the editor skips the full TextKit
+        /// measurement pass that `sizeThatFits` would otherwise run over the
+        /// entire draft on the main thread.
+        static let overflowCharacterCount = 2_000
+        static let overflowNewlineCount = 10
     }
     
     @Binding var messageText: String
@@ -959,8 +965,7 @@ struct CustomTextEditor: UIViewRepresentable {
         uiView.isEditable = true
         context.coordinator.refreshAccessibility(uiView)
 
-        let size = uiView.sizeThatFits(CGSize(width: uiView.frame.width, height: CGFloat.greatestFiniteMagnitude))
-        let newHeight = min(MessageInputView.Layout.maximumHeight, max(MessageInputView.Layout.minimumHeight, size.height))
+        let newHeight = context.coordinator.measuredHeight(for: uiView)
 
         if textHeight != newHeight {
             DispatchQueue.main.async {
@@ -977,9 +982,47 @@ struct CustomTextEditor: UIViewRepresentable {
         var parent: CustomTextEditor
         var isEditing = false
         var hasFocusedFromFlag = false
+        private var lastMeasurement: (text: String, width: CGFloat, pointSize: CGFloat, height: CGFloat)?
 
         init(_ parent: CustomTextEditor) {
             self.parent = parent
+        }
+
+        /// Returns the editor height for the current draft, avoiding repeated
+        /// full-document TextKit layout: results are cached per text/width/font
+        /// so keyboard-driven SwiftUI updates don't re-measure an unchanged
+        /// draft, and drafts that trivially exceed the height cap skip
+        /// measurement entirely.
+        func measuredHeight(for textView: UITextView) -> CGFloat {
+            let text = textView.text ?? ""
+            let width = textView.frame.width
+            let pointSize = textView.font?.pointSize ?? 0
+
+            if let last = lastMeasurement,
+               last.text == text, last.width == width, last.pointSize == pointSize {
+                return last.height
+            }
+
+            let height: CGFloat
+            if Self.exceedsMaximumHeight(text) {
+                height = MessageInputView.Layout.maximumHeight
+            } else {
+                let size = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+                height = min(MessageInputView.Layout.maximumHeight, max(MessageInputView.Layout.minimumHeight, size.height))
+            }
+
+            lastMeasurement = (text, width, pointSize, height)
+            return height
+        }
+
+        private static func exceedsMaximumHeight(_ text: String) -> Bool {
+            if text.count >= MessageInputView.Layout.overflowCharacterCount { return true }
+            var newlines = 0
+            for character in text where character == "\n" {
+                newlines += 1
+                if newlines >= MessageInputView.Layout.overflowNewlineCount { return true }
+            }
+            return false
         }
 
         /// Keeps VoiceOver from reading the gray placeholder as if it were
@@ -1038,8 +1081,7 @@ struct CustomTextEditor: UIViewRepresentable {
                 parent.text = textView.text
                 
                 // Calculate and update the height
-                let size = textView.sizeThatFits(CGSize(width: textView.frame.width, height: CGFloat.greatestFiniteMagnitude))
-                let newHeight = min(MessageInputView.Layout.maximumHeight, max(MessageInputView.Layout.minimumHeight, size.height))
+                let newHeight = measuredHeight(for: textView)
                 
                 if parent.textHeight != newHeight {
                     parent.textHeight = newHeight

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1129,12 +1129,32 @@ final class PastingTextView: UITextView {
         UIPasteboard.general.urls?.filter { $0.isFileURL } ?? []
     }
 
+    /// UIKit probes `canPerformAction` many times while assembling the edit
+    /// menu, and each `hasImages`/`urls` read is a synchronous XPC round trip
+    /// to the pasteboard service. Cache the answers per pasteboard
+    /// generation so only the first probe pays that cost.
+    private var cachedPasteboardState: (changeCount: Int, hasImages: Bool, hasFileURLs: Bool)?
+
+    private func pasteboardState() -> (hasImages: Bool, hasFileURLs: Bool) {
+        let changeCount = UIPasteboard.general.changeCount
+        if let cached = cachedPasteboardState, cached.changeCount == changeCount {
+            return (cached.hasImages, cached.hasFileURLs)
+        }
+        let state = (
+            changeCount: changeCount,
+            hasImages: UIPasteboard.general.hasImages,
+            hasFileURLs: !pasteboardFileURLs.isEmpty
+        )
+        cachedPasteboardState = state
+        return (state.hasImages, state.hasFileURLs)
+    }
+
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if action == #selector(paste(_:)) {
-            if allowsImagePaste && UIPasteboard.general.hasImages && onPasteImage != nil {
+            if allowsImagePaste && onPasteImage != nil && pasteboardState().hasImages {
                 return true
             }
-            if !pasteboardFileURLs.isEmpty && onPasteFile != nil {
+            if onPasteFile != nil && pasteboardState().hasFileURLs {
                 return true
             }
         }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -447,6 +447,10 @@ struct MessageInputView: View {
                     .glassEffect(.regular.interactive(), in: .circle)
                     .clipShape(.circle)
                     .tint(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
+                    .disabled(
+                        !viewModel.isLoading
+                        && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
+                    )
                     .accessibilityLabel(viewModel.isLoading ? "Stop generating" : "Send message")
                     .padding(.trailing, 8)
                 }
@@ -547,6 +551,10 @@ struct MessageInputView: View {
                                 .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
                         }
                     }
+                    .disabled(
+                        !viewModel.isLoading
+                        && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
+                    )
                     .accessibilityLabel(viewModel.isLoading ? "Stop generating" : "Send message")
                     .accessibleHitTarget()
                     .padding(.trailing, 8)

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1,8 +1,28 @@
 import SwiftUI
 import UIKit
+import AVFoundation
 import PhotosUI
 import RevenueCat
 import RevenueCatUI
+
+enum CameraPermissionAction: Equatable {
+    case presentCamera
+    case requestAccess
+    case showSettingsAlert
+}
+
+func cameraPermissionAction(for status: AVAuthorizationStatus) -> CameraPermissionAction {
+    switch status {
+    case .authorized:
+        return .presentCamera
+    case .notDetermined:
+        return .requestAccess
+    case .denied, .restricted:
+        return .showSettingsAlert
+    @unknown default:
+        return .showSettingsAlert
+    }
+}
 
 /// Input area for typing messages, including attachments and send button
 struct MessageInputView: View {
@@ -49,6 +69,7 @@ struct MessageInputView: View {
 
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     @State private var pendingPickerAction: PickerAction?
+    @State private var showCameraPermissionAlert = false
 
     private enum PickerAction {
         case camera, photos, files
@@ -88,6 +109,14 @@ struct MessageInputView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("To use voice input, please enable microphone access in Settings.")
+            }
+            .alert("Camera Access Required", isPresented: $showCameraPermissionAlert) {
+                Button("Open Settings") {
+                    openSettings()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("To take photos, please enable camera access in Settings.")
             }
             .alert("Transcription Error", isPresented: showAudioError) {
                 Button("OK", role: .cancel) {}
@@ -134,7 +163,7 @@ struct MessageInputView: View {
                 guard let action = pendingPickerAction else { return }
                 pendingPickerAction = nil
                 switch action {
-                case .camera: viewModel.showCamera = true
+                case .camera: requestCameraAccess()
                 case .photos: viewModel.showPhotoPicker = true
                 case .files: viewModel.showDocumentPicker = true
                 }
@@ -620,6 +649,25 @@ struct MessageInputView: View {
             } else {
                 await viewModel.startAudioRecording()
             }
+        }
+    }
+
+    private func requestCameraAccess() {
+        switch cameraPermissionAction(for: AVCaptureDevice.authorizationStatus(for: .video)) {
+        case .presentCamera:
+            viewModel.showCamera = true
+        case .requestAccess:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        viewModel.showCamera = true
+                    } else {
+                        showCameraPermissionAlert = true
+                    }
+                }
+            }
+        case .showSettingsAlert:
+            showCameraPermissionAlert = true
         }
     }
 

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -169,7 +169,12 @@ struct MessageTableView: UIViewRepresentable {
 
                 let coordinator = context.coordinator
                 DispatchQueue.main.async {
-                    guard let currentMessage = coordinator.parent.messages.last else { return }
+                    // The chat may have been swapped (e.g. a new chat created on
+                    // foregrounding) between enqueue and execution; updating the
+                    // stale wrapper or recalculating heights against the old row
+                    // set would desync the table from its datasource.
+                    guard coordinator.lastChatId == currentChatId,
+                          let currentMessage = coordinator.parent.messages.last else { return }
 
                     wrapper.update(
                         message: currentMessage,
@@ -181,7 +186,8 @@ struct MessageTableView: UIViewRepresentable {
                         messageIndex: coordinator.parent.messages.count - 1
                     )
 
-                    if needsBufferExtension && !coordinator.isKeyboardTransitioning {
+                    if needsBufferExtension && !coordinator.isKeyboardTransitioning &&
+                        tableView.numberOfRows(inSection: 0) == coordinator.parent.messages.count {
                         tableView.beginUpdates()
                         tableView.endUpdates()
                     }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -977,6 +977,7 @@ private struct LongMessageDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
+    @State private var showSelectText = false
 
     var body: some View {
         NavigationStack {
@@ -1003,6 +1004,16 @@ private struct LongMessageDetailView: View {
                         dismiss()
                     }
                 }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Select Text") {
+                        showSelectText = true
+                    }
+                }
+            }
+            .sheet(isPresented: $showSelectText) {
+                UserMessageSelectView(content: message.content)
+                    .presentationDetents([.medium, .large])
+                    .iPadSheetSizing()
             }
         }
         .preferredColorScheme(.dark)

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1367,6 +1367,15 @@ struct ThoughtsSheetView: View {
     let generationTimeSeconds: Double?
     let isDarkMode: Bool
     @Environment(\.dismiss) private var dismiss
+    /// Chunks rebuilt from `thinkingText` when the message was loaded from
+    /// storage, where streaming chunks are not persisted. Chunked (and
+    /// laid out lazily) so a very large thought never becomes one Text view
+    /// whose CoreText layout blocks the main thread.
+    @State private var reconstructedChunks: [ThinkingChunk]? = nil
+
+    private var displayChunks: [ThinkingChunk] {
+        thinkingChunks.isEmpty ? (reconstructedChunks ?? []) : thinkingChunks
+    }
 
     private var titleText: String {
         if let seconds = generationTimeSeconds {
@@ -1378,16 +1387,15 @@ struct ThoughtsSheetView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    if !thinkingChunks.isEmpty {
-                        ForEach(thinkingChunks) { chunk in
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if !displayChunks.isEmpty {
+                        ForEach(displayChunks) { chunk in
                             ThinkingChunkView(chunk: chunk, isDarkMode: isDarkMode)
                                 .equatable()
                         }
-                    } else {
-                        Text(thinkingText)
-                            .font(.system(.body))
-                            .foregroundColor(isDarkMode ? .white.opacity(0.9) : Color.black.opacity(0.8))
+                    } else if !thinkingText.isEmpty {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
                     }
                 }
                 .padding(16)
@@ -1399,6 +1407,13 @@ struct ThoughtsSheetView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .task {
+                guard thinkingChunks.isEmpty, reconstructedChunks == nil, !thinkingText.isEmpty else { return }
+                let text = thinkingText
+                reconstructedChunks = await Task.detached {
+                    ThinkingTextChunker.chunk(text)
+                }.value
             }
         }
     }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -981,7 +981,15 @@ private struct LongMessageDetailView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                MarkdownText(content: message.content, isDarkMode: colorScheme == .dark)
+                // Inline Textual selection installs a custom UITextInput per
+                // fragment, whose first-responder pasteboard warm-up has hung
+                // the main thread on very long messages. Above the cap users
+                // still get plain-text selection via the Select Text sheet.
+                MarkdownText(
+                    content: message.content,
+                    isDarkMode: colorScheme == .dark,
+                    textSelectionEnabled: message.content.count <= Constants.Rendering.maxInlineSelectionCharacters
+                )
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(20)
             }
@@ -1248,17 +1256,21 @@ struct MarkdownText: View {
     let content: String
     let isDarkMode: Bool
     let horizontalPadding: CGFloat
+    let textSelectionEnabled: Bool
 
-    init(content: String, isDarkMode: Bool, horizontalPadding: CGFloat = 0) {
+    init(content: String, isDarkMode: Bool, horizontalPadding: CGFloat = 0, textSelectionEnabled: Bool = true) {
         self.content = content
         self.isDarkMode = isDarkMode
         self.horizontalPadding = horizontalPadding
+        self.textSelectionEnabled = textSelectionEnabled
     }
 
     var body: some View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
-            .textual.textSelection(.enabled)
+            .if(textSelectionEnabled) { view in
+                view.textual.textSelection(.enabled)
+            }
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, horizontalPadding)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -339,12 +339,12 @@ struct SettingsView: View {
     
     /// Shared destructive cleanup used by both "Delete Everything" and "Delete Account".
     private func performFullDataCleanup() async {
+        await ProfileManager.shared.clearLocalProfileForAccountRemoval()
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.hasLaunchedBefore)
         await chatViewModel.clearAllChatsFromDevice()
         settings.clearAllSettings()
-        ProfileManager.shared.clearProfile()
     }
 
     private var accountSection: some View {

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -533,12 +533,17 @@ struct SettingsView: View {
         Section {
             Toggle("Haptic Feedback", isOn: $settings.hapticFeedbackEnabled)
                 .tint(Color.accentPrimary)
-            Toggle("Generative UI", isOn: $settings.genUIEnabled)
-                .tint(Color.accentPrimary)
+            Toggle(isOn: $settings.genUIEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Generative UI")
+                    Text("Let the AI render interactive widgets like charts and timelines. When off, no tool capabilities are sent to the model.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .tint(Color.accentPrimary)
         } header: {
             Text("Preferences")
-        } footer: {
-            Text("Let the AI render interactive widgets like charts and timelines. When off, no tool capabilities are sent to the model.")
         }
         .listRowBackground(Color.cardSurface(for: colorScheme))
     }

--- a/TinfoilChatTests/AttachmentProcessingTests.swift
+++ b/TinfoilChatTests/AttachmentProcessingTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import TinfoilChat
+
+@Suite("Attachment Processing Tests")
+struct AttachmentProcessingTests {
+    @Test("Only completed attachments can be sent")
+    func onlyCompletedAttachmentsAreReady() {
+        let completed = Attachment(
+            type: .document,
+            fileName: "complete.txt",
+            processingState: .completed
+        )
+        let processing = Attachment(
+            type: .image,
+            fileName: "processing.jpg",
+            processingState: .processing
+        )
+        let failed = Attachment(
+            type: .document,
+            fileName: "failed.pdf",
+            processingState: .failed
+        )
+
+        #expect(attachmentsAreReadyToSend([completed]))
+        #expect(!attachmentsAreReadyToSend([completed, processing]))
+        #expect(!attachmentsAreReadyToSend([failed]))
+    }
+}

--- a/TinfoilChatTests/CameraPermissionTests.swift
+++ b/TinfoilChatTests/CameraPermissionTests.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Camera Permission Tests")
+struct CameraPermissionTests {
+    @Test("Presents the camera when access is authorized")
+    func presentsCameraWhenAuthorized() {
+        #expect(cameraPermissionAction(for: .authorized) == .presentCamera)
+    }
+
+    @Test("Requests access when permission is undetermined")
+    func requestsUndeterminedAccess() {
+        #expect(cameraPermissionAction(for: .notDetermined) == .requestAccess)
+    }
+
+    @Test("Shows Settings guidance when camera access is unavailable")
+    func showsSettingsGuidance() {
+        #expect(cameraPermissionAction(for: .denied) == .showSettingsAlert)
+        #expect(cameraPermissionAction(for: .restricted) == .showSettingsAlert)
+    }
+}

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -207,6 +207,45 @@ struct ProfileMergeTests {
         #expect(result.conflicts.isEmpty)
     }
 
+    @Test("keeps the local value when the remote omits a field")
+    func preservesLocalOnRemoteOmission() {
+        let baseline = ProfileData(nickname: "Ada", chatFont: "serif")
+        var local = ProfileData(nickname: "Ada", chatFont: "serif")
+        local.fieldClocks = ["chatFont": EditClock(v: 3, w: "A")]
+        // Remote comes from a client that does not model chatFont.
+        var remote = ProfileData(nickname: "Ada")
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline,
+            local: trusted(local),
+            remote: remote
+        )
+
+        #expect(result.merged.chatFont == "serif")
+        #expect(result.conflicts.isEmpty)
+        #expect(result.merged.fieldClocks?["chatFont"] == EditClock(v: 3, w: "A"))
+    }
+
+    @Test("keeps the higher clock when both sides wrote the same value")
+    func keepsHigherClockOnEqualValues() {
+        let baseline = ProfileData(nickname: "Ada")
+        var local = ProfileData(nickname: "Grace")
+        local.fieldClocks = ["nickname": EditClock(v: 5, w: "A")]
+        var remote = ProfileData(nickname: "Grace")
+        remote.fieldClocks = ["nickname": EditClock(v: 9, w: "B")]
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline,
+            local: trusted(local),
+            remote: trusted(remote)
+        )
+
+        #expect(result.merged.nickname == "Grace")
+        #expect(result.merged.fieldClocks?["nickname"] == EditClock(v: 9, w: "B"))
+        #expect(result.conflicts.isEmpty)
+    }
+
     @Test("retains local value and reports ambiguous conflict")
     func reportsAmbiguousConflict() {
         let baseline = ProfileData(nickname: "Ada")

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -153,6 +153,76 @@ struct ProfileMergeTests {
         let fields = ProfileMerge.changedProfileFields(local: local, baseline: baseline)
         #expect(Set(fields) == Set(["nickname", "traits"]))
     }
+
+    @Test("adopts populated remote fields when local stayed empty")
+    func staleEmptyAdoptsRemote() {
+        let baseline = ProfileData(nickname: "", customSystemPrompt: "")
+        let local = baseline
+        var remote = ProfileData(nickname: "Ada", customSystemPrompt: "Be concise")
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline,
+            local: local,
+            remote: remote
+        )
+
+        #expect(result.merged.nickname == "Ada")
+        #expect(result.merged.customSystemPrompt == "Be concise")
+        #expect(result.conflicts.isEmpty)
+    }
+
+    @Test("combines independent local and remote edits")
+    func combinesIndependentEdits() {
+        let baseline = ProfileData(nickname: "Ada", profession: "Engineer")
+        let local = ProfileData(nickname: "Grace", profession: "Engineer")
+        var remote = ProfileData(nickname: "Ada", profession: "Researcher")
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline,
+            local: local,
+            remote: remote
+        )
+
+        #expect(result.merged.nickname == "Grace")
+        #expect(result.merged.profession == "Researcher")
+        #expect(result.conflicts.isEmpty)
+    }
+
+    @Test("preserves an intentional local reset")
+    func preservesIntentionalReset() {
+        let baseline = ProfileData(customSystemPrompt: "Use headings")
+        let local = ProfileData(customSystemPrompt: "")
+        var remote = baseline
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline,
+            local: local,
+            remote: remote
+        )
+
+        #expect(result.merged.customSystemPrompt == "")
+        #expect(result.conflicts.isEmpty)
+    }
+
+    @Test("retains local value and reports ambiguous conflict")
+    func reportsAmbiguousConflict() {
+        let baseline = ProfileData(nickname: "Ada")
+        let local = ProfileData(nickname: "Grace")
+        var remote = ProfileData(nickname: "Lin")
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline,
+            local: local,
+            remote: remote
+        )
+
+        #expect(result.merged.nickname == "Grace")
+        #expect(result.conflicts == ["nickname"])
+    }
 }
 
 @Suite("Clock-aware conflict resolution")

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -50,6 +50,15 @@ struct SharedImportStoreTests {
         #expect(fixture.store.pendingRequests().isEmpty)
     }
 
+    @Test("Keeps the extension when truncating an overlong file name")
+    func keepsExtensionWhenTruncating() {
+        let longStem = String(repeating: "a", count: 300)
+        let sanitized = SharedImportStore.sanitizedFileName("\(longStem).pdf")
+
+        #expect(sanitized.count <= SharedImportConfiguration.maximumFileNameLength)
+        #expect(sanitized.hasSuffix(".pdf"))
+    }
+
     @Test("Ignores requests with corrupted manifests")
     func ignoresCorruptedManifest() throws {
         let fixture = try makeFixture()

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+@testable import TinfoilChat
+
+@Suite("Shared Import Store Tests")
+struct SharedImportStoreTests {
+    @Test("Classifies supported images and documents")
+    func classifiesSupportedTypes() {
+        #expect(
+            SharedImportClassifier.kind(
+                typeIdentifier: UTType.png.identifier,
+                fileName: "photo.png"
+            ) == .image
+        )
+        #expect(
+            SharedImportClassifier.kind(
+                typeIdentifier: UTType.pdf.identifier,
+                fileName: "document.pdf"
+            ) == .document
+        )
+        #expect(
+            SharedImportClassifier.kind(
+                typeIdentifier: UTType.movie.identifier,
+                fileName: "video.pdf"
+            ) == nil
+        )
+    }
+
+    @Test("Persists and removes a shared attachment")
+    func persistsAndRemovesSharedAttachment() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let sourceURL = fixture.rootURL.appendingPathComponent("source.pdf")
+        let sourceData = Data("%PDF-1.7 shared document".utf8)
+        try sourceData.write(to: sourceURL)
+
+        let request = try fixture.store.enqueue(
+            sourceURL: sourceURL,
+            typeIdentifier: UTType.pdf.identifier,
+            originalFileName: "../../Quarterly Report?.pdf"
+        )
+
+        #expect(request.item.originalFileName == "Quarterly Report_.pdf")
+        #expect(fixture.store.pendingRequests() == [request])
+        #expect(try Data(contentsOf: fixture.store.payloadURL(for: request)) == sourceData)
+
+        fixture.store.removeRequest(id: request.id)
+        #expect(fixture.store.pendingRequests().isEmpty)
+    }
+
+    @Test("Ignores requests with corrupted manifests")
+    func ignoresCorruptedManifest() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let sourceURL = fixture.rootURL.appendingPathComponent("source.txt")
+        try Data("Shared text".utf8).write(to: sourceURL)
+
+        let request = try fixture.store.enqueue(
+            sourceURL: sourceURL,
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "Notes.txt"
+        )
+        let manifestURL = fixture.inboxURL
+            .appendingPathComponent(request.id.uuidString.lowercased(), isDirectory: true)
+            .appendingPathComponent(SharedImportConfiguration.manifestFileName)
+        try Data("invalid".utf8).write(to: manifestURL)
+
+        #expect(fixture.store.pendingRequests().isEmpty)
+    }
+
+    private func makeFixture() throws -> (
+        store: SharedImportStore,
+        rootURL: URL,
+        inboxURL: URL
+    ) {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        let inboxURL = rootURL.appendingPathComponent("ShareInbox", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: rootURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        return (
+            try SharedImportStore(inboxURL: inboxURL),
+            rootURL,
+            inboxURL
+        )
+    }
+}

--- a/TinfoilChatTests/StatCardsLayoutTests.swift
+++ b/TinfoilChatTests/StatCardsLayoutTests.swift
@@ -1,0 +1,17 @@
+import CoreGraphics
+import Testing
+@testable import TinfoilChat
+
+@Suite("Stat Cards Layout Tests")
+struct StatCardsLayoutTests {
+    @Test("Uses the tallest content height for every card")
+    func usesTallestContentHeight() {
+        var height = StatCardHeightPreferenceKey.defaultValue
+
+        StatCardHeightPreferenceKey.reduce(value: &height) { 72 }
+        StatCardHeightPreferenceKey.reduce(value: &height) { 128 }
+        StatCardHeightPreferenceKey.reduce(value: &height) { 96 }
+
+        #expect(height == 128)
+    }
+}

--- a/TinfoilShareExtension/Info.plist
+++ b/TinfoilShareExtension/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Tinfoil</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>extensionItems.@count == 1 AND SUBQUERY(extensionItems, $extensionItem, $extensionItem.attachments.@count == 1 AND SUBQUERY($extensionItem.attachments, $attachment, ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.adobe.pdf" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.html" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.comma-separated-values-text" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.json" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.xml" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "net.daringfireball.markdown" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.openxmlformats.wordprocessingml.document" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.openxmlformats.presentationml.presentation" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.openxmlformats.spreadsheetml.sheet").@count == 1).@count == 1</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/TinfoilShareExtension/ShareViewController.swift
+++ b/TinfoilShareExtension/ShareViewController.swift
@@ -1,0 +1,260 @@
+import UIKit
+import UniformTypeIdentifiers
+
+final class ShareViewController: UIViewController {
+    private enum Layout {
+        static let contentSpacing: CGFloat = 20
+        static let buttonSpacing: CGFloat = 12
+        static let horizontalPadding: CGFloat = 24
+        static let verticalPadding: CGFloat = 28
+        static let buttonHeight: CGFloat = 50
+    }
+
+    private let titleLabel = UILabel()
+    private let detailLabel = UILabel()
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
+    private lazy var cancelButton = makeButton(title: "Cancel", primary: false, action: #selector(cancel))
+    private lazy var addButton = makeButton(title: "Add to Tinfoil", primary: true, action: #selector(addToTinfoil))
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+        updateSharedItemDetails()
+    }
+
+    private func configureView() {
+        view.backgroundColor = .systemBackground
+
+        titleLabel.text = "Share with Tinfoil"
+        titleLabel.font = .preferredFont(forTextStyle: .title2)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.textAlignment = .center
+
+        detailLabel.font = .preferredFont(forTextStyle: .body)
+        detailLabel.adjustsFontForContentSizeCategory = true
+        detailLabel.textColor = .secondaryLabel
+        detailLabel.textAlignment = .center
+        detailLabel.numberOfLines = 3
+
+        activityIndicator.hidesWhenStopped = true
+
+        let buttonStack = UIStackView(arrangedSubviews: [cancelButton, addButton])
+        buttonStack.axis = .horizontal
+        buttonStack.spacing = Layout.buttonSpacing
+        buttonStack.distribution = .fillEqually
+
+        let contentStack = UIStackView(arrangedSubviews: [
+            titleLabel,
+            detailLabel,
+            activityIndicator,
+            buttonStack,
+        ])
+        contentStack.axis = .vertical
+        contentStack.spacing = Layout.contentSpacing
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                constant: Layout.horizontalPadding
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: -Layout.horizontalPadding
+            ),
+            contentStack.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: Layout.verticalPadding
+            ),
+            contentStack.bottomAnchor.constraint(
+                lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -Layout.verticalPadding
+            ),
+            cancelButton.heightAnchor.constraint(equalToConstant: Layout.buttonHeight),
+            addButton.heightAnchor.constraint(equalToConstant: Layout.buttonHeight),
+        ])
+    }
+
+    private func updateSharedItemDetails() {
+        guard let provider = sharedItemProvider(),
+              let typeIdentifier = supportedTypeIdentifier(for: provider),
+              let kind = SharedImportClassifier.kind(
+                typeIdentifier: typeIdentifier,
+                fileName: provider.suggestedName
+              ) else {
+            detailLabel.text = SharedImportError.unsupportedType.localizedDescription
+            addButton.isEnabled = false
+            return
+        }
+
+        let itemName = provider.suggestedName ?? (kind == .image ? "Image" : "Document")
+        detailLabel.text = "\(itemName)\nIt will be attached when you open Tinfoil."
+    }
+
+    @objc private func cancel() {
+        extensionContext?.cancelRequest(
+            withError: NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
+        )
+    }
+
+    @objc private func addToTinfoil() {
+        guard let provider = sharedItemProvider(),
+              let typeIdentifier = supportedTypeIdentifier(for: provider) else {
+            showError(SharedImportError.unsupportedType)
+            return
+        }
+
+        setSaving(true)
+        provider.loadFileRepresentation(forTypeIdentifier: typeIdentifier) { [weak self] url, error in
+            guard let self else { return }
+
+            if let url {
+                saveSharedItem(
+                    from: url,
+                    provider: provider,
+                    typeIdentifier: typeIdentifier
+                )
+            } else {
+                loadDataFallback(
+                    provider: provider,
+                    typeIdentifier: typeIdentifier,
+                    underlyingError: error
+                )
+            }
+        }
+    }
+
+    private func loadDataFallback(
+        provider: NSItemProvider,
+        typeIdentifier: String,
+        underlyingError: Error?
+    ) {
+        provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { [weak self] data, error in
+            guard let self else { return }
+            guard let data else {
+                showError(error ?? underlyingError ?? SharedImportError.invalidFile)
+                return
+            }
+
+            let temporaryURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString.lowercased())
+            do {
+                try data.write(to: temporaryURL, options: .atomic)
+                saveSharedItem(
+                    from: temporaryURL,
+                    provider: provider,
+                    typeIdentifier: typeIdentifier
+                )
+                try? FileManager.default.removeItem(at: temporaryURL)
+            } catch {
+                showError(error)
+            }
+        }
+    }
+
+    private func saveSharedItem(
+        from sourceURL: URL,
+        provider: NSItemProvider,
+        typeIdentifier: String
+    ) {
+        do {
+            let store = try SharedImportStore()
+            _ = try store.enqueue(
+                sourceURL: sourceURL,
+                typeIdentifier: typeIdentifier,
+                originalFileName: sharedFileName(
+                    provider: provider,
+                    typeIdentifier: typeIdentifier
+                )
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.extensionContext?.completeRequest(returningItems: nil)
+            }
+        } catch {
+            showError(error)
+        }
+    }
+
+    private func sharedItemProvider() -> NSItemProvider? {
+        let providers = (extensionContext?.inputItems as? [NSExtensionItem])?
+            .flatMap { $0.attachments ?? [] } ?? []
+        guard providers.count == 1 else {
+            return nil
+        }
+        return providers[0]
+    }
+
+    private func supportedTypeIdentifier(for provider: NSItemProvider) -> String? {
+        if let imageType = provider.registeredTypeIdentifiers.first(where: {
+            UTType($0)?.conforms(to: .image) == true
+        }) {
+            return imageType
+        }
+
+        return provider.registeredTypeIdentifiers.first {
+            SharedImportClassifier.kind(
+                typeIdentifier: $0,
+                fileName: provider.suggestedName
+            ) == .document
+        }
+    }
+
+    private func sharedFileName(
+        provider: NSItemProvider,
+        typeIdentifier: String
+    ) -> String {
+        if let suggestedName = provider.suggestedName, !suggestedName.isEmpty {
+            return suggestedName
+        }
+
+        let kind = SharedImportClassifier.kind(typeIdentifier: typeIdentifier, fileName: nil)
+        let baseName = kind == .image ? "Shared Image" : "Shared Document"
+        guard let fileExtension = UTType(typeIdentifier)?.preferredFilenameExtension else {
+            return baseName
+        }
+        return "\(baseName).\(fileExtension)"
+    }
+
+    private func setSaving(_ isSaving: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            self?.addButton.isEnabled = !isSaving
+            self?.cancelButton.isEnabled = !isSaving
+            if isSaving {
+                self?.activityIndicator.startAnimating()
+            } else {
+                self?.activityIndicator.stopAnimating()
+            }
+        }
+    }
+
+    private func showError(_ error: Error) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            setSaving(false)
+            let alert = UIAlertController(
+                title: "Unable to Add Attachment",
+                message: error.localizedDescription,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            present(alert, animated: true)
+        }
+    }
+
+    private func makeButton(
+        title: String,
+        primary: Bool,
+        action: Selector
+    ) -> UIButton {
+        var configuration = primary
+            ? UIButton.Configuration.filled()
+            : UIButton.Configuration.gray()
+        configuration.title = title
+        configuration.cornerStyle = .large
+
+        let button = UIButton(configuration: configuration)
+        button.addTarget(self, action: action, for: .touchUpInside)
+        return button
+    }
+}

--- a/TinfoilShareExtension/TinfoilShareExtension.entitlements
+++ b/TinfoilShareExtension/TinfoilShareExtension.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>webcredentials:tinfoil.sh</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.sh.tinfoil.TinfoilChat</string>

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -8,6 +8,9 @@ enum SharedImportConfiguration {
     static let maximumFileNameLength = 120
     static let maximumImageSizeBytes: Int64 = 10 * 1024 * 1024
     static let maximumDocumentSizeBytes: Int64 = 20 * 1024 * 1024
+    /// Hidden staging directories older than this are treated as abandoned
+    /// by an interrupted share and swept from the app-group inbox.
+    static let staleStagingLifetimeSeconds: TimeInterval = 24 * 60 * 60
     static let supportedDocumentExtensions: Set<String> = [
         "pdf", "docx", "pptx", "xlsx", "txt", "md", "csv", "html", "json", "xml",
     ]

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -1,0 +1,104 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum SharedImportConfiguration {
+    static let appGroupIdentifier = "group.sh.tinfoil.TinfoilChat"
+    static let inboxDirectoryName = "ShareInbox"
+    static let manifestFileName = "request.json"
+    static let maximumFileNameLength = 120
+    static let maximumImageSizeBytes: Int64 = 10 * 1024 * 1024
+    static let maximumDocumentSizeBytes: Int64 = 20 * 1024 * 1024
+    static let supportedDocumentExtensions: Set<String> = [
+        "pdf", "docx", "pptx", "xlsx", "txt", "md", "csv", "html", "json", "xml",
+    ]
+}
+
+enum SharedImportKind: String, Codable, Equatable {
+    case image
+    case document
+
+    var maximumSizeBytes: Int64 {
+        switch self {
+        case .image:
+            return SharedImportConfiguration.maximumImageSizeBytes
+        case .document:
+            return SharedImportConfiguration.maximumDocumentSizeBytes
+        }
+    }
+}
+
+struct SharedImportRequest: Codable, Equatable, Identifiable {
+    let id: UUID
+    let createdAt: Date
+    let item: SharedImportItem
+}
+
+struct SharedImportItem: Codable, Equatable, Identifiable {
+    let id: UUID
+    let kind: SharedImportKind
+    let typeIdentifier: String
+    let originalFileName: String
+    let stagedFileName: String
+    let byteCount: Int64
+}
+
+enum SharedImportClassifier {
+    static func kind(typeIdentifier: String, fileName: String?) -> SharedImportKind? {
+        let contentType = UTType(typeIdentifier)
+        if contentType?.conforms(to: .image) == true {
+            return .image
+        }
+
+        let fileExtension = fileName
+            .map { URL(fileURLWithPath: $0).pathExtension.lowercased() }
+            .flatMap { $0.isEmpty ? nil : $0 }
+            ?? contentType?.preferredFilenameExtension?.lowercased()
+
+        guard let fileExtension,
+              SharedImportConfiguration.supportedDocumentExtensions.contains(fileExtension) else {
+            return nil
+        }
+
+        guard let contentType else {
+            return .document
+        }
+        if contentType == .data || contentType == .item || contentType == .content {
+            return .document
+        }
+        guard let inferredType = UTType(filenameExtension: fileExtension),
+              contentType.conforms(to: inferredType) || inferredType.conforms(to: contentType) else {
+            return nil
+        }
+        return .document
+    }
+}
+
+enum SharedImportError: LocalizedError {
+    case sharedContainerUnavailable
+    case unsupportedType
+    case invalidFile
+    case fileTooLarge(kind: SharedImportKind, size: Int64)
+    case invalidRequest
+
+    var errorDescription: String? {
+        switch self {
+        case .sharedContainerUnavailable:
+            return "Tinfoil's shared storage is unavailable."
+        case .unsupportedType:
+            return "This file type is not supported by Tinfoil."
+        case .invalidFile:
+            return "The shared file could not be read."
+        case .fileTooLarge(let kind, let size):
+            let maximumSize = kind.maximumSizeBytes / 1_048_576
+            let sizeInMegabytes = Double(size) / 1_048_576
+            return String(
+                format: "This %@ is too large (%.1f MB). Maximum is %lld MB.",
+                kind == .image ? "image" : "file",
+                sizeInMegabytes,
+                maximumSize
+            )
+        case .invalidRequest:
+            return "The shared file request is invalid."
+        }
+    }
+}

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -81,7 +81,6 @@ struct SharedImportStore {
         )
         let requestDirectory = directoryURL(for: requestID)
 
-        try? fileManager.removeItem(at: temporaryDirectory)
         try fileManager.createDirectory(
             at: temporaryDirectory,
             withIntermediateDirectories: false,
@@ -115,6 +114,8 @@ struct SharedImportStore {
     }
 
     func pendingRequests() -> [SharedImportRequest] {
+        removeStaleTemporaryDirectories()
+
         let directories = (try? fileManager.contentsOfDirectory(
             at: inboxURL,
             includingPropertiesForKeys: [.isDirectoryKey],
@@ -124,6 +125,30 @@ struct SharedImportStore {
         return directories
             .compactMap { loadRequest(from: $0) }
             .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    /// Removes staging directories abandoned by an interrupted share (the
+    /// extension was killed between copy and publish), so they don't retain
+    /// app-group storage indefinitely. Only directories older than the
+    /// staging lifetime are removed, to never race a share in progress.
+    private func removeStaleTemporaryDirectories() {
+        let cutoff = Date().addingTimeInterval(
+            -SharedImportConfiguration.staleStagingLifetimeSeconds
+        )
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: inboxURL,
+            includingPropertiesForKeys: [.creationDateKey],
+            options: []
+        )) ?? []
+        for url in entries {
+            let name = url.lastPathComponent
+            guard name.hasPrefix("."), name.hasSuffix(".tmp") else { continue }
+            let created = (try? url.resourceValues(forKeys: [.creationDateKey]))?
+                .creationDate ?? .distantPast
+            if created < cutoff {
+                try? fileManager.removeItem(at: url)
+            }
+        }
     }
 
     func payloadURL(for request: SharedImportRequest) throws -> URL {
@@ -166,7 +191,20 @@ struct SharedImportStore {
         let sanitized = String(sanitizedScalars)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let fallbackName = sanitized.isEmpty ? "Shared File" : sanitized
-        return String(fallbackName.prefix(SharedImportConfiguration.maximumFileNameLength))
+        let maxLength = SharedImportConfiguration.maximumFileNameLength
+        guard fallbackName.count > maxLength else { return fallbackName }
+
+        // Truncate the stem, never the extension: enqueue and payload
+        // validation both classify by the final extension, so dropping
+        // it would stage a file that later fails validation silently.
+        let fileExtension = URL(fileURLWithPath: fallbackName).pathExtension
+        guard !fileExtension.isEmpty, fileExtension.count + 1 < maxLength else {
+            return String(fallbackName.prefix(maxLength))
+        }
+        let stem = URL(fileURLWithPath: fallbackName)
+            .deletingPathExtension()
+            .lastPathComponent
+        return "\(stem.prefix(maxLength - fileExtension.count - 1)).\(fileExtension)"
     }
 
     private func loadRequest(from directoryURL: URL) -> SharedImportRequest? {

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -1,0 +1,229 @@
+import Foundation
+import UniformTypeIdentifiers
+
+struct SharedImportStore {
+    private let fileManager: FileManager
+    let inboxURL: URL
+
+    init(fileManager: FileManager = .default, inboxURL: URL? = nil) throws {
+        self.fileManager = fileManager
+
+        if let inboxURL {
+            self.inboxURL = inboxURL
+        } else {
+            guard let containerURL = fileManager.containerURL(
+                forSecurityApplicationGroupIdentifier: SharedImportConfiguration.appGroupIdentifier
+            ) else {
+                throw SharedImportError.sharedContainerUnavailable
+            }
+            self.inboxURL = containerURL
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent(SharedImportConfiguration.inboxDirectoryName, isDirectory: true)
+        }
+
+        try fileManager.createDirectory(
+            at: self.inboxURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+    }
+
+    @discardableResult
+    func enqueue(
+        sourceURL: URL,
+        typeIdentifier: String,
+        originalFileName: String
+    ) throws -> SharedImportRequest {
+        guard let kind = SharedImportClassifier.kind(
+            typeIdentifier: typeIdentifier,
+            fileName: originalFileName
+        ) else {
+            throw SharedImportError.unsupportedType
+        }
+
+        let sourceValues = try sourceURL.resourceValues(
+            forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
+        )
+        guard sourceValues.isRegularFile == true, sourceValues.isSymbolicLink != true else {
+            throw SharedImportError.invalidFile
+        }
+
+        let byteCount = Int64(sourceValues.fileSize ?? 0)
+        guard byteCount <= kind.maximumSizeBytes else {
+            throw SharedImportError.fileTooLarge(kind: kind, size: byteCount)
+        }
+
+        let requestID = UUID()
+        let itemID = UUID()
+        let fileName = Self.sanitizedFileName(originalFileName)
+        let stagedFileName = Self.stagedFileName(
+            id: itemID,
+            originalFileName: fileName,
+            typeIdentifier: typeIdentifier
+        )
+        let request = SharedImportRequest(
+            id: requestID,
+            createdAt: Date(),
+            item: SharedImportItem(
+                id: itemID,
+                kind: kind,
+                typeIdentifier: typeIdentifier,
+                originalFileName: fileName,
+                stagedFileName: stagedFileName,
+                byteCount: byteCount
+            )
+        )
+
+        let temporaryDirectory = inboxURL.appendingPathComponent(
+            ".\(requestID.uuidString.lowercased()).tmp",
+            isDirectory: true
+        )
+        let requestDirectory = directoryURL(for: requestID)
+
+        try? fileManager.removeItem(at: temporaryDirectory)
+        try fileManager.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: false,
+            attributes: nil
+        )
+
+        do {
+            let stagedURL = temporaryDirectory.appendingPathComponent(stagedFileName)
+            try fileManager.copyItem(at: sourceURL, to: stagedURL)
+
+            let copiedSize = try fileSize(at: stagedURL)
+            guard copiedSize == byteCount else {
+                throw SharedImportError.invalidFile
+            }
+
+            let manifestURL = temporaryDirectory.appendingPathComponent(
+                SharedImportConfiguration.manifestFileName
+            )
+            let encoder = JSONEncoder()
+            try encoder.encode(request).write(to: manifestURL, options: .atomic)
+
+            protectAndExcludeFromBackup(stagedURL)
+            protectAndExcludeFromBackup(manifestURL)
+            protectAndExcludeFromBackup(temporaryDirectory)
+            try fileManager.moveItem(at: temporaryDirectory, to: requestDirectory)
+            return request
+        } catch {
+            try? fileManager.removeItem(at: temporaryDirectory)
+            throw error
+        }
+    }
+
+    func pendingRequests() -> [SharedImportRequest] {
+        let directories = (try? fileManager.contentsOfDirectory(
+            at: inboxURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        return directories
+            .compactMap { loadRequest(from: $0) }
+            .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func payloadURL(for request: SharedImportRequest) throws -> URL {
+        guard request.item.stagedFileName == URL(
+            fileURLWithPath: request.item.stagedFileName
+        ).lastPathComponent else {
+            throw SharedImportError.invalidRequest
+        }
+
+        let payloadURL = directoryURL(for: request.id)
+            .appendingPathComponent(request.item.stagedFileName)
+        let values = try payloadURL.resourceValues(
+            forKeys: [.isRegularFileKey, .isSymbolicLinkKey]
+        )
+        guard values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              try fileSize(at: payloadURL) == request.item.byteCount,
+              request.item.byteCount <= request.item.kind.maximumSizeBytes,
+              SharedImportClassifier.kind(
+                typeIdentifier: request.item.typeIdentifier,
+                fileName: request.item.originalFileName
+              ) == request.item.kind else {
+            throw SharedImportError.invalidRequest
+        }
+        return payloadURL
+    }
+
+    func removeRequest(id: UUID) {
+        try? fileManager.removeItem(at: directoryURL(for: id))
+    }
+
+    static func sanitizedFileName(_ fileName: String) -> String {
+        let lastPathComponent = URL(fileURLWithPath: fileName).lastPathComponent
+        let allowedCharacters = CharacterSet.alphanumerics.union(
+            CharacterSet(charactersIn: " ._-")
+        )
+        let sanitizedScalars = lastPathComponent.unicodeScalars.map {
+            allowedCharacters.contains($0) ? Character(String($0)) : "_"
+        }
+        let sanitized = String(sanitizedScalars)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackName = sanitized.isEmpty ? "Shared File" : sanitized
+        return String(fallbackName.prefix(SharedImportConfiguration.maximumFileNameLength))
+    }
+
+    private func loadRequest(from directoryURL: URL) -> SharedImportRequest? {
+        guard UUID(uuidString: directoryURL.lastPathComponent) != nil else {
+            return nil
+        }
+
+        let manifestURL = directoryURL.appendingPathComponent(
+            SharedImportConfiguration.manifestFileName
+        )
+        let decoder = JSONDecoder()
+
+        guard let data = try? Data(contentsOf: manifestURL),
+              let request = try? decoder.decode(SharedImportRequest.self, from: data),
+              directoryURL == self.directoryURL(for: request.id),
+              (try? payloadURL(for: request)) != nil else {
+            return nil
+        }
+        return request
+    }
+
+    private func directoryURL(for requestID: UUID) -> URL {
+        inboxURL.appendingPathComponent(requestID.uuidString.lowercased(), isDirectory: true)
+    }
+
+    private func fileSize(at url: URL) throws -> Int64 {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard let size = attributes[.size] as? NSNumber else {
+            throw SharedImportError.invalidFile
+        }
+        return size.int64Value
+    }
+
+    private func protectAndExcludeFromBackup(_ url: URL) {
+        try? fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: url.path
+        )
+        var protectedURL = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? protectedURL.setResourceValues(values)
+    }
+
+    private static func stagedFileName(
+        id: UUID,
+        originalFileName: String,
+        typeIdentifier: String
+    ) -> String {
+        let originalExtension = URL(fileURLWithPath: originalFileName).pathExtension.lowercased()
+        let fileExtension = originalExtension.isEmpty
+            ? UTType(typeIdentifier)?.preferredFilenameExtension
+            : originalExtension
+
+        guard let fileExtension, !fileExtension.isEmpty else {
+            return id.uuidString.lowercased()
+        }
+        return "\(id.uuidString.lowercased()).\(fileExtension)"
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a share extension to import images and documents into chats and moves response streaming off the main thread for a smoother UI. Strengthens sync, account switching, and long‑content handling; fixes camera, image viewer, and layout issues, and plugs edge cases with search progress, huge code blocks, and stale profile writes.

- **New Features**
  - iOS share extension for images/documents via app group `group.sh.tinfoil.TinfoilChat`; imports on launch and when returning to the app.
  - Off‑main‑thread streaming processor with smarter chunking for long “thinking” and markdown.

- **Bug Fixes**
  - Camera preview no longer shows blank; image viewer allows panning when zoomed.
  - Long content: prevents freezes with very long messages and late “thinking” chunks, restores text selection via sheet for huge messages, and keeps huge code blocks from stalling rendering; typing stays responsive and the text edit menu opens faster.
  - Safer profile/chat sync and accounts: three‑way merges preserve settings and unknown fields, keep state consistent after conflicts, prevent cross‑account uploads, fully reset profile on account removal, stop sign‑out races from restoring an old session, and block stale writes from resurrecting removed profiles.
  - Attachments/imports: send only after all attachments finish processing; avoid crash on duplicate attachment IDs; shared imports are more robust.
  - Web search progress is isolated to the active chat and hides when leaving the streaming chat.
  - UI polish and stability: stat cards keep equal heights; settings descriptions stay with their controls; cloud pulls fall back to encrypted placeholders when keys are missing; stale table updates are guarded.
  - Updated `tinfoil-swift` to 0.6.3; added targeted tests (attachments, camera permissions, shared import, profile merge, stat cards).

<sup>Written for commit ebd704edd0a8119e4cc13145ad416007205c1698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

