### PR TITLE
Perf: prompt prefix caching

### DIFF
--- a/TinfoilChat/Models/PromptPreset.swift
+++ b/TinfoilChat/Models/PromptPreset.swift
@@ -87,7 +87,7 @@ praise; acknowledge progress only when it reflects real understanding.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),
@@ -120,7 +120,7 @@ doesn't reproduce on a careful second look. Don't pad the review.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),
@@ -151,7 +151,7 @@ fragments; if they write in long periodic sentences, do the same.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),
@@ -184,7 +184,7 @@ recommendation unless the user explicitly asks.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),
@@ -218,7 +218,7 @@ expanding into every alternative.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),
@@ -273,7 +273,7 @@ Once the scene is set, dive straight in.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),
@@ -300,7 +300,7 @@ depth, they'll ask.
 
 {USER_PREFERENCES}
 
-Respond in {LANGUAGE}. Current time: {CURRENT_DATETIME} ({TIMEZONE}).
+Respond in {LANGUAGE}. The user's timezone is {TIMEZONE}.
 """),
             isBuiltIn: true
         ),

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -48,6 +48,11 @@ struct ChatQueryBuilder {
     ///     `model` becomes `AutoModel.requestModel` and the ordered candidates
     ///     (with per-candidate reasoning params) are attached under
     ///     `AutoModel.optionsField` for the router to resolve.
+    ///   - includeTimeReminder: Append an ephemeral current-time reminder as
+    ///     the final message. The reminder is built at request time and never
+    ///     persisted, keeping the system prompt and history byte-stable so
+    ///     prefix caching works. Defaults to `false` so internal utilities
+    ///     (title gen, memory) stay unaffected.
     /// - Returns: A configured ChatQuery
     @MainActor
     static func buildQuery(
@@ -63,7 +68,8 @@ struct ChatQueryBuilder {
         reasoningEffort: ReasoningEffort = .medium,
         thinkingEnabled: Bool = true,
         genUIEnabled: Bool = true,
-        autoCandidates: [ModelType]? = nil
+        autoCandidates: [ModelType]? = nil,
+        includeTimeReminder: Bool = false
     ) -> ChatQuery {
 
         var messages: [ChatQuery.ChatCompletionMessageParam] = []
@@ -191,6 +197,10 @@ struct ChatQueryBuilder {
                     }
                 }
             }
+        }
+
+        if includeTimeReminder {
+            messages.append(.user(.init(content: .string(TimeReminder.formatCurrentTimeReminder()))))
         }
 
         let tools: [ChatQuery.ChatCompletionToolParam]? = genUIEnabled

--- a/TinfoilChat/Utilities/TimeReminder.swift
+++ b/TinfoilChat/Utilities/TimeReminder.swift
@@ -1,0 +1,26 @@
+//
+//  TimeReminder.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+
+import Foundation
+
+/// Builds the ephemeral current-time reminder appended to the end of chat
+/// requests. Keeping the timestamp out of the system prompt (the first
+/// message) preserves server-side prefix caching: only the tail of the
+/// prompt changes between turns.
+///
+/// Minute granularity (no seconds) so retries and regenerations within the
+/// same minute produce byte-identical requests.
+enum TimeReminder {
+
+    static func formatCurrentTimeReminder(now: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "EEEE, MMMM d, yyyy, hh:mm a zzz"
+        let dateTime = formatter.string(from: now)
+        let timezone = TimeZone.current.identifier
+        return "<system-reminder>Current time: \(dateTime) (\(timezone))</system-reminder>"
+    }
+}

--- a/TinfoilChat/Utilities/TimeReminder.swift
+++ b/TinfoilChat/Utilities/TimeReminder.swift
@@ -15,10 +15,18 @@ import Foundation
 /// same minute produce byte-identical requests.
 enum TimeReminder {
 
-    static func formatCurrentTimeReminder(now: Date = Date()) -> String {
+    private static let dateFormat = "EEEE, MMMM d, yyyy, hh:mm a zzz"
+
+    // en_US_POSIX guarantees invariant fixed-format output (QA1480): plain
+    // en_US would let the user's 24-hour time override rewrite "hh:mm a".
+    private static let formatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateFormat = "EEEE, MMMM d, yyyy, hh:mm a zzz"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = dateFormat
+        return formatter
+    }()
+
+    static func formatCurrentTimeReminder(now: Date = Date()) -> String {
         let dateTime = formatter.string(from: now)
         let timezone = TimeZone.current.identifier
         return "<system-reminder>Current time: \(dateTime) (\(timezone))</system-reminder>"

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1940,14 +1940,8 @@ class ChatViewModel: ObservableObject {
                     systemPrompt = systemPrompt.replacingOccurrences(of: "{USER_PREFERENCES}", with: "")
                 }
                 
-                // Stable replacement for the legacy {CURRENT_DATETIME} placeholder.
-                // The live timestamp is delivered via an ephemeral reminder message
-                // at the end of the request instead, so the system prompt stays
-                // byte-stable and server-side prefix caching keeps working.
-                let currentDateTimePointer = "provided in a reminder message at the end of the conversation"
                 let timezone = TimeZone.current.abbreviation() ?? TimeZone.current.identifier
                 
-                systemPrompt = systemPrompt.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTimePointer)
                 systemPrompt = systemPrompt.replacingOccurrences(of: "{TIMEZONE}", with: timezone)
                 systemPrompt = ProjectContextBuilder.applyProjectContext(
                     to: systemPrompt,
@@ -1967,7 +1961,6 @@ class ChatViewModel: ObservableObject {
                         processedRules = processedRules.replacingOccurrences(of: "{USER_PREFERENCES}", with: "")
                     }
 
-                    processedRules = processedRules.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTimePointer)
                     processedRules = processedRules.replacingOccurrences(of: "{TIMEZONE}", with: timezone)
                 }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1940,13 +1940,14 @@ class ChatViewModel: ObservableObject {
                     systemPrompt = systemPrompt.replacingOccurrences(of: "{USER_PREFERENCES}", with: "")
                 }
                 
-                // Add current date/time and timezone
-                let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-                let currentDateTime = dateFormatter.string(from: Date())
+                // Stable replacement for the legacy {CURRENT_DATETIME} placeholder.
+                // The live timestamp is delivered via an ephemeral reminder message
+                // at the end of the request instead, so the system prompt stays
+                // byte-stable and server-side prefix caching keeps working.
+                let currentDateTimePointer = "provided in a reminder message at the end of the conversation"
                 let timezone = TimeZone.current.abbreviation() ?? TimeZone.current.identifier
                 
-                systemPrompt = systemPrompt.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTime)
+                systemPrompt = systemPrompt.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTimePointer)
                 systemPrompt = systemPrompt.replacingOccurrences(of: "{TIMEZONE}", with: timezone)
                 systemPrompt = ProjectContextBuilder.applyProjectContext(
                     to: systemPrompt,
@@ -1966,7 +1967,7 @@ class ChatViewModel: ObservableObject {
                         processedRules = processedRules.replacingOccurrences(of: "{USER_PREFERENCES}", with: "")
                     }
 
-                    processedRules = processedRules.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTime)
+                    processedRules = processedRules.replacingOccurrences(of: "{CURRENT_DATETIME}", with: currentDateTimePointer)
                     processedRules = processedRules.replacingOccurrences(of: "{TIMEZONE}", with: timezone)
                 }
 
@@ -1983,7 +1984,8 @@ class ChatViewModel: ObservableObject {
                     reasoningEffort: streamReasoningEffort,
                     thinkingEnabled: streamThinkingEnabled,
                     genUIEnabled: SettingsManager.shared.genUIEnabled,
-                    autoCandidates: modelSelection.autoCandidates
+                    autoCandidates: modelSelection.autoCandidates,
+                    includeTimeReminder: true
                 )
 
                 let hapticEnabled = SettingsManager.shared.hapticFeedbackEnabled

--- a/TinfoilChat/Views/PromptLibraryView.swift
+++ b/TinfoilChat/Views/PromptLibraryView.swift
@@ -466,7 +466,7 @@ struct PromptEditorView: View {
                 } header: {
                     Text("System Prompt")
                 } footer: {
-                    Text("Placeholders supported: {USER_PREFERENCES}, {LANGUAGE}, {CURRENT_DATETIME}, {TIMEZONE}.")
+                    Text("Placeholders supported: {USER_PREFERENCES}, {LANGUAGE}, {TIMEZONE}. The current time is always provided to the model automatically.")
                         .font(.caption)
                 }
                 .listRowBackground(Color.cardSurface(for: colorScheme))

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -1258,7 +1258,7 @@ struct CustomSystemPromptView: View {
                         .font(.caption)
                     
                     if isUsingCustomPrompt {
-                        Text("Tip: Use placeholders like {USER_PREFERENCES}, {LANGUAGE}, {CURRENT_DATETIME}, and {TIMEZONE} to tell the model about your preferences, timezone, and the current time and date.")
+                        Text("Tip: Use placeholders like {USER_PREFERENCES}, {LANGUAGE}, and {TIMEZONE} to tell the model about your preferences and timezone. The current time and date are always provided to the model automatically.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .padding(.top, 4)

--- a/TinfoilChatTests/TimeReminderTests.swift
+++ b/TinfoilChatTests/TimeReminderTests.swift
@@ -1,0 +1,76 @@
+//
+//  TimeReminderTests.swift
+//  TinfoilChatTests
+//
+//  Verifies the ephemeral current-time reminder: it is appended as the last
+//  message only when requested, and its formatting has minute granularity so
+//  retries within the same minute produce byte-identical requests, keeping
+//  server-side prefix caching effective.
+//
+
+import Foundation
+import OpenAI
+import Testing
+@testable import TinfoilChat
+
+struct TimeReminderTests {
+
+    @Test @MainActor
+    func appendsTimeReminderAsLastMessageWhenRequested() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "gpt-oss-120b",
+            systemPrompt: "be helpful",
+            rules: "",
+            conversationMessages: [
+                Message(role: .user, content: "hello")
+            ],
+            stream: false,
+            genUIEnabled: false,
+            includeTimeReminder: true
+        )
+
+        let messages = try encodedMessages(from: query)
+        let last = try #require(messages.last)
+        #expect(last["role"] as? String == "user")
+        let content = try #require(last["content"] as? String)
+        #expect(content.hasPrefix("<system-reminder>Current time: "))
+        #expect(content.hasSuffix("</system-reminder>"))
+        let secondToLast = messages[messages.count - 2]
+        #expect(secondToLast["content"] as? String == "hello")
+    }
+
+    @Test @MainActor
+    func omitsTimeReminderByDefault() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "gpt-oss-120b",
+            systemPrompt: "be helpful",
+            rules: "",
+            conversationMessages: [
+                Message(role: .user, content: "hello")
+            ],
+            stream: false,
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        let hasReminder = messages.contains { message in
+            (message["content"] as? String)?.contains("<system-reminder>") == true
+        }
+        #expect(!hasReminder)
+    }
+
+    @Test
+    func formattingIsStableWithinTheSameMinute() {
+        let base = Date(timeIntervalSince1970: 1_784_800_800)
+        let first = TimeReminder.formatCurrentTimeReminder(now: base.addingTimeInterval(1))
+        let second = TimeReminder.formatCurrentTimeReminder(now: base.addingTimeInterval(42))
+
+        #expect(first == second)
+    }
+
+    private func encodedMessages(from query: ChatQuery) throws -> [[String: Any]] {
+        let data = try JSONEncoder().encode(query)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return object?["messages"] as? [[String: Any]] ?? []
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves the current time out of the system prompt and into a final ephemeral message to enable server-side prefix caching. Speeds up chats and makes retries/regens identical within the same minute.

- **New Features**
  - Ephemeral time reminder appended as the last user message via `includeTimeReminder` in `ChatQueryBuilder`.
  - `TimeReminder.formatCurrentTimeReminder()` builds the reminder.
  - Tests cover opt-in behavior and minute-stable formatting.

- **Refactors**
  - Removed `{CURRENT_DATETIME}` and updated built-in presets to use only `{TIMEZONE}` (“The user's timezone is {TIMEZONE}.”).
  - `ChatViewModel` enables `includeTimeReminder` for chats; internal utilities remain default `false`.
  - Help text in Prompt Library and Settings updated.
  - Made time formatting locale-invariant with `en_US_P0SIX` and a reused formatter; minute precision ensures stable retries.
  - Migration: If you use a custom system prompt with `{CURRENT_DATETIME}`, remove it; the model now gets the current time automatically.

<sup>Written for commit 420dd015e518c393814ade3511cd410ef25d29df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

