### PR TITLE
Support chat search

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -20,13 +20,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		99AB00022FABC00200ABC002 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 99F153BA2F4F5F0200E9174E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 99AB00082FABC00800ABC008;
-			remoteInfo = TinfoilShareExtension;
-		};
 		992FC2992F532EA800699029 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 99F153BA2F4F5F0200E9174E /* Project object */;
@@ -34,7 +27,28 @@
 			remoteGlobalIDString = 99F153C12F4F5F0200E9174E;
 			remoteInfo = TinfoilChat;
 		};
+		99AB00022FABC00200ABC002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 99F153BA2F4F5F0200E9174E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 99AB00082FABC00800ABC008;
+			remoteInfo = TinfoilShareExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		99AB000C2FABC00C00ABC00C /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				99AB00012FABC00100ABC001 /* TinfoilShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		992FC2952F532EA800699029 /* TinfoilChatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinfoilChatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -47,7 +61,6 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
-				TinfoilShareExtension.entitlements,
 			);
 			target = 99AB00082FABC00800ABC008 /* TinfoilShareExtension */;
 		};
@@ -217,8 +230,8 @@
 				99AB000B2FABC00B00ABC00B /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				99F153C42F4F5F0200E9174E /* TinfoilChat */,
 				99AB00062FABC00600ABC006 /* TinfoilShared */,
