### PR TITLE
feat: queue messages sent while the assistant is responding

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -439,6 +439,14 @@ enum Constants {
         static let warningThreshold = 3
     }
 
+    enum MessageQueue {
+        /// Longest text preview shown for a queued message; mirrors the
+        /// webapp's QUEUED_PREVIEW_MAX_LENGTH.
+        static let previewMaxLength = 240
+        static let previewLineLimit = 2
+        static let imageThumbnailSize: CGFloat = 48
+    }
+
     enum Attachments {
         static let maxImageDimension: CGFloat = 768
         static let imageCompressionQuality: CGFloat = 0.85

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -440,6 +440,7 @@ enum Constants {
     }
 
     enum MessageQueue {
+        static let maxQueuedMessages = 1
         /// Longest text preview shown for a queued message; mirrors the
         /// webapp's QUEUED_PREVIEW_MAX_LENGTH.
         static let previewMaxLength = 240

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -664,6 +664,24 @@ struct GenUIToolCall: Codable, Equatable, Identifiable {
 // `TimelineToolCallBlock.resolution` so chats round-trip across
 // platforms.
 
+/// A user message submitted while the assistant was busy, held until the
+/// current response finishes. Mirrors the webapp's `QueuedMessage`.
+struct QueuedMessage: Identifiable, Equatable {
+    let id: String
+    let text: String
+    let attachments: [Attachment]
+
+    init(
+        id: String = UUID().uuidString.lowercased(),
+        text: String,
+        attachments: [Attachment] = []
+    ) {
+        self.id = id
+        self.text = text
+        self.attachments = attachments
+    }
+}
+
 /// Represents a single message in a chat
 struct Message: Identifiable, Codable, Equatable {
     let id: String

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -253,6 +253,11 @@ class ChatViewModel: ObservableObject {
         return messageQueues[chatId] ?? []
     }
 
+    /// True when the on-screen chat can't accept another queued message.
+    var isMessageQueueFull: Bool {
+        queuedMessages.count >= Constants.MessageQueue.maxQueuedMessages
+    }
+
     // Project properties
     @Published var projects: [Project] = []
     @Published var activeProject: Project?
@@ -1561,15 +1566,19 @@ class ChatViewModel: ObservableObject {
     /// Sends a user message and generates a response. When the current chat
     /// is already streaming, the message is queued instead and dispatched
     /// once the assistant goes idle, mirroring the webapp's message queue.
-    func sendMessage(text: String) {
+    /// Returns whether the message was accepted (sent or queued), so callers
+    /// can keep the draft in the input when it wasn't.
+    @discardableResult
+    func sendMessage(text: String) -> Bool {
         let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasAttachments = !pendingAttachments.isEmpty
-        guard hasText || hasAttachments else { return }
-        guard attachmentsAreReadyToSend(pendingAttachments) else { return }
+        guard hasText || hasAttachments else { return false }
+        guard attachmentsAreReadyToSend(pendingAttachments) else { return false }
 
         if isLoading {
+            guard !isMessageQueueFull else { return false }
             enqueueMessage(text: text)
-            return
+            return true
         }
 
         // Block send when free-tier requests are exhausted
@@ -1585,13 +1594,14 @@ class ChatViewModel: ObservableObject {
         // shows the paywall.
         if let rl = rateLimit, rl.remaining <= 0, rl.kind != .hourly {
             showRateLimitPaywall = true
-            return
+            return false
         }
 
         let messageAttachments = pendingAttachments
         clearPendingAttachments(acknowledgeSharedImports: false)
 
         dispatchMessage(text: text, attachments: messageAttachments, dismissKeyboard: true)
+        return true
     }
 
     /// Adds a user message to the conversation and starts the response
@@ -1634,6 +1644,7 @@ class ChatViewModel: ObservableObject {
     /// message and are cleared from the input.
     private func enqueueMessage(text: String) {
         guard let chatId = currentChat?.id else { return }
+        guard (messageQueues[chatId]?.count ?? 0) < Constants.MessageQueue.maxQueuedMessages else { return }
         let messageAttachments = pendingAttachments
         clearPendingAttachments(acknowledgeSharedImports: false)
         let item = QueuedMessage(text: text, attachments: messageAttachments)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1615,9 +1615,7 @@ class ChatViewModel: ObservableObject {
             attachments: attachments
         )
         addMessage(userMessage)
-        for requestID in attachments.compactMap(\.sharedImportRequestID) {
-            SharedImportCoordinator.shared.acknowledge(requestID: requestID)
-        }
+        acknowledgeSharedImports(in: attachments)
 
         // If this is the first message, mark as modified (title will be generated after assistant reply)
         if var chat = currentChat, chat.messages.count == 1 {
@@ -1649,9 +1647,7 @@ class ChatViewModel: ObservableObject {
     private func discardMessageQueue(chatId: String) {
         guard let queue = messageQueues.removeValue(forKey: chatId) else { return }
         for item in queue {
-            for requestID in item.attachments.compactMap(\.sharedImportRequestID) {
-                SharedImportCoordinator.shared.acknowledge(requestID: requestID)
-            }
+            acknowledgeSharedImports(in: item.attachments)
         }
     }
 
@@ -1662,9 +1658,7 @@ class ChatViewModel: ObservableObject {
               let index = queue.firstIndex(where: { $0.id == id }) else { return }
         let removed = queue.remove(at: index)
         messageQueues[chatId] = queue.isEmpty ? nil : queue
-        for requestID in removed.attachments.compactMap(\.sharedImportRequestID) {
-            SharedImportCoordinator.shared.acknowledge(requestID: requestID)
-        }
+        acknowledgeSharedImports(in: removed.attachments)
     }
 
     /// Dispatches the next queued message for a chat, one at a time. Only
@@ -1700,6 +1694,15 @@ class ChatViewModel: ObservableObject {
     }
 
     // MARK: - Attachment Management
+
+    /// Marks the share-inbox requests behind these attachments as handled.
+    /// Single funnel for every path that consumes or discards attachments,
+    /// so acknowledgment behavior can't drift between them.
+    private func acknowledgeSharedImports(in attachments: [Attachment]) {
+        for requestID in attachments.compactMap(\.sharedImportRequestID) {
+            SharedImportCoordinator.shared.acknowledge(requestID: requestID)
+        }
+    }
 
     func addDocumentAttachment(
         url: URL,
@@ -1787,28 +1790,22 @@ class ChatViewModel: ObservableObject {
     }
 
     func removePendingAttachment(id: String) {
-        let sharedImportRequestID = pendingAttachments
-            .first(where: { $0.id == id })?
-            .sharedImportRequestID
+        let removed = pendingAttachments.filter { $0.id == id }
         pendingAttachments.removeAll { $0.id == id }
         pendingImageThumbnails.removeValue(forKey: id)
-        if let sharedImportRequestID {
-            SharedImportCoordinator.shared.acknowledge(requestID: sharedImportRequestID)
-        }
+        acknowledgeSharedImports(in: removed)
         if pendingAttachments.isEmpty {
             attachmentError = nil
         }
     }
 
     func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
-        let sharedImportRequestIDs = pendingAttachments.compactMap(\.sharedImportRequestID)
+        let removed = pendingAttachments
         pendingAttachments.removeAll()
         pendingImageThumbnails.removeAll()
         attachmentError = nil
         if acknowledgeSharedImports {
-            for requestID in sharedImportRequestIDs {
-                SharedImportCoordinator.shared.acknowledge(requestID: requestID)
-            }
+            self.acknowledgeSharedImports(in: removed)
         }
     }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -66,6 +66,12 @@ class ChatViewModel: ObservableObject {
             if isWebSearchEnabled != enabled {
                 isWebSearchEnabled = enabled
             }
+            // Resume draining messages queued while this chat was
+            // backgrounded. Guarded on the id changing so the frequent
+            // same-chat reassignments during streaming stay cheap.
+            if let chatId = currentChat?.id, chatId != oldValue?.id {
+                scheduleMessageQueueDrain(chatId: chatId)
+            }
         }
     }
     @Published var activeStorageTab: ChatStorageTab = .cloud
@@ -232,6 +238,19 @@ class ChatViewModel: ObservableObject {
     @Published var pendingImageThumbnails: [String: String] = [:]
     var isProcessingAttachment: Bool {
         pendingAttachments.contains { $0.processingState == .processing }
+    }
+
+    // Per-chat queues of messages submitted while the assistant was busy.
+    // Each chat owns its own queue so a streaming conversation never blocks
+    // a different conversation; a backgrounded chat keeps its queued
+    // messages and resumes draining when reopened. In-memory only, mirroring
+    // the webapp's per-session queue.
+    @Published private(set) var messageQueues: [String: [QueuedMessage]] = [:]
+
+    /// Queued messages for the chat on screen.
+    var queuedMessages: [QueuedMessage] {
+        guard let chatId = currentChat?.id else { return [] }
+        return messageQueues[chatId] ?? []
     }
 
     // Project properties
@@ -824,6 +843,7 @@ class ChatViewModel: ObservableObject {
         // Exit temporary mode when the user explicitly creates a fresh chat.
         if isTemporaryMode {
             if let temp = currentChat, temp.isTemporary {
+                discardMessageQueue(chatId: temp.id)
                 cancelGeneration(chatId: temp.id, announce: false)
                 if temp.isLocalOnly {
                     localChats.removeAll { $0.id == temp.id }
@@ -1198,6 +1218,7 @@ class ChatViewModel: ObservableObject {
         if isTemporaryMode {
             // Exit temporary mode: drop the ephemeral chat and restore previous.
             if let current = currentChat, current.isTemporary {
+                discardMessageQueue(chatId: current.id)
                 cancelGeneration(chatId: current.id, announce: false)
                 if current.isLocalOnly {
                     localChats.removeAll { $0.id == current.id }
@@ -1254,6 +1275,7 @@ class ChatViewModel: ObservableObject {
         // over normally below.
         if isTemporaryMode && !chat.isTemporary {
             if let temp = currentChat, temp.isTemporary {
+                discardMessageQueue(chatId: temp.id)
                 cancelGeneration(chatId: temp.id, announce: false)
                 if temp.isLocalOnly {
                     localChats.removeAll { $0.id == temp.id }
@@ -1367,6 +1389,7 @@ class ChatViewModel: ObservableObject {
         }
 
         let userId = currentUserId
+        discardMessageQueue(chatId: id)
         let canceledStreamTask = cancelGeneration(
             chatId: id,
             announce: false
@@ -1535,13 +1558,19 @@ class ChatViewModel: ObservableObject {
         sendMessage(text: resultText)
     }
 
-    /// Sends a user message and generates a response
+    /// Sends a user message and generates a response. When the current chat
+    /// is already streaming, the message is queued instead and dispatched
+    /// once the assistant goes idle, mirroring the webapp's message queue.
     func sendMessage(text: String) {
-        guard !isLoading else { return }
         let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasAttachments = !pendingAttachments.isEmpty
         guard hasText || hasAttachments else { return }
         guard attachmentsAreReadyToSend(pendingAttachments) else { return }
+
+        if isLoading {
+            enqueueMessage(text: text)
+            return
+        }
 
         // Block send when free-tier requests are exhausted
         #if DEBUG
@@ -1559,23 +1588,34 @@ class ChatViewModel: ObservableObject {
             return
         }
 
+        let messageAttachments = pendingAttachments
+        clearPendingAttachments(acknowledgeSharedImports: false)
+
+        dispatchMessage(text: text, attachments: messageAttachments, dismissKeyboard: true)
+    }
+
+    /// Adds a user message to the conversation and starts the response
+    /// stream. Shared by the direct send path and the queue drain.
+    private func dispatchMessage(
+        text: String,
+        attachments: [Attachment],
+        dismissKeyboard: Bool
+    ) {
         // Optimistically decrement the remaining request count
         SessionTokenManager.shared.snapshotAndDecrementRemaining()
 
-        // Dismiss keyboard
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-
-        let messageAttachments = pendingAttachments
-        clearPendingAttachments(acknowledgeSharedImports: false)
+        if dismissKeyboard {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
 
         // Create and add user message — attachments carry all data
         let userMessage = Message(
             role: .user,
             content: text,
-            attachments: messageAttachments
+            attachments: attachments
         )
         addMessage(userMessage)
-        for requestID in messageAttachments.compactMap(\.sharedImportRequestID) {
+        for requestID in attachments.compactMap(\.sharedImportRequestID) {
             SharedImportCoordinator.shared.acknowledge(requestID: requestID)
         }
 
@@ -1586,7 +1626,77 @@ class ChatViewModel: ObservableObject {
             updateChat(chat)
         }
 
-        generateResponse()
+        generateResponse(dismissKeyboard: dismissKeyboard)
+    }
+
+    // MARK: - Message Queue
+
+    /// Holds a message for the current chat while its assistant response is
+    /// still streaming. Pending attachments ride along with the queued
+    /// message and are cleared from the input.
+    private func enqueueMessage(text: String) {
+        guard let chatId = currentChat?.id else { return }
+        let messageAttachments = pendingAttachments
+        clearPendingAttachments(acknowledgeSharedImports: false)
+        let item = QueuedMessage(text: text, attachments: messageAttachments)
+        messageQueues[chatId, default: []].append(item)
+    }
+
+    /// Drops a chat's entire queue, acknowledging any shared imports riding
+    /// on queued attachments so they don't stay staged in the share inbox.
+    /// Must run wherever a chat is removed (deletion, temporary-chat
+    /// teardown) so queued messages never become unreachable.
+    private func discardMessageQueue(chatId: String) {
+        guard let queue = messageQueues.removeValue(forKey: chatId) else { return }
+        for item in queue {
+            for requestID in item.attachments.compactMap(\.sharedImportRequestID) {
+                SharedImportCoordinator.shared.acknowledge(requestID: requestID)
+            }
+        }
+    }
+
+    /// Removes a queued message before it is dispatched.
+    func removeQueuedMessage(id: String) {
+        guard let chatId = currentChat?.id,
+              var queue = messageQueues[chatId],
+              let index = queue.firstIndex(where: { $0.id == id }) else { return }
+        let removed = queue.remove(at: index)
+        messageQueues[chatId] = queue.isEmpty ? nil : queue
+        for requestID in removed.attachments.compactMap(\.sharedImportRequestID) {
+            SharedImportCoordinator.shared.acknowledge(requestID: requestID)
+        }
+    }
+
+    /// Dispatches the next queued message for a chat, one at a time. Only
+    /// the chat on screen drains; a backgrounded chat keeps its queue and
+    /// resumes when reopened. Dispatch keeps the keyboard up so a draft the
+    /// user is typing is never interrupted.
+    private func drainMessageQueue(chatId: String) {
+        guard currentChat?.id == chatId,
+              !streamState.isStreaming(chatId: chatId),
+              var queue = messageQueues[chatId],
+              !queue.isEmpty else { return }
+
+        // Same free-tier gate as a direct send: the message stays queued so
+        // it can dispatch after an upgrade or on the next drain.
+        if let rl = rateLimit, rl.remaining <= 0, rl.kind != .hourly {
+            showRateLimitPaywall = true
+            return
+        }
+
+        let next = queue.removeFirst()
+        messageQueues[chatId] = queue.isEmpty ? nil : queue
+        dispatchMessage(text: next.text, attachments: next.attachments, dismissKeyboard: false)
+    }
+
+    /// Defers the drain one runloop turn so stream teardown (state resets,
+    /// final chat updates) fully settles before the next dispatch mutates
+    /// the conversation.
+    private func scheduleMessageQueueDrain(chatId: String) {
+        guard messageQueues[chatId]?.isEmpty == false else { return }
+        Task { @MainActor [weak self] in
+            self?.drainMessageQueue(chatId: chatId)
+        }
     }
 
     // MARK: - Attachment Management
@@ -1703,14 +1813,17 @@ class ChatViewModel: ObservableObject {
     }
 
     /// Generates an assistant response for the current conversation (expects user message to already be in chat)
-    private func generateResponse() {
+    private func generateResponse(dismissKeyboard: Bool = true) {
         guard let initialChat = currentChat,
               !streamState.isStreaming(chatId: initialChat.id) else {
             return
         }
 
-        // Dismiss keyboard
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        // Dismiss keyboard, except on queue-driven dispatches where the user
+        // may be typing the next message.
+        if dismissKeyboard {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
 
         AccessibilityAnnouncer.announce(Constants.Accessibility.generatingResponse)
 
@@ -2627,6 +2740,7 @@ class ChatViewModel: ObservableObject {
         streamTasks.removeValue(forKey: chatId)
         thinkingSummaryServices.removeValue(forKey: chatId)?.reset()
         streamState.finish(chatId: chatId)
+        scheduleMessageQueueDrain(chatId: chatId)
     }
 
     /// Regenerates the last assistant response by removing it and resending the last user message

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -212,7 +212,17 @@ class ChatViewModel: ObservableObject {
     var verificationError: String? { verification.error }
     
     // Rate limit properties
-    @Published var rateLimit: RateLimitInfo?
+    @Published var rateLimit: RateLimitInfo? {
+        didSet {
+            // A drain stopped by the daily cap has no retrigger of its own,
+            // so returning capacity (quota refresh, or an upgrade clearing
+            // the limit to nil) must resume the on-screen chat's queue.
+            let hasCapacity = rateLimit.map { $0.remaining > 0 || $0.kind == .hourly } ?? true
+            if hasCapacity, let chatId = currentChat?.id {
+                scheduleMessageQueueDrain(chatId: chatId)
+            }
+        }
+    }
     @Published var showRateLimitPaywall: Bool = false
 
     // Model properties

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -100,6 +100,11 @@ struct ChatListView: View {
                     )
                     .transition(.opacity)
                 }
+                MessageQueueView(
+                    queue: viewModel.queuedMessages,
+                    isDarkMode: isDarkMode,
+                    onRemove: { viewModel.removeQueuedMessage(id: $0) }
+                )
                 MessageInputView(
                     messageText: $messageText,
                     viewModel: viewModel,

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -70,9 +70,10 @@ struct MessageInputView: View {
     // State for pulsing animation
     @State private var isPulsing = false
 
-    // Bumped on send so the editor clears its UITextView even while it keeps
-    // focus (queued sends don't dismiss the keyboard).
-    @State private var clearInputTrigger = UUID()
+    // Clears the editor's UITextView imperatively at send time, so the draft
+    // disappears even while the editor keeps focus (queued sends don't
+    // dismiss the keyboard) without depending on render timing.
+    @State private var editorHandle = CustomTextEditorHandle()
 
     /// A draft that can actually be sent or queued right now: attachments
     /// all processed, plus either non-whitespace text or at least one
@@ -375,7 +376,7 @@ struct MessageInputView: View {
                          textHeight: $textHeight,
                          placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
                          shouldFocusInput: viewModel.shouldFocusInput,
-                         clearTrigger: clearInputTrigger,
+                         handle: editorHandle,
                          allowsImagePaste: viewModel.currentModel.isMultimodal,
                          onFocusHandled: { viewModel.shouldFocusInput = false },
                          onSendMessage: { text in viewModel.sendMessage(text: text) },
@@ -659,7 +660,7 @@ struct MessageInputView: View {
             // queued; a rejected draft (full queue, rate limit) stays put.
             if viewModel.sendMessage(text: messageText) {
                 messageText = ""
-                clearInputTrigger = UUID()
+                editorHandle.clearDraft()
                 textHeight = Layout.defaultHeight
             }
         }
@@ -900,13 +901,25 @@ struct ModelSelectorSheetView: View {
     }
 }
 
+/// Lets the owning view reach into the editor imperatively. Clearing the
+/// draft through the coordinator keeps the UITextView, the binding, and the
+/// keyboard focus consistent in one synchronous step, instead of relying on
+/// a render pass to propagate an emptied binding back into UIKit.
+final class CustomTextEditorHandle {
+    fileprivate weak var coordinator: CustomTextEditor.Coordinator?
+
+    func clearDraft() {
+        coordinator?.clearDraft()
+    }
+}
+
 /// Custom UIViewRepresentable for a properly managed text editor
 struct CustomTextEditor: UIViewRepresentable {
     @Binding var text: String
     @Binding var textHeight: CGFloat
     var placeholderText: String
     var shouldFocusInput: Bool
-    var clearTrigger: UUID
+    var handle: CustomTextEditorHandle? = nil
     var allowsImagePaste: Bool = false
     var onFocusHandled: () -> Void
     /// Returns whether the message was accepted, so the editor only clears
@@ -936,6 +949,9 @@ struct CustomTextEditor: UIViewRepresentable {
         textView.adjustsFontForContentSizeCategory = true
         textView.accessibilityLabel = "Message"
 
+        context.coordinator.textView = textView
+        handle?.coordinator = context.coordinator
+
         // Initialize with placeholder or actual text
         if text.isEmpty {
             textView.text = placeholderText
@@ -953,6 +969,7 @@ struct CustomTextEditor: UIViewRepresentable {
     
     func updateUIView(_ uiView: UITextView, context: Context) {
         context.coordinator.parent = self
+        handle?.coordinator = context.coordinator
         if let pastingView = uiView as? PastingTextView {
             pastingView.allowsImagePaste = allowsImagePaste
             pastingView.onPasteImage = onPasteImage
@@ -973,20 +990,17 @@ struct CustomTextEditor: UIViewRepresentable {
             context.coordinator.hasFocusedFromFlag = false
         }
 
-        // An explicit clear (message sent or queued) must win over the
-        // stale-binding resync below: while the editor keeps focus, an empty
-        // binding with a non-empty view is otherwise read as "binding lagging
-        // behind typed text" and the draft is pushed back into it.
-        if context.coordinator.lastClearTrigger != clearTrigger {
-            context.coordinator.lastClearTrigger = clearTrigger
-            if isCurrentlyEditing {
-                uiView.text = ""
-                uiView.textColor = UIColor { traitCollection in
-                    return traitCollection.userInterfaceStyle == .dark ? .white : .black
-                }
+        // A clear can race a render whose state snapshot predates it: the
+        // view model publishes on every streaming token, so such a pass can
+        // still read the old draft from the binding after `clearDraft` ran
+        // and would write it straight back into the emptied editor. Treat
+        // exactly that value as empty until a fresher one arrives.
+        var text = self.text
+        if let clearedDraft = context.coordinator.clearedDraft {
+            if text == clearedDraft {
+                text = ""
             } else {
-                uiView.text = placeholderText
-                uiView.textColor = .lightGray
+                context.coordinator.clearedDraft = nil
             }
         }
 
@@ -1031,12 +1045,41 @@ struct CustomTextEditor: UIViewRepresentable {
         var parent: CustomTextEditor
         var isEditing = false
         var hasFocusedFromFlag = false
-        var lastClearTrigger: UUID
+        weak var textView: UITextView?
+        /// The draft text at the moment `clearDraft` ran. While streaming, the
+        /// view model publishes on every token, so a render transaction whose
+        /// state snapshot predates the send can reach `updateUIView` after the
+        /// clear, still carrying the old draft in the binding. That value must
+        /// be recognized and ignored or it gets written back into the emptied
+        /// editor and then resynced into the binding, undoing the clear.
+        var clearedDraft: String?
         private var lastMeasurement: (text: String, width: CGFloat, pointSize: CGFloat, height: CGFloat)?
 
         init(_ parent: CustomTextEditor) {
             self.parent = parent
-            self.lastClearTrigger = parent.clearTrigger
+        }
+
+        /// Empties the draft in one synchronous step: the UITextView, the
+        /// text binding, and the reported height all reset together, keeping
+        /// focus (and the keyboard) exactly as they were. Without this, an
+        /// emptied binding reaching `updateUIView` while the editor is still
+        /// focused is indistinguishable from a stale binding and the draft
+        /// text gets resynced right back into it.
+        func clearDraft() {
+            guard let textView else { return }
+            clearedDraft = textView.text
+            if isEditing {
+                textView.text = ""
+                textView.textColor = UIColor { traitCollection in
+                    return traitCollection.userInterfaceStyle == .dark ? .white : .black
+                }
+            } else {
+                textView.text = parent.placeholderText
+                textView.textColor = .lightGray
+            }
+            parent.text = ""
+            parent.textHeight = MessageInputView.Layout.defaultHeight
+            refreshAccessibility(textView)
         }
 
         /// Returns the editor height for the current draft, avoiding repeated
@@ -1097,6 +1140,7 @@ struct CustomTextEditor: UIViewRepresentable {
 
                     // Sending while a response is streaming queues the message.
                     if !trimmedText.isEmpty && parent.onSendMessage(trimmedText) {
+                        clearedDraft = currentText
                         textView.text = ""
                         parent.text = ""
                         parent.textHeight = MessageInputView.Layout.defaultHeight

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -70,6 +70,23 @@ struct MessageInputView: View {
     // State for pulsing animation
     @State private var isPulsing = false
 
+    /// A draft that can actually be sent or queued right now: attachments
+    /// all processed, plus either non-whitespace text or at least one
+    /// attachment. Matches `sendMessage`'s own guards so the button never
+    /// offers a send that would be rejected.
+    private var hasSubmittableContent: Bool {
+        guard attachmentsAreReadyToSend(viewModel.pendingAttachments) else { return false }
+        return !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !viewModel.pendingAttachments.isEmpty
+    }
+
+    /// While a response is streaming, the send button only becomes a stop
+    /// button when there is nothing submittable; a sendable draft keeps it
+    /// a send button so the message can be queued. Mirrors the webapp.
+    private var showStopAction: Bool {
+        viewModel.isLoading && !hasSubmittableContent
+    }
+
     // Attachment picker state
 
 
@@ -345,7 +362,6 @@ struct MessageInputView: View {
                          textHeight: $textHeight,
                          placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
                          shouldFocusInput: viewModel.shouldFocusInput,
-                         isLoading: viewModel.isLoading,
                          allowsImagePaste: viewModel.currentModel.isMultimodal,
                          onFocusHandled: { viewModel.shouldFocusInput = false },
                          onSendMessage: { text in viewModel.sendMessage(text: text) },
@@ -443,7 +459,7 @@ struct MessageInputView: View {
                     }
 
                     Button(action: sendOrCancelMessage) {
-                        Image(systemName: viewModel.isLoading ? "stop.fill" : "arrow.up")
+                        Image(systemName: showStopAction ? "stop.fill" : "arrow.up")
                             .font(.system(size: 16, weight: .semibold))
                             .frame(width: 24, height: 24)
                             .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
@@ -454,10 +470,10 @@ struct MessageInputView: View {
                     .clipShape(.circle)
                     .tint(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
                     .disabled(
-                        !viewModel.isLoading
+                        !showStopAction
                         && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
                     )
-                    .accessibilityLabel(viewModel.isLoading ? "Stop generating" : "Send message")
+                    .accessibilityLabel(showStopAction ? "Stop generating" : "Send message")
                     .padding(.trailing, 8)
                 }
                 .padding(.vertical, 8)
@@ -552,16 +568,16 @@ struct MessageInputView: View {
                                 .fill(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
                                 .frame(width: 32, height: 32)
 
-                            Image(systemName: viewModel.isLoading ? "stop.fill" : "arrow.up")
+                            Image(systemName: showStopAction ? "stop.fill" : "arrow.up")
                                 .font(.system(size: 16, weight: .semibold))
                                 .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
                         }
                     }
                     .disabled(
-                        !viewModel.isLoading
+                        !showStopAction
                         && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
                     )
-                    .accessibilityLabel(viewModel.isLoading ? "Stop generating" : "Send message")
+                    .accessibilityLabel(showStopAction ? "Stop generating" : "Send message")
                     .accessibleHitTarget()
                     .padding(.trailing, 8)
                 }
@@ -597,7 +613,7 @@ struct MessageInputView: View {
                 .foregroundColor(.secondary)
                 .frame(width: 24, height: 24)
         }
-        .disabled(viewModel.isLoading || viewModel.isProcessingAttachment)
+        .disabled(viewModel.isProcessingAttachment)
         .accessibilityLabel("Add attachment")
         .accessibleHitTarget()
         .padding(.leading, 8)
@@ -628,9 +644,9 @@ struct MessageInputView: View {
     }
 
     private func sendOrCancelMessage() {
-        if viewModel.isLoading {
+        if showStopAction {
             viewModel.cancelGeneration()
-        } else if !messageText.isEmpty || !viewModel.pendingAttachments.isEmpty {
+        } else if hasSubmittableContent {
             viewModel.sendMessage(text: messageText)
             messageText = ""
             textHeight = Layout.defaultHeight
@@ -878,7 +894,6 @@ struct CustomTextEditor: UIViewRepresentable {
     @Binding var textHeight: CGFloat
     var placeholderText: String
     var shouldFocusInput: Bool
-    var isLoading: Bool
     var allowsImagePaste: Bool = false
     var onFocusHandled: () -> Void
     var onSendMessage: (String) -> Void
@@ -1046,7 +1061,8 @@ struct CustomTextEditor: UIViewRepresentable {
                     let currentText = textView.text ?? ""
                     let trimmedText = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-                    if !trimmedText.isEmpty && !parent.isLoading {
+                    // Sending while a response is streaming queues the message.
+                    if !trimmedText.isEmpty {
                         parent.onSendMessage(trimmedText)
 
                         textView.text = ""

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -70,6 +70,10 @@ struct MessageInputView: View {
     // State for pulsing animation
     @State private var isPulsing = false
 
+    // Bumped on send so the editor clears its UITextView even while it keeps
+    // focus (queued sends don't dismiss the keyboard).
+    @State private var clearInputTrigger = UUID()
+
     /// A draft that can actually be sent or queued right now: attachments
     /// all processed, plus either non-whitespace text or at least one
     /// attachment. Matches `sendMessage`'s own guards so the button never
@@ -362,6 +366,7 @@ struct MessageInputView: View {
                          textHeight: $textHeight,
                          placeholderText: viewModel.currentChat?.messages.isEmpty ?? true ? "What's on your mind?" : "Message",
                          shouldFocusInput: viewModel.shouldFocusInput,
+                         clearTrigger: clearInputTrigger,
                          allowsImagePaste: viewModel.currentModel.isMultimodal,
                          onFocusHandled: { viewModel.shouldFocusInput = false },
                          onSendMessage: { text in viewModel.sendMessage(text: text) },
@@ -649,6 +654,7 @@ struct MessageInputView: View {
         } else if hasSubmittableContent {
             viewModel.sendMessage(text: messageText)
             messageText = ""
+            clearInputTrigger = UUID()
             textHeight = Layout.defaultHeight
         }
     }
@@ -894,6 +900,7 @@ struct CustomTextEditor: UIViewRepresentable {
     @Binding var textHeight: CGFloat
     var placeholderText: String
     var shouldFocusInput: Bool
+    var clearTrigger: UUID
     var allowsImagePaste: Bool = false
     var onFocusHandled: () -> Void
     var onSendMessage: (String) -> Void
@@ -958,6 +965,23 @@ struct CustomTextEditor: UIViewRepresentable {
             context.coordinator.hasFocusedFromFlag = false
         }
 
+        // An explicit clear (message sent or queued) must win over the
+        // stale-binding resync below: while the editor keeps focus, an empty
+        // binding with a non-empty view is otherwise read as "binding lagging
+        // behind typed text" and the draft is pushed back into it.
+        if context.coordinator.lastClearTrigger != clearTrigger {
+            context.coordinator.lastClearTrigger = clearTrigger
+            if isCurrentlyEditing {
+                uiView.text = ""
+                uiView.textColor = UIColor { traitCollection in
+                    return traitCollection.userInterfaceStyle == .dark ? .white : .black
+                }
+            } else {
+                uiView.text = placeholderText
+                uiView.textColor = .lightGray
+            }
+        }
+
         if text.isEmpty && !isCurrentlyEditing && uiView.textColor != .lightGray {
             uiView.text = placeholderText
             uiView.textColor = .lightGray
@@ -999,10 +1023,12 @@ struct CustomTextEditor: UIViewRepresentable {
         var parent: CustomTextEditor
         var isEditing = false
         var hasFocusedFromFlag = false
+        var lastClearTrigger: UUID
         private var lastMeasurement: (text: String, width: CGFloat, pointSize: CGFloat, height: CGFloat)?
 
         init(_ parent: CustomTextEditor) {
             self.parent = parent
+            self.lastClearTrigger = parent.clearTrigger
         }
 
         /// Returns the editor height for the current draft, avoiding repeated

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1136,17 +1136,12 @@ struct CustomTextEditor: UIViewRepresentable {
                     let currentText = textView.text ?? ""
                     let trimmedText = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-                    // Sending while a response is streaming queues the message.
+                    // Sending while a response is streaming queues the message
+                    // and keeps focus so the next draft can be typed; a direct
+                    // send dismisses the keyboard itself, after which the
+                    // clear falls back to showing the placeholder.
                     if !trimmedText.isEmpty && parent.onSendMessage(trimmedText) {
-                        clearedDraft = currentText
-                        textView.text = ""
-                        parent.text = ""
-                        parent.textHeight = MessageInputView.Layout.defaultHeight
-
-                        textView.text = parent.placeholderText
-                        textView.textColor = .lightGray
-
-                        textView.resignFirstResponder()
+                        clearDraft()
                     }
 
                     return false

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -91,6 +91,15 @@ struct MessageInputView: View {
         viewModel.isLoading && !hasSubmittableContent
     }
 
+    /// The send button greys out while a draft can't be dispatched: an
+    /// attachment is still processing, or the queue already holds the
+    /// maximum number of follow-ups for the streaming response.
+    private var isSendActionDisabled: Bool {
+        !showStopAction
+        && (!attachmentsAreReadyToSend(viewModel.pendingAttachments)
+            || (viewModel.isLoading && viewModel.isMessageQueueFull))
+    }
+
     // Attachment picker state
 
 
@@ -474,10 +483,7 @@ struct MessageInputView: View {
                     .glassEffect(.regular.interactive(), in: .circle)
                     .clipShape(.circle)
                     .tint(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
-                    .disabled(
-                        !showStopAction
-                        && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
-                    )
+                    .disabled(isSendActionDisabled)
                     .accessibilityLabel(showStopAction ? "Stop generating" : "Send message")
                     .padding(.trailing, 8)
                 }
@@ -578,10 +584,7 @@ struct MessageInputView: View {
                                 .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
                         }
                     }
-                    .disabled(
-                        !showStopAction
-                        && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
-                    )
+                    .disabled(isSendActionDisabled)
                     .accessibilityLabel(showStopAction ? "Stop generating" : "Send message")
                     .accessibleHitTarget()
                     .padding(.trailing, 8)
@@ -652,10 +655,13 @@ struct MessageInputView: View {
         if showStopAction {
             viewModel.cancelGeneration()
         } else if hasSubmittableContent {
-            viewModel.sendMessage(text: messageText)
-            messageText = ""
-            clearInputTrigger = UUID()
-            textHeight = Layout.defaultHeight
+            // Only clear the input when the message was actually sent or
+            // queued; a rejected draft (full queue, rate limit) stays put.
+            if viewModel.sendMessage(text: messageText) {
+                messageText = ""
+                clearInputTrigger = UUID()
+                textHeight = Layout.defaultHeight
+            }
         }
     }
 
@@ -903,7 +909,9 @@ struct CustomTextEditor: UIViewRepresentable {
     var clearTrigger: UUID
     var allowsImagePaste: Bool = false
     var onFocusHandled: () -> Void
-    var onSendMessage: (String) -> Void
+    /// Returns whether the message was accepted, so the editor only clears
+    /// itself when the draft was actually sent or queued.
+    var onSendMessage: (String) -> Bool
     var onPasteImage: ((Data, String) -> Void)? = nil
     var onPasteFile: ((URL, String) -> Void)? = nil
     var onPasteFileError: ((String) -> Void)? = nil
@@ -1088,9 +1096,7 @@ struct CustomTextEditor: UIViewRepresentable {
                     let trimmedText = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
 
                     // Sending while a response is streaming queues the message.
-                    if !trimmedText.isEmpty {
-                        parent.onSendMessage(trimmedText)
-
+                    if !trimmedText.isEmpty && parent.onSendMessage(trimmedText) {
                         textView.text = ""
                         parent.text = ""
                         parent.textHeight = MessageInputView.Layout.defaultHeight

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -85,20 +85,18 @@ struct MessageInputView: View {
             || !viewModel.pendingAttachments.isEmpty
     }
 
-    /// While a response is streaming, the send button only becomes a stop
-    /// button when there is nothing submittable; a sendable draft keeps it
-    /// a send button so the message can be queued. Mirrors the webapp.
+    /// While a response is streaming, the button stays a send button only
+    /// while a sendable draft can actually be queued; with nothing
+    /// submittable, or the queue already full, it reverts to a stop button
+    /// so the stream can always be cancelled. Mirrors the webapp.
     private var showStopAction: Bool {
-        viewModel.isLoading && !hasSubmittableContent
+        viewModel.isLoading && (!hasSubmittableContent || viewModel.isMessageQueueFull)
     }
 
-    /// The send button greys out while a draft can't be dispatched: an
-    /// attachment is still processing, or the queue already holds the
-    /// maximum number of follow-ups for the streaming response.
+    /// The send button greys out while a draft can't be dispatched because
+    /// an attachment is still processing.
     private var isSendActionDisabled: Bool {
-        !showStopAction
-        && (!attachmentsAreReadyToSend(viewModel.pendingAttachments)
-            || (viewModel.isLoading && viewModel.isMessageQueueFull))
+        !showStopAction && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
     }
 
     // Attachment picker state

--- a/TinfoilChat/Views/MessageQueueView.swift
+++ b/TinfoilChat/Views/MessageQueueView.swift
@@ -54,6 +54,14 @@ private struct QueuedMessageRow: View {
         }
     }
 
+    private var thumbnailStrip: some View {
+        HStack(spacing: 6) {
+            ForEach(imageAttachments) { attachment in
+                QueuedImageThumbnail(attachment: attachment, isDarkMode: isDarkMode)
+            }
+        }
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "list.bullet")
@@ -63,11 +71,11 @@ private struct QueuedMessageRow: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 if !imageAttachments.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 6) {
-                            ForEach(imageAttachments) { attachment in
-                                QueuedImageThumbnail(attachment: attachment, isDarkMode: isDarkMode)
-                            }
+                    // Hug the thumbnails when they fit; scroll on overflow.
+                    ViewThatFits(in: .horizontal) {
+                        thumbnailStrip
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            thumbnailStrip
                         }
                     }
                 }
@@ -75,7 +83,6 @@ private struct QueuedMessageRow: View {
                     .font(.system(size: 14))
                     .foregroundColor(.secondary)
                     .lineLimit(Constants.MessageQueue.previewLineLimit)
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             Button {
@@ -84,10 +91,13 @@ private struct QueuedMessageRow: View {
                 Image(systemName: "trash")
                     .font(.system(size: 12))
                     .foregroundColor(.secondary)
-                    .frame(width: 24, height: 24)
+                    // Lays out at one text line's height so the compact row
+                    // isn't inflated; the hit area alone grows to the 44pt
+                    // minimum via the inset content shape.
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle().inset(by: -12))
             }
             .accessibilityLabel("Remove queued message")
-            .accessibleHitTarget()
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -95,6 +105,9 @@ private struct QueuedMessageRow: View {
             RoundedRectangle(cornerRadius: 16)
                 .fill(Color.chatSurface(isDarkMode: isDarkMode))
         )
+        // Sizes like a user bubble: hugs the text and caps at the same
+        // adaptive width, trailing-aligned above the input.
+        .modifier(MessageBubbleModifier(isUserMessage: true))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Queued message: \(previewText.isEmpty ? fallbackLabel : previewText)")
     }

--- a/TinfoilChat/Views/MessageQueueView.swift
+++ b/TinfoilChat/Views/MessageQueueView.swift
@@ -1,0 +1,126 @@
+//
+//  MessageQueueView.swift
+//  TinfoilChat
+//
+//  Copyright © 2025 Tinfoil. All rights reserved.
+//
+//  Shows messages queued while the assistant is responding, above the
+//  input area. Mirrors the webapp's MessageQueue component.
+
+import SwiftUI
+
+struct MessageQueueView: View {
+    let queue: [QueuedMessage]
+    let isDarkMode: Bool
+    let onRemove: (String) -> Void
+
+    var body: some View {
+        if !queue.isEmpty {
+            VStack(spacing: 6) {
+                ForEach(queue) { item in
+                    QueuedMessageRow(item: item, isDarkMode: isDarkMode, onRemove: onRemove)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 6)
+        }
+    }
+}
+
+private struct QueuedMessageRow: View {
+    let item: QueuedMessage
+    let isDarkMode: Bool
+    let onRemove: (String) -> Void
+
+    private var previewText: String {
+        let trimmed = item.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count > Constants.MessageQueue.previewMaxLength {
+            return String(trimmed.prefix(Constants.MessageQueue.previewMaxLength)) + "…"
+        }
+        return trimmed
+    }
+
+    private var fallbackLabel: String {
+        let attachmentCount = item.attachments.count
+        if attachmentCount > 0 {
+            return "\(attachmentCount) attachment\(attachmentCount == 1 ? "" : "s")"
+        }
+        return "Queued message"
+    }
+
+    private var imageAttachments: [Attachment] {
+        item.attachments.filter {
+            $0.type == .image && ($0.thumbnailBase64 ?? $0.base64) != nil
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "list.bullet")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.secondary)
+                .padding(.top, 3)
+
+            VStack(alignment: .leading, spacing: 6) {
+                if !imageAttachments.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 6) {
+                            ForEach(imageAttachments) { attachment in
+                                QueuedImageThumbnail(attachment: attachment, isDarkMode: isDarkMode)
+                            }
+                        }
+                    }
+                }
+                Text(previewText.isEmpty ? fallbackLabel : previewText)
+                    .font(.system(size: 14))
+                    .foregroundColor(.secondary)
+                    .lineLimit(Constants.MessageQueue.previewLineLimit)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Button {
+                onRemove(item.id)
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+                    .frame(width: 24, height: 24)
+            }
+            .accessibilityLabel("Remove queued message")
+            .accessibleHitTarget()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color.chatSurface(isDarkMode: isDarkMode))
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Queued message: \(previewText.isEmpty ? fallbackLabel : previewText)")
+    }
+}
+
+private struct QueuedImageThumbnail: View {
+    let attachment: Attachment
+    let isDarkMode: Bool
+
+    private var previewBase64: String? {
+        attachment.thumbnailBase64 ?? attachment.base64
+    }
+
+    var body: some View {
+        DecodedBase64ImageView(
+            base64: previewBase64,
+            cacheKey: "queued-message-\(attachment.id)-\(previewBase64?.hashValue ?? 0)"
+        ) {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isDarkMode ? Color.white.opacity(0.08) : Color.black.opacity(0.06))
+        }
+        .frame(
+            width: Constants.MessageQueue.imageThumbnailSize,
+            height: Constants.MessageQueue.imageThumbnailSize
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityLabel(attachment.fileName)
+    }
+}

--- a/TinfoilChat/Views/MessageQueueView.swift
+++ b/TinfoilChat/Views/MessageQueueView.swift
@@ -54,6 +54,15 @@ private struct QueuedMessageRow: View {
         }
     }
 
+    /// Attachments that can't be shown as a thumbnail (documents, or images
+    /// without preview data). Listed by name so the queued payload stays
+    /// verifiable even when the row also has preview text.
+    private var namedAttachments: [Attachment] {
+        item.attachments.filter { attachment in
+            !(attachment.type == .image && (attachment.thumbnailBase64 ?? attachment.base64) != nil)
+        }
+    }
+
     private var thumbnailStrip: some View {
         HStack(spacing: 6) {
             ForEach(imageAttachments) { attachment in
@@ -79,10 +88,23 @@ private struct QueuedMessageRow: View {
                         }
                     }
                 }
-                Text(previewText.isEmpty ? fallbackLabel : previewText)
-                    .font(.system(size: 14))
+                ForEach(namedAttachments) { attachment in
+                    HStack(spacing: 4) {
+                        Image(systemName: "doc.text")
+                            .font(.system(size: 11))
+                        Text(attachment.fileName)
+                            .font(.system(size: 12))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
                     .foregroundColor(.secondary)
-                    .lineLimit(Constants.MessageQueue.previewLineLimit)
+                }
+                if !previewText.isEmpty || item.attachments.isEmpty {
+                    Text(previewText.isEmpty ? fallbackLabel : previewText)
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                        .lineLimit(Constants.MessageQueue.previewLineLimit)
+                }
             }
 
             Button {

--- a/TinfoilChat/Views/MessageQueueView.swift
+++ b/TinfoilChat/Views/MessageQueueView.swift
@@ -48,19 +48,21 @@ private struct QueuedMessageRow: View {
         return "Queued message"
     }
 
+    /// Single source of truth for whether an attachment renders as a
+    /// thumbnail; everything else is listed by name instead.
+    private func hasImagePreview(_ attachment: Attachment) -> Bool {
+        attachment.type == .image && (attachment.thumbnailBase64 ?? attachment.base64) != nil
+    }
+
     private var imageAttachments: [Attachment] {
-        item.attachments.filter {
-            $0.type == .image && ($0.thumbnailBase64 ?? $0.base64) != nil
-        }
+        item.attachments.filter(hasImagePreview)
     }
 
     /// Attachments that can't be shown as a thumbnail (documents, or images
     /// without preview data). Listed by name so the queued payload stays
     /// verifiable even when the row also has preview text.
     private var namedAttachments: [Attachment] {
-        item.attachments.filter { attachment in
-            !(attachment.type == .image && (attachment.thumbnailBase64 ?? attachment.base64) != nil)
-        }
+        item.attachments.filter { !hasImagePreview($0) }
     }
 
     private var thumbnailStrip: some View {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -89,6 +89,24 @@ struct MessageTableView: UIViewRepresentable {
         let isIdConversion = chatIdChanged && !currentMessageIds.isEmpty &&
             currentMessageIds == context.coordinator.lastMessageIds
 
+        // Track which row is streaming synchronously, before any reload below
+        // measures cells. A queued message dispatched right as a stream ends
+        // can move `isLoading` false -> true and append rows within a single
+        // update, so the finished message's wrapper still claims to be the
+        // streaming last row when the reload measures it (wrapper updates are
+        // deferred a runloop tick). The cell's streaming buffer keys off this
+        // coordinator value instead, so the finished row measures at its
+        // collapsed height immediately and can't overlap the rows added after
+        // it. The stale wrapper's buffer state and cached height go with it.
+        let previousStreamingMessageId = context.coordinator.streamingMessageId
+        context.coordinator.streamingMessageId = isLoading ? messages.last?.id : nil
+        if let staleId = previousStreamingMessageId,
+           staleId != messages.last?.id,
+           let staleWrapper = context.coordinator.messageWrappers[staleId] {
+            staleWrapper.resetBuffer()
+            context.coordinator.messageHeightCache.removeValue(forKey: staleId)
+        }
+
         if chatIdChanged {
             context.coordinator.lastChatId = currentChatId
             context.coordinator.preservedOffsetAfterStreaming = nil
@@ -249,8 +267,17 @@ struct MessageTableView: UIViewRepresentable {
                         return
                     }
                     UIView.performWithoutAnimation {
-                        tableView.beginUpdates()
-                        tableView.endUpdates()
+                        // A queued message can be dispatched between the stream
+                        // ending and this deferred collapse, growing the
+                        // datasource before the table has reloaded for it.
+                        // begin/endUpdates would assert on the mismatched row
+                        // counts; the imminent reload from that count change
+                        // re-measures heights anyway, so the collapse pass is
+                        // only run while the counts still agree.
+                        if tableView.numberOfRows(inSection: 0) == context.coordinator.parent.messages.count {
+                            tableView.beginUpdates()
+                            tableView.endUpdates()
+                        }
                         context.coordinator.isCollapsingStreamingBuffer = false
                         context.coordinator.updateContentInset()
                         tableView.layoutIfNeeded()
@@ -342,6 +369,9 @@ struct MessageTableView: UIViewRepresentable {
         var isUserMessageScrollMode = false
         var preservedOffsetAfterStreaming: CGFloat?
         var isCollapsingStreamingBuffer = false
+        /// The message currently rendered with a streaming buffer, updated
+        /// synchronously with the datasource (wrapper flags lag one tick).
+        var streamingMessageId: String?
         var heightCache: [IndexPath: CGFloat] = [:]
         var messageHeightCache: [String: CGFloat] = [:]
         var contentEstimateCache: [String: CGFloat] = [:]
@@ -568,9 +598,17 @@ struct MessageTableView: UIViewRepresentable {
 
         private func isStreamingRow(at indexPath: IndexPath) -> Bool {
             guard indexPath.row < parent.messages.count else { return false }
-            guard indexPath.row == parent.messages.count - 1 else { return false }
             let message = parent.messages[indexPath.row]
-            return parent.isLoading || messageWrappers[message.id]?.isLoading == true
+            // Wrapper flags lag the datasource by a runloop tick, so a message
+            // that just stopped being the streaming last row (queued dispatch
+            // appended rows behind it) can still render its buffer this tick.
+            // Trust the wrapper's claim wherever the row sits so that inflated
+            // frame never enters the height caches.
+            if let wrapper = messageWrappers[message.id], wrapper.isLoading, wrapper.isLastMessage {
+                return true
+            }
+            guard indexPath.row == parent.messages.count - 1 else { return false }
+            return parent.isLoading
         }
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -877,6 +915,15 @@ struct ObservableMessageCell: View {
         )
     }
 
+    /// Wrapper flags update a runloop tick behind the datasource, so they can
+    /// still mark a finished message as the streaming last row while a reload
+    /// is measuring cells (queued dispatch landing at stream end). Requiring
+    /// the coordinator's synchronous id keeps the buffer off such rows.
+    private var showsStreamingBuffer: Bool {
+        wrapper.isLoading && wrapper.isLastMessage
+            && coordinator?.streamingMessageId == wrapper.message.id
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if wrapper.showArchiveSeparator {
@@ -898,7 +945,7 @@ struct ObservableMessageCell: View {
             }
 
             ZStack(alignment: .topLeading) {
-                if wrapper.isLoading && wrapper.isLastMessage {
+                if showsStreamingBuffer {
                     Color.clear
                         .frame(height: bufferHeight)
                 }
@@ -919,7 +966,7 @@ struct ObservableMessageCell: View {
                     view.frame(maxWidth: 900)
                         .frame(maxWidth: .infinity)
                 }
-                .if(wrapper.isLoading && wrapper.isLastMessage) { view in
+                .if(showsStreamingBuffer) { view in
                     view.background(
                         GeometryReader { geometry in
                             Color.clear


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Let users send messages while the assistant is responding. Each chat has a one-item in-memory queue that auto-sends when the assistant goes idle, on reopen, or when request capacity returns; the list stays stable at stream end, and the input clears after queueing.

- New Features
  - Per-chat message queue (max 1); attachments ride along and clear; queues drop on chat delete or temporary-chat teardown; shared imports always acknowledged.
  - Auto-drain only for the active chat on stream end or reopen; drains also resume after a quota refresh or upgrade; keyboard stays up while draining.
  - Queue UI above the input: 240‑char, 2‑line text preview, image thumbnails, document names for non-image files, content-fitting user-bubble width, remove action, compact spacing with an aligned remove icon.
  - Input: send stays active during streaming when sendable; Enter queues and keeps focus; stop stays reachable when the queue is full; send disables while attachments process or the queue is full; the attachment button stays enabled during streaming.
  - Honors free-tier limits; queued messages wait until the limit resets or the user upgrades.

- Bug Fixes
  - Prevented instability when a queued message dispatches as streaming ends: the streaming buffer collapses cleanly, no flicker or overlap.
  - Clearing the input after queueing is now reliable; a stale render can’t restore the cleared draft.
  - Queued message rows now show document attachments by name; image preview detection is consistent.

<sup>Written for commit fdea78dd73adbed024a77b73feb20deed14b44c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

