### PR TITLE
fix: classify app errors without parsing messages

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -140,6 +140,14 @@ enum Constants {
             /// Wire code returned with a 429 when a subscriber exceeds the
             /// per-account hourly inference-token cap.
             static let hourlyLimitReached = "HOURLY_LIMIT_REACHED"
+            /// OpenAI-style structured codes carried in the error body when
+            /// a request is rejected for quota or rate-limit reasons.
+            static let insufficientQuota = "insufficient_quota"
+            static let rateLimitExceeded = "rate_limit_exceeded"
+        }
+
+        enum ErrorType {
+            static let rateLimit = "rate_limit_error"
         }
     }
 

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -672,6 +672,10 @@ struct Message: Identifiable, Codable, Equatable {
     /// than the free-tier daily limit, so the UI shows a transient
     /// "try again shortly" message instead of an upgrade prompt.
     var isHourlyLimitError: Bool = false
+    /// True when the stream failed on connectivity (classified from the
+    /// URLError at catch time), so the error card shows the wifi icon and
+    /// "Connection Lost" header without inspecting the message text.
+    var isConnectionError: Bool = false
     var generationTimeSeconds: Double? = nil
     var contentChunks: [ContentChunk] = []
     var thinkingChunks: [ThinkingChunk] = []
@@ -767,7 +771,7 @@ struct Message: Identifiable, Codable, Equatable {
     // MARK: - Codable Implementation
     
     enum CodingKeys: String, CodingKey {
-        case id, role, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, generationTimeSeconds, webSearchState
+        case id, role, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, isConnectionError, generationTimeSeconds, webSearchState
         case webSearch // Alternative key used by React app
         case urlFetches
         case attachments
@@ -806,6 +810,7 @@ struct Message: Identifiable, Codable, Equatable {
         isRequestError = try container.decodeIfPresent(Bool.self, forKey: .isRequestError) ?? false
         isRateLimitError = try container.decodeIfPresent(Bool.self, forKey: .isRateLimitError) ?? false
         isHourlyLimitError = try container.decodeIfPresent(Bool.self, forKey: .isHourlyLimitError) ?? false
+        isConnectionError = try container.decodeIfPresent(Bool.self, forKey: .isConnectionError) ?? false
         generationTimeSeconds = try container.decodeIfPresent(Double.self, forKey: .generationTimeSeconds)
         // contentChunks and thinkingChunks are transient UI rendering state — never decoded from storage
         contentChunks = []
@@ -974,6 +979,7 @@ struct Message: Identifiable, Codable, Equatable {
         if isRequestError { try container.encode(isRequestError, forKey: .isRequestError) }
         if isRateLimitError { try container.encode(isRateLimitError, forKey: .isRateLimitError) }
         if isHourlyLimitError { try container.encode(isHourlyLimitError, forKey: .isHourlyLimitError) }
+        if isConnectionError { try container.encode(isConnectionError, forKey: .isConnectionError) }
         try container.encodeIfPresent(generationTimeSeconds, forKey: .generationTimeSeconds)
         // contentChunks is transient UI rendering state — never encode it
         // Encode as "webSearch" for React app compatibility

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -810,7 +810,15 @@ struct Message: Identifiable, Codable, Equatable {
         isRequestError = try container.decodeIfPresent(Bool.self, forKey: .isRequestError) ?? false
         isRateLimitError = try container.decodeIfPresent(Bool.self, forKey: .isRateLimitError) ?? false
         isHourlyLimitError = try container.decodeIfPresent(Bool.self, forKey: .isHourlyLimitError) ?? false
-        isConnectionError = try container.decodeIfPresent(Bool.self, forKey: .isConnectionError) ?? false
+        // Messages persisted before the typed flag existed (or written by
+        // clients that don't emit it) lack the key entirely; fall back to
+        // the legacy text heuristic so their error cards keep rendering as
+        // connection failures.
+        if let decodedConnectionError = try container.decodeIfPresent(Bool.self, forKey: .isConnectionError) {
+            isConnectionError = decodedConnectionError
+        } else {
+            isConnectionError = Self.isLegacyConnectionErrorText(streamError)
+        }
         generationTimeSeconds = try container.decodeIfPresent(Double.self, forKey: .generationTimeSeconds)
         // contentChunks and thinkingChunks are transient UI rendering state — never decoded from storage
         contentChunks = []
@@ -1160,6 +1168,17 @@ struct Message: Identifiable, Codable, Equatable {
     }
 
     // MARK: - Legacy Format Reconstruction
+
+    /// Classifies a persisted error message as a connection failure using
+    /// the text heuristic that predates the typed `isConnectionError` flag.
+    /// Only used when decoding messages that lack the flag.
+    private static func isLegacyConnectionErrorText(_ streamError: String?) -> Bool {
+        guard let msg = streamError?.lowercased() else { return false }
+        return msg.contains("internet connection")
+            || msg.contains("network")
+            || msg.contains("connection was lost")
+            || msg.contains("unable to connect")
+    }
 
     /// Reconstructs attachments from React's legacy format (documents + imageData + documentContent + multimodalText).
     /// React stored these as parallel arrays: documents[i].name paired with imageData[i] for images.

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -987,7 +987,12 @@ struct Message: Identifiable, Codable, Equatable {
         if isRequestError { try container.encode(isRequestError, forKey: .isRequestError) }
         if isRateLimitError { try container.encode(isRateLimitError, forKey: .isRateLimitError) }
         if isHourlyLimitError { try container.encode(isHourlyLimitError, forKey: .isHourlyLimitError) }
-        if isConnectionError { try container.encode(isConnectionError, forKey: .isConnectionError) }
+        // Always persisted alongside a stream error (even when false) so
+        // the decode-time legacy text heuristic only applies to messages
+        // written before the typed flag existed.
+        if streamError != nil || isConnectionError {
+            try container.encode(isConnectionError, forKey: .isConnectionError)
+        }
         try container.encodeIfPresent(generationTimeSeconds, forKey: .generationTimeSeconds)
         // contentChunks is transient UI rendering state — never encode it
         // Encode as "webSearch" for React app compatibility

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -226,34 +226,21 @@ enum EnclaveErrorRecovery {
     }
 
     /// True for URLSession-level transport failures we know retry
-    /// can plausibly heal. URLError bridges to NSError under
-    /// NSURLErrorDomain so both casts are checked. TLS/cert
+    /// can plausibly heal. TLS/cert
     /// failures are intentionally excluded — they are almost
     /// always persistent (misconfigured server, expired cert,
     /// pinning failure) and retrying just burns the budget; they
     /// fall through to the terminal default so the recovery
     /// dispatcher surfaces them.
     static func isTransientNetwork(_ error: Error) -> Bool {
-        let transientURLCodes: Set<Int> = [
-            NSURLErrorTimedOut,
-            NSURLErrorCannotFindHost,
-            NSURLErrorCannotConnectToHost,
-            NSURLErrorNetworkConnectionLost,
-            NSURLErrorNotConnectedToInternet,
-            NSURLErrorDNSLookupFailed,
-            NSURLErrorResourceUnavailable,
-            NSURLErrorInternationalRoamingOff,
-            NSURLErrorCallIsActive,
-            NSURLErrorDataNotAllowed,
-            NSURLErrorRequestBodyStreamExhausted,
-        ]
-        if let urlError = error as? URLError {
-            return transientURLCodes.contains(urlError.errorCode)
+        if URLErrorClassifier.isConnectivityFailure(error) {
+            return true
         }
+        // Request-body stream exhaustion is retry-worthy here (the retry
+        // rebuilds the body) but is not a connection loss, so it extends
+        // the shared connectivity set rather than living in it.
         let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain {
-            return transientURLCodes.contains(nsError.code)
-        }
-        return false
+        return nsError.domain == NSURLErrorDomain
+            && nsError.code == NSURLErrorRequestBodyStreamExhausted
     }
 }

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -132,14 +132,6 @@ enum EnclaveErrorRecovery {
                 message: message
             )
         }
-        if isAttestation(error) {
-            return EnclaveErrorClassification(
-                kind: .terminal,
-                code: .attestationFailed,
-                status: nil,
-                message: message
-            )
-        }
         return EnclaveErrorClassification(
             kind: .terminal,
             code: nil,
@@ -231,14 +223,6 @@ enum EnclaveErrorRecovery {
             // same request can never heal it.
             return .abort(reason: .preconditionRequired)
         }
-    }
-
-    private static func isAttestation(_ error: Error) -> Bool {
-        let msg = (error as NSError).localizedDescription.lowercased()
-        return msg.contains("attestation")
-            || msg.contains("enclave verification")
-            || msg.contains("verification document")
-            || msg.contains("verifier")
     }
 
     /// True for URLSession-level transport failures we know retry

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
@@ -201,12 +201,19 @@ actor SyncEnclaveClient {
             return try await existing.value
         }
         try Self.assertSecureURL(enclaveURL)
+        // The task itself produces the wrapped error so concurrent callers
+        // awaiting `existing.value` above receive the same typed error as
+        // the creator, keeping every waiter on the recovery path.
         let task = Task<SecureClient, Error> { [enclaveURL, configRepo] in
             let newClient = SecureClient(
                 githubRepo: configRepo,
                 enclaveURL: enclaveURL
             )
-            _ = try await newClient.verify()
+            do {
+                _ = try await newClient.verify()
+            } catch {
+                throw Self.wrapVerificationError(error)
+            }
             return newClient
         }
         verificationTask = task
@@ -218,7 +225,7 @@ actor SyncEnclaveClient {
             return verified
         } catch {
             self.verificationTask = nil
-            throw Self.wrapVerificationError(error)
+            throw error
         }
     }
 

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
@@ -171,6 +171,26 @@ actor SyncEnclaveClient {
         )
     }
 
+    /// Attestation failures can only originate from the `verify()` call
+    /// below, so they are stamped with the ATTESTATION_FAILED wire code
+    /// here at the source — the recovery classifier matches the typed
+    /// code, never the error text. Transient transport failures keep the
+    /// NETWORK code so verification is retried, and cancellation is
+    /// rethrown untouched.
+    static func wrapVerificationError(_ error: Error) -> Error {
+        if error is CancellationError { return error }
+        if EnclaveErrorRecovery.isTransientNetwork(error) {
+            return SyncEnclaveError(
+                message: "Sync enclave verification failed: \(error.localizedDescription)",
+                code: WireCodes.network
+            )
+        }
+        return SyncEnclaveError(
+            message: error.localizedDescription,
+            code: WireCodes.attestationFailed
+        )
+    }
+
     // MARK: - Private
 
     private func getClient() async throws -> SecureClient {
@@ -198,7 +218,7 @@ actor SyncEnclaveClient {
             return verified
         } catch {
             self.verificationTask = nil
-            throw error
+            throw Self.wrapVerificationError(error)
         }
     }
 

--- a/TinfoilChat/Utilities/URLErrorClassifier.swift
+++ b/TinfoilChat/Utilities/URLErrorClassifier.swift
@@ -1,0 +1,37 @@
+//
+//  URLErrorClassifier.swift
+//  TinfoilChat
+//
+//  Single source of truth for classifying NSURLErrorDomain failures
+//  as connectivity losses. URLError bridges to NSError under
+//  NSURLErrorDomain, so one NSError check covers both forms.
+//
+
+import Foundation
+
+enum URLErrorClassifier {
+    /// URLError codes that represent a lost or unavailable network
+    /// connection. Cancellation, malformed requests, TLS/cert failures,
+    /// and request-body stream exhaustion share NSURLErrorDomain but are
+    /// not connection losses, so they are excluded here. Retry-oriented
+    /// consumers extend this set (see
+    /// `EnclaveErrorRecovery.isTransientNetwork`).
+    static let connectivityErrorCodes: Set<Int> = [
+        NSURLErrorTimedOut,
+        NSURLErrorCannotFindHost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorDNSLookupFailed,
+        NSURLErrorResourceUnavailable,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorCallIsActive,
+        NSURLErrorDataNotAllowed,
+    ]
+
+    static func isConnectivityFailure(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain
+            && connectivityErrorCodes.contains(nsError.code)
+    }
+}

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2443,29 +2443,9 @@ class ChatViewModel: ObservableObject {
         return nil
     }
 
-    /// URLError codes that represent a lost or unavailable network
-    /// connection. Intentionally narrower than retry-oriented predicates:
-    /// cancellation, malformed requests, TLS/cert failures, and
-    /// request-body stream exhaustion share NSURLErrorDomain but are not
-    /// connection losses, so they keep the generic error classification.
-    private static let connectivityErrorCodes: Set<Int> = [
-        NSURLErrorTimedOut,
-        NSURLErrorCannotFindHost,
-        NSURLErrorCannotConnectToHost,
-        NSURLErrorNetworkConnectionLost,
-        NSURLErrorNotConnectedToInternet,
-        NSURLErrorDNSLookupFailed,
-        NSURLErrorResourceUnavailable,
-        NSURLErrorInternationalRoamingOff,
-        NSURLErrorCallIsActive,
-        NSURLErrorDataNotAllowed,
-    ]
-
     /// Checks if an error is a connectivity failure.
     static func isConnectionError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        return nsError.domain == NSURLErrorDomain
-            && connectivityErrorCodes.contains(nsError.code)
+        URLErrorClassifier.isConnectivityFailure(error)
     }
 
     /// Checks if an error indicates the user has hit their rate limit

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2279,8 +2279,9 @@ class ChatViewModel: ObservableObject {
                             }
                             chat.messages[lastIndex].isRequestError = self.isRequestError(error)
                             chat.messages[lastIndex].streamError = userFriendlyError
-                            chat.messages[lastIndex].isRateLimitError = self.isRateLimitError(error) || hitHourlyCap
+                            chat.messages[lastIndex].isRateLimitError = Self.isRateLimitError(error) || hitHourlyCap
                             chat.messages[lastIndex].isHourlyLimitError = hitHourlyCap
+                            chat.messages[lastIndex].isConnectionError = Self.isConnectionError(error)
 
                             self.updateChat(chat)
                         }
@@ -2442,13 +2443,26 @@ class ChatViewModel: ObservableObject {
         return nil
     }
 
+    /// Checks if an error is a connectivity failure. URLSession reports
+    /// every transport-level failure under NSURLErrorDomain, so the domain
+    /// check covers URLError and its NSError bridge in one place.
+    static func isConnectionError(_ error: Error) -> Bool {
+        (error as NSError).domain == NSURLErrorDomain
+    }
+
     /// Checks if an error indicates the user has hit their rate limit
-    private func isRateLimitError(_ error: Error) -> Bool {
+    static func isRateLimitError(_ error: Error) -> Bool {
         if case OpenAIError.statusError(_, let statusCode) = error, statusCode == 429 {
             return true
         }
-        let msg = error.localizedDescription.lowercased()
-        return msg.contains("rate limit") || msg.contains("request limit") || msg.contains("insufficient_quota")
+        // Non-streaming path: the SDK decodes the response body into
+        // APIErrorResponse, which carries the structured code field.
+        if let apiError = error as? APIErrorResponse {
+            return apiError.error.type == Constants.API.ErrorType.rateLimit
+                || apiError.error.code == Constants.API.ErrorCode.insufficientQuota
+                || apiError.error.code == Constants.API.ErrorCode.rateLimitExceeded
+        }
+        return false
     }
 
     /// Checks if an error is a client request error (4xx, excluding 401 which is handled by retry)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2443,11 +2443,12 @@ class ChatViewModel: ObservableObject {
         return nil
     }
 
-    /// Checks if an error is a connectivity failure. URLSession reports
-    /// every transport-level failure under NSURLErrorDomain, so the domain
-    /// check covers URLError and its NSError bridge in one place.
+    /// Checks if an error is a connectivity failure. Only transient
+    /// transport codes count — cancellation, malformed requests, and
+    /// TLS/cert failures share NSURLErrorDomain but are not connection
+    /// losses, so they keep the generic error classification.
     static func isConnectionError(_ error: Error) -> Bool {
-        (error as NSError).domain == NSURLErrorDomain
+        EnclaveErrorRecovery.isTransientNetwork(error)
     }
 
     /// Checks if an error indicates the user has hit their rate limit

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2443,12 +2443,29 @@ class ChatViewModel: ObservableObject {
         return nil
     }
 
-    /// Checks if an error is a connectivity failure. Only transient
-    /// transport codes count — cancellation, malformed requests, and
-    /// TLS/cert failures share NSURLErrorDomain but are not connection
-    /// losses, so they keep the generic error classification.
+    /// URLError codes that represent a lost or unavailable network
+    /// connection. Intentionally narrower than retry-oriented predicates:
+    /// cancellation, malformed requests, TLS/cert failures, and
+    /// request-body stream exhaustion share NSURLErrorDomain but are not
+    /// connection losses, so they keep the generic error classification.
+    private static let connectivityErrorCodes: Set<Int> = [
+        NSURLErrorTimedOut,
+        NSURLErrorCannotFindHost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorDNSLookupFailed,
+        NSURLErrorResourceUnavailable,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorCallIsActive,
+        NSURLErrorDataNotAllowed,
+    ]
+
+    /// Checks if an error is a connectivity failure.
     static func isConnectionError(_ error: Error) -> Bool {
-        EnclaveErrorRecovery.isTransientNetwork(error)
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain
+            && connectivityErrorCodes.contains(nsError.code)
     }
 
     /// Checks if an error indicates the user has hit their rate limit

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -593,6 +593,7 @@ struct MessageView: View {
                         isRequestError: message.isRequestError,
                         isRateLimitError: message.isRateLimitError,
                         isHourlyLimit: message.isHourlyLimitError,
+                        isConnectionError: message.isConnectionError,
                         onRegenerate: isLastMessage ? { viewModel.regenerateLastResponse() } : nil,
                         onUpgrade: (message.isRateLimitError && !message.isHourlyLimitError) ? { viewModel.showRateLimitPaywall = true } : nil
                     )
@@ -1709,16 +1710,12 @@ struct ErrorMessageView: View {
     var isRequestError: Bool = false
     var isRateLimitError: Bool = false
     var isHourlyLimit: Bool = false
+    var isConnectionError: Bool = false
     var onRegenerate: (() -> Void)? = nil
     var onUpgrade: (() -> Void)? = nil
 
     private var accentColor: Color {
         isRateLimitError ? .orange : (isRequestError ? .red : .orange)
-    }
-
-    private var isConnectionError: Bool {
-        let msg = errorMessage.lowercased()
-        return msg.contains("internet connection") || msg.contains("network") || msg.contains("connection was lost") || msg.contains("unable to connect")
     }
 
     private var headerIcon: String {

--- a/TinfoilChatTests/AuthenticationErrorTests.swift
+++ b/TinfoilChatTests/AuthenticationErrorTests.swift
@@ -104,6 +104,68 @@ struct AuthenticationErrorTests {
         #expect(ChatViewModel.isAuthenticationError(error) == false)
     }
 
+    // MARK: - Typed rate-limit and connection classification
+
+    @Test("Detects HTTP 429 as rate-limit error")
+    func detectsStatusError429AsRateLimit() {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        let error = OpenAIError.statusError(response: response, statusCode: 429)
+        #expect(ChatViewModel.isRateLimitError(error) == true)
+    }
+
+    @Test("Detects structured rate-limit API type")
+    func detectsStructuredRateLimitType() {
+        let error = Self.makeAPIErrorResponse(
+            message: "Request rejected",
+            type: Constants.API.ErrorType.rateLimit,
+            code: nil
+        )
+        #expect(ChatViewModel.isRateLimitError(error) == true)
+    }
+
+    @Test("Detects structured rate-limit API codes")
+    func detectsStructuredRateLimitCodes() {
+        let insufficientQuota = Self.makeAPIErrorResponse(
+            message: "Quota exhausted",
+            type: "invalid_request_error",
+            code: Constants.API.ErrorCode.insufficientQuota
+        )
+        let rateLimitExceeded = Self.makeAPIErrorResponse(
+            message: "Too many requests",
+            type: "invalid_request_error",
+            code: Constants.API.ErrorCode.rateLimitExceeded
+        )
+
+        #expect(ChatViewModel.isRateLimitError(insufficientQuota) == true)
+        #expect(ChatViewModel.isRateLimitError(rateLimitExceeded) == true)
+    }
+
+    @Test("Does not infer rate limit from unstructured prose")
+    func doesNotInferRateLimitFromMessage() {
+        let error = NSError(
+            domain: "test",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "rate limit exceeded"]
+        )
+        #expect(ChatViewModel.isRateLimitError(error) == false)
+    }
+
+    @Test("Classifies URL transport errors without inspecting prose")
+    func classifiesConnectionErrorsByDomain() {
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorNetworkConnectionLost,
+            userInfo: [NSLocalizedDescriptionKey: "arbitrary localized text"]
+        )
+        #expect(ChatViewModel.isConnectionError(error) == true)
+        #expect(ChatViewModel.isConnectionError(NSError(domain: "test", code: 1)) == false)
+    }
+
     // MARK: - Live API: streaming path
 
     @Test("Streaming with bad API key throws error detected by isAuthenticationError")

--- a/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
+++ b/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
@@ -103,17 +103,32 @@ struct EnclaveErrorRecoveryTests {
 
     // MARK: - Non-SyncEnclaveError fallback
 
-    @Test func attestationMessageDetectsBlockAllSync() {
+    @Test func wrappedVerificationFailureMapsToBlockAllSync() {
+        // Attestation failures are tagged at the verify() call site, so
+        // classification never depends on what the error text says.
         struct E: LocalizedError {
-            let errorDescription: String? = "Attestation verifier failed"
+            let errorDescription: String? = "code measurement mismatch"
         }
-        let decision = EnclaveErrorRecovery.decide(E())
+        let wrapped = SyncEnclaveClient.wrapVerificationError(E())
+        let decision = EnclaveErrorRecovery.decide(wrapped)
         #expect(decision.action == .blockAllSync(reason: .attestationFailed))
+        #expect(decision.classification.code == .attestationFailed)
     }
 
-    @Test func plainErrorMapsToAbortUnknown() {
+    @Test func transientNetworkFailureDuringVerificationRetries() {
+        let wrapped = SyncEnclaveClient.wrapVerificationError(URLError(.timedOut))
+        let decision = EnclaveErrorRecovery.decide(wrapped)
+        #expect(decision.action == .retry(reason: .network))
+    }
+
+    @Test func cancellationDuringVerificationIsNotWrapped() {
+        let wrapped = SyncEnclaveClient.wrapVerificationError(CancellationError())
+        #expect(wrapped is CancellationError)
+    }
+
+    @Test func rawAttestationProseDoesNotControlClassification() {
         struct E: LocalizedError {
-            let errorDescription: String? = "unrelated failure"
+            let errorDescription: String? = "Attestation verifier failed"
         }
         let decision = EnclaveErrorRecovery.decide(E())
         #expect(decision.action == .abort(reason: .unknown))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Classifies rate-limit, connection, and enclave verification errors using structured codes and a shared URL error classifier instead of parsing messages. Prevents mislabeling on reload and gives all waiters consistent, typed verification failures.

- **Bug Fixes**
  - Rate limits: detect via HTTP 429 and `APIErrorResponse` type/code (`rate_limit_error`, `insufficient_quota`, `rate_limit_exceeded`); added constants; no string matching.
  - Connection issues: mark only `NSURLErrorDomain` connectivity codes (centralized in `URLErrorClassifier`); set and persist `Message.isConnectionError`; apply legacy text heuristic only when the flag is missing so saved messages keep their labels. Retry logic separately allows `NSURLErrorRequestBodyStreamExhausted` without labeling it as a connection loss.
  - Enclave verification: wrap `verify()` errors with wire codes (`ATTESTATION_FAILED` or `NETWORK`) at the source and throw from the shared verification task so all waiters see the same typed error; cancellations pass through.
  - Tests: added cases for 429 and structured codes, classifier-based connection detection, and verification wrapping/retry behavior.

<sup>Written for commit a8c9bd7b9a30fa3d918f9c45805d94f8815742ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

