### PR TITLE
UI + UX improvements

### DIFF
--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -88,8 +88,13 @@ final class ChatSearchController: ObservableObject {
                 if settled == .completed || settled == .partial {
                     await run(term: term, userId: userId)
                 } else {
+                    // The rebuild failed, timed out, or was skipped, but
+                    // the query above still answered from the partial
+                    // index. Keep any hits it produced; only degrade to
+                    // the caller's local title fallback when that partial
+                    // index had nothing to offer.
                     isIndexing = false
-                    available = false
+                    available = !results.isEmpty
                 }
             }
         } catch {

--- a/TinfoilChat/ViewModels/ChatSearchController.swift
+++ b/TinfoilChat/ViewModels/ChatSearchController.swift
@@ -58,6 +58,10 @@ final class ChatSearchController: ObservableObject {
             return nil
         }
         isSearching = true
+        // The indexing banner describes the previous term's outcome;
+        // clear it so a fresh query shows the plain searching state
+        // until the enclave answers for this term.
+        isIndexing = false
         searchTask = Task { [weak self] in
             try? await Task.sleep(
                 nanoseconds: UInt64(Constants.SyncEnclave.Search.debounceSeconds * 1_000_000_000)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -930,11 +930,21 @@ class ChatViewModel: ObservableObject {
     }
 
     func enterProject(projectId: String) async {
-        guard hasChatAccess else { return }
+        guard await loadProject(projectId: projectId) else { return }
+        createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
+    }
+
+    /// Loads a project and makes it the active context without touching
+    /// the current chat selection. Returns true when the project became
+    /// active.
+    @discardableResult
+    func loadProject(projectId: String) async -> Bool {
+        guard hasChatAccess else { return false }
 
         isLoadingProject = true
         projectError = nil
         isViewingProjectChat = false
+        var loaded = false
         do {
             let project = try await projectStorage.getProject(projectId)
             guard let project else {
@@ -949,12 +959,12 @@ class ChatViewModel: ObservableObject {
             if syncResult.downloaded > 0 || syncResult.uploaded > 0 || activeProjectChats.isEmpty {
                 await loadProjectChatsIntoMemory(projectId: projectId)
             }
-
-            createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
+            loaded = true
         } catch {
             projectError = error.localizedDescription
         }
         isLoadingProject = false
+        return loaded
     }
 
     func exitProject() {
@@ -997,16 +1007,27 @@ class ChatViewModel: ObservableObject {
             pendingSearchResultChatId = chat.id
             Task {
                 if activeProject?.id != projectId {
-                    await enterProject(projectId: projectId)
+                    // loadProject (not enterProject) so no blank chat is
+                    // selected along the way, which would clear the pending
+                    // token below before it could be checked.
+                    await loadProject(projectId: projectId)
                 }
-                // Open the hit only when it is still the pending one (no
-                // newer selection landed while the project loaded) and its
-                // project actually became active (the load can fail, e.g.
-                // for a deleted project, leaving the previous context in
-                // place); otherwise the chat would open under the wrong
-                // project or none at all.
-                guard pendingSearchResultChatId == chat.id,
-                      activeProject?.id == projectId else { return }
+                // A newer selection during the load supersedes this one:
+                // leave it in charge, and drop the just-loaded project
+                // context if that selection lives outside it so the
+                // project page doesn't cover the chosen chat.
+                guard pendingSearchResultChatId == chat.id else {
+                    if activeProject?.id == projectId, currentChat?.projectId != projectId {
+                        activeProject = nil
+                        projectDocuments = []
+                        isViewingProjectChat = false
+                    }
+                    return
+                }
+                // The load can also fail (e.g. a deleted project), leaving
+                // some other context in place; never open the chat under
+                // the wrong project or none at all.
+                guard activeProject?.id == projectId else { return }
                 openProjectChat(chat)
             }
         } else {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -983,19 +983,34 @@ class ChatViewModel: ObservableObject {
         isViewingProjectChat = true
     }
 
+    /// Search hit whose project is still loading. Any newer chat
+    /// selection replaces or clears it, so a slow project load can
+    /// never navigate away from what the user picked afterwards.
+    private var pendingSearchResultChatId: String?
+
     /// Opens a sidebar search hit, which may live outside the current
     /// context: project chats are opened inside their project so the
     /// conversation keeps its documents and instructions, and root
     /// chats leave any active project first.
     func openSearchResult(_ chat: Chat) {
         if let projectId = chat.projectId {
+            pendingSearchResultChatId = chat.id
             Task {
                 if activeProject?.id != projectId {
                     await enterProject(projectId: projectId)
                 }
+                // Open the hit only when it is still the pending one (no
+                // newer selection landed while the project loaded) and its
+                // project actually became active (the load can fail, e.g.
+                // for a deleted project, leaving the previous context in
+                // place); otherwise the chat would open under the wrong
+                // project or none at all.
+                guard pendingSearchResultChatId == chat.id,
+                      activeProject?.id == projectId else { return }
                 openProjectChat(chat)
             }
         } else {
+            pendingSearchResultChatId = nil
             if activeProject != nil {
                 activeProject = nil
                 projectDocuments = []
@@ -1278,6 +1293,9 @@ class ChatViewModel: ObservableObject {
 
     /// Selects a chat as the current chat
     func selectChat(_ chat: Chat) {
+        // Any explicit selection supersedes a search hit whose project
+        // is still loading.
+        pendingSearchResultChatId = nil
         // If the user picked a different chat while in temporary mode, drop
         // the ephemeral chat and exit temporary mode. The selected chat takes
         // over normally below.

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -934,12 +934,20 @@ class ChatViewModel: ObservableObject {
         createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
     }
 
+    /// Monotonic token for project loads. A newer load supersedes any
+    /// in-flight one, which then resumes stale and must neither mutate
+    /// the shared project context nor report success.
+    private var projectLoadGeneration = 0
+
     /// Loads a project and makes it the active context without touching
     /// the current chat selection. Returns true when the project became
-    /// active.
+    /// active and this load is still the most recent one.
     @discardableResult
     func loadProject(projectId: String) async -> Bool {
         guard hasChatAccess else { return false }
+
+        projectLoadGeneration += 1
+        let generation = projectLoadGeneration
 
         isLoadingProject = true
         projectError = nil
@@ -952,6 +960,7 @@ class ChatViewModel: ObservableObject {
             }
 
             let documents = try await projectStorage.listDocuments(projectId: projectId, includeContent: true)
+            guard generation == projectLoadGeneration else { return false }
             activeProject = project
             projectDocuments = documents
 
@@ -959,8 +968,10 @@ class ChatViewModel: ObservableObject {
             if syncResult.downloaded > 0 || syncResult.uploaded > 0 || activeProjectChats.isEmpty {
                 await loadProjectChatsIntoMemory(projectId: projectId)
             }
+            guard generation == projectLoadGeneration else { return false }
             loaded = true
         } catch {
+            guard generation == projectLoadGeneration else { return false }
             projectError = error.localizedDescription
         }
         isLoadingProject = false
@@ -1020,6 +1031,7 @@ class ChatViewModel: ObservableObject {
                     if activeProject?.id == projectId, currentChat?.projectId != projectId {
                         activeProject = nil
                         projectDocuments = []
+                        projectError = nil
                         isViewingProjectChat = false
                     }
                     return

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -302,6 +302,12 @@ class ChatViewModel: ObservableObject {
         return streamState.isStreaming(chatId: chatId)
     }
 
+    /// Whether the given chat has a response currently being generated,
+    /// regardless of which chat is on screen.
+    func isChatStreaming(_ chatId: String) -> Bool {
+        streamState.isStreaming(chatId: chatId)
+    }
+
     var thinkingSummary: String {
         guard let chatId = currentChat?.id else { return "" }
         return streamState.thinkingSummaries[chatId] ?? ""

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -983,6 +983,29 @@ class ChatViewModel: ObservableObject {
         isViewingProjectChat = true
     }
 
+    /// Opens a sidebar search hit, which may live outside the current
+    /// context: project chats are opened inside their project so the
+    /// conversation keeps its documents and instructions, and root
+    /// chats leave any active project first.
+    func openSearchResult(_ chat: Chat) {
+        if let projectId = chat.projectId {
+            Task {
+                if activeProject?.id != projectId {
+                    await enterProject(projectId: projectId)
+                }
+                openProjectChat(chat)
+            }
+        } else {
+            if activeProject != nil {
+                activeProject = nil
+                projectDocuments = []
+                projectError = nil
+                isViewingProjectChat = false
+            }
+            selectChat(chat)
+        }
+    }
+
     func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
         guard let project = activeProject else { return }
 

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -9,15 +9,15 @@ import SwiftUI
 import ClerkKit
 import SafariServices
 
-func isRootSidebarChat(_ chat: Chat) -> Bool {
-    !chat.isTemporary && chat.projectId == nil && !chat.decryptionFailed
-}
-
 /// Search results, unlike the root list, do surface project chats (the
 /// index covers every synced chat and the webapp shows them too); only
 /// temporary and undecryptable chats are excluded.
 func isSearchResultSidebarChat(_ chat: Chat) -> Bool {
     !chat.isTemporary && !chat.decryptionFailed
+}
+
+func isRootSidebarChat(_ chat: Chat) -> Bool {
+    isSearchResultSidebarChat(chat) && chat.projectId == nil
 }
 
 func isSidebarChatSearchEnabled(

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -13,6 +13,13 @@ func isRootSidebarChat(_ chat: Chat) -> Bool {
     !chat.isTemporary && chat.projectId == nil && !chat.decryptionFailed
 }
 
+/// Search results, unlike the root list, do surface project chats (the
+/// index covers every synced chat and the webapp shows them too); only
+/// temporary and undecryptable chats are excluded.
+func isSearchResultSidebarChat(_ chat: Chat) -> Bool {
+    !chat.isTemporary && !chat.decryptionFailed
+}
+
 func isSidebarChatSearchEnabled(
     isAuthenticated: Bool,
     isCloudSyncEnabled: Bool,
@@ -94,10 +101,7 @@ struct ChatSidebar: View {
                 !$0.isBlankChat && $0.title.lowercased().contains(needle)
             }
         }
-        // The index covers every synced chat, so results can include
-        // project chats; apply the same root-list exclusions so search
-        // never surfaces rows this list would not show.
-        return chatSearch.results.filter(isRootSidebarChat)
+        return chatSearch.results.filter(isSearchResultSidebarChat)
     }
 
     private var displayedChats: [Chat] {
@@ -379,7 +383,11 @@ struct ChatSidebar: View {
                     syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
                     isGenerating: viewModel.isChatStreaming(chat.id),
                     onSelect: {
-                        viewModel.selectChat(chat)
+                        if isChatSearchActive {
+                            viewModel.openSearchResult(chat)
+                        } else {
+                            viewModel.selectChat(chat)
+                        }
                     },
                     onEdit: {
                         if editingChatId == chat.id {
@@ -770,6 +778,12 @@ struct ChatListItem: View {
                         }
                     } else {
                         HStack(spacing: 4) {
+                            if chat.projectId != nil {
+                                Image(systemName: "folder")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .accessibilityHidden(true)
+                            }
                             Text(chat.title)
                                 .foregroundColor(.primary)
                                 .lineLimit(1)
@@ -865,6 +879,9 @@ struct ChatListItem: View {
             return "Encrypted chat. Failed to decrypt, wrong key."
         }
         var components = [chat.title.isEmpty ? "Untitled chat" : chat.title]
+        if chat.projectId != nil {
+            components.append("Project chat")
+        }
         if chat.isBlankChat {
             components.append("New chat")
         } else if !createdTimeString.isEmpty {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -92,13 +92,17 @@ struct ChatSidebar: View {
         guard isChatSearchActive else { return [] }
         // Enclave unavailable (older deploy, no eligible key): degrade
         // to filtering the locally loaded titles so the box still does
-        // something useful.
+        // something useful. Draw from the loaded cloud chats with the
+        // search-result predicate so project chats stay findable here
+        // too, matching the server-backed results.
         guard chatSearch.available else {
             let needle = chatSearchTerm
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .lowercased()
-            return filteredChats.filter {
-                !$0.isBlankChat && $0.title.lowercased().contains(needle)
+            return viewModel.chats.filter {
+                isSearchResultSidebarChat($0)
+                    && !$0.isBlankChat
+                    && $0.title.lowercased().contains(needle)
             }
         }
         return chatSearch.results.filter(isSearchResultSidebarChat)

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -377,6 +377,7 @@ struct ChatSidebar: View {
                     updatedTimeString: chat.isBlankChat ? "" : updatedTimeString(for: chat),
                     isSyncing: !chat.isBlankChat && cloudSync.pendingUploadChatIds.contains(chat.id),
                     syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
+                    isGenerating: viewModel.isChatStreaming(chat.id),
                     onSelect: {
                         viewModel.selectChat(chat)
                     },
@@ -735,6 +736,7 @@ struct ChatListItem: View {
     let updatedTimeString: String
     var isSyncing: Bool = false
     var syncFailed: Bool = false
+    var isGenerating: Bool = false
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -808,7 +810,11 @@ struct ChatListItem: View {
                                 + Text(updatedTimeString.isEmpty ? "" : " · \(updatedTimeString)")
                                 .foregroundColor(Color(UIColor.tertiaryLabel)))
                                 .font(.caption)
-                            if syncFailed {
+                            if isGenerating {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(width: 12, height: 12)
+                            } else if syncFailed {
                                 Image(systemName: "exclamationmark.triangle")
                                     .font(.caption2)
                                     .foregroundColor(.orange)
@@ -867,7 +873,9 @@ struct ChatListItem: View {
                 components.append(updatedTimeString)
             }
         }
-        if syncFailed {
+        if isGenerating {
+            components.append("Generating response")
+        } else if syncFailed {
             components.append("Couldn't sync with cloud")
         } else if isSyncing {
             components.append("Syncing with cloud")

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -93,12 +93,16 @@ struct MessageTableView: UIViewRepresentable {
             context.coordinator.lastChatId = currentChatId
             context.coordinator.preservedOffsetAfterStreaming = nil
             context.coordinator.isCollapsingStreamingBuffer = false
-            // Sync the loading flag on chat switches so the buffer-collapse
-            // path below never runs for a switch away from a chat that is
-            // still streaming; it only describes a stream ending in place.
-            context.coordinator.lastIsLoading = isLoading
 
             if !isIdConversion {
+                // Sync the loading flag on real chat switches so the
+                // buffer-collapse path below never runs for a switch away
+                // from a chat that is still streaming; it only describes a
+                // stream ending in place. ID conversions keep the prior value:
+                // the same conversation stays on screen with its wrappers
+                // retained, so a stream that ends across the conversion must
+                // still collapse its buffer through the normal path.
+                context.coordinator.lastIsLoading = isLoading
                 context.coordinator.messageWrappers.removeAll()
                 context.coordinator.shownMessageIds.removeAll()
 

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -93,10 +93,25 @@ struct MessageTableView: UIViewRepresentable {
             context.coordinator.lastChatId = currentChatId
             context.coordinator.preservedOffsetAfterStreaming = nil
             context.coordinator.isCollapsingStreamingBuffer = false
+            // Sync the loading flag on chat switches so the buffer-collapse
+            // path below never runs for a switch away from a chat that is
+            // still streaming; it only describes a stream ending in place.
+            context.coordinator.lastIsLoading = isLoading
 
             if !isIdConversion {
                 context.coordinator.messageWrappers.removeAll()
                 context.coordinator.shownMessageIds.removeAll()
+
+                // Drop any streaming inset left behind by the previous chat,
+                // and reset a blank chat to the top since no scroll trigger
+                // will fire to position it.
+                UIView.performWithoutAnimation {
+                    tableView.contentInset.bottom = 0
+                    tableView.verticalScrollIndicatorInsets.bottom = 0
+                    if messages.isEmpty {
+                        tableView.contentOffset.y = -tableView.adjustedContentInset.top
+                    }
+                }
             }
             context.coordinator.lastMessageIds = currentMessageIds
         } else if currentMessageIds != context.coordinator.lastMessageIds {
@@ -923,6 +938,15 @@ struct ObservableMessageCell: View {
                     view.background(
                         GeometryReader { geometry in
                             Color.clear
+                                // Report the initial height too: when the user
+                                // switches back to a chat that is mid-stream its
+                                // wrapper is recreated, and without this the
+                                // content height stays 0 until the next token,
+                                // so the unused buffer cannot be inset away and
+                                // scroll-to-bottom lands in blank space.
+                                .onAppear {
+                                    wrapper.actualContentHeight = geometry.size.height
+                                }
                                 .onChange(of: geometry.size.height) { _, newHeight in
                                     wrapper.actualContentHeight = newHeight
                                 }

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -32,6 +32,39 @@ struct ChatSearchControllerTests {
     }
 
     @Test
+    func keepsPartialIndexResultsWhenTheRebuildFails() async {
+        let recorder = ChatSearchServiceTests.Recorder()
+        let service = ChatSearchServiceTests.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(
+                    results: [EnclaveSearchQueryResult(id: "a", score: 1)],
+                    totalIndexed: 1,
+                    needsReindex: true
+                )
+            },
+            searchReindex: { _ in
+                EnclaveSearchReindexStatusResponse(
+                    jobId: "job-1", status: "failed", indexed: 0, failed: 1,
+                    totalIndexed: 1, partial: true, error: "chat could not be indexed"
+                )
+            },
+            loadLocalChat: { chatId, _ in
+                ChatSearchServiceTests.makeChat(id: chatId, title: "Pond notes")
+            }
+        )
+        let controller = ChatSearchController(service: service)
+
+        await controller.updateTerm("ducks", userId: "user-1")?.value
+
+        #expect(controller.results.map(\.id) == ["a"])
+        #expect(controller.available == true)
+        #expect(controller.isIndexing == false)
+        #expect(controller.isSearching == false)
+        #expect(recorder.queryRequests.count == 1)
+    }
+
+    @Test
     func clearsIndexingAfterFailedRebuild() async {
         let recorder = ChatSearchServiceTests.Recorder()
         let service = ChatSearchServiceTests.makeService(

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -139,11 +139,21 @@ struct ChatSearchControllerTests {
     }
 
     @Test
-    func rootSidebarFilterExcludesProjectSearchResults() {
+    func searchResultFilterKeepsProjectChatsButDropsTemporaryAndEncrypted() {
         let root = ChatSearchServiceTests.makeChat(id: "root", title: "Root")
         var project = ChatSearchServiceTests.makeChat(id: "project", title: "Project")
         project.projectId = "project-1"
+        var temporary = ChatSearchServiceTests.makeChat(id: "temp", title: "Temp")
+        temporary.isTemporary = true
+        var encrypted = ChatSearchServiceTests.makeChat(id: "encrypted", title: "Encrypted")
+        encrypted.decryptionFailed = true
 
+        let visible = [root, project, temporary, encrypted]
+            .filter(isSearchResultSidebarChat)
+            .map(\.id)
+        #expect(visible == ["root", "project"])
+
+        // The root chat list itself still excludes project chats.
         #expect([root, project].filter(isRootSidebarChat).map(\.id) == ["root"])
     }
 

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -65,6 +65,35 @@ struct ChatSearchControllerTests {
     }
 
     @Test
+    func clearsStaleIndexingBannerWhenANewTermStartsSearching() async {
+        let recorder = ChatSearchServiceTests.Recorder()
+        let service = ChatSearchServiceTests.makeService(
+            recorder: recorder,
+            searchQuery: { _ in
+                EnclaveSearchQueryResponse(results: [], totalIndexed: 0, needsReindex: true)
+            },
+            searchReindex: { _ in
+                // Keep the rebuild in flight so isIndexing stays raised
+                // from the first term's outcome.
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return ChatSearchServiceTests.runningStatus()
+            }
+        )
+        let controller = ChatSearchController(service: service)
+
+        controller.updateTerm("duck", userId: "user-1")
+        for _ in 0..<100 where !controller.isIndexing {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(controller.isIndexing == true)
+
+        controller.updateTerm("ducks", userId: "user-1")
+
+        #expect(controller.isIndexing == false)
+        #expect(controller.isSearching == true)
+    }
+
+    @Test
     func clearsIndexingAfterFailedRebuild() async {
         let recorder = ChatSearchServiceTests.Recorder()
         let service = ChatSearchServiceTests.makeService(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a global `webSearchAvailable` and a per‑chat `webSearchEnabled`. Enables parallel streaming with per‑chat progress, shows generating state in the sidebar, upgrades search (includes project chats), and hardens navigation so stale project loads can’t override newer selections.

- New Features
  - Global `webSearchAvailable`; stored in `UserDefaults`, profile‑synced, defaults on.
  - Chats persist `webSearchEnabled` (default on, legacy‑safe); blank/temporary seed from `webSearchAvailable`.
  - Multiple simultaneous responses with per‑chat thinking/web‑search progress; sidebar shows a spinner for generating chats.
  - Sidebar search includes project chats and opens them inside their project; local fallback uses the same filter; opens project results directly without a blank chat detour.

- Bug Fixes
  - Preserve scroll position and insets when switching/returning to streaming chats; collapse streaming buffer on ID conversions; report initial content height on reappear.
  - Cancel per‑chat streams and pending saves on deletion/sign‑out; scope throttles/timers per chat; stronger cancel/error handling prevents cross‑chat leaks and clears summaries on finish/cancel.
  - Keep search results visible when index rebuild fails/times out/skips; hide stale “indexing” banners when a new term starts.
  - Prevent stale project loads from overriding newer selections; only open project hits after a successful load; never open under the wrong project.
  - Migrate from the legacy shared web search key to `webSearchAvailable`.

<sup>Written for commit b729093b39e90162812627554aa563463d703da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

