### PR TITLE
Enable Siri app intents, concurrent chats, web search controls

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -336,6 +336,7 @@ enum Constants {
             static let hapticFeedbackEnabled = "tinfoil-settings-haptic-feedback-enabled"
             static let selectedLanguage = "tinfoil-settings-selected-language"
             static let webSearchEnabled = "tinfoil-settings-web-search-enabled"
+            static let webSearchAvailable = "tinfoil-settings-web-search-available"
             static let genUIEnabled = "tinfoil-settings-genui-enabled"
             static let reasoningEffort = "tinfoil-settings-reasoning-effort"
             static let thinkingEnabled = "tinfoil-settings-thinking-enabled"

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -47,7 +47,7 @@ struct ContentView: View {
             authManager.setChatViewModel(chatViewModel)
             requestAppReviewIfEligible()
             importSharedAttachmentsIfReady()
-            performPendingIntentActionIfReady()
+            performPendingIntentActionsIfReady()
 
             // Initialize encryption with existing key only (no auto-creation)
             Task {
@@ -163,12 +163,12 @@ struct ContentView: View {
                 if authManager.isAuthenticated {
                     chatViewModel.handleSignIn()
                 }
-                performPendingIntentActionIfReady()
+                performPendingIntentActionsIfReady()
             }
         }
-        .onChange(of: intentCoordinator.pendingAction) { _, action in
-            guard action != nil else { return }
-            performPendingIntentActionIfReady()
+        .onChange(of: intentCoordinator.pendingActions) { _, actions in
+            guard !actions.isEmpty else { return }
+            performPendingIntentActionsIfReady()
         }
         .onChange(of: authManager.hasActiveSubscription) { _, hasSubscription in
             // Update available models when subscription status changes
@@ -217,19 +217,34 @@ struct ContentView: View {
         SharedImportCoordinator.shared.importPendingAttachments(into: chatViewModel)
     }
 
-    private func performPendingIntentActionIfReady() {
+    private func performPendingIntentActionsIfReady() {
         guard !authManager.isLoading else { return }
-        guard let action = intentCoordinator.consumePendingAction() else { return }
-        switch action {
+        while let action = intentCoordinator.consumeNextAction() {
+            perform(intentAction: action)
+        }
+    }
+
+    private func perform(intentAction: AppIntentCoordinator.Action) {
+        switch intentAction {
         case .askQuestion(let prompt):
+            // Signed-out users cannot create chats, so the prompt is sent to
+            // their single session chat, same as typing it in the UI.
             chatViewModel.createNewChat(focusInput: false)
+            guard chatViewModel.currentChat != nil else { return }
             chatViewModel.sendMessage(text: prompt)
         case .newChat:
             chatViewModel.createNewChat()
         case .startDictation:
-            chatViewModel.createNewChat(focusInput: false)
-            Task {
-                await chatViewModel.startAudioRecording()
+            if chatViewModel.canUseAudioInput {
+                chatViewModel.createNewChat(focusInput: false)
+                Task {
+                    await chatViewModel.startAudioRecording()
+                }
+            } else {
+                // Audio input is a premium feature; fall back to a focused
+                // text input so the intent still gives visible feedback.
+                chatViewModel.createNewChat()
+                chatViewModel.shouldFocusInput = true
             }
         }
     }

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @EnvironmentObject private var authManager: AuthManager
     @StateObject private var chatViewModel = TinfoilChat.ChatViewModel()
     @ObservedObject private var passkeyManager = PasskeyManager.shared
+    @ObservedObject private var intentCoordinator = AppIntentCoordinator.shared
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.requestReview) private var requestReview
@@ -46,6 +47,7 @@ struct ContentView: View {
             authManager.setChatViewModel(chatViewModel)
             requestAppReviewIfEligible()
             importSharedAttachmentsIfReady()
+            performPendingIntentActionIfReady()
 
             // Initialize encryption with existing key only (no auto-creation)
             Task {
@@ -161,7 +163,12 @@ struct ContentView: View {
                 if authManager.isAuthenticated {
                     chatViewModel.handleSignIn()
                 }
+                performPendingIntentActionIfReady()
             }
+        }
+        .onChange(of: intentCoordinator.pendingAction) { _, action in
+            guard action != nil else { return }
+            performPendingIntentActionIfReady()
         }
         .onChange(of: authManager.hasActiveSubscription) { _, hasSubscription in
             // Update available models when subscription status changes
@@ -208,6 +215,23 @@ struct ContentView: View {
     private func importSharedAttachmentsIfReady() {
         guard !authManager.isLoading else { return }
         SharedImportCoordinator.shared.importPendingAttachments(into: chatViewModel)
+    }
+
+    private func performPendingIntentActionIfReady() {
+        guard !authManager.isLoading else { return }
+        guard let action = intentCoordinator.consumePendingAction() else { return }
+        switch action {
+        case .askQuestion(let prompt):
+            chatViewModel.createNewChat(focusInput: false)
+            chatViewModel.sendMessage(text: prompt)
+        case .newChat:
+            chatViewModel.createNewChat()
+        case .startDictation:
+            chatViewModel.createNewChat(focusInput: false)
+            Task {
+                await chatViewModel.startAudioRecording()
+            }
+        }
     }
 }
 

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -170,6 +170,10 @@ struct ContentView: View {
             guard !actions.isEmpty else { return }
             performPendingIntentActionsIfReady()
         }
+        .onChange(of: chatViewModel.isLoading) { _, isLoading in
+            guard !isLoading, !intentCoordinator.pendingActions.isEmpty else { return }
+            performPendingIntentActionsIfReady()
+        }
         .onChange(of: authManager.hasActiveSubscription) { _, hasSubscription in
             // Update available models when subscription status changes
             chatViewModel.updateModelBasedOnAuthStatus(
@@ -219,8 +223,24 @@ struct ContentView: View {
 
     private func performPendingIntentActionsIfReady() {
         guard !authManager.isLoading else { return }
-        while let action = intentCoordinator.consumeNextAction() {
+        while let action = intentCoordinator.peekNextAction() {
+            // Stop draining at the first action that cannot run yet so queued
+            // actions stay in order; the isLoading observer resumes the drain.
+            guard canPerform(intentAction: action) else { return }
+            intentCoordinator.popNextAction()
             perform(intentAction: action)
+        }
+    }
+
+    private func canPerform(intentAction: AppIntentCoordinator.Action) -> Bool {
+        switch intentAction {
+        case .askQuestion:
+            // Signed-out users cannot get a fresh chat from createNewChat, so
+            // their single chat must finish streaming before the next prompt,
+            // otherwise sendMessage's isLoading guard would drop it.
+            return chatViewModel.hasChatAccess || !chatViewModel.isLoading
+        case .newChat, .startDictation:
+            return true
         }
     }
 

--- a/TinfoilChat/Intents/AppIntentCoordinator.swift
+++ b/TinfoilChat/Intents/AppIntentCoordinator.swift
@@ -28,8 +28,12 @@ final class AppIntentCoordinator: ObservableObject {
         pendingActions.append(action)
     }
 
-    func consumeNextAction() -> Action? {
-        guard !pendingActions.isEmpty else { return nil }
-        return pendingActions.removeFirst()
+    func peekNextAction() -> Action? {
+        pendingActions.first
+    }
+
+    func popNextAction() {
+        guard !pendingActions.isEmpty else { return }
+        pendingActions.removeFirst()
     }
 }

--- a/TinfoilChat/Intents/AppIntentCoordinator.swift
+++ b/TinfoilChat/Intents/AppIntentCoordinator.swift
@@ -1,0 +1,35 @@
+//
+//  AppIntentCoordinator.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+//
+
+import Foundation
+
+/// Buffers actions requested by App Intents (Siri, Shortcuts, Action button)
+/// until the chat UI is ready to perform them. Intents run before or while
+/// the app is foregrounding, so the live ChatViewModel may not exist yet.
+@MainActor
+final class AppIntentCoordinator: ObservableObject {
+    static let shared = AppIntentCoordinator()
+
+    enum Action: Equatable {
+        case askQuestion(String)
+        case newChat
+        case startDictation
+    }
+
+    @Published private(set) var pendingAction: Action?
+
+    private init() {}
+
+    func enqueue(_ action: Action) {
+        pendingAction = action
+    }
+
+    func consumePendingAction() -> Action? {
+        defer { pendingAction = nil }
+        return pendingAction
+    }
+}

--- a/TinfoilChat/Intents/AppIntentCoordinator.swift
+++ b/TinfoilChat/Intents/AppIntentCoordinator.swift
@@ -20,16 +20,16 @@ final class AppIntentCoordinator: ObservableObject {
         case startDictation
     }
 
-    @Published private(set) var pendingAction: Action?
+    @Published private(set) var pendingActions: [Action] = []
 
     private init() {}
 
     func enqueue(_ action: Action) {
-        pendingAction = action
+        pendingActions.append(action)
     }
 
-    func consumePendingAction() -> Action? {
-        defer { pendingAction = nil }
-        return pendingAction
+    func consumeNextAction() -> Action? {
+        guard !pendingActions.isEmpty else { return nil }
+        return pendingActions.removeFirst()
     }
 }

--- a/TinfoilChat/Intents/TinfoilAppIntents.swift
+++ b/TinfoilChat/Intents/TinfoilAppIntents.swift
@@ -1,0 +1,97 @@
+//
+//  TinfoilAppIntents.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+//
+
+import AppIntents
+
+/// Asks a question by voice or text. Siri collects the prompt, the app opens,
+/// starts a new chat, and sends the message.
+struct AskTinfoilIntent: AppIntent {
+    static let title: LocalizedStringResource = "Ask Tinfoil"
+    static let description = IntentDescription(
+        "Starts a new private chat and sends your question.",
+        categoryName: "Chat"
+    )
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Prompt", requestValueDialog: "What would you like to ask?")
+    var prompt: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        AppIntentCoordinator.shared.enqueue(.askQuestion(prompt))
+        return .result()
+    }
+}
+
+/// Opens the app with a fresh chat ready for input.
+struct NewChatIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start New Chat"
+    static let description = IntentDescription(
+        "Opens Tinfoil with a fresh private chat.",
+        categoryName: "Chat"
+    )
+    static let openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        AppIntentCoordinator.shared.enqueue(.newChat)
+        return .result()
+    }
+}
+
+/// Opens the app and immediately starts recording a voice message.
+struct StartDictationIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Voice Dictation"
+    static let description = IntentDescription(
+        "Opens Tinfoil and starts recording a voice message.",
+        categoryName: "Chat"
+    )
+    static let openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        AppIntentCoordinator.shared.enqueue(.startDictation)
+        return .result()
+    }
+}
+
+/// Registers Siri phrases so the intents work by voice without any setup,
+/// and surfaces them in Spotlight, the Shortcuts app, and the Action button.
+struct TinfoilAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AskTinfoilIntent(),
+            phrases: [
+                "Ask \(.applicationName)",
+                "Ask \(.applicationName) a question",
+                "Ask a question in \(.applicationName)"
+            ],
+            shortTitle: "Ask Tinfoil",
+            systemImageName: "bubble.left.and.text.bubble.right"
+        )
+        AppShortcut(
+            intent: NewChatIntent(),
+            phrases: [
+                "Start a new chat in \(.applicationName)",
+                "New \(.applicationName) chat",
+                "Create a new chat in \(.applicationName)"
+            ],
+            shortTitle: "New Chat",
+            systemImageName: "plus.bubble"
+        )
+        AppShortcut(
+            intent: StartDictationIntent(),
+            phrases: [
+                "Start dictation in \(.applicationName)",
+                "Dictate to \(.applicationName)",
+                "Start voice input in \(.applicationName)"
+            ],
+            shortTitle: "Voice Dictation",
+            systemImageName: "mic"
+        )
+    }
+}

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -60,6 +60,8 @@ struct Chat: Identifiable, Codable {
     // user preset whose system prompt overrides the default for this chat.
     var promptPresetId: String?
 
+    var webSearchEnabled: Bool = true
+
     // Transient flag for ephemeral "temporary" chats. Never persisted to disk
     // or cloud. Used to power the toolbar incognito toggle.
     var isTemporary: Bool = false
@@ -112,7 +114,8 @@ struct Chat: Identifiable, Codable {
         formatVersion: Int? = nil,
         isLocalOnly: Bool = false,
         projectId: String? = nil,
-        promptPresetId: String? = nil)
+        promptPresetId: String? = nil,
+        webSearchEnabled: Bool = true)
     {
         let resolvedTitleState = titleState ?? Chat.deriveTitleState(for: title, messages: messages)
 
@@ -134,6 +137,7 @@ struct Chat: Identifiable, Codable {
         self.isLocalOnly = isLocalOnly
         self.projectId = projectId
         self.promptPresetId = promptPresetId
+        self.webSearchEnabled = webSearchEnabled
     }
     
     // MARK: - Factory Methods
@@ -155,7 +159,8 @@ struct Chat: Identifiable, Codable {
         updatedAt: Date? = nil,
         isLocalOnly: Bool = false,
         projectId: String? = nil,
-        promptPresetId: String? = nil
+        promptPresetId: String? = nil,
+        webSearchEnabled: Bool? = nil
     ) -> Chat {
         // Try to use the provided model, fall back to current model, then first available
         guard let model = modelType ?? AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first else {
@@ -176,7 +181,8 @@ struct Chat: Identifiable, Codable {
             updatedAt: updatedAt,
             isLocalOnly: isLocalOnly,
             projectId: projectId,
-            promptPresetId: promptPresetId
+            promptPresetId: promptPresetId,
+            webSearchEnabled: webSearchEnabled ?? SettingsManager.shared.webSearchAvailable
         )
     }
     
@@ -186,6 +192,7 @@ struct Chat: Identifiable, Codable {
         case id, title, titleState, messages, createdAt, modelType, language, userId
         case syncVersion, syncedAt, locallyModified, updatedAt
         case decryptionFailed, dataCorrupted, formatVersion, isLocalOnly, projectId, promptPresetId
+        case webSearchEnabled
         case clock, writer, clockVersion
     }
 
@@ -216,6 +223,7 @@ struct Chat: Identifiable, Codable {
         isLocalOnly = try container.decodeIfPresent(Bool.self, forKey: .isLocalOnly) ?? false
         projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
         promptPresetId = try container.decodeIfPresent(String.self, forKey: .promptPresetId)
+        webSearchEnabled = try container.decodeIfPresent(Bool.self, forKey: .webSearchEnabled) ?? true
         clock = try container.decodeIfPresent(Int.self, forKey: .clock)
         writer = try container.decodeIfPresent(String.self, forKey: .writer)
         clockVersion = try container.decodeIfPresent(Int.self, forKey: .clockVersion)
@@ -246,6 +254,7 @@ struct Chat: Identifiable, Codable {
         try container.encode(isLocalOnly, forKey: .isLocalOnly)
         try container.encodeIfPresent(projectId, forKey: .projectId)
         try container.encodeIfPresent(promptPresetId, forKey: .promptPresetId)
+        try container.encode(webSearchEnabled, forKey: .webSearchEnabled)
         try container.encodeIfPresent(clock, forKey: .clock)
         try container.encodeIfPresent(writer, forKey: .writer)
         try container.encodeIfPresent(clockVersion, forKey: .clockVersion)

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -87,6 +87,8 @@ struct StoredChat: Codable {
     // Active prompt-library preset for this chat (shared with React via presetId)
     var promptPresetId: String?
 
+    var webSearchEnabled: Bool?
+
     // For tracking streaming state
     var hasActiveStream: Bool?
 
@@ -139,6 +141,7 @@ struct StoredChat: Codable {
         self.modelType = nil
         self.language = nil
         self.userId = nil
+        self.webSearchEnabled = nil
         self.syncVersion = syncVersion
         self.syncedAt = nil
         self.locallyModified = locallyModified
@@ -161,6 +164,7 @@ struct StoredChat: Codable {
         self.formatVersion = chat.formatVersion
         self.projectId = chat.projectId
         self.promptPresetId = chat.promptPresetId
+        self.webSearchEnabled = chat.webSearchEnabled
         self.hasActiveStream = chat.hasActiveStream
         self.clock = chat.clock
         self.writer = chat.writer
@@ -198,7 +202,8 @@ struct StoredChat: Codable {
             dataCorrupted: dataCorrupted ?? false,
             formatVersion: formatVersion,
             projectId: projectId,
-            promptPresetId: promptPresetId
+            promptPresetId: promptPresetId,
+            webSearchEnabled: webSearchEnabled ?? true
         )
 
         if let hasActiveStream = hasActiveStream {
@@ -219,6 +224,7 @@ struct StoredChat: Codable {
         case syncVersion, syncedAt, locallyModified
         case decryptionFailed, dataCorrupted, formatVersion, projectId
         case promptPresetId = "presetId"
+        case webSearchEnabled
         case clock, writer, clockVersion
     }
 
@@ -252,6 +258,7 @@ struct StoredChat: Codable {
         try container.encodeIfPresent(formatVersion, forKey: .formatVersion)
         try container.encodeIfPresent(projectId, forKey: .projectId)
         try container.encodeIfPresent(promptPresetId, forKey: .promptPresetId)
+        try container.encodeIfPresent(webSearchEnabled, forKey: .webSearchEnabled)
         try container.encodeIfPresent(clock, forKey: .clock)
         try container.encodeIfPresent(writer, forKey: .writer)
         try container.encodeIfPresent(clockVersion, forKey: .clockVersion)
@@ -315,6 +322,7 @@ struct StoredChat: Codable {
         formatVersion = try container.decodeIfPresent(Int.self, forKey: .formatVersion)
         projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
         promptPresetId = try container.decodeIfPresent(String.self, forKey: .promptPresetId)
+        webSearchEnabled = try container.decodeIfPresent(Bool.self, forKey: .webSearchEnabled)
         clock = try container.decodeIfPresent(Int.self, forKey: .clock)
         writer = try container.decodeIfPresent(String.self, forKey: .writer)
         clockVersion = try container.decodeIfPresent(Int.self, forKey: .clockVersion)
@@ -448,7 +456,6 @@ struct ProfileData: Codable {
     // Shared chat defaults
     var reasoningEffort: String?
     var thinkingEnabled: Bool?
-    var webSearchEnabled: Bool?
     var webSearchAvailable: Bool?
     var codeExecutionEnabled: Bool?
     var piiCheckEnabled: Bool?

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -449,6 +449,7 @@ struct ProfileData: Codable {
     var reasoningEffort: String?
     var thinkingEnabled: Bool?
     var webSearchEnabled: Bool?
+    var webSearchAvailable: Bool?
     var codeExecutionEnabled: Bool?
     var piiCheckEnabled: Bool?
     var genUIEnabled: Bool?

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -226,7 +226,6 @@ class ProfileManager: ObservableObject {
             favoritePromptPresetIds: favoritePromptPresetIds,
             reasoningEffort: reasoningEffort,
             thinkingEnabled: thinkingEnabled,
-            webSearchEnabled: SettingsManager.shared.webSearchEnabled,
             webSearchAvailable: SettingsManager.shared.webSearchAvailable,
             codeExecutionEnabled: codeExecutionEnabled,
             piiCheckEnabled: piiCheckEnabled,
@@ -290,9 +289,6 @@ class ProfileManager: ObservableObject {
         }
         if let thinkingEnabled = profile.thinkingEnabled {
             UserDefaults.standard.set(thinkingEnabled, forKey: Constants.StorageKeys.Settings.thinkingEnabled)
-        }
-        if let webSearchEnabled = profile.webSearchEnabled {
-            SettingsManager.shared.webSearchEnabled = webSearchEnabled
         }
         if let webSearchAvailable = profile.webSearchAvailable {
             SettingsManager.shared.webSearchAvailable = webSearchAvailable
@@ -819,7 +815,6 @@ class ProfileManager: ObservableObject {
                p1.favoritePromptPresetIds != p2.favoritePromptPresetIds ||
                p1.reasoningEffort != p2.reasoningEffort ||
                p1.thinkingEnabled != p2.thinkingEnabled ||
-               p1.webSearchEnabled != p2.webSearchEnabled ||
                p1.webSearchAvailable != p2.webSearchAvailable ||
                p1.codeExecutionEnabled != p2.codeExecutionEnabled ||
                p1.piiCheckEnabled != p2.piiCheckEnabled ||
@@ -830,7 +825,7 @@ class ProfileManager: ObservableObject {
 
     func sharedSettingsDidChange() {
         // Ignore changes that originate from applying a synced/loaded profile.
-        // Settings applied mid-`applyProfile` (e.g. webSearchEnabled) would
+        // Settings applied mid-`applyProfile` (e.g. webSearchAvailable) would
         // otherwise persist a partially-applied snapshot, since fields applied
         // later in the sequence still hold their pre-apply values. The applying
         // flow persists the full profile itself once application completes.

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -227,6 +227,7 @@ class ProfileManager: ObservableObject {
             reasoningEffort: reasoningEffort,
             thinkingEnabled: thinkingEnabled,
             webSearchEnabled: SettingsManager.shared.webSearchEnabled,
+            webSearchAvailable: SettingsManager.shared.webSearchAvailable,
             codeExecutionEnabled: codeExecutionEnabled,
             piiCheckEnabled: piiCheckEnabled,
             genUIEnabled: SettingsManager.shared.genUIEnabled,
@@ -292,6 +293,9 @@ class ProfileManager: ObservableObject {
         }
         if let webSearchEnabled = profile.webSearchEnabled {
             SettingsManager.shared.webSearchEnabled = webSearchEnabled
+        }
+        if let webSearchAvailable = profile.webSearchAvailable {
+            SettingsManager.shared.webSearchAvailable = webSearchAvailable
         }
         if let codeExecutionEnabled = profile.codeExecutionEnabled {
             self.codeExecutionEnabled = codeExecutionEnabled
@@ -816,6 +820,7 @@ class ProfileManager: ObservableObject {
                p1.reasoningEffort != p2.reasoningEffort ||
                p1.thinkingEnabled != p2.thinkingEnabled ||
                p1.webSearchEnabled != p2.webSearchEnabled ||
+               p1.webSearchAvailable != p2.webSearchAvailable ||
                p1.codeExecutionEnabled != p2.codeExecutionEnabled ||
                p1.piiCheckEnabled != p2.piiCheckEnabled ||
                p1.genUIEnabled != p2.genUIEnabled ||

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -26,7 +26,8 @@ enum ProfileMerge {
         "traits", "additionalContext", "isUsingPersonalization",
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
         "favoritePromptPresetIds", "reasoningEffort",
-        "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
+        "thinkingEnabled", "webSearchEnabled", "webSearchAvailable",
+        "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont",
         "projectUploadPreference",
     ]

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -26,7 +26,7 @@ enum ProfileMerge {
         "traits", "additionalContext", "isUsingPersonalization",
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
         "favoritePromptPresetIds", "reasoningEffort",
-        "thinkingEnabled", "webSearchEnabled", "webSearchAvailable",
+        "thinkingEnabled", "webSearchAvailable",
         "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont",
         "projectUploadPreference",

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -51,7 +51,7 @@ class ProfileSyncService: ObservableObject {
         "traits", "additionalContext", "isUsingPersonalization",
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
         "favoritePromptPresetIds", "reasoningEffort",
-        "thinkingEnabled", "webSearchEnabled", "webSearchAvailable", "codeExecutionEnabled",
+        "thinkingEnabled", "webSearchAvailable", "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont", "projectUploadPreference",
         "version", "updatedAt", "fieldClocks", "clockVersion",
     ]

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -51,7 +51,7 @@ class ProfileSyncService: ObservableObject {
         "traits", "additionalContext", "isUsingPersonalization",
         "isUsingCustomPrompt", "customSystemPrompt", "customPromptPresets",
         "favoritePromptPresetIds", "reasoningEffort",
-        "thinkingEnabled", "webSearchEnabled", "codeExecutionEnabled",
+        "thinkingEnabled", "webSearchEnabled", "webSearchAvailable", "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont", "projectUploadPreference",
         "version", "updatedAt", "fieldClocks", "clockVersion",
     ]

--- a/TinfoilChat/Services/ThinkingSummaryService.swift
+++ b/TinfoilChat/Services/ThinkingSummaryService.swift
@@ -18,7 +18,7 @@ class ThinkingSummaryService {
     private var lastGenerationTime: Date?
     private var summarizedContentLength: Int = 0
 
-    private init() {}
+    init() {}
 
     /// Generate a summary of the thinking content
     /// - Parameters:

--- a/TinfoilChat/Services/ThinkingSummaryService.swift
+++ b/TinfoilChat/Services/ThinkingSummaryService.swift
@@ -10,8 +10,6 @@ import Foundation
 /// Service for generating thinking summaries during streaming
 @MainActor
 class ThinkingSummaryService {
-    static let shared = ThinkingSummaryService()
-
     private var isGenerating = false
     private var currentSummary: String = ""
     private var generationTask: Task<Void, Never>?

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1367,10 +1367,16 @@ class ChatViewModel: ObservableObject {
         }
 
         let userId = currentUserId
-        cancelGeneration(chatId: id, announce: false)
+        let canceledStreamTask = cancelGeneration(
+            chatId: id,
+            announce: false
+        )
 
         // Delete from file storage and cloud
         Task {
+            await canceledStreamTask?.value
+            await drainPendingSaves()
+
             if !isLocal && SettingsManager.shared.isCloudSyncEnabled {
                 do {
                     try await cloudSync.deleteFromCloud(id)
@@ -2250,6 +2256,8 @@ class ChatViewModel: ObservableObject {
                     }
                 }
 
+                guard !Task.isCancelled else { return }
+
                 // Save with the resolved title and trigger cloud backup
                 await MainActor.run {
                     if let chat = finalizedChat {
@@ -2565,14 +2573,19 @@ class ChatViewModel: ObservableObject {
     /// Cancels the current message generation
     func cancelGeneration() {
         guard let chatId = currentChat?.id else { return }
-        cancelGeneration(chatId: chatId, announce: true)
+        _ = cancelGeneration(chatId: chatId, announce: true)
         self.showVerifierSheet = false
     }
 
-    private func cancelGeneration(chatId: String, announce: Bool) {
-        guard streamState.isStreaming(chatId: chatId) else { return }
+    @discardableResult
+    private func cancelGeneration(
+        chatId: String,
+        announce: Bool
+    ) -> Task<Void, Never>? {
+        guard streamState.isStreaming(chatId: chatId) else { return nil }
 
-        streamTasks[chatId]?.cancel()
+        let streamTask = streamTasks[chatId]
+        streamTask?.cancel()
         flushPendingStreamUpdate(chatId: chatId)
         if let location = findChatLocation(chatId) {
             var chat = chat(at: location)
@@ -2587,11 +2600,21 @@ class ChatViewModel: ObservableObject {
         if announce {
             AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
         }
+        return streamTask
     }
 
-    private func cancelAllGenerations() {
-        for chatId in Array(streamState.activeChatIds) {
-            cancelGeneration(chatId: chatId, announce: false)
+    private func cancelAllGenerations() -> [Task<Void, Never>] {
+        Array(streamState.activeChatIds).compactMap { chatId in
+            cancelGeneration(
+                chatId: chatId,
+                announce: false
+            )
+        }
+    }
+
+    private func drainStreamTasks(_ tasks: [Task<Void, Never>]) async {
+        for task in tasks {
+            await task.value
         }
     }
 
@@ -2958,6 +2981,10 @@ class ChatViewModel: ObservableObject {
             }
         }
     }
+
+    private func drainPendingSaves() async {
+        await pendingSaveTask?.value
+    }
     
     
     // MARK: - Model Management
@@ -3027,7 +3054,8 @@ class ChatViewModel: ObservableObject {
         // Allow a new sign-in flow after sign-out
         isSignInInProgress = false
         hasPerformedInitialSync = false
-        cancelAllGenerations()
+        let canceledStreamTasks = cancelAllGenerations()
+        await drainStreamTasks(canceledStreamTasks)
 
         // Stop auto-sync timer when signing out
         autoSyncTimer?.invalidate()
@@ -3081,7 +3109,7 @@ class ChatViewModel: ObservableObject {
     
     /// Clear all local chats and reset to fresh state
     func clearAllChatsFromDevice() async {
-        cancelAllGenerations()
+        let canceledStreamTasks = cancelAllGenerations()
 
         // Clear all chats from memory
         chats.removeAll()
@@ -3090,6 +3118,8 @@ class ChatViewModel: ObservableObject {
         
         // Clear from file storage (both local and cloud stores)
         let userId = currentUserId
+        await drainStreamTasks(canceledStreamTasks)
+        await drainPendingSaves()
         await Chat.deleteAllChatsFromStorage(userId: userId)
         
         // Reset sync state
@@ -3118,7 +3148,7 @@ class ChatViewModel: ObservableObject {
         // awaiting the latest task flushes every earlier one. Otherwise a
         // detached save kicked off by handleSignOut could land after the
         // wipe and resurrect the signed-out user's chat files.
-        await pendingSaveTask?.value
+        await drainPendingSaves()
         await Chat.deleteAllChatsFromStorage(userId: currentUserId)
     }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1723,10 +1723,12 @@ class ChatViewModel: ObservableObject {
                 let turnHasImages = self.messages.contains { message in
                     message.attachments.contains { $0.type == .image }
                 }
+                let webSearchEnabled = self.isWebSearchEnabled
+                    && SettingsManager.shared.webSearchAvailable
                 let modelSelection = AppConfig.shared.resolveModelSelection(
                     currentModel,
                     preferMultimodal: turnHasImages,
-                    preferToolCalling: self.isWebSearchEnabled || SettingsManager.shared.genUIEnabled
+                    preferToolCalling: webSearchEnabled || SettingsManager.shared.genUIEnabled
                 )
                 let representativeModel = modelSelection.representative
 
@@ -1825,7 +1827,7 @@ class ChatViewModel: ObservableObject {
                     rules: processedRules,
                     conversationMessages: self.messages,
                     contextWindow: representativeModel.contextWindow,
-                    webSearchEnabled: self.isWebSearchEnabled,
+                    webSearchEnabled: webSearchEnabled,
                     isMultimodal: representativeModel.isMultimodal,
                     reasoningConfig: representativeModel.reasoningConfig,
                     reasoningEffort: self.reasoningEffort,

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -26,6 +26,34 @@ enum ReasoningEffort: String, CaseIterable, Sendable {
     case high
 }
 
+struct ChatStreamState {
+    private(set) var activeChatIds: Set<String> = []
+    private(set) var thinkingSummaries: [String: String] = [:]
+    private(set) var webSearchSummaries: [String: String] = [:]
+
+    mutating func start(chatId: String) {
+        activeChatIds.insert(chatId)
+    }
+
+    mutating func setThinkingSummary(_ summary: String?, chatId: String) {
+        thinkingSummaries[chatId] = summary
+    }
+
+    mutating func setWebSearchSummary(_ summary: String?, chatId: String) {
+        webSearchSummaries[chatId] = summary
+    }
+
+    mutating func finish(chatId: String) {
+        activeChatIds.remove(chatId)
+        thinkingSummaries[chatId] = nil
+        webSearchSummaries[chatId] = nil
+    }
+
+    func isStreaming(chatId: String) -> Bool {
+        activeChatIds.contains(chatId)
+    }
+}
+
 @MainActor
 class ChatViewModel: ObservableObject {
     // Published properties for UI updates
@@ -41,9 +69,7 @@ class ChatViewModel: ObservableObject {
         }
     }
     @Published var activeStorageTab: ChatStorageTab = .cloud
-    @Published var isLoading: Bool = false
-    @Published var thinkingSummary: String = ""
-    @Published var webSearchSummary: String = ""
+    @Published private var streamState = ChatStreamState()
     @Published var showVerifierSheet: Bool = false
     @Published var showAddSheet: Bool = false
     @Published var showModelSelectorSheet: Bool = false
@@ -219,14 +245,15 @@ class ChatViewModel: ObservableObject {
 
     // Private properties
     private var client: TinfoilAI?
-    private var currentTask: Task<Void, Error>?
+    private var streamTasks: [String: Task<Void, Never>] = [:]
+    private var thinkingSummaryServices: [String: ThinkingSummaryService] = [:]
     private var autoSyncTimer: Timer?
     private var didBecomeActiveObserver: NSObjectProtocol?
     private var willResignActiveObserver: NSObjectProtocol?
     private var sharedSettingsObserver: NSObjectProtocol?
     private var networkStatusCancellable: AnyCancellable?
-    private var streamUpdateTimer: Timer?
-    private var pendingStreamUpdate: Chat?
+    private var streamUpdateTimers: [String: Timer] = [:]
+    private var pendingStreamUpdates: [String: Chat] = [:]
     private var pendingSaveTask: Task<Void, Never>?
     private var lastKnownAuthState: Bool?
     
@@ -268,6 +295,21 @@ class ChatViewModel: ObservableObject {
     
     var messages: [Message] {
         currentChat?.messages ?? []
+    }
+
+    var isLoading: Bool {
+        guard let chatId = currentChat?.id else { return false }
+        return streamState.isStreaming(chatId: chatId)
+    }
+
+    var thinkingSummary: String {
+        guard let chatId = currentChat?.id else { return "" }
+        return streamState.thinkingSummaries[chatId] ?? ""
+    }
+
+    var webSearchSummary: String {
+        guard let chatId = currentChat?.id else { return "" }
+        return streamState.webSearchSummaries[chatId] ?? ""
     }
 
     var isProjectMode: Bool {
@@ -451,9 +493,11 @@ class ChatViewModel: ObservableObject {
         autoSyncTimer?.invalidate()
         autoSyncTimer = nil
 
-        // Stop stream update timer
-        streamUpdateTimer?.invalidate()
-        streamUpdateTimer = nil
+        // Stop stream update timers
+        streamUpdateTimers.values.forEach { $0.invalidate() }
+        streamUpdateTimers.removeAll()
+        streamTasks.values.forEach { $0.cancel() }
+        streamTasks.removeAll()
 
         // Cancel network status observer
         networkStatusCancellable?.cancel()
@@ -525,7 +569,7 @@ class ChatViewModel: ObservableObject {
                 }
                 
                 // Skip auto-sync if actively sending a message or streaming
-                if self.isLoading {
+                if !self.streamState.activeChatIds.isEmpty {
                     return
                 }
                 
@@ -734,7 +778,7 @@ class ChatViewModel: ObservableObject {
             return
         }
 
-        guard !isLoading else {
+        guard streamState.activeChatIds.isEmpty else {
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
                 self?.retryClientSetup()
             }
@@ -777,14 +821,10 @@ class ChatViewModel: ObservableObject {
         // Allow creating new chats for all authenticated users
         guard hasChatAccess else { return }
         
-        // Cancel any ongoing generation first
-        if isLoading {
-            cancelGeneration()
-        }
-
         // Exit temporary mode when the user explicitly creates a fresh chat.
         if isTemporaryMode {
             if let temp = currentChat, temp.isTemporary {
+                cancelGeneration(chatId: temp.id, announce: false)
                 if temp.isLocalOnly {
                     localChats.removeAll { $0.id == temp.id }
                 } else {
@@ -809,7 +849,8 @@ class ChatViewModel: ObservableObject {
             shouldBeLocal = activeStorageTab == .local
         }
 
-        // Check if we already have a blank chat in the target list
+        // A reused blank represents a fresh chat, so reset its preference to
+        // the current global default before selecting it.
         if shouldBeLocal {
             if let index = localChats.firstIndex(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
                 localChats[index].webSearchEnabled = SettingsManager.shared.webSearchAvailable
@@ -1154,13 +1195,10 @@ class ChatViewModel: ObservableObject {
     func toggleTemporaryMode() {
         guard hasChatAccess else { return }
 
-        if isLoading {
-            cancelGeneration()
-        }
-
         if isTemporaryMode {
             // Exit temporary mode: drop the ephemeral chat and restore previous.
             if let current = currentChat, current.isTemporary {
+                cancelGeneration(chatId: current.id, announce: false)
                 if current.isLocalOnly {
                     localChats.removeAll { $0.id == current.id }
                 } else {
@@ -1211,16 +1249,12 @@ class ChatViewModel: ObservableObject {
 
     /// Selects a chat as the current chat
     func selectChat(_ chat: Chat) {
-        // Cancel any ongoing generation first
-        if isLoading {
-            cancelGeneration()
-        }
-
         // If the user picked a different chat while in temporary mode, drop
         // the ephemeral chat and exit temporary mode. The selected chat takes
         // over normally below.
         if isTemporaryMode && !chat.isTemporary {
             if let temp = currentChat, temp.isTemporary {
+                cancelGeneration(chatId: temp.id, announce: false)
                 if temp.isLocalOnly {
                     localChats.removeAll { $0.id == temp.id }
                 } else {
@@ -1274,12 +1308,16 @@ class ChatViewModel: ObservableObject {
 
     func setWebSearchEnabled(_ enabled: Bool) {
         guard var chat = currentChat else {
-            isWebSearchEnabled = enabled
+            if isWebSearchEnabled != enabled {
+                isWebSearchEnabled = enabled
+            }
             return
         }
 
-        isWebSearchEnabled = enabled
         guard chat.webSearchEnabled != enabled else { return }
+        if isWebSearchEnabled != enabled {
+            isWebSearchEnabled = enabled
+        }
 
         chat.webSearchEnabled = enabled
         chat.locallyModified = true
@@ -1329,6 +1367,7 @@ class ChatViewModel: ObservableObject {
         }
 
         let userId = currentUserId
+        cancelGeneration(chatId: id, announce: false)
 
         // Delete from file storage and cloud
         Task {
@@ -1520,9 +1559,6 @@ class ChatViewModel: ObservableObject {
         // Dismiss keyboard
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
 
-        // Update UI state
-        isLoading = true
-
         let messageAttachments = pendingAttachments
         clearPendingAttachments(acknowledgeSharedImports: false)
 
@@ -1662,36 +1698,41 @@ class ChatViewModel: ObservableObject {
 
     /// Generates an assistant response for the current conversation (expects user message to already be in chat)
     private func generateResponse() {
+        guard let initialChat = currentChat,
+              !streamState.isStreaming(chatId: initialChat.id) else {
+            return
+        }
+
         // Dismiss keyboard
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
 
-        // Update UI state
-        isLoading = true
         AccessibilityAnnouncer.announce(Constants.Accessibility.generatingResponse)
 
         // Create initial empty assistant message as a placeholder
         let assistantMessage = Message(role: .assistant, content: "", isCollapsed: true)
         addMessage(assistantMessage)
 
-        // Set the chat as having an active stream
-        if var chat = currentChat {
-            chat.hasActiveStream = true
-            updateChat(chat)
-            // Track streaming for cloud sync
-            streamingTracker.startStreaming(chat.id)
-        }
-        
-        // Store the current chat for stream validation
-        // We'll track by messages rather than ID to handle ID changes
-        let _ = currentChat
-        let _ = currentChat?.messages.count ?? 0
-        let streamChatId = currentChat?.id
-        
-        // Cancel any existing task
-        currentTask?.cancel()
+        guard var updatedStreamChat = currentChat else { return }
+        let streamChatId = updatedStreamChat.id
+        updatedStreamChat.hasActiveStream = true
+        updateChat(updatedStreamChat)
+        let streamChat = updatedStreamChat
+        streamState.start(chatId: streamChatId)
+        streamingTracker.startStreaming(streamChatId)
+
+        let conversationMessages = streamChat.messages
+        let streamModel = currentModel
+        let streamProject = activeProject
+        let streamProjectDocuments = projectDocuments
+        let streamReasoningEffort = reasoningEffort
+        let streamThinkingEnabled = thinkingEnabled
+        let streamWebSearchEnabled = isWebSearchEnabled
+            && SettingsManager.shared.webSearchAvailable
+        let summaryService = ThinkingSummaryService()
+        thinkingSummaryServices[streamChatId] = summaryService
         
         // Create and start a new task for the streaming request
-        currentTask = Task {
+        let streamTask = Task<Void, Never> {
             // Begin background task to allow stream to complete if app goes to background
             var backgroundTaskId: UIBackgroundTaskIdentifier = .invalid
             backgroundTaskId = UIApplication.shared.beginBackgroundTask(withName: Constants.Sync.backgroundTaskName) {
@@ -1744,13 +1785,12 @@ class ChatViewModel: ObservableObject {
                 // model plus an ordered candidate list. Preferences narrow the
                 // Auto candidates: multimodal when the turn carries images, and
                 // tool-calling when web search or GenUI tools may be used.
-                let turnHasImages = self.messages.contains { message in
+                let turnHasImages = conversationMessages.contains { message in
                     message.attachments.contains { $0.type == .image }
                 }
-                let webSearchEnabled = self.isWebSearchEnabled
-                    && SettingsManager.shared.webSearchAvailable
+                let webSearchEnabled = streamWebSearchEnabled
                 let modelSelection = AppConfig.shared.resolveModelSelection(
-                    currentModel,
+                    streamModel,
                     preferMultimodal: turnHasImages,
                     preferToolCalling: webSearchEnabled || SettingsManager.shared.genUIEnabled
                 )
@@ -1766,7 +1806,7 @@ class ChatViewModel: ObservableObject {
                 var suppressDefaultRules = false
                 
                 // Precedence: per-chat prompt preset > custom prompt toggle > default
-                if let preset = profileManager.promptPreset(for: currentChat?.promptPresetId) {
+                if let preset = profileManager.promptPreset(for: streamChat.promptPresetId) {
                     systemPrompt = preset.systemPrompt
                 } else if let customPrompt = profileManager.getCustomSystemPrompt() {
                     systemPrompt = customPrompt
@@ -1789,7 +1829,7 @@ class ChatViewModel: ObservableObject {
                 } else if settingsManager.selectedLanguage != "System" {
                     // Use the language from settings
                     languageToUse = settingsManager.selectedLanguage
-                } else if let chat = currentChat, let chatLanguage = chat.language {
+                } else if let chatLanguage = streamChat.language {
                     // Fall back to chat's language if set
                     languageToUse = chatLanguage
                 } else {
@@ -1824,8 +1864,8 @@ class ChatViewModel: ObservableObject {
                 systemPrompt = systemPrompt.replacingOccurrences(of: "{TIMEZONE}", with: timezone)
                 systemPrompt = ProjectContextBuilder.applyProjectContext(
                     to: systemPrompt,
-                    project: self.activeProject,
-                    documents: self.projectDocuments
+                    project: streamProject,
+                    documents: streamProjectDocuments
                 )
                 
                 // Process rules with same replacements
@@ -1849,13 +1889,13 @@ class ChatViewModel: ObservableObject {
                     modelId: modelId,
                     systemPrompt: systemPrompt,
                     rules: processedRules,
-                    conversationMessages: self.messages,
+                    conversationMessages: conversationMessages,
                     contextWindow: representativeModel.contextWindow,
                     webSearchEnabled: webSearchEnabled,
                     isMultimodal: representativeModel.isMultimodal,
                     reasoningConfig: representativeModel.reasoningConfig,
-                    reasoningEffort: self.reasoningEffort,
-                    thinkingEnabled: self.thinkingEnabled,
+                    reasoningEffort: streamReasoningEffort,
+                    thinkingEnabled: streamThinkingEnabled,
                     genUIEnabled: SettingsManager.shared.genUIEnabled,
                     autoCandidates: modelSelection.autoCandidates
                 )
@@ -1872,13 +1912,12 @@ class ChatViewModel: ObservableObject {
                 var initialThoughts: String? = nil
                 var initialGenerationTime: TimeInterval? = nil
                 var initialIsThinking = false
-                if let chat = self.currentChat,
-                   !chat.messages.isEmpty,
-                   let lastIndex = chat.messages.indices.last {
-                    initialResponseContent = chat.messages[lastIndex].content
-                    initialThoughts = chat.messages[lastIndex].thoughts
-                    initialGenerationTime = chat.messages[lastIndex].generationTimeSeconds
-                    initialIsThinking = chat.messages[lastIndex].isThinking
+                if !streamChat.messages.isEmpty,
+                   let lastIndex = streamChat.messages.indices.last {
+                    initialResponseContent = streamChat.messages[lastIndex].content
+                    initialThoughts = streamChat.messages[lastIndex].thoughts
+                    initialGenerationTime = streamChat.messages[lastIndex].generationTimeSeconds
+                    initialIsThinking = streamChat.messages[lastIndex].isThinking
                 }
 
                 // All per-chunk parsing state (event markers, chunkers, the
@@ -1913,17 +1952,11 @@ class ChatViewModel: ObservableObject {
                     // Look up the streaming chat by ID, not self.currentChat,
                     // so an event landing after the user switched chats never
                     // writes search state into the newly selected chat.
-                    guard let sid = streamChatId,
-                          let location = self.findChatLocation(sid) else { return }
+                    let sid = streamChatId
+                    guard let location = self.findChatLocation(sid) else { return }
                     var chat = self.chat(at: location)
                     guard !chat.messages.isEmpty,
                           let lastIndex = chat.messages.indices.last else { return }
-                    // webSearchSummary drives the status line of whichever
-                    // chat is on screen, so only surface new search progress
-                    // while the user is still viewing the streaming chat
-                    // (clearing it is always safe).
-                    let isViewingStreamChat = self.currentChat?.id == sid
-
                     if event.action?.type == "open_page", let url = event.action?.url {
                         let fetchId = event.itemId ?? url
                         switch event.status {
@@ -1971,9 +2004,10 @@ class ChatViewModel: ObservableObject {
                             status: .searching,
                             sources: existingSources
                         )
-                        if isViewingStreamChat {
-                            self.webSearchSummary = event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web"
-                        }
+                        self.streamState.setWebSearchSummary(
+                            event.action?.query.map { "Searching the web: \($0)" } ?? "Searching the web",
+                            chatId: sid
+                        )
                     case .completed:
                         let eventSources = event.sources?.compactMap { source -> WebSearchSource? in
                             guard let url = source.url, !url.isEmpty else { return nil }
@@ -2008,7 +2042,7 @@ class ChatViewModel: ObservableObject {
                             chat.messages[lastIndex].webSearchState?.sources = merged
                         }
                         chat.messages[lastIndex].webSearchState?.status = .completed
-                        self.webSearchSummary = ""
+                        self.streamState.setWebSearchSummary(nil, chatId: sid)
                     case .failed:
                         let eventSources = event.sources?.compactMap { source -> WebSearchSource? in
                             guard let url = source.url, !url.isEmpty else { return nil }
@@ -2026,7 +2060,7 @@ class ChatViewModel: ObservableObject {
                             )
                         }
                         chat.messages[lastIndex].webSearchState?.status = .failed
-                        self.webSearchSummary = ""
+                        self.streamState.setWebSearchSummary(nil, chatId: sid)
                     case .blocked:
                         let existing = processor.findSearchInstance(matching: event.itemId)
                         let id = existing?.id ?? event.itemId ?? processor.allocateSearchId()
@@ -2044,7 +2078,7 @@ class ChatViewModel: ObservableObject {
                             status: .blocked,
                             reason: event.error?.code
                         )
-                        self.webSearchSummary = ""
+                        self.streamState.setWebSearchSummary(nil, chatId: sid)
                     }
                     chat.messages[lastIndex].segments = processor.currentSegments
                     chat.messages[lastIndex].webSearches = processor.currentWebSearches
@@ -2090,13 +2124,13 @@ class ChatViewModel: ObservableObject {
                             case .beginThinkingSession:
                                 pendingSummaryThoughts = nil
                                 await MainActor.run {
-                                    ThinkingSummaryService.shared.reset()
+                                    summaryService.reset()
                                 }
                             case .endThinkingSession:
                                 pendingSummaryThoughts = nil
                                 await MainActor.run {
-                                    ThinkingSummaryService.shared.reset()
-                                    self?.thinkingSummary = ""
+                                    summaryService.reset()
+                                    self?.streamState.setThinkingSummary(nil, chatId: streamChatId)
                                 }
                             case .generate(let thoughts):
                                 pendingSummaryThoughts = thoughts
@@ -2114,8 +2148,9 @@ class ChatViewModel: ObservableObject {
                                 guard let self else { return }
                                 self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
                                 if let thoughtsForSummary {
-                                    ThinkingSummaryService.shared.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
-                                        self?.thinkingSummary = summary
+                                    summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
+                                        guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
+                                        self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
                                     }
                                 }
                             }
@@ -2132,6 +2167,7 @@ class ChatViewModel: ObservableObject {
                 } onCancel: {
                     consumeTask.cancel()
                 }
+                try Task.checkCancellation()
 
                 let finalSnapshot = processor.snapshot()
 
@@ -2139,27 +2175,21 @@ class ChatViewModel: ObservableObject {
                 // Look up the streaming chat by ID, not self.currentChat, because
                 // the user may have navigated away or toggled sync mid-stream.
                 var finalizedChat: Chat? = await MainActor.run {
-                    guard let sid = streamChatId,
-                          let location = self.findChatLocation(sid) else {
-                        self.isLoading = false
+                    let sid = streamChatId
+                    guard let location = self.findChatLocation(sid) else {
+                        self.finishStreamState(chatId: sid)
+                        self.streamingTracker.endStreaming(sid)
                         return nil
                     }
                     var chat = self.chat(at: location)
                     chat.hasActiveStream = false
 
-                    self.streamUpdateTimer?.invalidate()
-                    self.streamUpdateTimer = nil
-                    if let pending = self.pendingStreamUpdate {
-                        self.pendingStreamUpdate = nil
-                        if self.hasChatAccess {
-                            self.saveChat(pending)
-                        }
-                    }
+                    self.flushPendingStreamUpdate(chatId: sid)
 
                     // Finalize all message content
-                    ThinkingSummaryService.shared.reset()
-                    self.thinkingSummary = ""
-                    self.webSearchSummary = ""
+                    summaryService.reset()
+                    self.streamState.setThinkingSummary(nil, chatId: sid)
+                    self.streamState.setWebSearchSummary(nil, chatId: sid)
                     if !chat.messages.isEmpty, let lastIndex = chat.messages.indices.last {
                         chat.messages[lastIndex].content = finalSnapshot.responseContent
                         chat.messages[lastIndex].thoughts = finalSnapshot.thoughts
@@ -2190,17 +2220,18 @@ class ChatViewModel: ObservableObject {
                         }
                     }
 
-                    // Apply finalized content to currentChat BEFORE setting isLoading
-                    // to false. The isLoadingChanged path in MessageTableView.updateUIView
-                    // reads messages.last (from currentChat) to populate the wrapper. If
-                    // isLoading is cleared first, the wrapper captures stale throttled
+                    // Apply finalized content to currentChat before ending the stream.
+                    // The isLoadingChanged path in MessageTableView.updateUIView reads
+                    // messages.last (from currentChat) to populate the wrapper. If the
+                    // stream ends first, the wrapper captures stale throttled
                     // content. Title generation (async) then delays the real updateChat,
                     // and no subsequent updateUIView branch refreshes the wrapper — causing
                     // the first assistant response to appear truncated.
                     self.updateChat(chat)
-                    self.isLoading = false
-                    AccessibilityAnnouncer.announce(Constants.Accessibility.responseComplete)
-                    HapticFeedback.trigger(.success)
+                    if self.currentChat?.id == sid {
+                        AccessibilityAnnouncer.announce(Constants.Accessibility.responseComplete)
+                        HapticFeedback.trigger(.success)
+                    }
 
                     return chat
                 }
@@ -2225,8 +2256,13 @@ class ChatViewModel: ObservableObject {
                         self.updateChat(chat)
                         self.endStreamingAndBackup(chatId: chat.id)
                     }
+                    self.finishStreamState(chatId: streamChatId)
                 }
             } catch {
+                if error is CancellationError || Task.isCancelled {
+                    return
+                }
+
                 #if DEBUG
                 print("[Chat] generateResponse error: \(type(of: error)) — \(error)")
                 print("[Chat] isAuthError=\(ChatViewModel.isAuthenticationError(error)), isRequestError=\(self.isRequestError(error)), isRateLimitError=\(self.isRateLimitError(error))")
@@ -2254,36 +2290,31 @@ class ChatViewModel: ObservableObject {
 
                 // Handle error
                 await MainActor.run {
-                    self.isLoading = false
-                    AccessibilityAnnouncer.announce(Constants.Accessibility.responseFailed)
-                    HapticFeedback.trigger(.error)
-                    self.thinkingSummary = ""
-                    self.webSearchSummary = ""
+                    if self.currentChat?.id == streamChatId {
+                        AccessibilityAnnouncer.announce(Constants.Accessibility.responseFailed)
+                        HapticFeedback.trigger(.error)
+                    }
+                    self.streamState.setThinkingSummary(nil, chatId: streamChatId)
+                    self.streamState.setWebSearchSummary(nil, chatId: streamChatId)
 
                     // Mark the chat as no longer having an active stream
                     // Look up by streamChatId, not self.currentChat, in case user navigated away
-                    if let sid = streamChatId,
-                       let location = self.findChatLocation(sid) {
+                    let sid = streamChatId
+                    if let location = self.findChatLocation(sid) {
                         var chat = self.chat(at: location)
                         chat.hasActiveStream = false
 
                         // Force any pending stream updates to save immediately
-                        self.streamUpdateTimer?.invalidate()
-                        self.streamUpdateTimer = nil
-                        if let pending = self.pendingStreamUpdate {
-                            self.pendingStreamUpdate = nil
-                            if self.hasChatAccess {
-                                self.saveChat(pending)
-                            }
-                        }
+                        self.flushPendingStreamUpdate(chatId: sid)
 
                         self.updateChat(chat)  // Final update without throttling
 
                         self.endStreamingAndBackup(chatId: chat.id)
+                    } else {
+                        self.streamingTracker.endStreaming(sid)
                     }
 
-                    if let sid = streamChatId,
-                       let location = self.findChatLocation(sid) {
+                    if let location = self.findChatLocation(sid) {
                         var chat = self.chat(at: location)
                         if !chat.messages.isEmpty {
                             let lastIndex = chat.messages.count - 1
@@ -2312,20 +2343,23 @@ class ChatViewModel: ObservableObject {
                             self.updateChat(chat)
                         }
                     }
+                    self.finishStreamState(chatId: sid)
                 }
             }
 
             // Refresh rate limit from the server after each request completes (success or error)
             SessionTokenManager.shared.refreshRateLimit()
         }
+        streamTasks[streamChatId] = streamTask
     }
     
     /// Applies one throttled streaming snapshot to the streaming chat's last
     /// message. Snapshots are immutable values produced by the stream task's
     /// processor, so this never reads live parsing state.
-    private func applyStreamSnapshot(_ snapshot: StreamingResponseProcessor.Snapshot, streamChatId: String?) {
-        guard self.currentChat?.id == streamChatId else { return }
-        guard var chat = self.currentChat,
+    private func applyStreamSnapshot(_ snapshot: StreamingResponseProcessor.Snapshot, streamChatId: String) {
+        guard let location = findChatLocation(streamChatId) else { return }
+        var chat = chat(at: location)
+        guard
               chat.hasActiveStream,
               !chat.messages.isEmpty,
               let lastIndex = chat.messages.indices.last else {
@@ -2530,22 +2564,51 @@ class ChatViewModel: ObservableObject {
 
     /// Cancels the current message generation
     func cancelGeneration() {
-        currentTask?.cancel()
-        currentTask = nil
-        isLoading = false
-        AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
-        thinkingSummary = ""
-        webSearchSummary = ""
+        guard let chatId = currentChat?.id else { return }
+        cancelGeneration(chatId: chatId, announce: true)
+        self.showVerifierSheet = false
+    }
 
-        // Reset the hasActiveStream property
-        if var chat = currentChat {
+    private func cancelGeneration(chatId: String, announce: Bool) {
+        guard streamState.isStreaming(chatId: chatId) else { return }
+
+        streamTasks[chatId]?.cancel()
+        flushPendingStreamUpdate(chatId: chatId)
+        if let location = findChatLocation(chatId) {
+            var chat = chat(at: location)
             chat.hasActiveStream = false
             updateChat(chat)
-            // End streaming tracking for cloud sync
             streamingTracker.endStreaming(chat.id)
+        } else {
+            streamingTracker.endStreaming(chatId)
         }
 
-        self.showVerifierSheet = false
+        finishStreamState(chatId: chatId)
+        if announce {
+            AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
+        }
+    }
+
+    private func cancelAllGenerations() {
+        for chatId in Array(streamState.activeChatIds) {
+            cancelGeneration(chatId: chatId, announce: false)
+        }
+    }
+
+    private func flushPendingStreamUpdate(chatId: String) {
+        streamUpdateTimers.removeValue(forKey: chatId)?.invalidate()
+        if let pending = pendingStreamUpdates.removeValue(forKey: chatId),
+           hasChatAccess {
+            saveChat(pending)
+        }
+    }
+
+    private func finishStreamState(chatId: String) {
+        streamUpdateTimers.removeValue(forKey: chatId)?.invalidate()
+        pendingStreamUpdates.removeValue(forKey: chatId)
+        streamTasks.removeValue(forKey: chatId)
+        thinkingSummaryServices.removeValue(forKey: chatId)?.reset()
+        streamState.finish(chatId: chatId)
     }
 
     /// Regenerates the last assistant response by removing it and resending the last user message
@@ -2607,8 +2670,6 @@ class ChatViewModel: ObservableObject {
 
         // Dismiss keyboard
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-
-        isLoading = true
 
         let userMessage = Message(role: .user, content: trimmedContent)
         addMessage(userMessage)
@@ -2842,7 +2903,7 @@ class ChatViewModel: ObservableObject {
         
         // If the chat has an active stream or is being actively modified, ensure it's marked as locally modified
         // This prevents sync from overwriting it while messages are being sent
-        if chat.hasActiveStream || isLoading {
+        if chat.hasActiveStream {
             updatedChat.locallyModified = true
             updatedChat.updatedAt = Date()
         }
@@ -2857,18 +2918,13 @@ class ChatViewModel: ObservableObject {
         // During streaming, batch saves to reduce disk I/O
         if throttleForStreaming {
             // Store pending update
-            pendingStreamUpdate = updatedChat
+            pendingStreamUpdates[updatedChat.id] = updatedChat
 
             // Cancel existing timer and create new one
-            streamUpdateTimer?.invalidate()
-            streamUpdateTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
+            streamUpdateTimers[updatedChat.id]?.invalidate()
+            streamUpdateTimers[updatedChat.id] = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
                 Task { @MainActor in
-                    if let pending = self?.pendingStreamUpdate {
-                        self?.pendingStreamUpdate = nil
-                        if self?.hasChatAccess == true {
-                            self?.saveChat(pending)
-                        }
-                    }
+                    self?.flushPendingStreamUpdate(chatId: updatedChat.id)
                 }
             }
         } else {
@@ -2910,11 +2966,6 @@ class ChatViewModel: ObservableObject {
     func changeModel(to modelType: ModelType, shouldUpdateChat: Bool = true) {
         // Only proceed if the model is actually changing
         guard modelType != currentModel else { return }
-        
-        // Cancel any ongoing tasks
-        currentTask?.cancel()
-        currentTask = nil
-        isLoading = false
         
         // Update model settings
         self.currentModel = modelType
@@ -2976,6 +3027,7 @@ class ChatViewModel: ObservableObject {
         // Allow a new sign-in flow after sign-out
         isSignInInProgress = false
         hasPerformedInitialSync = false
+        cancelAllGenerations()
 
         // Stop auto-sync timer when signing out
         autoSyncTimer?.invalidate()
@@ -3029,6 +3081,8 @@ class ChatViewModel: ObservableObject {
     
     /// Clear all local chats and reset to fresh state
     func clearAllChatsFromDevice() async {
+        cancelAllGenerations()
+
         // Clear all chats from memory
         chats.removeAll()
         localChats.removeAll()

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -31,7 +31,15 @@ class ChatViewModel: ObservableObject {
     // Published properties for UI updates
     @Published var chats: [Chat] = []
     @Published var localChats: [Chat] = []
-    @Published var currentChat: Chat?
+    @Published var currentChat: Chat? {
+        didSet {
+            let enabled = currentChat?.webSearchEnabled
+                ?? SettingsManager.shared.webSearchAvailable
+            if isWebSearchEnabled != enabled {
+                isWebSearchEnabled = enabled
+            }
+        }
+    }
     @Published var activeStorageTab: ChatStorageTab = .cloud
     @Published var isLoading: Bool = false
     @Published var thinkingSummary: String = ""
@@ -365,8 +373,6 @@ class ChatViewModel: ObservableObject {
             fatalError("ChatViewModel cannot be initialized without available models. Ensure AppConfig loads models before creating ChatViewModel.")
         }
         self.currentModel = model
-        self.isWebSearchEnabled = SettingsManager.shared.webSearchEnabled
-
         // Load persisted reasoning preferences. Both default to the most
         // permissive setting (thinking on, medium effort) when no value has
         // been saved yet, matching the webapp.
@@ -407,6 +413,7 @@ class ChatViewModel: ObservableObject {
         let newChat = Chat.create(modelType: currentModel)
         currentChat = newChat
         chats = [newChat]
+        isWebSearchEnabled = newChat.webSearchEnabled
         
         // Load any previously persisted pagination state (per-user)
         // Delay enabling persistence until after load to avoid overwriting saved values
@@ -484,9 +491,6 @@ class ChatViewModel: ObservableObject {
         }
         if let thinkingEnabled = profile.thinkingEnabled {
             self.thinkingEnabled = thinkingEnabled
-        }
-        if let webSearchEnabled = profile.webSearchEnabled {
-            isWebSearchEnabled = webSearchEnabled
         }
     }
     
@@ -807,14 +811,16 @@ class ChatViewModel: ObservableObject {
 
         // Check if we already have a blank chat in the target list
         if shouldBeLocal {
-            if let existing = localChats.first(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
-                selectChat(existing)
+            if let index = localChats.firstIndex(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
+                localChats[index].webSearchEnabled = SettingsManager.shared.webSearchAvailable
+                selectChat(localChats[index])
                 shouldFocusInput = focusInput
                 return
             }
         } else {
-            if let existing = chats.first(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
-                selectChat(existing)
+            if let index = chats.firstIndex(where: { $0.isBlankChat && $0.projectId == targetProjectId }) {
+                chats[index].webSearchEnabled = SettingsManager.shared.webSearchAvailable
+                selectChat(chats[index])
                 shouldFocusInput = focusInput
                 return
             }
@@ -1187,7 +1193,8 @@ class ChatViewModel: ObservableObject {
                 title: "Temporary Chat",
                 modelType: model,
                 userId: currentUserId,
-                isLocalOnly: true
+                isLocalOnly: true,
+                webSearchEnabled: SettingsManager.shared.webSearchAvailable
             )
             temp.isTemporary = true
 
@@ -1263,6 +1270,23 @@ class ChatViewModel: ObservableObject {
                 self.applyLoadedImages(loadedImages, toChatId: chatId)
             }
         }
+    }
+
+    func setWebSearchEnabled(_ enabled: Bool) {
+        guard var chat = currentChat else {
+            isWebSearchEnabled = enabled
+            return
+        }
+
+        isWebSearchEnabled = enabled
+        guard chat.webSearchEnabled != enabled else { return }
+
+        chat.webSearchEnabled = enabled
+        chat.locallyModified = true
+        chat.updatedAt = Date()
+        currentChat = chat
+        replaceChat(chat)
+        saveChat(chat)
     }
     
     /// Merge fetched image base64 data into the current messages of a chat by attachment ID.
@@ -1862,7 +1886,7 @@ class ChatViewModel: ObservableObject {
                 // lives in the processor so the stream can be consumed off
                 // the main actor.
                 let processor = StreamingResponseProcessor(
-                    isWebSearchEnabled: self.isWebSearchEnabled,
+                    isWebSearchEnabled: webSearchEnabled,
                     hapticEnabled: hapticEnabled,
                     responseContent: initialResponseContent,
                     currentThoughts: initialThoughts,
@@ -2748,11 +2772,15 @@ class ChatViewModel: ObservableObject {
 
         // Add exactly one blank chat at position 0 if user has chat access
         if hasChatAccess {
+            let webSearchEnabled = wasCurrentChatBlank
+                ? currentChat?.webSearchEnabled
+                : nil
             let blankChat = Chat.create(
                 modelType: currentModel,
                 language: nil,
                 userId: currentUserId,
-                isLocalOnly: isLocal
+                isLocalOnly: isLocal,
+                webSearchEnabled: webSearchEnabled
             )
             result.insert(blankChat, at: 0)
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2265,7 +2265,7 @@ class ChatViewModel: ObservableObject {
 
                 #if DEBUG
                 print("[Chat] generateResponse error: \(type(of: error)) — \(error)")
-                print("[Chat] isAuthError=\(ChatViewModel.isAuthenticationError(error)), isRequestError=\(self.isRequestError(error)), isRateLimitError=\(self.isRateLimitError(error))")
+                print("[Chat] isAuthError=\(ChatViewModel.isAuthenticationError(error)), isRequestError=\(self.isRequestError(error)), isRateLimitError=\(Self.isRateLimitError(error))")
                 #endif
 
                 // Check if this is a 401 auth error and we haven't retried yet

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2193,9 +2193,6 @@ class ChatViewModel: ObservableObject {
                     self.flushPendingStreamUpdate(chatId: sid)
 
                     // Finalize all message content
-                    summaryService.reset()
-                    self.streamState.setThinkingSummary(nil, chatId: sid)
-                    self.streamState.setWebSearchSummary(nil, chatId: sid)
                     if !chat.messages.isEmpty, let lastIndex = chat.messages.indices.last {
                         chat.messages[lastIndex].content = finalSnapshot.responseContent
                         chat.messages[lastIndex].thoughts = finalSnapshot.thoughts
@@ -2302,8 +2299,6 @@ class ChatViewModel: ObservableObject {
                         AccessibilityAnnouncer.announce(Constants.Accessibility.responseFailed)
                         HapticFeedback.trigger(.error)
                     }
-                    self.streamState.setThinkingSummary(nil, chatId: streamChatId)
-                    self.streamState.setWebSearchSummary(nil, chatId: streamChatId)
 
                     // Mark the chat as no longer having an active stream
                     // Look up by streamChatId, not self.currentChat, in case user navigated away

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -734,14 +734,16 @@ struct AddToSheetView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 20)
 
-                Toggle(isOn: $viewModel.isWebSearchEnabled) {
-                    Label("Web Search", systemImage: "globe")
+                if settings.webSearchAvailable {
+                    Toggle(isOn: $viewModel.isWebSearchEnabled) {
+                        Label("Web Search", systemImage: "globe")
+                    }
+                    .tint(.green)
+                    .onChange(of: viewModel.isWebSearchEnabled) { _, newValue in
+                        settings.webSearchEnabled = newValue
+                    }
+                    .padding(.horizontal, 20)
                 }
-                .tint(.green)
-                .onChange(of: viewModel.isWebSearchEnabled) { _, newValue in
-                    settings.webSearchEnabled = newValue
-                }
-                .padding(.horizontal, 20)
 
                 if let contextUsage {
                     HStack {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -735,13 +735,13 @@ struct AddToSheetView: View {
                     .padding(.horizontal, 20)
 
                 if settings.webSearchAvailable {
-                    Toggle(isOn: $viewModel.isWebSearchEnabled) {
+                    Toggle(isOn: Binding(
+                        get: { viewModel.isWebSearchEnabled },
+                        set: { viewModel.setWebSearchEnabled($0) }
+                    )) {
                         Label("Web Search", systemImage: "globe")
                     }
                     .tint(.green)
-                    .onChange(of: viewModel.isWebSearchEnabled) { _, newValue in
-                        settings.webSearchEnabled = newValue
-                    }
                     .padding(.horizontal, 20)
                 }
 

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -79,16 +79,6 @@ class SettingsManager: ObservableObject {
     // singleton is still being initialized (applyProfile runs inside init).
     var isApplyingSharedProfile = false
 
-    // Web search toggle
-    @Published var webSearchEnabled: Bool {
-        didSet {
-            UserDefaults.standard.set(webSearchEnabled, forKey: Constants.StorageKeys.Settings.webSearchEnabled)
-            if !isApplyingSharedProfile {
-                ProfileManager.shared.sharedSettingsDidChange()
-            }
-        }
-    }
-
     @Published var webSearchAvailable: Bool {
         didSet {
             UserDefaults.standard.set(webSearchAvailable, forKey: Constants.StorageKeys.Settings.webSearchAvailable)
@@ -150,8 +140,6 @@ class SettingsManager: ObservableObject {
         self.isUsingCustomPrompt = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled) as? Bool ?? false
         self.customSystemPrompt = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt) ?? ""
 
-        // Initialize web search setting
-        self.webSearchEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.webSearchEnabled) as? Bool ?? true
         self.webSearchAvailable = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.webSearchAvailable) as? Bool ?? true
 
         // Initialize Generative UI setting (defaults to on)
@@ -211,7 +199,6 @@ class SettingsManager: ObservableObject {
         additionalContext = ""
         isUsingCustomPrompt = false
         customSystemPrompt = ""
-        webSearchEnabled = true
         webSearchAvailable = true
         genUIEnabled = true
         isCloudSyncEnabled = false

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -89,6 +89,15 @@ class SettingsManager: ObservableObject {
         }
     }
 
+    @Published var webSearchAvailable: Bool {
+        didSet {
+            UserDefaults.standard.set(webSearchAvailable, forKey: Constants.StorageKeys.Settings.webSearchAvailable)
+            if !isApplyingSharedProfile {
+                ProfileManager.shared.sharedSettingsDidChange()
+            }
+        }
+    }
+
     // Generative UI toggle. When off, no render_* tool capabilities are sent.
     @Published var genUIEnabled: Bool {
         didSet {
@@ -143,6 +152,7 @@ class SettingsManager: ObservableObject {
 
         // Initialize web search setting
         self.webSearchEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.webSearchEnabled) as? Bool ?? true
+        self.webSearchAvailable = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.webSearchAvailable) as? Bool ?? true
 
         // Initialize Generative UI setting (defaults to on)
         self.genUIEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.genUIEnabled) as? Bool ?? true
@@ -186,6 +196,7 @@ class SettingsManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.webSearchEnabled)
+        UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.webSearchAvailable)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.genUIEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.cloudSyncEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.localOnlyModeEnabled)
@@ -201,6 +212,7 @@ class SettingsManager: ObservableObject {
         isUsingCustomPrompt = false
         customSystemPrompt = ""
         webSearchEnabled = true
+        webSearchAvailable = true
         genUIEnabled = true
         isCloudSyncEnabled = false
         isLocalOnlyModeEnabled = false
@@ -533,6 +545,15 @@ struct SettingsView: View {
         Section {
             Toggle("Haptic Feedback", isOn: $settings.hapticFeedbackEnabled)
                 .tint(Color.accentPrimary)
+            Toggle(isOn: $settings.webSearchAvailable) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Web Search")
+                    Text("Show web search controls and allow chats to search the web.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .tint(Color.accentPrimary)
             Toggle(isOn: $settings.genUIEnabled) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Generative UI")

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -155,6 +155,9 @@ class SettingsManager: ObservableObject {
         } else {
             self.webSearchAvailable = true
         }
+        UserDefaults.standard.removeObject(
+            forKey: Constants.StorageKeys.Settings.webSearchEnabled
+        )
 
         // Initialize Generative UI setting (defaults to on)
         self.genUIEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.genUIEnabled) as? Bool ?? true

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -140,7 +140,21 @@ class SettingsManager: ObservableObject {
         self.isUsingCustomPrompt = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled) as? Bool ?? false
         self.customSystemPrompt = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt) ?? ""
 
-        self.webSearchAvailable = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.webSearchAvailable) as? Bool ?? true
+        if let storedValue = UserDefaults.standard.object(
+            forKey: Constants.StorageKeys.Settings.webSearchAvailable
+        ) as? Bool {
+            self.webSearchAvailable = storedValue
+        } else if let legacyValue = UserDefaults.standard.object(
+            forKey: Constants.StorageKeys.Settings.webSearchEnabled
+        ) as? Bool {
+            self.webSearchAvailable = legacyValue
+            UserDefaults.standard.set(
+                legacyValue,
+                forKey: Constants.StorageKeys.Settings.webSearchAvailable
+            )
+        } else {
+            self.webSearchAvailable = true
+        }
 
         // Initialize Generative UI setting (defaults to on)
         self.genUIEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.genUIEnabled) as? Bool ?? true

--- a/TinfoilChatTests/ChatStreamStateTests.swift
+++ b/TinfoilChatTests/ChatStreamStateTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import TinfoilChat
+
+struct ChatStreamStateTests {
+    @Test func tracksStreamsIndependentlyByChat() {
+        var state = ChatStreamState()
+
+        state.start(chatId: "chat-a")
+        state.start(chatId: "chat-b")
+
+        #expect(state.isStreaming(chatId: "chat-a"))
+        #expect(state.isStreaming(chatId: "chat-b"))
+
+        state.finish(chatId: "chat-a")
+
+        #expect(!state.isStreaming(chatId: "chat-a"))
+        #expect(state.isStreaming(chatId: "chat-b"))
+    }
+
+    @Test func keepsProgressSummariesScopedToTheirChat() {
+        var state = ChatStreamState()
+        state.start(chatId: "chat-a")
+        state.start(chatId: "chat-b")
+        state.setThinkingSummary("Planning A", chatId: "chat-a")
+        state.setWebSearchSummary("Searching B", chatId: "chat-b")
+
+        state.finish(chatId: "chat-a")
+
+        #expect(state.thinkingSummaries["chat-a"] == nil)
+        #expect(state.webSearchSummaries["chat-b"] == "Searching B")
+        #expect(state.isStreaming(chatId: "chat-b"))
+    }
+}

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -148,10 +148,20 @@ struct ProfileMergeTests {
 
     @Test("changedProfileFields diffs values")
     func changedFields() {
-        let baseline = ProfileData(nickname: "a", traits: ["x"], thinkingEnabled: true)
-        let local = ProfileData(nickname: "b", traits: ["x", "y"], thinkingEnabled: true)
+        let baseline = ProfileData(
+            nickname: "a",
+            traits: ["x"],
+            thinkingEnabled: true,
+            webSearchAvailable: true
+        )
+        let local = ProfileData(
+            nickname: "b",
+            traits: ["x", "y"],
+            thinkingEnabled: true,
+            webSearchAvailable: false
+        )
         let fields = ProfileMerge.changedProfileFields(local: local, baseline: baseline)
-        #expect(Set(fields) == Set(["nickname", "traits"]))
+        #expect(Set(fields) == Set(["nickname", "traits", "webSearchAvailable"]))
     }
 
     @Test("adopts populated remote fields when local stayed empty")

--- a/TinfoilChatTests/ProjectChatEncodingTests.swift
+++ b/TinfoilChatTests/ProjectChatEncodingTests.swift
@@ -47,3 +47,65 @@ struct ProjectChatEncodingTests {
         )
     )
 }
+
+struct WebSearchChatPreferenceTests {
+    @Test
+    func chatDefaultsWebSearchToOn() {
+        let chat = Chat(modelType: Self.testModel)
+
+        #expect(chat.webSearchEnabled)
+    }
+
+    @Test
+    func chatRoundTripsDisabledWebSearch() throws {
+        let chat = Chat(modelType: Self.testModel, webSearchEnabled: false)
+        let data = try JSONEncoder().encode(chat)
+        let decoded = try JSONDecoder().decode(Chat.self, from: data)
+
+        #expect(decoded.webSearchEnabled == false)
+    }
+
+    @Test
+    func legacyChatDefaultsWebSearchToOn() throws {
+        let chat = Chat(modelType: Self.testModel, webSearchEnabled: false)
+        let data = try JSONEncoder().encode(chat)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        object.removeValue(forKey: "webSearchEnabled")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(Chat.self, from: legacyData)
+
+        #expect(decoded.webSearchEnabled)
+    }
+
+    @Test @MainActor
+    func storedChatRoundTripsDisabledWebSearch() throws {
+        let chat = Chat(modelType: Self.testModel, webSearchEnabled: false)
+        let data = try JSONEncoder().encode(StoredChat(from: chat))
+        let stored = try JSONDecoder().decode(StoredChat.self, from: data)
+        let decoded = try #require(stored.toChat())
+
+        #expect(stored.webSearchEnabled == false)
+        #expect(decoded.webSearchEnabled == false)
+    }
+
+    private static let testModel = ModelType(
+        from: AppModelConfig(
+            modelName: "gpt-oss-120b",
+            image: "openai.png",
+            name: "GPT OSS 120B",
+            nameShort: "GPT OSS",
+            description: "",
+            details: "",
+            parameters: "",
+            contextWindow: "64k tokens",
+            type: "chat",
+            chat: true,
+            paid: false,
+            multimodal: false,
+            reasoningConfig: nil
+        )
+    )
+}

--- a/TinfoilChatTests/ProjectChatEncodingTests.swift
+++ b/TinfoilChatTests/ProjectChatEncodingTests.swift
@@ -2,12 +2,30 @@ import Foundation
 import Testing
 @testable import TinfoilChat
 
+private let testModel = ModelType(
+    from: AppModelConfig(
+        modelName: "gpt-oss-120b",
+        image: "openai.png",
+        name: "GPT OSS 120B",
+        nameShort: "GPT OSS",
+        description: "",
+        details: "",
+        parameters: "",
+        contextWindow: "64k tokens",
+        type: "chat",
+        chat: true,
+        paid: false,
+        multimodal: false,
+        reasoningConfig: nil
+    )
+)
+
 struct ProjectChatEncodingTests {
     @Test @MainActor
     func chatCreatePreservesProjectId() {
         let chat = Chat.create(
             id: "chat-1",
-            modelType: Self.testModel,
+            modelType: testModel,
             projectId: "project-1"
         )
 
@@ -19,7 +37,7 @@ struct ProjectChatEncodingTests {
     func storedChatRoundTripsProjectId() throws {
         let chat = Chat.create(
             id: "chat-1",
-            modelType: Self.testModel,
+            modelType: testModel,
             projectId: "project-1"
         )
         let stored = StoredChat(from: chat)
@@ -28,37 +46,19 @@ struct ProjectChatEncodingTests {
 
         #expect(decoded.projectId == "project-1")
     }
-
-    private static let testModel = ModelType(
-        from: AppModelConfig(
-            modelName: "gpt-oss-120b",
-            image: "openai.png",
-            name: "GPT OSS 120B",
-            nameShort: "GPT OSS",
-            description: "",
-            details: "",
-            parameters: "",
-            contextWindow: "64k tokens",
-            type: "chat",
-            chat: true,
-            paid: false,
-            multimodal: false,
-            reasoningConfig: nil
-        )
-    )
 }
 
 struct WebSearchChatPreferenceTests {
     @Test
     func chatDefaultsWebSearchToOn() {
-        let chat = Chat(modelType: Self.testModel)
+        let chat = Chat(modelType: testModel)
 
         #expect(chat.webSearchEnabled)
     }
 
     @Test
     func chatRoundTripsDisabledWebSearch() throws {
-        let chat = Chat(modelType: Self.testModel, webSearchEnabled: false)
+        let chat = Chat(modelType: testModel, webSearchEnabled: false)
         let data = try JSONEncoder().encode(chat)
         let decoded = try JSONDecoder().decode(Chat.self, from: data)
 
@@ -67,7 +67,7 @@ struct WebSearchChatPreferenceTests {
 
     @Test
     func legacyChatDefaultsWebSearchToOn() throws {
-        let chat = Chat(modelType: Self.testModel, webSearchEnabled: false)
+        let chat = Chat(modelType: testModel, webSearchEnabled: false)
         let data = try JSONEncoder().encode(chat)
         var object = try #require(
             JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -82,7 +82,7 @@ struct WebSearchChatPreferenceTests {
 
     @Test @MainActor
     func storedChatRoundTripsDisabledWebSearch() throws {
-        let chat = Chat(modelType: Self.testModel, webSearchEnabled: false)
+        let chat = Chat(modelType: testModel, webSearchEnabled: false)
         let data = try JSONEncoder().encode(StoredChat(from: chat))
         let stored = try JSONDecoder().decode(StoredChat.self, from: data)
         let decoded = try #require(stored.toChat())
@@ -90,22 +90,4 @@ struct WebSearchChatPreferenceTests {
         #expect(stored.webSearchEnabled == false)
         #expect(decoded.webSearchEnabled == false)
     }
-
-    private static let testModel = ModelType(
-        from: AppModelConfig(
-            modelName: "gpt-oss-120b",
-            image: "openai.png",
-            name: "GPT OSS 120B",
-            nameShort: "GPT OSS",
-            description: "",
-            details: "",
-            parameters: "",
-            contextWindow: "64k tokens",
-            type: "chat",
-            chat: true,
-            paid: false,
-            multimodal: false,
-            reasoningConfig: nil
-        )
-    )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Siri app intents so you can ask a question, start a new chat, or begin voice dictation by voice or Shortcuts. Also reworked chat streaming to allow multiple chats to respond at once and added per‑chat web search controls with a global availability toggle.

- **New Features**
  - Siri/Shortcuts: Ask Tinfoil, Start New Chat, and Start Voice Dictation. Actions are queued via `AppIntentCoordinator` and dictation falls back to focused text input when audio isn’t available.
  - Parallel streaming: multiple chats can respond simultaneously with per‑chat thinking and web search progress.
  - Web search controls: per‑chat toggle saved with each chat, plus a global “Web Search” availability setting in Settings (migrated from the old toggle).

- **Bug Fixes**
  - Disabled web search preference now round‑trips in JSON and cloud sync and defaults to on for legacy records.
  - Deleted chats and sign‑out no longer return old data; pending streams and saves are canceled and drained.
  - Centralized streaming summary cleanup with clearer error diagnostics and no cross‑chat status leaks.
  - Siri/Shortcuts requests now wait for the app to finish loading or streaming and send in order; signed‑out flows no longer drop prompts.

<sup>Written for commit 034c6222588cd43002f9fbbcd81f9af4c336ad62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