+				99F153C42F4F5F0200E9174E /* TinfoilChat */,
 			);
 			name = TinfoilChat;
 			packageProductDependencies = (
@@ -311,20 +324,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		99AB000C2FABC00C00ABC00C /* Embed Foundation Extensions */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 13;
-			files = (
-				99AB00012FABC00100ABC001 /* TinfoilShareExtension.appex in Embed Foundation Extensions */,
-			);
-			name = "Embed Foundation Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		99F1547D2F4F615600E9174E /* ShellScript */ = {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -149,6 +149,7 @@ enum Constants {
         static let chatListLimit = 100
         static let projectListLimit = 100
         static let projectChatListLimit = 100
+        static let plaintextChatFormatVersion = 2
         /// Hard per-page cap the enclave's list-status endpoint
         /// enforces; requests above it are clamped server-side.
         static let listStatusPageLimit = 500

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -163,7 +163,10 @@ enum Constants {
             static let debounceSeconds: TimeInterval = 0.3
             static let resultLimit = 20
             static let reindexPollIntervalSeconds: TimeInterval = 2.0
-            static let reindexPollBudgetSeconds: TimeInterval = 10 * 60.0
+            static let reindexServerBudgetSeconds: TimeInterval = 20 * 60.0
+            static let reindexResponseGraceSeconds: TimeInterval = 30.0
+            static let reindexPollBudgetSeconds: TimeInterval =
+                reindexServerBudgetSeconds + reindexResponseGraceSeconds
             /// A failed rebuild puts further kicks on cooldown: every
             /// attempt re-pulls and re-embeds the whole corpus, so
             /// retrying on each query would loop a persistent failure

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -155,6 +155,21 @@ enum Constants {
         /// How many full chat blobs to request per pull call. Keeps
         /// individual response payloads bounded when syncing many chats.
         static let pullBatchSize = 20
+
+        /// Encrypted chat search over the sync enclave. Mirrors the
+        /// webapp constants so both clients drive the enclave's
+        /// reindex lifecycle the same way.
+        enum Search {
+            static let debounceSeconds: TimeInterval = 0.3
+            static let resultLimit = 20
+            static let reindexPollIntervalSeconds: TimeInterval = 2.0
+            static let reindexPollBudgetSeconds: TimeInterval = 10 * 60.0
+            /// A failed rebuild puts further kicks on cooldown: every
+            /// attempt re-pulls and re-embeds the whole corpus, so
+            /// retrying on each query would loop a persistent failure
+            /// at full rebuild cost.
+            static let reindexFailureCooldownSeconds: TimeInterval = 60.0
+        }
     }
 
 

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -37,10 +37,9 @@ struct ChatSearchOutcome: Equatable {
     /// True when the enclave has no complete index for this key yet and
     /// a rebuild has been kicked; results may be partial until it settles.
     let indexing: Bool
-    /// False when search cannot run at all: no primary key loaded,
-    /// fallback keys are still active, or the enclave has no search
-    /// backend (older deploy / unconfigured). The UI should fall back
-    /// to local title filtering.
+    /// False when search cannot run at all: no primary key loaded, or
+    /// the enclave has no search backend (older deploy / unconfigured).
+    /// The UI should fall back to local title filtering.
     let available: Bool
 
     static let unavailable = ChatSearchOutcome(
@@ -63,8 +62,12 @@ final class ChatSearchService {
         var loadLocalChat: (_ chatId: String, _ userId: String) async -> Chat?
         var decodeRemoteChat: (EnclavePullItem) async -> Chat?
         var primaryKeyB64: () -> String?
-        var hasActiveFallbackKeys: () -> Bool
         var pullKeys: () -> [EnclavePullKey]?
+        /// Primary plus retained legacy keys. Reindex is a sweep over
+        /// every stored blob, so it needs the alternatives too or chats
+        /// still sealed under an old CEK stay out of the index until
+        /// migration finishes.
+        var reindexKeys: () -> [EnclavePullKey]
         var sleep: (TimeInterval) async throws -> Void
         var now: () -> Date
     }
@@ -97,8 +100,7 @@ final class ChatSearchService {
         query: String,
         limit: Int = Constants.SyncEnclave.Search.resultLimit
     ) async throws -> ChatSearchOutcome {
-        guard let key = deps.primaryKeyB64(),
-              !deps.hasActiveFallbackKeys() else {
+        guard let key = deps.primaryKeyB64(), !key.isEmpty else {
             return .unavailable
         }
         let response: EnclaveSearchQueryResponse
@@ -130,8 +132,8 @@ final class ChatSearchService {
     /// re-kick after a failure, and every attempt re-pulls and
     /// re-embeds chats, so retrying on each query would loop a
     /// persistent failure at full rebuild cost. Never throws: failures
-    /// are logged and settle as `.failed` so fire-and-forget call
-    /// sites cannot leak errors.
+    /// settle as `.failed` so fire-and-forget call sites cannot leak
+    /// errors.
     @discardableResult
     func ensureSearchIndex() -> Task<ChatSearchReindexSettle, Never> {
         if let inFlight = reindexInFlight { return inFlight }
@@ -145,7 +147,6 @@ final class ChatSearchService {
             do {
                 result = try await self.runReindex()
             } catch {
-                print("[ChatSearch] reindex failed: \(error)")
                 result = .failed
             }
             self.recordReindexSettle(result)
@@ -209,14 +210,11 @@ final class ChatSearchService {
     }
 
     private func runReindex() async throws -> ChatSearchReindexSettle {
-        guard let primaryKey = deps.primaryKeyB64(),
-              !deps.hasActiveFallbackKeys() else {
-            return .skipped
-        }
+        let keys = deps.reindexKeys()
+        guard !keys.isEmpty else { return .skipped }
         let kicked = try await deps.searchReindex(
-            EnclaveSearchReindexRequest(keys: [EnclavePullKey(key: primaryKey)])
+            EnclaveSearchReindexRequest(keys: keys)
         )
-        print("[ChatSearch] reindex kicked job=\(kicked.jobId ?? "nil") status=\(kicked.status)")
         if Self.isTerminalStatus(kicked.status) { return Self.kickoffSettleResult(kicked) }
         let deadline = deps.now()
             .addingTimeInterval(Constants.SyncEnclave.Search.reindexPollBudgetSeconds)
@@ -224,7 +222,6 @@ final class ChatSearchService {
             try await deps.sleep(Constants.SyncEnclave.Search.reindexPollIntervalSeconds)
             let status = try await deps.searchReindexStatus()
             if Self.isTerminalStatus(status.status) {
-                print("[ChatSearch] reindex settled job=\(status.jobId ?? "nil") status=\(status.status) indexed=\(status.indexed) failed=\(status.failed) partial=\(status.partial)")
                 return Self.pollSettleResult(status)
             }
         }
@@ -270,9 +267,7 @@ final class ChatSearchService {
                         byId[item.id] = chat
                     }
                 }
-            } catch {
-                print("[ChatSearch] search result pull failed: \(error)")
-            }
+            } catch {}
         }
         return results.compactMap { byId[$0.id] }.filter { !$0.decryptionFailed }
     }
@@ -294,7 +289,7 @@ func decodeSearchPulledChat(_ item: EnclavePullItem) -> StoredChat? {
     if item.projectIdSet == true {
         stored.projectId = item.projectId
     }
-    stored.formatVersion = 2
+    stored.formatVersion = Constants.SyncEnclave.plaintextChatFormatVersion
     return stored
 }
 
@@ -314,10 +309,8 @@ extension ChatSearchService.Dependencies {
             return await stored.toChat()
         },
         primaryKeyB64: { try? CEKEncoding.requirePrimaryKeyB64() },
-        hasActiveFallbackKeys: {
-            !EncryptionService.shared.getActiveKeys().alternatives.isEmpty
-        },
         pullKeys: { CEKEncoding.pullKeysIfAvailable() },
+        reindexKeys: { CEKEncoding.migrationKeys() },
         sleep: { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) },
         now: { Date() }
     )

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -19,12 +19,13 @@
 
 import Foundation
 
-/// How a reindex request settled. `skipped` means no kick was sent
-/// (no keys loaded, or a recent failure put kicks on cooldown);
-/// `timeout` means the poll budget ran out while the job was still
-/// running server-side.
+/// How a reindex request settled. `partial` is a clean, resumable
+/// checkpoint; `skipped` means no kick was sent (no eligible key, or
+/// a recent failure put kicks on cooldown); `timeout` means the poll
+/// budget ran out while the job was still running server-side.
 enum ChatSearchReindexSettle: Equatable {
     case completed
+    case partial
     case failed
     case timeout
     case skipped
@@ -36,9 +37,10 @@ struct ChatSearchOutcome: Equatable {
     /// True when the enclave has no complete index for this key yet and
     /// a rebuild has been kicked; results may be partial until it settles.
     let indexing: Bool
-    /// False when search cannot run at all: no primary key loaded, or
-    /// the enclave has no search backend (older deploy / unconfigured).
-    /// The UI should fall back to local title filtering.
+    /// False when search cannot run at all: no primary key loaded,
+    /// fallback keys are still active, or the enclave has no search
+    /// backend (older deploy / unconfigured). The UI should fall back
+    /// to local title filtering.
     let available: Bool
 
     static let unavailable = ChatSearchOutcome(
@@ -61,12 +63,8 @@ final class ChatSearchService {
         var loadLocalChat: (_ chatId: String, _ userId: String) async -> Chat?
         var decodeRemoteChat: (EnclavePullItem) async -> Chat?
         var primaryKeyB64: () -> String?
+        var hasActiveFallbackKeys: () -> Bool
         var pullKeys: () -> [EnclavePullKey]?
-        /// Primary plus retained legacy keys. Reindex is a sweep over
-        /// every stored blob, so it needs the alternatives too or chats
-        /// still sealed under an old CEK stay out of the index until
-        /// migration finishes.
-        var reindexKeys: () -> [EnclavePullKey]
         var sleep: (TimeInterval) async throws -> Void
         var now: () -> Date
     }
@@ -99,7 +97,10 @@ final class ChatSearchService {
         query: String,
         limit: Int = Constants.SyncEnclave.Search.resultLimit
     ) async throws -> ChatSearchOutcome {
-        guard let key = deps.primaryKeyB64() else { return .unavailable }
+        guard let key = deps.primaryKeyB64(),
+              !deps.hasActiveFallbackKeys() else {
+            return .unavailable
+        }
         let response: EnclaveSearchQueryResponse
         do {
             response = try await deps.searchQuery(
@@ -158,7 +159,7 @@ final class ChatSearchService {
         switch result {
         case .failed:
             lastReindexFailureAt = deps.now()
-        case .completed:
+        case .completed, .partial:
             lastReindexFailureAt = nil
         case .timeout, .skipped:
             break
@@ -174,8 +175,24 @@ final class ChatSearchService {
     /// job's own result. An anomalous "idle" here means no job was
     /// created and must not read as success, or it would clear the
     /// failure cooldown and let callers re-query in a loop.
-    private static func kickoffSettleResult(_ status: String) -> ChatSearchReindexSettle {
-        status == "completed" ? .completed : .failed
+    private static func terminalSettleResult(
+        _ response: EnclaveSearchReindexStatusResponse
+    ) -> ChatSearchReindexSettle {
+        guard response.failed == 0 else { return .failed }
+        switch response.status {
+        case "completed":
+            return response.partial ? .partial : .completed
+        case "failed":
+            return .failed
+        default:
+            return .failed
+        }
+    }
+
+    private static func kickoffSettleResult(
+        _ response: EnclaveSearchReindexStatusResponse
+    ) -> ChatSearchReindexSettle {
+        terminalSettleResult(response)
     }
 
     /// In a poll, "idle" means no job record exists. The enclave only
@@ -184,19 +201,24 @@ final class ChatSearchService {
     /// expired. Treat that as completed: a re-query self-corrects if
     /// the index is still incomplete, whereas mapping it to failure
     /// would start the cooldown for a job that likely succeeded.
-    private static func pollSettleResult(_ status: String) -> ChatSearchReindexSettle {
-        switch status {
-        case "completed", "idle": return .completed
-        default: return .failed
-        }
+    private static func pollSettleResult(
+        _ response: EnclaveSearchReindexStatusResponse
+    ) -> ChatSearchReindexSettle {
+        guard response.failed == 0 else { return .failed }
+        if response.status == "idle" { return .completed }
+        return terminalSettleResult(response)
     }
 
     private func runReindex() async throws -> ChatSearchReindexSettle {
-        let keys = deps.reindexKeys()
-        guard !keys.isEmpty else { return .skipped }
-        let kicked = try await deps.searchReindex(EnclaveSearchReindexRequest(keys: keys))
+        guard let primaryKey = deps.primaryKeyB64(),
+              !deps.hasActiveFallbackKeys() else {
+            return .skipped
+        }
+        let kicked = try await deps.searchReindex(
+            EnclaveSearchReindexRequest(keys: [EnclavePullKey(key: primaryKey)])
+        )
         print("[ChatSearch] reindex kicked job=\(kicked.jobId ?? "nil") status=\(kicked.status)")
-        if Self.isTerminalStatus(kicked.status) { return Self.kickoffSettleResult(kicked.status) }
+        if Self.isTerminalStatus(kicked.status) { return Self.kickoffSettleResult(kicked) }
         let deadline = deps.now()
             .addingTimeInterval(Constants.SyncEnclave.Search.reindexPollBudgetSeconds)
         while deps.now() < deadline {
@@ -204,7 +226,7 @@ final class ChatSearchService {
             let status = try await deps.searchReindexStatus()
             if Self.isTerminalStatus(status.status) {
                 print("[ChatSearch] reindex settled job=\(status.jobId ?? "nil") status=\(status.status) indexed=\(status.indexed) failed=\(status.failed) partial=\(status.partial)")
-                return Self.pollSettleResult(status.status)
+                return Self.pollSettleResult(status)
             }
         }
         return .timeout
@@ -257,6 +279,26 @@ final class ChatSearchService {
     }
 }
 
+/// Decode a successful search-result pull while applying the row
+/// metadata that is authoritative outside the encrypted plaintext.
+func decodeSearchPulledChat(_ item: EnclavePullItem) -> StoredChat? {
+    guard item.ok,
+          let etag = item.etag,
+          let syncVersion = Int(etag),
+          syncVersion > 0,
+          let plaintextB64 = item.plaintext,
+          let plaintext = Data(base64Encoded: plaintextB64),
+          var stored = try? JSONDecoder().decode(StoredChat.self, from: plaintext) else {
+        return nil
+    }
+    stored.syncVersion = syncVersion
+    if item.projectIdSet == true {
+        stored.projectId = item.projectId
+    }
+    stored.formatVersion = 2
+    return stored
+}
+
 // MARK: - Live dependencies
 
 extension ChatSearchService.Dependencies {
@@ -269,17 +311,14 @@ extension ChatSearchService.Dependencies {
             (try? await EncryptedFileStorage.cloud.loadChat(chatId: chatId, userId: userId)) ?? nil
         },
         decodeRemoteChat: { item in
-            guard let plaintextB64 = item.plaintext,
-                  let plaintext = Data(base64Encoded: plaintextB64),
-                  var stored = try? JSONDecoder().decode(StoredChat.self, from: plaintext) else {
-                return nil
-            }
-            stored.formatVersion = 2
+            guard let stored = decodeSearchPulledChat(item) else { return nil }
             return await stored.toChat()
         },
         primaryKeyB64: { try? CEKEncoding.requirePrimaryKeyB64() },
+        hasActiveFallbackKeys: {
+            !EncryptionService.shared.getActiveKeys().alternatives.isEmpty
+        },
         pullKeys: { CEKEncoding.pullKeysIfAvailable() },
-        reindexKeys: { CEKEncoding.migrationKeys() },
         sleep: { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) },
         now: { Date() }
     )

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -267,7 +267,9 @@ final class ChatSearchService {
                         byId[item.id] = chat
                     }
                 }
-            } catch {}
+            } catch {
+                // Resolving remote hits is best-effort; locally available results remain usable.
+            }
         }
         return results.compactMap { byId[$0.id] }.filter { !$0.decryptionFailed }
     }

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -204,7 +204,6 @@ final class ChatSearchService {
     private static func pollSettleResult(
         _ response: EnclaveSearchReindexStatusResponse
     ) -> ChatSearchReindexSettle {
-        guard response.failed == 0 else { return .failed }
         if response.status == "idle" { return .completed }
         return terminalSettleResult(response)
     }

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -170,13 +170,21 @@ final class ChatSearchService {
         status != "running"
     }
 
-    /// "idle" means no job record exists. The enclave only retains a
-    /// finished job for a few minutes, so a poll that resumes late
-    /// (e.g. the app was suspended) can land after the record expired.
-    /// Treat that as completed: a re-query self-corrects if the index
-    /// is still incomplete, whereas mapping it to failure would start
-    /// the cooldown for a job that likely succeeded.
-    private static func settleResult(_ status: String) -> ChatSearchReindexSettle {
+    /// Kickoff always materializes a job, so its terminal status is the
+    /// job's own result. An anomalous "idle" here means no job was
+    /// created and must not read as success, or it would clear the
+    /// failure cooldown and let callers re-query in a loop.
+    private static func kickoffSettleResult(_ status: String) -> ChatSearchReindexSettle {
+        status == "completed" ? .completed : .failed
+    }
+
+    /// In a poll, "idle" means no job record exists. The enclave only
+    /// retains a finished job for a few minutes, so a poll that resumes
+    /// late (e.g. the app was suspended) can land after the record
+    /// expired. Treat that as completed: a re-query self-corrects if
+    /// the index is still incomplete, whereas mapping it to failure
+    /// would start the cooldown for a job that likely succeeded.
+    private static func pollSettleResult(_ status: String) -> ChatSearchReindexSettle {
         switch status {
         case "completed", "idle": return .completed
         default: return .failed
@@ -188,7 +196,7 @@ final class ChatSearchService {
         guard !keys.isEmpty else { return .skipped }
         let kicked = try await deps.searchReindex(EnclaveSearchReindexRequest(keys: keys))
         print("[ChatSearch] reindex kicked job=\(kicked.jobId ?? "nil") status=\(kicked.status)")
-        if Self.isTerminalStatus(kicked.status) { return Self.settleResult(kicked.status) }
+        if Self.isTerminalStatus(kicked.status) { return Self.kickoffSettleResult(kicked.status) }
         let deadline = deps.now()
             .addingTimeInterval(Constants.SyncEnclave.Search.reindexPollBudgetSeconds)
         while deps.now() < deadline {
@@ -196,7 +204,7 @@ final class ChatSearchService {
             let status = try await deps.searchReindexStatus()
             if Self.isTerminalStatus(status.status) {
                 print("[ChatSearch] reindex settled job=\(status.jobId ?? "nil") status=\(status.status) indexed=\(status.indexed) failed=\(status.failed) partial=\(status.partial)")
-                return Self.settleResult(status.status)
+                return Self.pollSettleResult(status.status)
             }
         }
         return .timeout

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -62,6 +62,11 @@ final class ChatSearchService {
         var decodeRemoteChat: (EnclavePullItem) async -> Chat?
         var primaryKeyB64: () -> String?
         var pullKeys: () -> [EnclavePullKey]?
+        /// Primary plus retained legacy keys. Reindex is a sweep over
+        /// every stored blob, so it needs the alternatives too or chats
+        /// still sealed under an old CEK stay out of the index until
+        /// migration finishes.
+        var reindexKeys: () -> [EnclavePullKey]
         var sleep: (TimeInterval) async throws -> Void
         var now: () -> Date
     }
@@ -165,12 +170,22 @@ final class ChatSearchService {
         status != "running"
     }
 
+    /// "idle" means no job record exists. The enclave only retains a
+    /// finished job for a few minutes, so a poll that resumes late
+    /// (e.g. the app was suspended) can land after the record expired.
+    /// Treat that as completed: a re-query self-corrects if the index
+    /// is still incomplete, whereas mapping it to failure would start
+    /// the cooldown for a job that likely succeeded.
     private static func settleResult(_ status: String) -> ChatSearchReindexSettle {
-        status == "completed" ? .completed : .failed
+        switch status {
+        case "completed", "idle": return .completed
+        default: return .failed
+        }
     }
 
     private func runReindex() async throws -> ChatSearchReindexSettle {
-        guard let keys = deps.pullKeys(), !keys.isEmpty else { return .skipped }
+        let keys = deps.reindexKeys()
+        guard !keys.isEmpty else { return .skipped }
         let kicked = try await deps.searchReindex(EnclaveSearchReindexRequest(keys: keys))
         print("[ChatSearch] reindex kicked job=\(kicked.jobId ?? "nil") status=\(kicked.status)")
         if Self.isTerminalStatus(kicked.status) { return Self.settleResult(kicked.status) }
@@ -256,6 +271,7 @@ extension ChatSearchService.Dependencies {
         },
         primaryKeyB64: { try? CEKEncoding.requirePrimaryKeyB64() },
         pullKeys: { CEKEncoding.pullKeysIfAvailable() },
+        reindexKeys: { CEKEncoding.migrationKeys() },
         sleep: { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) },
         now: { Date() }
     )

--- a/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
+++ b/TinfoilChat/Services/SyncEnclave/ChatSearchService.swift
@@ -1,0 +1,262 @@
+//
+//  ChatSearchService.swift
+//  TinfoilChat
+//
+//  Encrypted chat search over the sync enclave. Mirrors the webapp's
+//  `services/cloud/chat-search.ts`.
+//
+//  The enclave keeps a per-user search index sealed under a key
+//  derived from the CEK, so queries need the primary key on every
+//  call. Results are chat ids + scores only; `resolveSearchResultChats`
+//  maps them back to locally stored chats (falling back to a pull for
+//  chats outside the loaded pages).
+//
+//  When the enclave reports `needs_reindex` (index never built, sealed
+//  under a different key, or embedding model changed) this service
+//  kicks the background rebuild automatically and exposes the
+//  in-flight job as a task so callers can re-query once it settles.
+//
+
+import Foundation
+
+/// How a reindex request settled. `skipped` means no kick was sent
+/// (no keys loaded, or a recent failure put kicks on cooldown);
+/// `timeout` means the poll budget ran out while the job was still
+/// running server-side.
+enum ChatSearchReindexSettle: Equatable {
+    case completed
+    case failed
+    case timeout
+    case skipped
+}
+
+struct ChatSearchOutcome: Equatable {
+    let results: [EnclaveSearchQueryResult]
+    let totalIndexed: Int
+    /// True when the enclave has no complete index for this key yet and
+    /// a rebuild has been kicked; results may be partial until it settles.
+    let indexing: Bool
+    /// False when search cannot run at all: no primary key loaded, or
+    /// the enclave has no search backend (older deploy / unconfigured).
+    /// The UI should fall back to local title filtering.
+    let available: Bool
+
+    static let unavailable = ChatSearchOutcome(
+        results: [],
+        totalIndexed: 0,
+        indexing: false,
+        available: false
+    )
+}
+
+@MainActor
+final class ChatSearchService {
+
+    /// Injection seam for tests; production uses `.live`.
+    struct Dependencies {
+        var searchQuery: (EnclaveSearchQueryRequest) async throws -> EnclaveSearchQueryResponse
+        var searchReindex: (EnclaveSearchReindexRequest) async throws -> EnclaveSearchReindexStatusResponse
+        var searchReindexStatus: () async throws -> EnclaveSearchReindexStatusResponse
+        var pull: (EnclavePullRequest) async throws -> EnclavePullResponse
+        var loadLocalChat: (_ chatId: String, _ userId: String) async -> Chat?
+        var decodeRemoteChat: (EnclavePullItem) async -> Chat?
+        var primaryKeyB64: () -> String?
+        var pullKeys: () -> [EnclavePullKey]?
+        var sleep: (TimeInterval) async throws -> Void
+        var now: () -> Date
+    }
+
+    static let shared = ChatSearchService()
+
+    private let deps: Dependencies
+    private var reindexInFlight: Task<ChatSearchReindexSettle, Never>?
+    private var lastReindexFailureAt: Date?
+
+    init(dependencies: Dependencies = .live) {
+        self.deps = dependencies
+    }
+
+    /// The enclave answers 503 when the search backend is not
+    /// configured; an older enclave without the routes answers 404/405.
+    /// Both mean "no server-side search here", not a transient failure.
+    static func isSearchUnavailableError(_ error: Error) -> Bool {
+        guard let enclaveError = error as? SyncEnclaveError,
+              let status = enclaveError.status else { return false }
+        return status == 503 || status == 404 || status == 405
+    }
+
+    // MARK: - Query
+
+    /// Rank synced chats against a query using the caller's primary
+    /// CEK. Kicks a background reindex (once per settled job) when the
+    /// enclave reports the index is missing or incomplete.
+    func searchSyncedChats(
+        query: String,
+        limit: Int = Constants.SyncEnclave.Search.resultLimit
+    ) async throws -> ChatSearchOutcome {
+        guard let key = deps.primaryKeyB64() else { return .unavailable }
+        let response: EnclaveSearchQueryResponse
+        do {
+            response = try await deps.searchQuery(
+                EnclaveSearchQueryRequest(key: key, query: query, limit: limit)
+            )
+        } catch let error where Self.isSearchUnavailableError(error) {
+            return .unavailable
+        }
+        if response.needsReindex {
+            ensureSearchIndex()
+        }
+        return ChatSearchOutcome(
+            results: response.results,
+            totalIndexed: response.totalIndexed,
+            indexing: response.needsReindex,
+            available: true
+        )
+    }
+
+    // MARK: - Reindex coordination
+
+    /// Kick (or join) the enclave-side index rebuild; the returned task
+    /// resolves with how it settled. Concurrent callers share one poll
+    /// loop; the enclave itself dedupes kickoffs for the same key set,
+    /// so an extra kick after a settle is harmless. A failed run puts
+    /// further kicks on a cooldown: the enclave allows an immediate
+    /// re-kick after a failure, and every attempt re-pulls and
+    /// re-embeds chats, so retrying on each query would loop a
+    /// persistent failure at full rebuild cost. Never throws: failures
+    /// are logged and settle as `.failed` so fire-and-forget call
+    /// sites cannot leak errors.
+    @discardableResult
+    func ensureSearchIndex() -> Task<ChatSearchReindexSettle, Never> {
+        if let inFlight = reindexInFlight { return inFlight }
+        if let failedAt = lastReindexFailureAt,
+           deps.now().timeIntervalSince(failedAt)
+               < Constants.SyncEnclave.Search.reindexFailureCooldownSeconds {
+            return Task { .skipped }
+        }
+        let task = Task { () -> ChatSearchReindexSettle in
+            var result: ChatSearchReindexSettle
+            do {
+                result = try await self.runReindex()
+            } catch {
+                print("[ChatSearch] reindex failed: \(error)")
+                result = .failed
+            }
+            self.recordReindexSettle(result)
+            return result
+        }
+        reindexInFlight = task
+        return task
+    }
+
+    private func recordReindexSettle(_ result: ChatSearchReindexSettle) {
+        switch result {
+        case .failed:
+            lastReindexFailureAt = deps.now()
+        case .completed:
+            lastReindexFailureAt = nil
+        case .timeout, .skipped:
+            break
+        }
+        reindexInFlight = nil
+    }
+
+    private static func isTerminalStatus(_ status: String) -> Bool {
+        status != "running"
+    }
+
+    private static func settleResult(_ status: String) -> ChatSearchReindexSettle {
+        status == "completed" ? .completed : .failed
+    }
+
+    private func runReindex() async throws -> ChatSearchReindexSettle {
+        guard let keys = deps.pullKeys(), !keys.isEmpty else { return .skipped }
+        let kicked = try await deps.searchReindex(EnclaveSearchReindexRequest(keys: keys))
+        print("[ChatSearch] reindex kicked job=\(kicked.jobId ?? "nil") status=\(kicked.status)")
+        if Self.isTerminalStatus(kicked.status) { return Self.settleResult(kicked.status) }
+        let deadline = deps.now()
+            .addingTimeInterval(Constants.SyncEnclave.Search.reindexPollBudgetSeconds)
+        while deps.now() < deadline {
+            try await deps.sleep(Constants.SyncEnclave.Search.reindexPollIntervalSeconds)
+            let status = try await deps.searchReindexStatus()
+            if Self.isTerminalStatus(status.status) {
+                print("[ChatSearch] reindex settled job=\(status.jobId ?? "nil") status=\(status.status) indexed=\(status.indexed) failed=\(status.failed) partial=\(status.partial)")
+                return Self.settleResult(status.status)
+            }
+        }
+        return .timeout
+    }
+
+    // MARK: - Result resolution
+
+    /// Resolve search result ids to full chats, preserving the
+    /// enclave's ranking. Local storage is the fast path; anything not
+    /// on this device yet (results can reach past the loaded sidebar
+    /// pages) is pulled and decoded without being written back.
+    /// Unresolvable ids (e.g. a chat deleted between indexing and the
+    /// query) and undecryptable placeholders are dropped.
+    func resolveSearchResultChats(
+        _ results: [EnclaveSearchQueryResult],
+        userId: String?
+    ) async -> [Chat] {
+        var byId: [String: Chat] = [:]
+        var missing: [String] = []
+        for result in results {
+            if let userId,
+               let local = await deps.loadLocalChat(result.id, userId) {
+                byId[result.id] = local
+            } else {
+                missing.append(result.id)
+            }
+        }
+        if !missing.isEmpty, let keys = deps.pullKeys() {
+            do {
+                let response = try await deps.pull(
+                    EnclavePullRequest(
+                        scope: .chat,
+                        ids: missing,
+                        all: nil,
+                        cursor: nil,
+                        limit: nil,
+                        keys: keys
+                    )
+                )
+                for item in response.items where item.ok {
+                    if let chat = await deps.decodeRemoteChat(item) {
+                        byId[item.id] = chat
+                    }
+                }
+            } catch {
+                print("[ChatSearch] search result pull failed: \(error)")
+            }
+        }
+        return results.compactMap { byId[$0.id] }.filter { !$0.decryptionFailed }
+    }
+}
+
+// MARK: - Live dependencies
+
+extension ChatSearchService.Dependencies {
+    static let live = ChatSearchService.Dependencies(
+        searchQuery: { try await SyncEnclaveAPI.searchQuery($0) },
+        searchReindex: { try await SyncEnclaveAPI.searchReindex($0) },
+        searchReindexStatus: { try await SyncEnclaveAPI.searchReindexStatus() },
+        pull: { try await SyncEnclaveAPI.pull($0) },
+        loadLocalChat: { chatId, userId in
+            (try? await EncryptedFileStorage.cloud.loadChat(chatId: chatId, userId: userId)) ?? nil
+        },
+        decodeRemoteChat: { item in
+            guard let plaintextB64 = item.plaintext,
+                  let plaintext = Data(base64Encoded: plaintextB64),
+                  var stored = try? JSONDecoder().decode(StoredChat.self, from: plaintext) else {
+                return nil
+            }
+            stored.formatVersion = 2
+            return await stored.toChat()
+        },
+        primaryKeyB64: { try? CEKEncoding.requirePrimaryKeyB64() },
+        pullKeys: { CEKEncoding.pullKeysIfAvailable() },
+        sleep: { try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) },
+        now: { Date() }
+    )
+}

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
@@ -484,6 +484,96 @@ struct EnclaveMigrateAllResponse: Decodable {
 /// sync API.
 struct EnclaveEmptyRequest: Encodable {}
 
+// MARK: - Encrypted chat search
+
+struct EnclaveSearchQueryRequest: Encodable {
+    /// User's CEK, base64 raw 32 bytes. The enclave derives the
+    /// search-index subkey from it; the index never leaves the
+    /// enclave unencrypted.
+    let key: String
+    let query: String
+    let limit: Int?
+}
+
+struct EnclaveSearchQueryResult: Decodable, Equatable {
+    /// Chat id; contents come from the normal pull path.
+    let id: String
+    let score: Double
+}
+
+struct EnclaveSearchQueryResponse: Decodable {
+    let results: [EnclaveSearchQueryResult]
+    let totalIndexed: Int
+    /// True when no readable index exists for the supplied key (never
+    /// built, different key, or the enclave's embedding model changed).
+    /// The client should kick `/v1/search/reindex` and poll status.
+    let needsReindex: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case results
+        case totalIndexed = "total_indexed"
+        case needsReindex = "needs_reindex"
+    }
+}
+
+// Go marshals an empty slice as JSON null and omits `needs_reindex`
+// when false; normalize both. Lives in an extension to keep the
+// auto-synthesized memberwise initializer for tests.
+extension EnclaveSearchQueryResponse {
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            results: try c.decodeIfPresent([EnclaveSearchQueryResult].self, forKey: .results) ?? [],
+            totalIndexed: try c.decodeIfPresent(Int.self, forKey: .totalIndexed) ?? 0,
+            needsReindex: try c.decodeIfPresent(Bool.self, forKey: .needsReindex) ?? false
+        )
+    }
+}
+
+struct EnclaveSearchReindexRequest: Encodable {
+    /// Primary key first, then any legacy keys still sealing old rows.
+    let keys: [EnclavePullKey]
+}
+
+/// Wire shape returned by both the reindex kickoff and the status
+/// poll. Status is one of "idle" | "running" | "completed" | "failed";
+/// kept as a raw string so an unknown future state decodes instead of
+/// failing the poll loop.
+struct EnclaveSearchReindexStatusResponse: Decodable {
+    let jobId: String?
+    let status: String
+    let indexed: Int
+    let failed: Int
+    let totalIndexed: Int
+    /// True when the run stopped at its wall-clock budget before
+    /// draining every chat; a fresh kickoff resumes the build.
+    let partial: Bool
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, indexed, failed, partial, error
+        case jobId = "job_id"
+        case totalIndexed = "total_indexed"
+    }
+}
+
+// Tolerant decoding lives in an extension to keep the auto-synthesized
+// memberwise initializer available (tests build status snapshots).
+extension EnclaveSearchReindexStatusResponse {
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            jobId: try c.decodeIfPresent(String.self, forKey: .jobId),
+            status: try c.decode(String.self, forKey: .status),
+            indexed: try c.decodeIfPresent(Int.self, forKey: .indexed) ?? 0,
+            failed: try c.decodeIfPresent(Int.self, forKey: .failed) ?? 0,
+            totalIndexed: try c.decodeIfPresent(Int.self, forKey: .totalIndexed) ?? 0,
+            partial: try c.decodeIfPresent(Bool.self, forKey: .partial) ?? false,
+            error: try c.decodeIfPresent(String.self, forKey: .error)
+        )
+    }
+}
+
 // MARK: - Attachments
 
 struct EnclaveAttachmentPutRequest: Encodable {
@@ -658,6 +748,33 @@ enum SyncEnclaveAPI {
     static func migrateStatus() async throws -> EnclaveMigrateAllResponse {
         try await SyncEnclaveClient.shared.post(
             path: "/v1/blobs/migrate-status",
+            body: EnclaveEmptyRequest()
+        )
+    }
+
+    // MARK: Encrypted chat search
+
+    /// Rank the caller's synced chats against a natural-language query.
+    /// Returns chat ids + scores only; resolve titles/contents through
+    /// the normal pull path. `needsReindex == true` means the enclave
+    /// has no readable index for this key and the caller should drive
+    /// a reindex.
+    static func searchQuery(_ request: EnclaveSearchQueryRequest) async throws -> EnclaveSearchQueryResponse {
+        try await SyncEnclaveClient.shared.post(path: "/v1/search/query", body: request)
+    }
+
+    /// Kick off (or join) the enclave-side background job that rebuilds
+    /// the search index from the stored chat blobs. Returns the job's
+    /// current status snapshot; poll `searchReindexStatus()` until the
+    /// status is terminal.
+    static func searchReindex(_ request: EnclaveSearchReindexRequest) async throws -> EnclaveSearchReindexStatusResponse {
+        try await SyncEnclaveClient.shared.post(path: "/v1/search/reindex", body: request)
+    }
+
+    /// Poll the caller's current reindex job; `status: "idle"` when none.
+    static func searchReindexStatus() async throws -> EnclaveSearchReindexStatusResponse {
+        try await SyncEnclaveClient.shared.post(
+            path: "/v1/search/reindex-status",
             body: EnclaveEmptyRequest()
         )
     }

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
@@ -123,6 +123,10 @@ struct EnclavePullItem: Decodable {
     let keyId: String?
     let etag: String?
     let needsRewrap: Bool?
+    /// Present only when the enclave has authoritative project
+    /// membership for this chat, including an authoritative root nil.
+    let projectIdSet: Bool?
+    let projectId: String?
     /// Error code when `ok=false` (e.g. "NEEDS_REWRAP", "NOT_FOUND").
     let code: String?
     let reason: String?
@@ -131,6 +135,8 @@ struct EnclavePullItem: Decodable {
         case id, ok, plaintext, etag, reason, code
         case keyId = "key_id"
         case needsRewrap = "needs_rewrap"
+        case projectIdSet = "project_id_set"
+        case projectId = "project_id"
     }
 }
 
@@ -531,7 +537,8 @@ extension EnclaveSearchQueryResponse {
 }
 
 struct EnclaveSearchReindexRequest: Encodable {
-    /// Primary key first, then any legacy keys still sealing old rows.
+    /// The current primary CEK. Search is unavailable while legacy
+    /// fallback keys remain active.
     let keys: [EnclavePullKey]
 }
 
@@ -545,8 +552,9 @@ struct EnclaveSearchReindexStatusResponse: Decodable {
     let indexed: Int
     let failed: Int
     let totalIndexed: Int
-    /// True when the run stopped at its wall-clock budget before
-    /// draining every chat; a fresh kickoff resumes the build.
+    /// True when the run ended before every chat was indexed. A
+    /// completed response with zero failures is a clean checkpoint
+    /// that a fresh kickoff can resume.
     let partial: Bool
     let error: String?
 

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
@@ -537,8 +537,9 @@ extension EnclaveSearchQueryResponse {
 }
 
 struct EnclaveSearchReindexRequest: Encodable {
-    /// The current primary CEK. Search is unavailable while legacy
-    /// fallback keys remain active.
+    /// The current primary CEK followed by retained legacy CEKs. The
+    /// enclave uses the alternatives to unseal older chats while
+    /// rebuilding the index under the primary key.
     let keys: [EnclavePullKey]
 }
 

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -11,10 +11,16 @@ import Combine
 
 @MainActor
 class AuthManager: ObservableObject {
+    private static let userIdKey = "id"
+
     @Published var isAuthenticated = false
     @Published var isLoading = true
     @Published var localUserData: [String: Any]? = nil
     @Published var hasActiveSubscription = false
+
+    var localUserId: String? {
+        localUserData?[Self.userIdKey] as? String
+    }
     
     private var cancellables = Set<AnyCancellable>()
     private var timer: Timer?
@@ -97,7 +103,7 @@ class AuthManager: ObservableObject {
         self.clerk = clerk
         // Check if clerk is already loaded and has a user
         if let user = clerk.user {
-            if let cachedUserId = localUserData?["id"] as? String,
+            if let cachedUserId = localUserId,
                cachedUserId != user.id {
                 hasTriggeredSignIn = true
                 accountSwitchTask = Task { @MainActor [weak self] in
@@ -140,7 +146,7 @@ class AuthManager: ObservableObject {
         
         // Store relevant user data
         localUserData = [
-            "id": user.id,
+            Self.userIdKey: user.id,
             "email": user.primaryEmailAddress?.emailAddress ?? "",
             "name": user.firstName ?? "",
             "fullName": "\(user.firstName ?? "") \(user.lastName ?? "")",
@@ -210,7 +216,7 @@ class AuthManager: ObservableObject {
         let wasAuthenticated = isAuthenticated
 
         if let user = clerk.user {
-            if let cachedUserId = localUserData?["id"] as? String,
+            if let cachedUserId = localUserId,
                cachedUserId != user.id {
                 await clearAuthState()
                 await RevenueCatManager.shared.logoutUser()
@@ -252,7 +258,7 @@ class AuthManager: ObservableObject {
             // No chat view model is attached (e.g. sign-out resolved before
             // the UI wired one up); wipe directly so chat files never
             // outlive the account on a shared device.
-            await Chat.deleteAllChatsFromStorage(userId: localUserData?["id"] as? String)
+            await Chat.deleteAllChatsFromStorage(userId: localUserId)
         }
         SettingsManager.shared.clearAllSettings()
 

--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -1,0 +1,87 @@
+//
+//  ChatSearchController.swift
+//  TinfoilChat
+//
+//  Debounced encrypted search over synced chats, mirroring the
+//  webapp's `useChatSearch` hook. When the enclave reports it is
+//  rebuilding the index, the controller waits for the job to settle
+//  and re-runs the current term so results fill in without any user
+//  action.
+//
+
+import Foundation
+
+@MainActor
+final class ChatSearchController: ObservableObject {
+    /// Ranked, fully resolved hits for the current term.
+    @Published private(set) var results: [Chat] = []
+    /// True from the first keystroke until the current term's results land.
+    @Published private(set) var isSearching = false
+    /// True while the enclave rebuilds the index; results may be partial.
+    @Published private(set) var isIndexing = false
+    /// False when server-side search cannot run (no key loaded, enclave
+    /// without a search backend). Callers should fall back to filtering
+    /// locally loaded chats by title.
+    @Published private(set) var available = true
+
+    private let service: ChatSearchService
+    private var searchTask: Task<Void, Never>?
+
+    init(service: ChatSearchService = .shared) {
+        self.service = service
+    }
+
+    /// Debounce and run one search per term change. Cancelling the
+    /// previous task ensures completions from a superseded term never
+    /// set state or schedule a refresh.
+    func updateTerm(_ term: String, userId: String?) {
+        searchTask?.cancel()
+        searchTask = nil
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            results = []
+            isSearching = false
+            isIndexing = false
+            return
+        }
+        isSearching = true
+        searchTask = Task { [weak self] in
+            try? await Task.sleep(
+                nanoseconds: UInt64(Constants.SyncEnclave.Search.debounceSeconds * 1_000_000_000)
+            )
+            guard !Task.isCancelled else { return }
+            await self?.run(term: trimmed, userId: userId)
+        }
+    }
+
+    private func run(term: String, userId: String?) async {
+        do {
+            let outcome = try await service.searchSyncedChats(query: term)
+            guard !Task.isCancelled else { return }
+            available = outcome.available
+            isIndexing = outcome.indexing
+            let chats = await service.resolveSearchResultChats(outcome.results, userId: userId)
+            guard !Task.isCancelled else { return }
+            results = chats
+            isSearching = false
+            if outcome.indexing {
+                // Re-query only after a successful rebuild. Refreshing
+                // on a failed or skipped settle would report
+                // needs_reindex again and kick another full rebuild,
+                // looping a persistent failure at full embedding cost.
+                let settled = await service.ensureSearchIndex().value
+                guard !Task.isCancelled else { return }
+                if settled == .completed {
+                    await run(term: term, userId: userId)
+                } else {
+                    isIndexing = false
+                }
+            }
+        } catch {
+            guard !Task.isCancelled else { return }
+            print("[ChatSearch] search failed: \(error)")
+            results = []
+            isSearching = false
+        }
+    }
+}

--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -89,14 +89,15 @@ final class ChatSearchController: ObservableObject {
                     await run(term: term, userId: userId)
                 } else {
                     isIndexing = false
+                    available = false
                 }
             }
         } catch {
             guard !Task.isCancelled else { return }
-            print("[ChatSearch] search failed: \(error)")
             results = []
             isSearching = false
             isIndexing = false
+            available = false
         }
     }
 }

--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -31,6 +31,18 @@ final class ChatSearchController: ObservableObject {
         self.service = service
     }
 
+    /// Drop all cached state, including in-flight work. Called when the
+    /// authenticated user changes so one account's decrypted results
+    /// can never linger into another account's session.
+    func reset() {
+        searchTask?.cancel()
+        searchTask = nil
+        results = []
+        isSearching = false
+        isIndexing = false
+        available = true
+    }
+
     /// Debounce and run one search per term change. Cancelling the
     /// previous task ensures completions from a superseded term never
     /// set state or schedule a refresh.

--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -46,7 +46,8 @@ final class ChatSearchController: ObservableObject {
     /// Debounce and run one search per term change. Cancelling the
     /// previous task ensures completions from a superseded term never
     /// set state or schedule a refresh.
-    func updateTerm(_ term: String, userId: String?) {
+    @discardableResult
+    func updateTerm(_ term: String, userId: String?) -> Task<Void, Never>? {
         searchTask?.cancel()
         searchTask = nil
         let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -54,7 +55,7 @@ final class ChatSearchController: ObservableObject {
             results = []
             isSearching = false
             isIndexing = false
-            return
+            return nil
         }
         isSearching = true
         searchTask = Task { [weak self] in
@@ -64,9 +65,10 @@ final class ChatSearchController: ObservableObject {
             guard !Task.isCancelled else { return }
             await self?.run(term: trimmed, userId: userId)
         }
+        return searchTask
     }
 
-    func run(term: String, userId: String?) async {
+    private func run(term: String, userId: String?) async {
         do {
             let outcome = try await service.searchSyncedChats(query: term)
             guard !Task.isCancelled else { return }

--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -19,9 +19,9 @@ final class ChatSearchController: ObservableObject {
     @Published private(set) var isSearching = false
     /// True while the enclave rebuilds the index; results may be partial.
     @Published private(set) var isIndexing = false
-    /// False when server-side search cannot run (no key loaded, enclave
-    /// without a search backend). Callers should fall back to filtering
-    /// locally loaded chats by title.
+    /// False when server-side search cannot run (no eligible key,
+    /// enclave without a search backend). Callers should fall back to
+    /// filtering locally loaded chats by title.
     @Published private(set) var available = true
 
     private let service: ChatSearchService
@@ -66,7 +66,7 @@ final class ChatSearchController: ObservableObject {
         }
     }
 
-    private func run(term: String, userId: String?) async {
+    func run(term: String, userId: String?) async {
         do {
             let outcome = try await service.searchSyncedChats(query: term)
             guard !Task.isCancelled else { return }
@@ -77,13 +77,13 @@ final class ChatSearchController: ObservableObject {
             results = chats
             isSearching = false
             if outcome.indexing {
-                // Re-query only after a successful rebuild. Refreshing
-                // on a failed or skipped settle would report
-                // needs_reindex again and kick another full rebuild,
-                // looping a persistent failure at full embedding cost.
+                // Re-query after a full rebuild or a clean partial
+                // checkpoint. The latter reports needs_reindex again
+                // and resumes from the enclave's checkpoint. Failed,
+                // timed-out, and skipped rebuilds stop here.
                 let settled = await service.ensureSearchIndex().value
                 guard !Task.isCancelled else { return }
-                if settled == .completed {
+                if settled == .completed || settled == .partial {
                     await run(term: term, userId: userId)
                 } else {
                     isIndexing = false
@@ -94,6 +94,7 @@ final class ChatSearchController: ObservableObject {
             print("[ChatSearch] search failed: \(error)")
             results = []
             isSearching = false
+            isIndexing = false
         }
     }
 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -338,8 +338,7 @@ class ChatViewModel: ObservableObject {
     private var currentUserId: String? {
         guard let authManager = authManager,
               authManager.isAuthenticated,
-              let userData = authManager.localUserData,
-              let userId = userData["id"] as? String else {
+              let userId = authManager.localUserId else {
             return nil
         }
         return userId

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -23,6 +23,8 @@ struct ChatSidebar: View {
     @State private var isTabSwitching: Bool = false
     @State private var isProjectsExpanded: Bool = false
     @State private var isChatsExpanded: Bool = true
+    @State private var chatSearchTerm: String = ""
+    @StateObject private var chatSearch = ChatSearchController()
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var cloudSync = CloudSyncService.shared
     @ObservedObject private var syncHealth = SyncHealthStore.shared
@@ -49,6 +51,43 @@ struct ChatSidebar: View {
         // stay in storage so re-decryption can recover them once the
         // right key is active, at which point they reappear here.
         return source.filter { !$0.isTemporary && $0.projectId == nil && !$0.decryptionFailed }
+    }
+
+    // Encrypted server-side search over synced chats. Only offered on
+    // the cloud tab: local-only chats never reach the enclave, so the
+    // index cannot know about them.
+    private var isChatSearchEnabled: Bool {
+        authManager.isAuthenticated && settings.isCloudSyncEnabled
+            && !(settings.isLocalOnlyModeEnabled && activeTab == .local)
+    }
+
+    private var isChatSearchActive: Bool {
+        isChatSearchEnabled
+            && !chatSearchTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var searchResultChats: [Chat] {
+        guard isChatSearchActive else { return [] }
+        // Enclave unavailable (older deploy, no key): degrade to
+        // filtering the locally loaded titles so the box still does
+        // something useful.
+        guard chatSearch.available else {
+            let needle = chatSearchTerm
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            return filteredChats.filter {
+                !$0.isBlankChat && $0.title.lowercased().contains(needle)
+            }
+        }
+        return chatSearch.results
+    }
+
+    private var displayedChats: [Chat] {
+        isChatSearchActive ? searchResultChats : filteredChats
+    }
+
+    private var searchUserId: String? {
+        authManager.localUserData?["id"] as? String
     }
 
     // Timer to update relative time strings
@@ -204,6 +243,12 @@ struct ChatSidebar: View {
                             .padding(.horizontal, 16)
                             .padding(.top, 8)
 
+                        if isChatSearchEnabled {
+                            chatSearchField
+                                .padding(.horizontal, 16)
+                                .padding(.top, 8)
+                        }
+
                         chatList
                             .padding(.horizontal, 16)
                             .padding(.top, 8)
@@ -230,9 +275,74 @@ struct ChatSidebar: View {
         .frame(maxHeight: .infinity, alignment: .top)
     }
 
+    private var chatSearchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            TextField("Search chats...", text: $chatSearchTerm)
+                .font(.subheadline)
+                .textFieldStyle(PlainTextFieldStyle())
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .accessibilityLabel("Search chats")
+            if !chatSearchTerm.isEmpty {
+                Button {
+                    chatSearchTerm = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(UIColor.secondarySystemBackground).opacity(0.3))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(Color.gray.opacity(0.1), lineWidth: 1)
+        )
+        .onChange(of: chatSearchTerm) { _, term in
+            chatSearch.updateTerm(term, userId: searchUserId)
+        }
+    }
+
+    @ViewBuilder
+    private var chatSearchStatusRow: some View {
+        if chatSearch.isIndexing {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
+                    .scaleEffect(0.8)
+                Text("Building search index...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+        } else if chatSearch.isSearching && searchResultChats.isEmpty {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+        } else if searchResultChats.isEmpty {
+            Text("No matching chats")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+        }
+    }
+
     private var chatList: some View {
         VStack(spacing: 12) {
-            ForEach(Array(filteredChats.enumerated()), id: \.element.id) { _, chat in
+            ForEach(Array(displayedChats.enumerated()), id: \.element.id) { _, chat in
                 ChatListItem(
                     chat: chat,
                     isSelected: viewModel.currentChat?.id == chat.id,
@@ -271,7 +381,9 @@ struct ChatSidebar: View {
                 }
             }
 
-            if viewModel.hasMoreChats && activeTab != .local {
+            if isChatSearchActive {
+                chatSearchStatusRow
+            } else if viewModel.hasMoreChats && activeTab != .local {
                 if viewModel.isLoadingMore {
                     HStack {
                         ProgressView()

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -9,6 +9,10 @@ import SwiftUI
 import ClerkKit
 import SafariServices
 
+func isRootSidebarChat(_ chat: Chat) -> Bool {
+    !chat.isTemporary && chat.projectId == nil && !chat.decryptionFailed
+}
+
 struct ChatSidebar: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(Clerk.self) private var clerk
@@ -50,7 +54,7 @@ struct ChatSidebar: View {
         // sidebar. Chats that failed to decrypt are hidden entirely; they
         // stay in storage so re-decryption can recover them once the
         // right key is active, at which point they reappear here.
-        return source.filter { !$0.isTemporary && $0.projectId == nil && !$0.decryptionFailed }
+        return source.filter(isRootSidebarChat)
     }
 
     // Encrypted server-side search over synced chats. Only offered on
@@ -68,8 +72,8 @@ struct ChatSidebar: View {
 
     private var searchResultChats: [Chat] {
         guard isChatSearchActive else { return [] }
-        // Enclave unavailable (older deploy, no key): degrade to
-        // filtering the locally loaded titles so the box still does
+        // Enclave unavailable (older deploy, no eligible key): degrade
+        // to filtering the locally loaded titles so the box still does
         // something useful.
         guard chatSearch.available else {
             let needle = chatSearchTerm
@@ -82,9 +86,7 @@ struct ChatSidebar: View {
         // The index covers every synced chat, so results can include
         // project chats; apply the same root-list exclusions so search
         // never surfaces rows this list would not show.
-        return chatSearch.results.filter {
-            !$0.isTemporary && $0.projectId == nil && !$0.decryptionFailed
-        }
+        return chatSearch.results.filter(isRootSidebarChat)
     }
 
     private var displayedChats: [Chat] {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -13,6 +13,14 @@ func isRootSidebarChat(_ chat: Chat) -> Bool {
     !chat.isTemporary && chat.projectId == nil && !chat.decryptionFailed
 }
 
+func isSidebarChatSearchEnabled(
+    isAuthenticated: Bool,
+    isCloudSyncEnabled: Bool,
+    activeTab: ChatStorageTab
+) -> Bool {
+    isAuthenticated && isCloudSyncEnabled && activeTab == .cloud
+}
+
 struct ChatSidebar: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(Clerk.self) private var clerk
@@ -61,8 +69,11 @@ struct ChatSidebar: View {
     // the cloud tab: local-only chats never reach the enclave, so the
     // index cannot know about them.
     private var isChatSearchEnabled: Bool {
-        authManager.isAuthenticated && settings.isCloudSyncEnabled
-            && !(settings.isLocalOnlyModeEnabled && activeTab == .local)
+        isSidebarChatSearchEnabled(
+            isAuthenticated: authManager.isAuthenticated,
+            isCloudSyncEnabled: settings.isCloudSyncEnabled,
+            activeTab: activeTab
+        )
     }
 
     private var isChatSearchActive: Bool {
@@ -94,7 +105,7 @@ struct ChatSidebar: View {
     }
 
     private var searchUserId: String? {
-        authManager.localUserData?["id"] as? String
+        authManager.localUserId
     }
 
     // Timer to update relative time strings

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -79,7 +79,12 @@ struct ChatSidebar: View {
                 !$0.isBlankChat && $0.title.lowercased().contains(needle)
             }
         }
-        return chatSearch.results
+        // The index covers every synced chat, so results can include
+        // project chats; apply the same root-list exclusions so search
+        // never surfaces rows this list would not show.
+        return chatSearch.results.filter {
+            !$0.isTemporary && $0.projectId == nil && !$0.decryptionFailed
+        }
     }
 
     private var displayedChats: [Chat] {
@@ -151,6 +156,13 @@ struct ChatSidebar: View {
             }
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+        }
+        // Covers sign-out (id -> nil) and account switches: search
+        // results hold decrypted titles, so they must never survive
+        // into another account's session.
+        .onChange(of: searchUserId) { _, _ in
+            chatSearchTerm = ""
+            chatSearch.reset()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CheckAuthState"))) { _ in
             Task {

--- a/TinfoilChat/Views/GatedPaywallView.swift
+++ b/TinfoilChat/Views/GatedPaywallView.swift
@@ -50,7 +50,7 @@ struct GatedPaywallView: View {
     }
 
     private func prepare() async {
-        guard let clerkUserId = authManager.localUserData?["id"] as? String else {
+        guard let clerkUserId = authManager.localUserId else {
             gateState = .failed
             return
         }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -330,10 +330,10 @@ struct SettingsView: View {
             AsyncImage(url: url) { image in
                 image.resizable().aspectRatio(contentMode: .fill)
             } placeholder: {
-                PixelAvatarView(name: (userData["id"] as? String) ?? "user", size: 40)
+                PixelAvatarView(name: authManager.localUserId ?? "user", size: 40)
             }
         } else {
-            PixelAvatarView(name: clerk.user?.id ?? (authManager.localUserData?["id"] as? String) ?? "user", size: 40)
+            PixelAvatarView(name: clerk.user?.id ?? authManager.localUserId ?? "user", size: 40)
         }
     }
     

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -52,7 +52,31 @@ struct ChatSearchControllerTests {
 
         #expect(controller.isIndexing == false)
         #expect(controller.isSearching == false)
+        #expect(controller.available == false)
         #expect(recorder.queryRequests.count == 1)
+    }
+
+    @Test
+    func fallsBackToLocalSearchAfterTimedOutRebuild() async {
+        let recorder = ChatSearchServiceTests.Recorder()
+        let service = ChatSearchServiceTests.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(results: [], totalIndexed: 0, needsReindex: true)
+            },
+            searchReindex: { _ in ChatSearchServiceTests.runningStatus() },
+            searchReindexStatus: {
+                recorder.advance(Constants.SyncEnclave.Search.reindexPollBudgetSeconds)
+                return ChatSearchServiceTests.runningStatus()
+            }
+        )
+        let controller = ChatSearchController(service: service)
+
+        await controller.updateTerm("ducks", userId: "user-1")?.value
+
+        #expect(controller.isIndexing == false)
+        #expect(controller.isSearching == false)
+        #expect(controller.available == false)
     }
 
     @Test
@@ -77,6 +101,7 @@ struct ChatSearchControllerTests {
 
         #expect(controller.isIndexing == false)
         #expect(controller.isSearching == false)
+        #expect(controller.available == false)
         #expect(recorder.queryRequests.count == 2)
     }
 
@@ -87,5 +112,23 @@ struct ChatSearchControllerTests {
         project.projectId = "project-1"
 
         #expect([root, project].filter(isRootSidebarChat).map(\.id) == ["root"])
+    }
+
+    @Test
+    func sidebarSearchIsOnlyEnabledForCloudChats() {
+        #expect(
+            isSidebarChatSearchEnabled(
+                isAuthenticated: true,
+                isCloudSyncEnabled: true,
+                activeTab: .cloud
+            )
+        )
+        #expect(
+            !isSidebarChatSearchEnabled(
+                isAuthenticated: true,
+                isCloudSyncEnabled: true,
+                activeTab: .local
+            )
+        )
     }
 }

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -1,0 +1,91 @@
+import Testing
+@testable import TinfoilChat
+
+@MainActor
+struct ChatSearchControllerTests {
+    @Test
+    func requeriesAfterCleanPartialCompletion() async {
+        let recorder = ChatSearchServiceTests.Recorder()
+        let service = ChatSearchServiceTests.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(
+                    results: [],
+                    totalIndexed: 0,
+                    needsReindex: recorder.queryRequests.count == 1
+                )
+            },
+            searchReindex: { _ in
+                EnclaveSearchReindexStatusResponse(
+                    jobId: "job-1", status: "completed", indexed: 2, failed: 0,
+                    totalIndexed: 2, partial: true, error: nil
+                )
+            }
+        )
+        let controller = ChatSearchController(service: service)
+
+        await controller.run(term: "ducks", userId: "user-1")
+
+        #expect(recorder.queryRequests.count == 2)
+        #expect(controller.isIndexing == false)
+        #expect(controller.isSearching == false)
+    }
+
+    @Test
+    func clearsIndexingAfterFailedRebuild() async {
+        let recorder = ChatSearchServiceTests.Recorder()
+        let service = ChatSearchServiceTests.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(results: [], totalIndexed: 0, needsReindex: true)
+            },
+            searchReindex: { _ in
+                EnclaveSearchReindexStatusResponse(
+                    jobId: "job-1", status: "failed", indexed: 0, failed: 1,
+                    totalIndexed: 0, partial: true, error: "chat could not be indexed"
+                )
+            }
+        )
+        let controller = ChatSearchController(service: service)
+
+        await controller.run(term: "ducks", userId: "user-1")
+
+        #expect(controller.isIndexing == false)
+        #expect(controller.isSearching == false)
+        #expect(recorder.queryRequests.count == 1)
+    }
+
+    @Test
+    func clearsIndexingWhenARefreshThrows() async {
+        let recorder = ChatSearchServiceTests.Recorder()
+        let service = ChatSearchServiceTests.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                if recorder.queryRequests.count == 1 {
+                    return EnclaveSearchQueryResponse(
+                        results: [],
+                        totalIndexed: 0,
+                        needsReindex: true
+                    )
+                }
+                throw SyncEnclaveError(message: "network down")
+            }
+        )
+        let controller = ChatSearchController(service: service)
+
+        await controller.run(term: "ducks", userId: "user-1")
+
+        #expect(controller.isIndexing == false)
+        #expect(controller.isSearching == false)
+        #expect(recorder.queryRequests.count == 2)
+    }
+
+    @Test
+    func rootSidebarFilterExcludesProjectSearchResults() {
+        let root = ChatSearchServiceTests.makeChat(id: "root", title: "Root")
+        var project = ChatSearchServiceTests.makeChat(id: "project", title: "Project")
+        project.projectId = "project-1"
+
+        #expect([root, project].filter(isRootSidebarChat).map(\.id) == ["root"])
+    }
+}

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -24,7 +24,7 @@ struct ChatSearchControllerTests {
         )
         let controller = ChatSearchController(service: service)
 
-        await controller.run(term: "ducks", userId: "user-1")
+        await controller.updateTerm("ducks", userId: "user-1")?.value
 
         #expect(recorder.queryRequests.count == 2)
         #expect(controller.isIndexing == false)
@@ -48,7 +48,7 @@ struct ChatSearchControllerTests {
         )
         let controller = ChatSearchController(service: service)
 
-        await controller.run(term: "ducks", userId: "user-1")
+        await controller.updateTerm("ducks", userId: "user-1")?.value
 
         #expect(controller.isIndexing == false)
         #expect(controller.isSearching == false)
@@ -73,7 +73,7 @@ struct ChatSearchControllerTests {
         )
         let controller = ChatSearchController(service: service)
 
-        await controller.run(term: "ducks", userId: "user-1")
+        await controller.updateTerm("ducks", userId: "user-1")?.value
 
         #expect(controller.isIndexing == false)
         #expect(controller.isSearching == false)

--- a/TinfoilChatTests/ChatSearchServiceTests.swift
+++ b/TinfoilChatTests/ChatSearchServiceTests.swift
@@ -55,7 +55,8 @@ struct ChatSearchServiceTests {
         loadLocalChat: @escaping (String, String) async -> Chat? = { _, _ in nil },
         decodeRemoteChat: @escaping (EnclavePullItem) async -> Chat? = { _ in nil },
         primaryKeyB64: @escaping () -> String? = { "primary-b64" },
-        pullKeys: @escaping () -> [EnclavePullKey]? = { [EnclavePullKey(key: "primary-b64")] }
+        pullKeys: @escaping () -> [EnclavePullKey]? = { [EnclavePullKey(key: "primary-b64")] },
+        reindexKeys: @escaping () -> [EnclavePullKey] = { [EnclavePullKey(key: "primary-b64")] }
     ) -> ChatSearchService {
         ChatSearchService(dependencies: ChatSearchService.Dependencies(
             searchQuery: { request in
@@ -78,6 +79,7 @@ struct ChatSearchServiceTests {
             decodeRemoteChat: decodeRemoteChat,
             primaryKeyB64: primaryKeyB64,
             pullKeys: pullKeys,
+            reindexKeys: reindexKeys,
             sleep: { _ in },
             now: { recorder.now }
         ))
@@ -203,10 +205,34 @@ struct ChatSearchServiceTests {
     @Test
     func skipsTheKickWhenNoKeysAreLoaded() async {
         let recorder = Recorder()
-        let service = Self.makeService(recorder: recorder, pullKeys: { nil })
+        let service = Self.makeService(recorder: recorder, reindexKeys: { [] })
         let settled = await service.ensureSearchIndex().value
         #expect(settled == .skipped)
         #expect(recorder.reindexRequests.isEmpty)
+    }
+
+    @Test
+    func treatsAnIdleStatusPollAsACompletedRebuild() async {
+        // A finished job is only retained briefly server-side; a poll
+        // that resumes after suspension can land on "idle". That must
+        // not start the failure cooldown.
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            searchReindex: { _ in Self.runningStatus() },
+            searchReindexStatus: {
+                EnclaveSearchReindexStatusResponse(
+                    jobId: nil, status: "idle", indexed: 0, failed: 0,
+                    totalIndexed: 4, partial: false, error: nil
+                )
+            }
+        )
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .completed)
+
+        let rekick = await service.ensureSearchIndex().value
+        #expect(rekick == .completed)
+        #expect(recorder.reindexRequests.count == 2)
     }
 
     @Test

--- a/TinfoilChatTests/ChatSearchServiceTests.swift
+++ b/TinfoilChatTests/ChatSearchServiceTests.swift
@@ -236,6 +236,26 @@ struct ChatSearchServiceTests {
     }
 
     @Test
+    func treatsAnIdleKickoffResponseAsAFailureAndStartsTheCooldown() async {
+        // Kickoff always materializes a job, so an "idle" answer means
+        // none was created; success here would clear the cooldown and
+        // let callers loop.
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchReindex: { _ in
+            EnclaveSearchReindexStatusResponse(
+                jobId: nil, status: "idle", indexed: 0, failed: 0,
+                totalIndexed: 0, partial: false, error: nil
+            )
+        })
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .failed)
+
+        let rekick = await service.ensureSearchIndex().value
+        #expect(rekick == .skipped)
+        #expect(recorder.reindexRequests.count == 1)
+    }
+
+    @Test
     func putsKicksOnCooldownAfterAFailedRunInsteadOfLoopingRebuilds() async {
         let recorder = Recorder()
         let service = Self.makeService(recorder: recorder, searchReindex: { _ in

--- a/TinfoilChatTests/ChatSearchServiceTests.swift
+++ b/TinfoilChatTests/ChatSearchServiceTests.swift
@@ -430,6 +430,7 @@ struct ChatSearchServiceTests {
                     ],
                 ])
             },
+            pullKeys: { [EnclavePullKey(key: "pull-key")] },
             loadLocalChat: { chatId, userId in
                 #expect(userId == "user-1")
                 return chatId == "a" ? Self.makeChat(id: "a", title: "Local pond notes") : nil

--- a/TinfoilChatTests/ChatSearchServiceTests.swift
+++ b/TinfoilChatTests/ChatSearchServiceTests.swift
@@ -1,0 +1,344 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+/// Mirrors the webapp's `tests/services/cloud/chat-search.test.ts`.
+@MainActor
+struct ChatSearchServiceTests {
+
+    // MARK: - Harness
+
+    /// Mutable capture box shared between stub closures and assertions.
+    /// Deliberately not actor-isolated so the service's nonisolated
+    /// dependency closures can record calls synchronously; every test
+    /// runs single-threaded on the main actor.
+    final class Recorder {
+        var queryRequests: [EnclaveSearchQueryRequest] = []
+        var reindexRequests: [EnclaveSearchReindexRequest] = []
+        var statusPolls = 0
+        var pullRequests: [EnclavePullRequest] = []
+        var now = Date(timeIntervalSince1970: 1_000_000)
+
+        func advance(_ seconds: TimeInterval) {
+            now = now.addingTimeInterval(seconds)
+        }
+    }
+
+    nonisolated static func runningStatus() -> EnclaveSearchReindexStatusResponse {
+        EnclaveSearchReindexStatusResponse(
+            jobId: "job-1", status: "running", indexed: 0, failed: 0,
+            totalIndexed: 0, partial: false, error: nil
+        )
+    }
+
+    nonisolated static func completedStatus() -> EnclaveSearchReindexStatusResponse {
+        EnclaveSearchReindexStatusResponse(
+            jobId: "job-1", status: "completed", indexed: 4, failed: 0,
+            totalIndexed: 4, partial: false, error: nil
+        )
+    }
+
+    static func makeService(
+        recorder: Recorder,
+        searchQuery: @escaping (EnclaveSearchQueryRequest) async throws -> EnclaveSearchQueryResponse = { _ in
+            EnclaveSearchQueryResponse(results: [], totalIndexed: 0, needsReindex: false)
+        },
+        searchReindex: @escaping (EnclaveSearchReindexRequest) async throws -> EnclaveSearchReindexStatusResponse = { _ in
+            Self.completedStatus()
+        },
+        searchReindexStatus: @escaping () async throws -> EnclaveSearchReindexStatusResponse = {
+            Self.completedStatus()
+        },
+        pull: @escaping (EnclavePullRequest) async throws -> EnclavePullResponse = { _ in
+            throw SyncEnclaveError(message: "pull not stubbed")
+        },
+        loadLocalChat: @escaping (String, String) async -> Chat? = { _, _ in nil },
+        decodeRemoteChat: @escaping (EnclavePullItem) async -> Chat? = { _ in nil },
+        primaryKeyB64: @escaping () -> String? = { "primary-b64" },
+        pullKeys: @escaping () -> [EnclavePullKey]? = { [EnclavePullKey(key: "primary-b64")] }
+    ) -> ChatSearchService {
+        ChatSearchService(dependencies: ChatSearchService.Dependencies(
+            searchQuery: { request in
+                recorder.queryRequests.append(request)
+                return try await searchQuery(request)
+            },
+            searchReindex: { request in
+                recorder.reindexRequests.append(request)
+                return try await searchReindex(request)
+            },
+            searchReindexStatus: {
+                recorder.statusPolls += 1
+                return try await searchReindexStatus()
+            },
+            pull: { request in
+                recorder.pullRequests.append(request)
+                return try await pull(request)
+            },
+            loadLocalChat: loadLocalChat,
+            decodeRemoteChat: decodeRemoteChat,
+            primaryKeyB64: primaryKeyB64,
+            pullKeys: pullKeys,
+            sleep: { _ in },
+            now: { recorder.now }
+        ))
+    }
+
+    nonisolated static let testModel = ModelType(
+        from: AppModelConfig(
+            modelName: "gpt-oss-120b",
+            image: "openai.png",
+            name: "GPT OSS 120B",
+            nameShort: "GPT OSS",
+            description: "",
+            details: "",
+            parameters: "",
+            contextWindow: "64k tokens",
+            type: "chat",
+            chat: true,
+            paid: false,
+            multimodal: false,
+            reasoningConfig: nil
+        )
+    )
+
+    nonisolated static func makeChat(id: String, title: String) -> Chat {
+        Chat(id: id, title: title, modelType: testModel)
+    }
+
+    // MARK: - searchSyncedChats
+
+    @Test
+    func reportsUnavailableWhenNoPrimaryKeyIsLoaded() async throws {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, primaryKeyB64: { nil })
+        let outcome = try await service.searchSyncedChats(query: "ducks")
+        #expect(outcome == .unavailable)
+        #expect(recorder.queryRequests.isEmpty)
+    }
+
+    @Test
+    func mapsA503FromTheEnclaveToUnavailableInsteadOfThrowing() async throws {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchQuery: { _ in
+            throw SyncEnclaveError(message: "search backend not configured", status: 503)
+        })
+        let outcome = try await service.searchSyncedChats(query: "ducks")
+        #expect(outcome.available == false)
+        #expect(outcome.results.isEmpty)
+    }
+
+    @Test
+    func rethrowsTransientErrorsSoCallersCanDistinguishThem() async {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchQuery: { _ in
+            throw SyncEnclaveError(message: "embedding service failed", status: 502)
+        })
+        await #expect(throws: SyncEnclaveError.self) {
+            try await service.searchSyncedChats(query: "ducks")
+        }
+    }
+
+    @Test
+    func returnsRankedResultsAndPassesKeyAndLimitToTheEnclave() async throws {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchQuery: { _ in
+            EnclaveSearchQueryResponse(
+                results: [
+                    EnclaveSearchQueryResult(id: "b", score: 2),
+                    EnclaveSearchQueryResult(id: "a", score: 1),
+                ],
+                totalIndexed: 9,
+                needsReindex: false
+            )
+        })
+        let outcome = try await service.searchSyncedChats(query: "duck pond", limit: 7)
+        #expect(outcome.results.map(\.id) == ["b", "a"])
+        #expect(outcome.totalIndexed == 9)
+        #expect(outcome.indexing == false)
+        #expect(outcome.available == true)
+        #expect(recorder.queryRequests.count == 1)
+        #expect(recorder.queryRequests[0].key == "primary-b64")
+        #expect(recorder.queryRequests[0].query == "duck pond")
+        #expect(recorder.queryRequests[0].limit == 7)
+        #expect(recorder.reindexRequests.isEmpty)
+    }
+
+    // MARK: - ensureSearchIndex
+
+    @Test
+    func kicksOneSharedReindexWhenQueriesReportNeedsReindexAndPollsItToCompletion() async throws {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(results: [], totalIndexed: 0, needsReindex: true)
+            },
+            searchReindex: { _ in Self.runningStatus() },
+            searchReindexStatus: {
+                recorder.statusPolls < 2 ? Self.runningStatus() : Self.completedStatus()
+            }
+        )
+
+        let first = try await service.searchSyncedChats(query: "ducks")
+        let second = try await service.searchSyncedChats(query: "taxes")
+        #expect(first.indexing == true)
+        #expect(second.indexing == true)
+
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .completed)
+        #expect(recorder.reindexRequests.count == 1)
+        #expect(recorder.reindexRequests[0].keys.map(\.key) == ["primary-b64"])
+        #expect(recorder.statusPolls == 2)
+    }
+
+    @Test
+    func doesNotPollWhenTheKickoffAlreadyReportsATerminalStatus() async {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder)
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .completed)
+        #expect(recorder.statusPolls == 0)
+    }
+
+    @Test
+    func skipsTheKickWhenNoKeysAreLoaded() async {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, pullKeys: { nil })
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .skipped)
+        #expect(recorder.reindexRequests.isEmpty)
+    }
+
+    @Test
+    func putsKicksOnCooldownAfterAFailedRunInsteadOfLoopingRebuilds() async {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchReindex: { _ in
+            EnclaveSearchReindexStatusResponse(
+                jobId: "job-1", status: "failed", indexed: 0, failed: 1,
+                totalIndexed: 0, partial: false, error: "embedding service failed"
+            )
+        })
+
+        let first = await service.ensureSearchIndex().value
+        #expect(first == .failed)
+        #expect(recorder.reindexRequests.count == 1)
+
+        let second = await service.ensureSearchIndex().value
+        #expect(second == .skipped)
+        #expect(recorder.reindexRequests.count == 1)
+
+        recorder.advance(Constants.SyncEnclave.Search.reindexFailureCooldownSeconds)
+        let third = await service.ensureSearchIndex().value
+        #expect(third == .failed)
+        #expect(recorder.reindexRequests.count == 2)
+    }
+
+    @Test
+    func settlesAsFailedWhenTheRebuildKickThrows() async {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchReindex: { _ in
+            throw SyncEnclaveError(message: "network down")
+        })
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .failed)
+    }
+
+    @Test
+    func timesOutWhenTheJobOutlivesThePollBudget() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            searchReindex: { _ in Self.runningStatus() },
+            searchReindexStatus: {
+                // Each poll burns poll-interval wall time on the fake clock.
+                recorder.advance(Constants.SyncEnclave.Search.reindexPollBudgetSeconds / 2)
+                return Self.runningStatus()
+            }
+        )
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .timeout)
+    }
+
+    // MARK: - resolveSearchResultChats
+
+    @Test
+    func resolvesResultsLocallyFirstPullsTheRestAndPreservesRanking() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            pull: { _ in
+                EnclavePullResponse(json: [
+                    "items": [
+                        ["id": "b", "ok": true, "plaintext": "ignored-by-stub"],
+                        ["id": "c", "ok": false, "code": "NOT_FOUND"],
+                    ],
+                ])
+            },
+            loadLocalChat: { chatId, userId in
+                #expect(userId == "user-1")
+                return chatId == "a" ? Self.makeChat(id: "a", title: "Local pond notes") : nil
+            },
+            decodeRemoteChat: { item in
+                item.id == "b" ? Self.makeChat(id: "b", title: "Remote tax chat") : nil
+            }
+        )
+
+        let chats = await service.resolveSearchResultChats(
+            [
+                EnclaveSearchQueryResult(id: "b", score: 3),
+                EnclaveSearchQueryResult(id: "a", score: 2),
+                EnclaveSearchQueryResult(id: "c", score: 1),
+            ],
+            userId: "user-1"
+        )
+
+        #expect(chats.map(\.id) == ["b", "a"])
+        #expect(chats[0].title == "Remote tax chat")
+        #expect(chats[1].title == "Local pond notes")
+        #expect(recorder.pullRequests.count == 1)
+        #expect(recorder.pullRequests[0].ids == ["b", "c"])
+        #expect(recorder.pullRequests[0].scope == .chat)
+    }
+
+    @Test
+    func skipsThePullEntirelyWhenEveryResultResolvesLocally() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            loadLocalChat: { chatId, _ in Self.makeChat(id: chatId, title: "Local") }
+        )
+        let chats = await service.resolveSearchResultChats(
+            [EnclaveSearchQueryResult(id: "a", score: 1)],
+            userId: "user-1"
+        )
+        #expect(chats.count == 1)
+        #expect(recorder.pullRequests.isEmpty)
+    }
+
+    @Test
+    func dropsUndecryptablePlaceholdersFromResults() async {
+        let recorder = Recorder()
+        var placeholder = Self.makeChat(id: "a", title: "Encrypted")
+        placeholder.decryptionFailed = true
+        let service = Self.makeService(
+            recorder: recorder,
+            loadLocalChat: { _, _ in placeholder }
+        )
+        let chats = await service.resolveSearchResultChats(
+            [EnclaveSearchQueryResult(id: "a", score: 1)],
+            userId: "user-1"
+        )
+        #expect(chats.isEmpty)
+    }
+}
+
+// MARK: - Decodable fixtures
+
+private extension EnclavePullResponse {
+    /// Build a pull response through its Decodable path (the struct has
+    /// no memberwise initializer).
+    init(json: [String: Any]) {
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        self = try! JSONDecoder().decode(EnclavePullResponse.self, from: data)
+    }
+}

--- a/TinfoilChatTests/ChatSearchServiceTests.swift
+++ b/TinfoilChatTests/ChatSearchServiceTests.swift
@@ -55,8 +55,8 @@ struct ChatSearchServiceTests {
         loadLocalChat: @escaping (String, String) async -> Chat? = { _, _ in nil },
         decodeRemoteChat: @escaping (EnclavePullItem) async -> Chat? = { _ in nil },
         primaryKeyB64: @escaping () -> String? = { "primary-b64" },
-        hasActiveFallbackKeys: @escaping () -> Bool = { false },
         pullKeys: @escaping () -> [EnclavePullKey]? = { [EnclavePullKey(key: "primary-b64")] },
+        reindexKeys: @escaping () -> [EnclavePullKey] = { [EnclavePullKey(key: "primary-b64")] },
         sleep: @escaping (TimeInterval) async throws -> Void = { _ in }
     ) -> ChatSearchService {
         ChatSearchService(dependencies: ChatSearchService.Dependencies(
@@ -79,8 +79,8 @@ struct ChatSearchServiceTests {
             loadLocalChat: loadLocalChat,
             decodeRemoteChat: decodeRemoteChat,
             primaryKeyB64: primaryKeyB64,
-            hasActiveFallbackKeys: hasActiveFallbackKeys,
             pullKeys: pullKeys,
+            reindexKeys: reindexKeys,
             sleep: sleep,
             now: { recorder.now }
         ))
@@ -120,16 +120,27 @@ struct ChatSearchServiceTests {
     }
 
     @Test
-    func reportsUnavailableWhileFallbackKeysRemainActive() async throws {
+    func allowsQueriesWhileLegacyKeysRemainAvailableForReindex() async throws {
         let recorder = Recorder()
         let service = Self.makeService(
             recorder: recorder,
-            hasActiveFallbackKeys: { true }
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(results: [], totalIndexed: 0, needsReindex: true)
+            },
+            reindexKeys: {
+                [
+                    EnclavePullKey(key: "primary-b64"),
+                    EnclavePullKey(key: "legacy-b64"),
+                ]
+            }
         )
         let outcome = try await service.searchSyncedChats(query: "ducks")
-        #expect(outcome == .unavailable)
-        #expect(recorder.queryRequests.isEmpty)
-        #expect(recorder.reindexRequests.isEmpty)
+        #expect(outcome.available)
+        #expect(outcome.indexing)
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .completed)
+        #expect(recorder.queryRequests.map(\.key) == ["primary-b64"])
+        #expect(recorder.reindexRequests[0].keys.map(\.key) == ["primary-b64", "legacy-b64"])
     }
 
     @Test
@@ -219,19 +230,7 @@ struct ChatSearchServiceTests {
     @Test
     func skipsTheKickWhenNoKeysAreLoaded() async {
         let recorder = Recorder()
-        let service = Self.makeService(recorder: recorder, primaryKeyB64: { nil })
-        let settled = await service.ensureSearchIndex().value
-        #expect(settled == .skipped)
-        #expect(recorder.reindexRequests.isEmpty)
-    }
-
-    @Test
-    func skipsTheKickWhileFallbackKeysRemainActive() async {
-        let recorder = Recorder()
-        let service = Self.makeService(
-            recorder: recorder,
-            hasActiveFallbackKeys: { true }
-        )
+        let service = Self.makeService(recorder: recorder, reindexKeys: { [] })
         let settled = await service.ensureSearchIndex().value
         #expect(settled == .skipped)
         #expect(recorder.reindexRequests.isEmpty)
@@ -455,6 +454,7 @@ struct ChatSearchServiceTests {
         #expect(recorder.pullRequests.count == 1)
         #expect(recorder.pullRequests[0].ids == ["b", "c"])
         #expect(recorder.pullRequests[0].scope == .chat)
+        #expect(recorder.pullRequests[0].keys.map(\.key) == ["pull-key"])
     }
 
     @Test
@@ -503,7 +503,7 @@ struct ChatSearchServiceTests {
         let stored = try #require(decodeSearchPulledChat(item))
         #expect(stored.syncVersion == 12)
         #expect(stored.projectId == "project-new")
-        #expect(stored.formatVersion == 2)
+        #expect(stored.formatVersion == Constants.SyncEnclave.plaintextChatFormatVersion)
     }
 
     @Test

--- a/TinfoilChatTests/ChatSearchServiceTests.swift
+++ b/TinfoilChatTests/ChatSearchServiceTests.swift
@@ -55,8 +55,9 @@ struct ChatSearchServiceTests {
         loadLocalChat: @escaping (String, String) async -> Chat? = { _, _ in nil },
         decodeRemoteChat: @escaping (EnclavePullItem) async -> Chat? = { _ in nil },
         primaryKeyB64: @escaping () -> String? = { "primary-b64" },
+        hasActiveFallbackKeys: @escaping () -> Bool = { false },
         pullKeys: @escaping () -> [EnclavePullKey]? = { [EnclavePullKey(key: "primary-b64")] },
-        reindexKeys: @escaping () -> [EnclavePullKey] = { [EnclavePullKey(key: "primary-b64")] }
+        sleep: @escaping (TimeInterval) async throws -> Void = { _ in }
     ) -> ChatSearchService {
         ChatSearchService(dependencies: ChatSearchService.Dependencies(
             searchQuery: { request in
@@ -78,9 +79,9 @@ struct ChatSearchServiceTests {
             loadLocalChat: loadLocalChat,
             decodeRemoteChat: decodeRemoteChat,
             primaryKeyB64: primaryKeyB64,
+            hasActiveFallbackKeys: hasActiveFallbackKeys,
             pullKeys: pullKeys,
-            reindexKeys: reindexKeys,
-            sleep: { _ in },
+            sleep: sleep,
             now: { recorder.now }
         ))
     }
@@ -116,6 +117,19 @@ struct ChatSearchServiceTests {
         let outcome = try await service.searchSyncedChats(query: "ducks")
         #expect(outcome == .unavailable)
         #expect(recorder.queryRequests.isEmpty)
+    }
+
+    @Test
+    func reportsUnavailableWhileFallbackKeysRemainActive() async throws {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            hasActiveFallbackKeys: { true }
+        )
+        let outcome = try await service.searchSyncedChats(query: "ducks")
+        #expect(outcome == .unavailable)
+        #expect(recorder.queryRequests.isEmpty)
+        #expect(recorder.reindexRequests.isEmpty)
     }
 
     @Test
@@ -205,7 +219,19 @@ struct ChatSearchServiceTests {
     @Test
     func skipsTheKickWhenNoKeysAreLoaded() async {
         let recorder = Recorder()
-        let service = Self.makeService(recorder: recorder, reindexKeys: { [] })
+        let service = Self.makeService(recorder: recorder, primaryKeyB64: { nil })
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .skipped)
+        #expect(recorder.reindexRequests.isEmpty)
+    }
+
+    @Test
+    func skipsTheKickWhileFallbackKeysRemainActive() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            hasActiveFallbackKeys: { true }
+        )
         let settled = await service.ensureSearchIndex().value
         #expect(settled == .skipped)
         #expect(recorder.reindexRequests.isEmpty)
@@ -247,6 +273,65 @@ struct ChatSearchServiceTests {
                 totalIndexed: 0, partial: false, error: nil
             )
         })
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .failed)
+
+        let rekick = await service.ensureSearchIndex().value
+        #expect(rekick == .skipped)
+        #expect(recorder.reindexRequests.count == 1)
+    }
+
+    @Test
+    func treatsAnUnknownTerminalStatusAsFailure() async {
+        let recorder = Recorder()
+        let service = Self.makeService(recorder: recorder, searchReindex: { _ in
+            EnclaveSearchReindexStatusResponse(
+                jobId: "job-1", status: "paused", indexed: 0, failed: 0,
+                totalIndexed: 0, partial: false, error: nil
+            )
+        })
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .failed)
+
+        let rekick = await service.ensureSearchIndex().value
+        #expect(rekick == .skipped)
+        #expect(recorder.reindexRequests.count == 1)
+    }
+
+    @Test
+    func treatsCleanPartialCompletionAsResumableWithoutCooldown() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            searchReindex: { _ in Self.runningStatus() },
+            searchReindexStatus: {
+                EnclaveSearchReindexStatusResponse(
+                    jobId: "job-1", status: "completed", indexed: 4, failed: 0,
+                    totalIndexed: 4, partial: true, error: nil
+                )
+            }
+        )
+        let settled = await service.ensureSearchIndex().value
+        #expect(settled == .partial)
+
+        let resumed = await service.ensureSearchIndex().value
+        #expect(resumed == .partial)
+        #expect(recorder.reindexRequests.count == 2)
+    }
+
+    @Test
+    func treatsPositiveFailureCountAsFailureEvenWhenStatusIsCompleted() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            searchReindex: { _ in Self.runningStatus() },
+            searchReindexStatus: {
+                EnclaveSearchReindexStatusResponse(
+                    jobId: "job-1", status: "completed", indexed: 3, failed: 1,
+                    totalIndexed: 3, partial: true, error: nil
+                )
+            }
+        )
         let settled = await service.ensureSearchIndex().value
         #expect(settled == .failed)
 
@@ -303,6 +388,32 @@ struct ChatSearchServiceTests {
         )
         let settled = await service.ensureSearchIndex().value
         #expect(settled == .timeout)
+    }
+
+    @Test
+    func pollBudgetOutlivesTheServerJobBudget() async {
+        let recorder = Recorder()
+        let service = Self.makeService(
+            recorder: recorder,
+            searchReindex: { _ in Self.runningStatus() },
+            searchReindexStatus: {
+                if recorder.statusPolls == 1 {
+                    recorder.advance(
+                        Constants.SyncEnclave.Search.reindexServerBudgetSeconds
+                            + Constants.SyncEnclave.Search.reindexPollIntervalSeconds
+                    )
+                    return Self.runningStatus()
+                }
+                return Self.completedStatus()
+            }
+        )
+        let settled = await service.ensureSearchIndex().value
+        #expect(
+            Constants.SyncEnclave.Search.reindexPollBudgetSeconds
+                > Constants.SyncEnclave.Search.reindexServerBudgetSeconds
+        )
+        #expect(settled == .completed)
+        #expect(recorder.statusPolls == 2)
     }
 
     // MARK: - resolveSearchResultChats
@@ -375,6 +486,88 @@ struct ChatSearchServiceTests {
             userId: "user-1"
         )
         #expect(chats.isEmpty)
+    }
+
+    // MARK: - Pulled chat decoding
+
+    @Test
+    func pulledChatUsesAuthoritativeETagAndProjectAssignment() throws {
+        let item = Self.makePullItem(
+            etag: "12",
+            projectIdSet: true,
+            projectId: "project-new",
+            plaintextProjectId: "project-old",
+            plaintextSyncVersion: 3
+        )
+
+        let stored = try #require(decodeSearchPulledChat(item))
+        #expect(stored.syncVersion == 12)
+        #expect(stored.projectId == "project-new")
+        #expect(stored.formatVersion == 2)
+    }
+
+    @Test
+    func pulledChatClearsAuthoritativeRootProject() throws {
+        let item = Self.makePullItem(
+            etag: "12",
+            projectIdSet: true,
+            projectId: nil,
+            plaintextProjectId: "project-old"
+        )
+
+        let stored = try #require(decodeSearchPulledChat(item))
+        #expect(stored.projectId == nil)
+    }
+
+    @Test
+    func pulledChatPreservesProjectForOlderEnclaveResponse() throws {
+        let item = Self.makePullItem(
+            etag: "12",
+            projectIdSet: nil,
+            projectId: nil,
+            plaintextProjectId: "project-old"
+        )
+
+        let stored = try #require(decodeSearchPulledChat(item))
+        #expect(stored.projectId == "project-old")
+    }
+
+    @Test
+    func pulledChatRequiresAPositiveNumericETag() {
+        let invalidETags: [String?] = [nil, "", "not-a-number", "0", "-1"]
+        for etag in invalidETags {
+            let item = Self.makePullItem(etag: etag)
+            #expect(decodeSearchPulledChat(item) == nil)
+        }
+    }
+
+    private static func makePullItem(
+        etag: String?,
+        projectIdSet: Bool? = nil,
+        projectId: String? = nil,
+        plaintextProjectId: String? = nil,
+        plaintextSyncVersion: Int = 1
+    ) -> EnclavePullItem {
+        var chat = makeChat(id: "remote", title: "Remote")
+        chat.projectId = plaintextProjectId
+        let plaintext = try! JSONEncoder().encode(
+            StoredChat(from: chat, syncVersion: plaintextSyncVersion)
+        ).base64EncodedString()
+        var json: [String: Any] = [
+            "id": chat.id,
+            "ok": true,
+            "plaintext": plaintext,
+        ]
+        if let etag {
+            json["etag"] = etag
+        }
+        if let projectIdSet {
+            json["project_id_set"] = projectIdSet
+        }
+        if let projectId {
+            json["project_id"] = projectId
+        }
+        return EnclavePullResponse(json: ["items": [json]]).items[0]
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds encrypted chat search backed by the sync enclave and a new sidebar search box. Automatically rebuilds the index (including legacy keys), scopes results to the signed-in account and root list, and falls back to local title filtering when server-side search isn’t available or refreshes fail.

- **New Features**
  - `SyncEnclaveAPI`: client bindings for `/v1/search/query`, `/v1/search/reindex`, `/v1/search/reindex-status` with tolerant decoding.
  - `ChatSearchService`: queries the enclave, resolves result IDs to full chats (pulls when missing), applies authoritative metadata on decode, and coordinates reindex with polling, timeout, and failure cooldown.
  - `ChatSearchController`: debounces input, cancels superseded terms, exposes `results`, `isSearching`, `isIndexing`, `available`, and re-queries after a completed or clean-partial rebuild.
  - Sidebar: adds a search field on the cloud tab (only when authenticated and cloud sync is enabled); shows progress/indexing; results replace the list; degrades to local title filtering when search is unavailable.

- **Bug Fixes**
  - Reindex: treats an expired job as completed only when polling; treats an “idle” kickoff as failure to avoid loops; poll budget outlives the server job budget; failed runs start a cooldown.
  - Recovery: clears indexing state when a refresh throws or a rebuild fails/times out; state resets on account change to avoid cross-account leakage.
  - Scoping: results limited to the current account and the root list; search resolution applies authoritative project assignment and sync version, and excludes temporary, blank, and undecryptable chats.

<sup>Written for commit ec64a872aa18675662cddb12b07d53cb276b8a78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

