### PR TITLE
Recover interrupted chats across devices

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		99AB00012FABC00100ABC001 /* TinfoilShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 99AB00032FABC00300ABC003 /* TinfoilShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		99DDBFA42F6869250038A729 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 99DDBFA32F6869250038A729 /* Textual */; };
+		99EAB0012FC0000100EAB001 /* EHBP in Frameworks */ = {isa = PBXBuildFile; productRef = 99EAB0032FC0000300EAB003 /* EHBP */; };
 		99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */ = {isa = PBXBuildFile; productRef = 99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */; };
 		99F154692F4F60C500E9174E /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = 99F154682F4F60C500E9174E /* ClerkKit */; };
 		99F1546B2F4F60C500E9174E /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 99F1546A2F4F60C500E9174E /* ClerkKitUI */; };
@@ -121,6 +122,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				99EAB0012FC0000100EAB001 /* EHBP in Frameworks */,
 				99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */,
 				99F1547C2F4F614400E9174E /* Gzip in Frameworks */,
 				99F154822F4F632500E9174E /* Sentry in Frameworks */,
@@ -244,6 +246,7 @@
 				99F154832F4F632E00E9174E /* RevenueCat */,
 				99F154852F4F633400E9174E /* RevenueCatUI */,
 				99DDBFA32F6869250038A729 /* Textual */,
+				99EAB0032FC0000300EAB003 /* EHBP */,
 			);
 			productName = TinfoilChat;
 			productReference = 99F153C22F4F5F0200E9174E /* TinfoilChat.app */;
@@ -288,6 +291,7 @@
 				99F1547A2F4F614400E9174E /* XCRemoteSwiftPackageReference "GzipSwift" */,
 				99DDBFA22F68667C0038A729 /* XCRemoteSwiftPackageReference "textual" */,
 				99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */,
+				99EAB0022FC0000200EAB002 /* XCRemoteSwiftPackageReference "encrypted-http-body-protocol" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 99F153C32F4F5F0200E9174E /* Products */;
@@ -749,6 +753,14 @@
 				minimumVersion = 0.0.9;
 			};
 		};
+		99EAB0022FC0000200EAB002 /* XCRemoteSwiftPackageReference "encrypted-http-body-protocol" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tinfoilsh/encrypted-http-body-protocol.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.2.3;
+			};
+		};
 		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
@@ -804,6 +816,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 99DDBFA22F68667C0038A729 /* XCRemoteSwiftPackageReference "textual" */;
 			productName = Textual;
+		};
+		99EAB0032FC0000300EAB003 /* EHBP */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 99EAB0022FC0000200EAB002 /* XCRemoteSwiftPackageReference "encrypted-http-body-protocol" */;
+			productName = EHBP;
 		};
 		99EEFB1A2F9EE9E8005B3D75 /* TinfoilAI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -757,8 +757,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/encrypted-http-body-protocol.git";
 			requirement = {
-				kind = exactVersion;
-				version = 0.2.3;
+				branch = "feat/incremental-stream-recovery";
+				kind = branch;
 			};
 		};
 		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -757,8 +757,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/encrypted-http-body-protocol.git";
 			requirement = {
-				branch = "feat/incremental-stream-recovery";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.0;
 			};
 		};
 		99EEFB192F9EE9E8005B3D75 /* XCRemoteSwiftPackageReference "tinfoil-swift" */ = {
@@ -766,7 +766,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.3;
+				minimumVersion = 0.6.5;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/encrypted-http-body-protocol.git",
       "state" : {
-        "revision" : "9e321911a9abc13379e4d557b5a478745ba09eef",
-        "version" : "0.2.3"
+        "branch" : "feat/incremental-stream-recovery",
+        "revision" : "175e173835d2824980e36ee175bacb50d329221e"
       }
     },
     {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/encrypted-http-body-protocol.git",
       "state" : {
-        "branch" : "feat/incremental-stream-recovery",
-        "revision" : "175e173835d2824980e36ee175bacb50d329221e"
+        "revision" : "1bb648e9212739de454657f9a9e3eee762c86e8e",
+        "version" : "0.3.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/openai-swift-fork.git",
       "state" : {
-        "revision" : "f617227dd3657fe59dbf7fed2aaa9b4342119275",
-        "version" : "0.0.9"
+        "revision" : "6e0b975ac142cafa3e3ce65b59a594a930cd45b6",
+        "version" : "0.0.11"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "796b0610993a6577a8ea8580f7dce4ee6da14801",
-        "version" : "0.6.3"
+        "revision" : "54ba387ef14557b43a6d9dea763af76f0adaccb0",
+        "version" : "0.6.5"
       }
     }
   ],

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -180,6 +180,7 @@ enum Constants {
         static let keyIdHexLength = 32
         static let tokenFieldHexLength = 64
         static let requestTimeoutSeconds: TimeInterval = 30
+        static let scanStallTimeoutSeconds: TimeInterval = 120
         static let hkdfInfo = "tinfoil-chat-recovery-envelope-v1"
         static let aadLabel = "tinfoil-chat-recovery-envelope-aad-v1"
         static let sessionHeader = "X-Session-Id"

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -171,6 +171,7 @@ enum Constants {
         static let maxPendingPerChat = 8
         static let maxConcurrentScans = 3
         static let maxMutationAttempts = 4
+        static let maxStreamAttempts = 2
         static let maxCiphertextBytes = 4_096
         static let maxIdentifierLength = 256
         static let sessionIdBytes = 16

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -165,6 +165,31 @@ enum Constants {
         }
     }
 
+    enum ChatRecovery {
+        static let envelopeVersion = 1
+        static let envelopeLifetimeSeconds: TimeInterval = 7 * 24 * 60 * 60
+        static let maxPendingPerChat = 8
+        static let maxConcurrentScans = 3
+        static let maxMutationAttempts = 4
+        static let maxCiphertextBytes = 4_096
+        static let maxIdentifierLength = 256
+        static let sessionIdBytes = 16
+        static let nonceBytes = 12
+        static let authenticationTagBytes = 16
+        static let cekBytes = 32
+        static let keyIdHexLength = 32
+        static let tokenFieldHexLength = 64
+        static let requestTimeoutSeconds: TimeInterval = 30
+        static let hkdfInfo = "tinfoil-chat-recovery-envelope-v1"
+        static let aadLabel = "tinfoil-chat-recovery-envelope-aad-v1"
+        static let sessionHeader = "X-Session-Id"
+        static let enclaveHeader = "X-Tinfoil-Enclave-Url"
+        static let eventsHeader = "X-Tinfoil-Events"
+        static let webSearchEvent = "web_search"
+        static let statusPathPrefix = "/recovery"
+        static let userCacheKeyPrefix = "chat-recovery-user-cache-secret"
+    }
+
     enum SyncEnclave {
         static let url = "https://sync.tinfoil.sh"
         static let configRepo = "tinfoilsh/confidential-sync"

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -188,6 +188,16 @@ enum Constants {
         static let webSearchEvent = "web_search"
         static let statusPathPrefix = "/recovery"
         static let userCacheKeyPrefix = "chat-recovery-user-cache-secret"
+        static let indicatorTitle = "Recovering response"
+        static let indicatorDetail = "Decrypting and restoring this message. This can take up to a minute."
+        static let indicatorSpacing: CGFloat = 10
+        static let indicatorTextSpacing: CGFloat = 3
+        static let indicatorHorizontalPadding: CGFloat = 12
+        static let indicatorVerticalPadding: CGFloat = 10
+        static let indicatorCornerRadius: CGFloat = 12
+        static let indicatorTopPadding: CGFloat = 6
+        static let indicatorMaxWidth: CGFloat = 300
+        static let indicatorBorderWidth: CGFloat = 1
     }
 
     enum SyncEnclave {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -189,15 +189,12 @@ enum Constants {
         static let statusPathPrefix = "/recovery"
         static let userCacheKeyPrefix = "chat-recovery-user-cache-secret"
         static let indicatorTitle = "Recovering response"
-        static let indicatorDetail = "Decrypting and restoring this message. This can take up to a minute."
+        static let indicatorDetailGenerating = "This may take a few minutes"
+        static let indicatorDetailRestoring = indicatorDetailGenerating
         static let indicatorSpacing: CGFloat = 10
         static let indicatorTextSpacing: CGFloat = 3
-        static let indicatorHorizontalPadding: CGFloat = 12
-        static let indicatorVerticalPadding: CGFloat = 10
-        static let indicatorCornerRadius: CGFloat = 12
+        static let indicatorVerticalPadding: CGFloat = 6
         static let indicatorTopPadding: CGFloat = 6
-        static let indicatorMaxWidth: CGFloat = 300
-        static let indicatorBorderWidth: CGFloat = 1
     }
 
     enum SyncEnclave {

--- a/TinfoilChat/Models/ChatIndexEntry.swift
+++ b/TinfoilChat/Models/ChatIndexEntry.swift
@@ -26,6 +26,7 @@ struct ChatIndexEntry: Codable, Identifiable, Equatable {
     var isLocalOnly: Bool = false
     var userId: String?
     var language: String?
+    var hasPendingRecoveries: Bool?
 
     /// Whether this entry represents a chat worth showing in the sidebar
     var isDisplayable: Bool {
@@ -55,5 +56,6 @@ struct ChatIndexEntry: Codable, Identifiable, Equatable {
         self.isLocalOnly = chat.isLocalOnly
         self.userId = chat.userId
         self.language = chat.language
+        self.hasPendingRecoveries = chat.pendingRecoveries?.isEmpty == false
     }
 }

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -10,6 +10,16 @@ import Foundation
 import UIKit
 import ClerkKit
 
+struct PendingRecoveryEnvelope: Codable, Equatable, Sendable {
+    let v: Int
+    let turnId: String
+    let keyId: String
+    let createdAt: String
+    let expiresAt: String
+    let nonce: String
+    let ciphertext: String
+}
+
 /// Represents a chat conversation
 struct Chat: Identifiable, Codable {
     enum TitleState: String, Codable {
@@ -24,6 +34,7 @@ struct Chat: Identifiable, Codable {
     var title: String
     var titleState: TitleState
     var messages: [Message]
+    var pendingRecoveries: [PendingRecoveryEnvelope]?
     var hasActiveStream: Bool = false
     var createdAt: Date
     var modelType: ModelType
@@ -101,6 +112,7 @@ struct Chat: Identifiable, Codable {
         title: String = Chat.placeholderTitle,
         titleState: TitleState? = nil,
         messages: [Message] = [],
+        pendingRecoveries: [PendingRecoveryEnvelope]? = nil,
         createdAt: Date = Date(),
         modelType: ModelType,
         language: String? = nil,
@@ -123,6 +135,7 @@ struct Chat: Identifiable, Codable {
         self.title = title
         self.titleState = resolvedTitleState
         self.messages = messages
+        self.pendingRecoveries = pendingRecoveries
         self.createdAt = createdAt
         self.modelType = modelType
         self.language = language
@@ -189,7 +202,7 @@ struct Chat: Identifiable, Codable {
     // MARK: - Codable Implementation
     
     enum CodingKeys: String, CodingKey {
-        case id, title, titleState, messages, createdAt, modelType, language, userId
+        case id, title, titleState, messages, pendingRecoveries, createdAt, modelType, language, userId
         case syncVersion, syncedAt, locallyModified, updatedAt
         case decryptionFailed, dataCorrupted, formatVersion, isLocalOnly, projectId, promptPresetId
         case webSearchEnabled
@@ -202,6 +215,7 @@ struct Chat: Identifiable, Codable {
         id = try container.decode(String.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
         messages = try container.decode([Message].self, forKey: .messages)
+        pendingRecoveries = try container.decodeIfPresent([PendingRecoveryEnvelope].self, forKey: .pendingRecoveries)
         titleState = (try? container.decode(TitleState.self, forKey: .titleState)) ?? Chat.deriveTitleState(for: title, messages: messages)
         // hasActiveStream is transient UI state — always reset to false on decode
         hasActiveStream = false
@@ -235,6 +249,7 @@ struct Chat: Identifiable, Codable {
         try container.encode(title, forKey: .title)
         try container.encode(titleState, forKey: .titleState)
         try container.encode(messages, forKey: .messages)
+        try container.encodeIfPresent(pendingRecoveries, forKey: .pendingRecoveries)
         // hasActiveStream is transient UI state — never encode it
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(modelType, forKey: .modelType)
@@ -686,6 +701,7 @@ struct QueuedMessage: Identifiable, Equatable {
 struct Message: Identifiable, Codable, Equatable {
     let id: String
     let role: MessageRole
+    var turnId: String? = nil
     var content: String
     var thoughts: String? = nil
     var isThinking: Bool = false
@@ -780,9 +796,10 @@ struct Message: Identifiable, Codable, Equatable {
         return formatter
     }()
     
-    init(id: String = UUID().uuidString.lowercased(), role: MessageRole, content: String, thoughts: String? = nil, isThinking: Bool = false, timestamp: Date = Date(), isCollapsed: Bool = true, generationTimeSeconds: Double? = nil, contentChunks: [ContentChunk] = [], thinkingChunks: [ThinkingChunk] = [], webSearchState: WebSearchState? = nil, attachments: [Attachment] = []) {
+    init(id: String = UUID().uuidString.lowercased(), role: MessageRole, turnId: String? = nil, content: String, thoughts: String? = nil, isThinking: Bool = false, timestamp: Date = Date(), isCollapsed: Bool = true, generationTimeSeconds: Double? = nil, contentChunks: [ContentChunk] = [], thinkingChunks: [ThinkingChunk] = [], webSearchState: WebSearchState? = nil, attachments: [Attachment] = []) {
         self.id = id
         self.role = role
+        self.turnId = turnId
         self.content = content
         self.thoughts = thoughts
         self.isThinking = isThinking
@@ -798,7 +815,7 @@ struct Message: Identifiable, Codable, Equatable {
     // MARK: - Codable Implementation
     
     enum CodingKeys: String, CodingKey {
-        case id, role, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, isConnectionError, generationTimeSeconds, webSearchState
+        case id, role, turnId, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, isConnectionError, generationTimeSeconds, webSearchState
         case webSearch // Alternative key used by React app
         case urlFetches
         case attachments
@@ -815,6 +832,7 @@ struct Message: Identifiable, Codable, Equatable {
         // Make id optional for cross-platform compatibility with React
         id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString.lowercased()
         role = try container.decode(MessageRole.self, forKey: .role)
+        turnId = try container.decodeIfPresent(String.self, forKey: .turnId)
         content = try container.decode(String.self, forKey: .content)
         thoughts = try container.decodeIfPresent(String.self, forKey: .thoughts)
         isThinking = try container.decodeIfPresent(Bool.self, forKey: .isThinking) ?? false
@@ -1004,6 +1022,7 @@ struct Message: Identifiable, Codable, Equatable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(role.rawValue, forKey: .role)
+        try container.encodeIfPresent(turnId, forKey: .turnId)
         try container.encode(content, forKey: .content)
         try container.encodeIfPresent(thoughts, forKey: .thoughts)
         try container.encode(isThinking, forKey: .isThinking)

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -63,6 +63,7 @@ struct StoredChat: Codable {
     var title: String
     var titleState: Chat.TitleState?
     var messages: [Message]
+    var pendingRecoveries: [PendingRecoveryEnvelope]?
     var createdAt: Date      // Will be encoded as ISO string for API
     var updatedAt: Date      // Will be encoded as ISO string for API
     var modelType: ModelType?  // Not synced - local UI preference only
@@ -136,6 +137,7 @@ struct StoredChat: Codable {
         self.title = title
         self.titleState = nil
         self.messages = messages
+        self.pendingRecoveries = nil
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.modelType = nil
@@ -152,6 +154,7 @@ struct StoredChat: Codable {
         self.title = chat.title
         self.titleState = chat.titleState
         self.messages = chat.messages
+        self.pendingRecoveries = chat.pendingRecoveries
         self.createdAt = chat.createdAt
         self.updatedAt = chat.updatedAt
         self.modelType = chat.modelType
@@ -190,6 +193,7 @@ struct StoredChat: Codable {
             title: title,
             titleState: titleState,
             messages: messages,
+            pendingRecoveries: pendingRecoveries,
             createdAt: createdAt,
             modelType: model,
             language: language,
@@ -219,7 +223,7 @@ struct StoredChat: Codable {
     
     // Custom encoding for cross-platform compatibility
     enum CodingKeys: String, CodingKey {
-        case id, title, titleState, messages, createdAt, updatedAt
+        case id, title, titleState, messages, pendingRecoveries, createdAt, updatedAt
         case language, userId
         case syncVersion, syncedAt, locallyModified
         case decryptionFailed, dataCorrupted, formatVersion, projectId
@@ -235,6 +239,7 @@ struct StoredChat: Codable {
         try container.encode(title, forKey: .title)
         try container.encodeIfPresent(titleState, forKey: .titleState)
         try container.encode(messages, forKey: .messages)
+        try container.encodeIfPresent(pendingRecoveries, forKey: .pendingRecoveries)
 
         // Dates as ISO strings with fractional seconds (matching JavaScript's toISOString())
         let isoFormatter = ISO8601DateFormatter()
@@ -272,6 +277,7 @@ struct StoredChat: Codable {
         title = try container.decode(String.self, forKey: .title)
         titleState = try container.decodeIfPresent(Chat.TitleState.self, forKey: .titleState)
         messages = try container.decode([Message].self, forKey: .messages)
+        pendingRecoveries = try container.decodeIfPresent([PendingRecoveryEnvelope].self, forKey: .pendingRecoveries)
         
         // Dates from ISO strings - configure formatter to handle fractional seconds
         let isoFormatter = ISO8601DateFormatter()

--- a/TinfoilChat/Services/ChatRecoveryClient.swift
+++ b/TinfoilChat/Services/ChatRecoveryClient.swift
@@ -108,40 +108,72 @@ actor ChatRecoveryClient {
         sessionId: String,
         token: ChatRecoveryTokenFields
     ) async throws -> AsyncThrowingStream<ChatStreamResult, Error> {
-        let response = try await request(sessionId: sessionId)
+        guard let exportedSecret = Data(lowercaseHex: token.exportedSecret),
+              exportedSecret.count == EHBPConstants.exportLength,
+              let requestEnc = Data(lowercaseHex: token.requestEnc),
+              requestEnc.count == EHBPConstants.requestEncLength
+        else {
+            throw ChatRecoveryClientError.invalidResponse
+        }
+        let request = try await recoveryRequest(sessionId: sessionId)
+        let (bytes, urlResponse) = try await URLSession.shared.bytes(for: request)
+        guard let response = urlResponse as? HTTPURLResponse else {
+            bytes.task.cancel()
+            throw ChatRecoveryClientError.invalidResponse
+        }
         switch response.statusCode {
         case 404:
+            bytes.task.cancel()
             throw ChatRecoveryClientError.state(.missing)
         case 409:
+            bytes.task.cancel()
             throw ChatRecoveryClientError.state(.processing)
         case 410:
+            bytes.task.cancel()
             throw ChatRecoveryClientError.state(.failed)
+        case let statusCode where !(200..<300).contains(statusCode):
+            bytes.task.cancel()
+            throw ChatRecoveryClientError.httpStatus(statusCode)
         default:
-            let nonceHex = response.headers.first {
-                $0.key.caseInsensitiveCompare(EHBPProtocol.responseNonceHeader) == .orderedSame
-            }?.value
-            guard (200..<300).contains(response.statusCode),
-                  let nonceHex,
+            guard let nonceHex = response.value(
+                      forHTTPHeaderField: EHBPProtocol.responseNonceHeader
+                  ),
+                  nonceHex == nonceHex.lowercased(),
                   let nonce = Data(lowercaseHex: nonceHex),
-                  let exportedSecret = Data(lowercaseHex: token.exportedSecret),
-                  let requestEnc = Data(lowercaseHex: token.requestEnc)
+                  nonce.count == EHBPConstants.responseNonceLength
             else {
+                bytes.task.cancel()
                 throw ChatRecoveryClientError.invalidResponse
             }
-            let plaintext = try EHBP.decryptResponseBody(
-                token: SessionRecoveryToken(
-                    exportedSecret: exportedSecret,
-                    requestEnc: requestEnc
-                ),
-                responseNonce: nonce,
-                encryptedData: response.data
+            let responseDecryptor = try SessionRecoveryToken(
+                exportedSecret: exportedSecret,
+                requestEnc: requestEnc
+            ).makeResponseDecryptor(
+                responseNonce: nonce
             )
-            return Self.decodeSSE(
-                AsyncThrowingStream { continuation in
-                    continuation.yield(plaintext)
-                    continuation.finish()
+            let plaintext = AsyncThrowingStream<Data, Error> { continuation in
+                let task = Task {
+                    do {
+                        var decryptor = responseDecryptor
+                        for try await byte in bytes {
+                            try Task.checkCancellation()
+                            for chunk in try decryptor.push(Data([byte])) {
+                                continuation.yield(chunk)
+                            }
+                        }
+                        try decryptor.finish()
+                        continuation.finish()
+                    } catch {
+                        bytes.task.cancel()
+                        continuation.finish(throwing: error)
+                    }
                 }
-            )
+                continuation.onTermination = { _ in
+                    task.cancel()
+                    bytes.task.cancel()
+                }
+            }
+            return Self.decodeSSE(plaintext)
         }
     }
 
@@ -191,6 +223,29 @@ actor ChatRecoveryClient {
         suffix: String = "",
         method: String = "GET"
     ) async throws -> (data: Data, statusCode: Int, headers: [String: String]) {
+        let request = try await recoveryRequest(
+            sessionId: sessionId,
+            suffix: suffix,
+            method: method
+        )
+        let (data, urlResponse) = try await URLSession.shared.data(for: request)
+        guard let response = urlResponse as? HTTPURLResponse else {
+            throw ChatRecoveryClientError.invalidResponse
+        }
+        var headers: [String: String] = [:]
+        for (key, value) in response.allHeaderFields {
+            if let key = key as? String, let value = value as? String {
+                headers[key] = value
+            }
+        }
+        return (data, response.statusCode, headers)
+    }
+
+    private func recoveryRequest(
+        sessionId: String,
+        suffix: String = "",
+        method: String = "GET"
+    ) async throws -> URLRequest {
         try validateSessionId(sessionId)
         _ = try await endpoint()
         guard let baseURL = URL(string: Constants.API.baseURL),
@@ -205,17 +260,7 @@ actor ChatRecoveryClient {
         request.httpMethod = method
         request.timeoutInterval = Constants.ChatRecovery.requestTimeoutSeconds
         request.cachePolicy = .reloadIgnoringLocalCacheData
-        let (data, urlResponse) = try await URLSession.shared.data(for: request)
-        guard let response = urlResponse as? HTTPURLResponse else {
-            throw ChatRecoveryClientError.invalidResponse
-        }
-        var headers: [String: String] = [:]
-        for (key, value) in response.allHeaderFields {
-            if let key = key as? String, let value = value as? String {
-                headers[key] = value
-            }
-        }
-        return (data, response.statusCode, headers)
+        return request
     }
 
     private func validateSessionId(_ sessionId: String) throws {

--- a/TinfoilChat/Services/ChatRecoveryClient.swift
+++ b/TinfoilChat/Services/ChatRecoveryClient.swift
@@ -1,0 +1,310 @@
+@preconcurrency import EHBP
+import Foundation
+import Security
+@preconcurrency import TinfoilAI
+
+enum ChatRecoveryState: String, Decodable, Sendable {
+    case processing
+    case complete
+    case failed
+    case missing
+}
+
+enum ChatRecoveryClientError: Error {
+    case invalidSession
+    case unavailable
+    case invalidResponse
+    case httpStatus(Int)
+    case state(ChatRecoveryState)
+}
+
+struct RecoverableChatStream {
+    let stream: AsyncThrowingStream<ChatStreamResult, Error>
+    let token: ChatRecoveryTokenPayload
+}
+
+actor ChatRecoveryClient {
+    static let shared = ChatRecoveryClient()
+
+    private struct StatusResponse: Decodable {
+        let status: ChatRecoveryState
+    }
+
+    private var verifiedEndpoint: (enclaveURL: String, publicKey: Data)?
+
+    func start(
+        query: ChatQuery,
+        sessionId: String,
+        bearerToken: String,
+        userId: String
+    ) async throws -> RecoverableChatStream {
+        try validateSessionId(sessionId)
+        let endpoint = try await endpoint()
+        let client = try EHBPClient(
+            baseURL: Constants.API.baseURL,
+            publicKey: endpoint.publicKey
+        )
+        var streamingQuery = query
+        streamingQuery.stream = true
+        let encodedQuery = try JSONEncoder().encode(streamingQuery)
+        guard var bodyObject = try JSONSerialization.jsonObject(
+            with: encodedQuery
+        ) as? [String: Any] else {
+            throw ChatRecoveryClientError.invalidResponse
+        }
+        bodyObject["user_cache_secret"] = try promptCacheSecret(userId: userId)
+        let body = try JSONSerialization.data(withJSONObject: bodyObject)
+        let response = try await client.requestStream(
+            method: "POST",
+            path: Constants.API.chatCompletionsEndpoint,
+            headers: [
+                "Authorization": "Bearer \(bearerToken)",
+                "Content-Type": "application/json",
+                Constants.ChatRecovery.sessionHeader: sessionId,
+                Constants.ChatRecovery.eventsHeader: Constants.ChatRecovery.webSearchEvent,
+                Constants.ChatRecovery.enclaveHeader: endpoint.enclaveURL,
+            ],
+            body: body
+        )
+        guard (200..<300).contains(response.response.statusCode) else {
+            throw ChatRecoveryClientError.httpStatus(response.response.statusCode)
+        }
+        let token = try client.getSessionRecoveryToken()
+        let tokenFields = ChatRecoveryTokenFields(
+            exportedSecret: token.exportedSecret.hexEncodedString(),
+            requestEnc: token.requestEnc.hexEncodedString()
+        )
+        let serialized = String(
+            data: try JSONEncoder().encode(tokenFields),
+            encoding: .utf8
+        )
+        guard let serialized else {
+            throw ChatRecoveryClientError.invalidResponse
+        }
+        return RecoverableChatStream(
+            stream: Self.decodeSSE(response.stream),
+            token: .serialized(serialized)
+        )
+    }
+
+    func state(sessionId: String) async throws -> ChatRecoveryState {
+        let response = try await request(sessionId: sessionId, suffix: "/status")
+        switch response.statusCode {
+        case 404:
+            return .missing
+        case 410:
+            return .failed
+        default:
+            guard (200..<300).contains(response.statusCode),
+                  let status = try? JSONDecoder().decode(StatusResponse.self, from: response.data)
+            else {
+                throw ChatRecoveryClientError.invalidResponse
+            }
+            return status.status
+        }
+    }
+
+    func fetch(
+        sessionId: String,
+        token: ChatRecoveryTokenFields
+    ) async throws -> AsyncThrowingStream<ChatStreamResult, Error> {
+        let response = try await request(sessionId: sessionId)
+        switch response.statusCode {
+        case 404:
+            throw ChatRecoveryClientError.state(.missing)
+        case 409:
+            throw ChatRecoveryClientError.state(.processing)
+        case 410:
+            throw ChatRecoveryClientError.state(.failed)
+        default:
+            let nonceHex = response.headers.first {
+                $0.key.caseInsensitiveCompare(EHBPProtocol.responseNonceHeader) == .orderedSame
+            }?.value
+            guard (200..<300).contains(response.statusCode),
+                  let nonceHex,
+                  let nonce = Data(lowercaseHex: nonceHex),
+                  let exportedSecret = Data(lowercaseHex: token.exportedSecret),
+                  let requestEnc = Data(lowercaseHex: token.requestEnc)
+            else {
+                throw ChatRecoveryClientError.invalidResponse
+            }
+            let plaintext = try EHBP.decryptResponseBody(
+                token: SessionRecoveryToken(
+                    exportedSecret: exportedSecret,
+                    requestEnc: requestEnc
+                ),
+                responseNonce: nonce,
+                encryptedData: response.data
+            )
+            return Self.decodeSSE(
+                AsyncThrowingStream { continuation in
+                    continuation.yield(plaintext)
+                    continuation.finish()
+                }
+            )
+        }
+    }
+
+    func delete(sessionId: String) async throws {
+        let response = try await request(sessionId: sessionId, method: "DELETE")
+        guard (200..<300).contains(response.statusCode) || response.statusCode == 404 else {
+            throw ChatRecoveryClientError.invalidResponse
+        }
+    }
+
+    private func endpoint() async throws -> (enclaveURL: String, publicKey: Data) {
+        if let verifiedEndpoint {
+            return verifiedEndpoint
+        }
+        let verifier = SecureClient()
+        let groundTruth = try await verifier.verify()
+        guard let url = verifier.verifiedEnclaveURL,
+              let keyHex = groundTruth.hpkePublicKey,
+              let publicKey = Data(lowercaseHex: keyHex),
+              publicKey.count == Constants.ChatRecovery.cekBytes
+        else {
+            throw ChatRecoveryClientError.unavailable
+        }
+        let endpoint = (enclaveURL: url, publicKey: publicKey)
+        verifiedEndpoint = endpoint
+        return endpoint
+    }
+
+    private func promptCacheSecret(userId: String) throws -> String {
+        let key = "\(Constants.ChatRecovery.userCacheKeyPrefix)-\(userId)"
+        if let existing = KeychainHelper.shared.loadString(for: key), !existing.isEmpty {
+            return existing
+        }
+        var bytes = [UInt8](repeating: 0, count: Constants.ChatRecovery.cekBytes)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            throw ChatRecoveryClientError.unavailable
+        }
+        let secret = Data(bytes).base64EncodedString()
+        guard KeychainHelper.shared.save(secret, for: key) else {
+            throw ChatRecoveryClientError.unavailable
+        }
+        return secret
+    }
+
+    private func request(
+        sessionId: String,
+        suffix: String = "",
+        method: String = "GET"
+    ) async throws -> (data: Data, statusCode: Int, headers: [String: String]) {
+        try validateSessionId(sessionId)
+        _ = try await endpoint()
+        guard let baseURL = URL(string: Constants.API.baseURL),
+              let url = URL(
+                string: "\(Constants.ChatRecovery.statusPathPrefix)/\(sessionId)\(suffix)",
+                relativeTo: baseURL
+              )
+        else {
+            throw ChatRecoveryClientError.unavailable
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = Constants.ChatRecovery.requestTimeoutSeconds
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        let (data, urlResponse) = try await URLSession.shared.data(for: request)
+        guard let response = urlResponse as? HTTPURLResponse else {
+            throw ChatRecoveryClientError.invalidResponse
+        }
+        var headers: [String: String] = [:]
+        for (key, value) in response.allHeaderFields {
+            if let key = key as? String, let value = value as? String {
+                headers[key] = value
+            }
+        }
+        return (data, response.statusCode, headers)
+    }
+
+    private func validateSessionId(_ sessionId: String) throws {
+        guard sessionId.count == Constants.ChatRecovery.sessionIdBytes * 2,
+              Data(lowercaseHex: sessionId) != nil
+        else {
+            throw ChatRecoveryClientError.invalidSession
+        }
+    }
+
+    private static func decodeSSE(
+        _ byteStream: AsyncThrowingStream<Data, Error>
+    ) -> AsyncThrowingStream<ChatStreamResult, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var buffer = Data()
+                    for try await chunk in byteStream {
+                        try Task.checkCancellation()
+                        buffer.append(chunk)
+                        while let boundary = buffer.eventBoundary {
+                            let event = buffer.prefix(boundary.lowerBound)
+                            buffer.removeSubrange(..<boundary.upperBound)
+                            guard let payload = event.ssePayload, payload != "[DONE]" else {
+                                continue
+                            }
+                            let result = try JSONDecoder().decode(
+                                ChatStreamResult.self,
+                                from: Data(payload.utf8)
+                            )
+                            continuation.yield(result)
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+
+private extension Data {
+    init?(lowercaseHex: String) {
+        guard lowercaseHex.count.isMultiple(of: 2),
+              lowercaseHex.unicodeScalars.allSatisfy({
+                  (48...57).contains(Int($0.value)) || (97...102).contains(Int($0.value))
+              })
+        else {
+            return nil
+        }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(lowercaseHex.count / 2)
+        var index = lowercaseHex.startIndex
+        while index < lowercaseHex.endIndex {
+            let next = lowercaseHex.index(index, offsetBy: 2)
+            guard let byte = UInt8(lowercaseHex[index..<next], radix: 16) else {
+                return nil
+            }
+            bytes.append(byte)
+            index = next
+        }
+        self = Data(bytes)
+    }
+
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+
+    var eventBoundary: Range<Data.Index>? {
+        [
+            range(of: Data("\r\n\r\n".utf8)),
+            range(of: Data("\n\n".utf8)),
+            range(of: Data("\r\r".utf8)),
+        ]
+        .compactMap { $0 }
+        .min(by: { $0.lowerBound < $1.lowerBound })
+    }
+
+    var ssePayload: String? {
+        guard let string = String(data: self, encoding: .utf8) else { return nil }
+        let values = string
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> Substring? in
+                guard line.hasPrefix("data:") else { return nil }
+                return line.dropFirst(5).drop(while: { $0 == " " })
+            }
+        guard !values.isEmpty else { return nil }
+        return values.joined(separator: "\n")
+    }
+}

--- a/TinfoilChat/Services/ChatRecoveryClient.swift
+++ b/TinfoilChat/Services/ChatRecoveryClient.swift
@@ -23,6 +23,11 @@ struct RecoverableChatStream {
     let token: ChatRecoveryTokenPayload
 }
 
+struct RecoveredChatStream {
+    let stream: AsyncThrowingStream<ChatStreamResult, Error>
+    let statusCode: Int
+}
+
 actor ChatRecoveryClient {
     static let shared = ChatRecoveryClient()
 
@@ -107,7 +112,7 @@ actor ChatRecoveryClient {
     func fetch(
         sessionId: String,
         token: ChatRecoveryTokenFields
-    ) async throws -> AsyncThrowingStream<ChatStreamResult, Error> {
+    ) async throws -> RecoveredChatStream {
         guard let exportedSecret = Data(lowercaseHex: token.exportedSecret),
               exportedSecret.count == EHBPConstants.exportLength,
               let requestEnc = Data(lowercaseHex: token.requestEnc),
@@ -121,60 +126,45 @@ actor ChatRecoveryClient {
             bytes.task.cancel()
             throw ChatRecoveryClientError.invalidResponse
         }
-        switch response.statusCode {
-        case 404:
+        let nonce: Data
+        do {
+            nonce = try recoveryResponseNonce(from: response)
+        } catch {
             bytes.task.cancel()
-            throw ChatRecoveryClientError.state(.missing)
-        case 409:
-            bytes.task.cancel()
-            throw ChatRecoveryClientError.state(.processing)
-        case 410:
-            bytes.task.cancel()
-            throw ChatRecoveryClientError.state(.failed)
-        case let statusCode where !(200..<300).contains(statusCode):
-            bytes.task.cancel()
-            throw ChatRecoveryClientError.httpStatus(statusCode)
-        default:
-            guard let nonceHex = response.value(
-                      forHTTPHeaderField: EHBPProtocol.responseNonceHeader
-                  ),
-                  nonceHex == nonceHex.lowercased(),
-                  let nonce = Data(lowercaseHex: nonceHex),
-                  nonce.count == EHBPConstants.responseNonceLength
-            else {
-                bytes.task.cancel()
-                throw ChatRecoveryClientError.invalidResponse
-            }
-            let responseDecryptor = try SessionRecoveryToken(
-                exportedSecret: exportedSecret,
-                requestEnc: requestEnc
-            ).makeResponseDecryptor(
-                responseNonce: nonce
-            )
-            let plaintext = AsyncThrowingStream<Data, Error> { continuation in
-                let task = Task {
-                    do {
-                        var decryptor = responseDecryptor
-                        for try await byte in bytes {
-                            try Task.checkCancellation()
-                            if let chunk = try decryptor.push(byte) {
-                                continuation.yield(chunk)
-                            }
-                        }
-                        try decryptor.finish()
-                        continuation.finish()
-                    } catch {
-                        bytes.task.cancel()
-                        continuation.finish(throwing: error)
-                    }
-                }
-                continuation.onTermination = { _ in
-                    task.cancel()
-                    bytes.task.cancel()
-                }
-            }
-            return Self.decodeSSE(plaintext)
+            throw error
         }
+        let responseDecryptor = try SessionRecoveryToken(
+            exportedSecret: exportedSecret,
+            requestEnc: requestEnc
+        ).makeResponseDecryptor(
+            responseNonce: nonce
+        )
+        let plaintext = AsyncThrowingStream<Data, Error> { continuation in
+            let task = Task {
+                do {
+                    var decryptor = responseDecryptor
+                    for try await byte in bytes {
+                        try Task.checkCancellation()
+                        if let chunk = try decryptor.push(byte) {
+                            continuation.yield(chunk)
+                        }
+                    }
+                    try decryptor.finish()
+                    continuation.finish()
+                } catch {
+                    bytes.task.cancel()
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+                bytes.task.cancel()
+            }
+        }
+        return RecoveredChatStream(
+            stream: Self.decodeSSE(plaintext),
+            statusCode: response.statusCode
+        )
     }
 
     func delete(sessionId: String) async throws {
@@ -302,6 +292,30 @@ actor ChatRecoveryClient {
             continuation.onTermination = { _ in task.cancel() }
         }
     }
+}
+
+func recoveryResponseNonce(from response: HTTPURLResponse) throws -> Data {
+    guard let nonceHex = response.value(
+        forHTTPHeaderField: EHBPProtocol.responseNonceHeader
+    ) else {
+        switch response.statusCode {
+        case 404:
+            throw ChatRecoveryClientError.state(.missing)
+        case 410:
+            throw ChatRecoveryClientError.state(.failed)
+        case let statusCode where !(200..<300).contains(statusCode):
+            throw ChatRecoveryClientError.httpStatus(statusCode)
+        default:
+            throw ChatRecoveryClientError.invalidResponse
+        }
+    }
+    guard nonceHex == nonceHex.lowercased(),
+          let nonce = Data(lowercaseHex: nonceHex),
+          nonce.count == EHBPConstants.responseNonceLength
+    else {
+        throw ChatRecoveryClientError.invalidResponse
+    }
+    return nonce
 }
 
 private extension Data {

--- a/TinfoilChat/Services/ChatRecoveryClient.swift
+++ b/TinfoilChat/Services/ChatRecoveryClient.swift
@@ -157,7 +157,7 @@ actor ChatRecoveryClient {
                         var decryptor = responseDecryptor
                         for try await byte in bytes {
                             try Task.checkCancellation()
-                            for chunk in try decryptor.push(Data([byte])) {
+                            if let chunk = try decryptor.push(byte) {
                                 continuation.yield(chunk)
                             }
                         }

--- a/TinfoilChat/Services/ChatRecoveryClient.swift
+++ b/TinfoilChat/Services/ChatRecoveryClient.swift
@@ -26,14 +26,51 @@ struct RecoverableChatStream {
 struct RecoveredChatStream {
     let stream: AsyncThrowingStream<ChatStreamResult, Error>
     let statusCode: Int
+    let encryptedByteCount: @Sendable () async -> Int
+}
+
+struct ChatRecoveryStatus: Decodable, Sendable {
+    let state: ChatRecoveryState
+    let persistedBytes: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case state = "status"
+        case persistedBytes = "bytes"
+    }
+
+    init(state: ChatRecoveryState, persistedBytes: Int) {
+        self.state = state
+        self.persistedBytes = persistedBytes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        state = try container.decode(ChatRecoveryState.self, forKey: .state)
+        persistedBytes = try container.decode(Int.self, forKey: .persistedBytes)
+        guard persistedBytes >= 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .persistedBytes,
+                in: container,
+                debugDescription: "Persisted byte count must not be negative"
+            )
+        }
+    }
+}
+
+private actor ChatRecoveryByteCounter {
+    private var count = 0
+
+    func set(_ count: Int) {
+        self.count = count
+    }
+
+    func value() -> Int {
+        count
+    }
 }
 
 actor ChatRecoveryClient {
     static let shared = ChatRecoveryClient()
-
-    private struct StatusResponse: Decodable {
-        let status: ChatRecoveryState
-    }
 
     private var verifiedEndpoint: (enclaveURL: String, publicKey: Data)?
 
@@ -92,20 +129,23 @@ actor ChatRecoveryClient {
         )
     }
 
-    func state(sessionId: String) async throws -> ChatRecoveryState {
+    func status(sessionId: String) async throws -> ChatRecoveryStatus {
         let response = try await request(sessionId: sessionId, suffix: "/status")
         switch response.statusCode {
         case 404:
-            return .missing
+            return ChatRecoveryStatus(state: .missing, persistedBytes: 0)
         case 410:
-            return .failed
+            return ChatRecoveryStatus(state: .failed, persistedBytes: 0)
         default:
             guard (200..<300).contains(response.statusCode),
-                  let status = try? JSONDecoder().decode(StatusResponse.self, from: response.data)
+                  let status = try? JSONDecoder().decode(
+                      ChatRecoveryStatus.self,
+                      from: response.data
+                  )
             else {
                 throw ChatRecoveryClientError.invalidResponse
             }
-            return status.status
+            return status
         }
     }
 
@@ -139,19 +179,24 @@ actor ChatRecoveryClient {
         ).makeResponseDecryptor(
             responseNonce: nonce
         )
+        let byteCounter = ChatRecoveryByteCounter()
         let plaintext = AsyncThrowingStream<Data, Error> { continuation in
             let task = Task {
+                var encryptedByteCount = 0
                 do {
                     var decryptor = responseDecryptor
                     for try await byte in bytes {
                         try Task.checkCancellation()
+                        encryptedByteCount += 1
                         if let chunk = try decryptor.push(byte) {
                             continuation.yield(chunk)
                         }
                     }
                     try decryptor.finish()
+                    await byteCounter.set(encryptedByteCount)
                     continuation.finish()
                 } catch {
+                    await byteCounter.set(encryptedByteCount)
                     bytes.task.cancel()
                     continuation.finish(throwing: error)
                 }
@@ -163,7 +208,10 @@ actor ChatRecoveryClient {
         }
         return RecoveredChatStream(
             stream: Self.decodeSSE(plaintext),
-            statusCode: response.statusCode
+            statusCode: response.statusCode,
+            encryptedByteCount: {
+                await byteCounter.value()
+            }
         )
     }
 

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 @preconcurrency import OpenAI
 import Security
@@ -21,6 +22,46 @@ enum ChatRecoveryNotificationKey {
     static let storage = "storage"
 }
 
+enum ChatRecoveryPhase {
+    /// The proxy is still buffering the response because the model has not
+    /// finished generating it. Recovery cannot start yet.
+    case generating
+    /// The buffered response is complete and is being fetched, decrypted,
+    /// and reconstructed.
+    case restoring
+}
+
+/// Publishes the per-turn recovery phase observed by the coordinator's
+/// status polls so the UI can distinguish "waiting for generation to
+/// finish" from the brief restore step.
+@MainActor
+final class ChatRecoveryPhaseTracker: ObservableObject {
+    static let shared = ChatRecoveryPhaseTracker()
+
+    @Published private(set) var phases: [String: ChatRecoveryPhase] = [:]
+
+    private init() {}
+
+    func phase(forTurnId turnId: String?) -> ChatRecoveryPhase {
+        guard let turnId else { return .generating }
+        return phases[turnId] ?? .generating
+    }
+
+    func setPhase(_ phase: ChatRecoveryPhase, turnId: String) {
+        guard phases[turnId] != phase else { return }
+        phases[turnId] = phase
+    }
+
+    func clear(turnId: String) {
+        phases.removeValue(forKey: turnId)
+    }
+
+    func clearAll() {
+        guard !phases.isEmpty else { return }
+        phases.removeAll()
+    }
+}
+
 actor ChatRecoveryCoordinator {
     static let shared = ChatRecoveryCoordinator()
 
@@ -34,6 +75,9 @@ actor ChatRecoveryCoordinator {
         activeAccountId = accountId
         cancelledTurns.removeAll()
         isScanning = false
+        Task { @MainActor in
+            ChatRecoveryPhaseTracker.shared.clearAll()
+        }
     }
 
     func begin(
@@ -171,6 +215,9 @@ actor ChatRecoveryCoordinator {
             turnId: attempt.turnId,
             storage: attempt.storage
         ))
+        await MainActor.run {
+            ChatRecoveryPhaseTracker.shared.clear(turnId: attempt.turnId)
+        }
         try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
         do {
             try await ChatRecoverySync.shared.mutate(
@@ -333,8 +380,12 @@ actor ChatRecoveryCoordinator {
         }
         do {
             let state = try await ChatRecoveryClient.shared.state(sessionId: payload.sessionId)
+            let turnId = envelope.turnId
             switch state {
             case .processing:
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.setPhase(.generating, turnId: turnId)
+                }
                 return
             case .failed, .missing:
                 await removeTerminal(
@@ -346,7 +397,9 @@ actor ChatRecoveryCoordinator {
                 )
                 return
             case .complete:
-                break
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.setPhase(.restoring, turnId: turnId)
+                }
             }
             guard let token = payload.recoveryToken.fields else { return }
             let stream = try await ChatRecoveryClient.shared.fetch(
@@ -384,6 +437,9 @@ actor ChatRecoveryCoordinator {
                 )
             )
             try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
+            await MainActor.run {
+                ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
+            }
             postRecoveryUpdate(
                 chatId: chatId,
                 userId: userId,
@@ -391,6 +447,9 @@ actor ChatRecoveryCoordinator {
             )
         } catch ChatRecoverySyncError.envelopeMissing {
             try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
+            await MainActor.run {
+                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+            }
             if storage == .cloud {
                 try? await ChatRecoverySync.shared.refreshFromRemote(
                     chatId: chatId,
@@ -523,6 +582,9 @@ actor ChatRecoveryCoordinator {
     ) async {
         if let sessionId {
             try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+        }
+        await MainActor.run {
+            ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
         }
         do {
             try await ChatRecoverySync.shared.mutate(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -1,0 +1,519 @@
+import Foundation
+@preconcurrency import OpenAI
+import Security
+
+struct ChatRecoveryAttempt: Sendable {
+    let chatId: String
+    let turnId: String
+    let userId: String
+    let sessionId: String
+    let generation: Int
+}
+
+extension Notification.Name {
+    static let chatRecoveryDidUpdate = Notification.Name("chatRecoveryDidUpdate")
+}
+
+actor ChatRecoveryCoordinator {
+    static let shared = ChatRecoveryCoordinator()
+
+    private var accountGeneration = 0
+    private var cancelledTurns: Set<String> = []
+    private var activeAccountId: String?
+    private var isScanning = false
+
+    func reset(accountId: String?) {
+        accountGeneration += 1
+        activeAccountId = accountId
+        cancelledTurns.removeAll()
+        isScanning = false
+    }
+
+    func begin(
+        chatId: String,
+        turnId: String,
+        userId: String
+    ) throws -> ChatRecoveryAttempt {
+        if activeAccountId != userId {
+            reset(accountId: userId)
+        }
+        cancelledTurns.remove(turnKey(chatId: chatId, turnId: turnId))
+        return ChatRecoveryAttempt(
+            chatId: chatId,
+            turnId: turnId,
+            userId: userId,
+            sessionId: try randomSessionId(),
+            generation: accountGeneration
+        )
+    }
+
+    func register(
+        attempt: ChatRecoveryAttempt,
+        token: ChatRecoveryTokenPayload
+    ) async throws -> PendingRecoveryEnvelope {
+        let key = turnKey(chatId: attempt.chatId, turnId: attempt.turnId)
+        if cancelledTurns.contains(key)
+            || attempt.generation != accountGeneration
+            || activeAccountId != attempt.userId {
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+            throw CancellationError()
+        }
+        let cek = try EncryptionService.shared.getKeyBytesOrThrow()
+        let envelope = try ChatRecoveryCrypto.encrypt(
+            cek: cek,
+            userId: attempt.userId,
+            chatId: attempt.chatId,
+            turnId: attempt.turnId,
+            sessionId: attempt.sessionId,
+            recoveryToken: token
+        )
+        do {
+            try await ChatRecoverySync.shared.mutate(
+                chatId: attempt.chatId,
+                userId: attempt.userId,
+                mutation: .add(envelope)
+            )
+        } catch {
+            if case ChatRecoverySyncError.pendingLimitReached = error {
+                try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+            }
+            throw error
+        }
+        if cancelledTurns.contains(key)
+            || attempt.generation != accountGeneration
+            || activeAccountId != attempt.userId {
+            await cancel(attempt: attempt)
+            throw CancellationError()
+        }
+        return envelope
+    }
+
+    func complete(
+        attempt: ChatRecoveryAttempt,
+        envelope: PendingRecoveryEnvelope,
+        response: Message,
+        title: String? = nil,
+        titleState: Chat.TitleState? = nil
+    ) async throws {
+        let key = turnKey(chatId: attempt.chatId, turnId: attempt.turnId)
+        guard !cancelledTurns.contains(key),
+              attempt.generation == accountGeneration,
+              activeAccountId == attempt.userId
+        else {
+            await cancel(attempt: attempt)
+            throw CancellationError()
+        }
+        do {
+            try await ChatRecoverySync.shared.mutate(
+                chatId: attempt.chatId,
+                userId: attempt.userId,
+                mutation: .complete(
+                    envelope: envelope,
+                    response: response,
+                    title: title,
+                    titleState: titleState
+                )
+            )
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+        } catch ChatRecoverySyncError.envelopeMissing {
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+            try await ChatRecoverySync.shared.refreshFromRemote(
+                chatId: attempt.chatId,
+                userId: attempt.userId
+            )
+            postRecoveryUpdate(chatId: attempt.chatId)
+        } catch {
+            throw error
+        }
+    }
+
+    func cancel(attempt: ChatRecoveryAttempt, response: Message? = nil) async {
+        cancelledTurns.insert(turnKey(chatId: attempt.chatId, turnId: attempt.turnId))
+        try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+        do {
+            try await ChatRecoverySync.shared.mutate(
+                chatId: attempt.chatId,
+                userId: attempt.userId,
+                mutation: .cancel(turnId: attempt.turnId, response: response)
+            )
+        } catch ChatRecoverySyncError.envelopeMissing {
+            try? await ChatRecoverySync.shared.refreshFromRemote(
+                chatId: attempt.chatId,
+                userId: attempt.userId
+            )
+            postRecoveryUpdate(chatId: attempt.chatId)
+        } catch {
+            return
+        }
+    }
+
+    func deleteSession(attempt: ChatRecoveryAttempt) async {
+        try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+    }
+
+    func scan(userId: String) async {
+        if activeAccountId != userId {
+            reset(accountId: userId)
+        }
+        guard !isScanning else { return }
+        isScanning = true
+        defer { isScanning = false }
+        let generation = accountGeneration
+        let entries = (try? await EncryptedFileStorage.cloud.loadIndex(userId: userId)) ?? []
+        let storedChats = (try? await EncryptedFileStorage.cloud.loadChats(
+            chatIds: entries.map(\.id),
+            userId: userId
+        )) ?? []
+        let work = storedChats.flatMap { chat in
+            (chat.pendingRecoveries ?? []).map { (chat.id, $0) }
+        }
+        guard !work.isEmpty else { return }
+
+        await withTaskGroup(of: Void.self) { group in
+            var iterator = work.makeIterator()
+            for _ in 0..<min(Constants.ChatRecovery.maxConcurrentScans, work.count) {
+                if let item = iterator.next() {
+                    group.addTask {
+                        await self.recover(
+                            chatId: item.0,
+                            envelope: item.1,
+                            userId: userId,
+                            generation: generation
+                        )
+                    }
+                }
+            }
+            while await group.next() != nil {
+                if let item = iterator.next() {
+                    group.addTask {
+                        await self.recover(
+                            chatId: item.0,
+                            envelope: item.1,
+                            userId: userId,
+                            generation: generation
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func recover(
+        chatId: String,
+        envelope originalEnvelope: PendingRecoveryEnvelope,
+        userId: String,
+        generation: Int
+    ) async {
+        guard generation == accountGeneration, activeAccountId == userId else { return }
+        var envelope = originalEnvelope
+        let payload: ChatRecoveryEnvelopePayload
+        do {
+            if try ChatRecoveryCrypto.isExpired(envelope) {
+                throw ChatRecoveryCryptoError.expired
+            }
+            let opened = try openEnvelope(
+                envelope,
+                chatId: chatId,
+                userId: userId
+            )
+            payload = opened.payload
+            if opened.usedHistoricalKey {
+                let currentCEK = try EncryptionService.shared.getKeyBytesOrThrow()
+                let rewrapped = try ChatRecoveryCrypto.rewrap(
+                    envelope: envelope,
+                    userId: userId,
+                    chatId: chatId,
+                    oldCEK: opened.cek,
+                    newCEK: currentCEK
+                )
+                try await ChatRecoverySync.shared.mutate(
+                    chatId: chatId,
+                    userId: userId,
+                    mutation: .replace(old: envelope, new: rewrapped)
+                )
+                envelope = rewrapped
+                postRecoveryUpdate(chatId: chatId)
+            }
+        } catch ChatRecoveryCryptoError.expired {
+            await removeTerminal(
+                chatId: chatId,
+                turnId: envelope.turnId,
+                userId: userId,
+                sessionId: nil
+            )
+            return
+        } catch ChatRecoveryCryptoError.invalidEnvelope,
+                ChatRecoveryCryptoError.decryptionFailed {
+            await removeTerminal(
+                chatId: chatId,
+                turnId: envelope.turnId,
+                userId: userId,
+                sessionId: nil
+            )
+            return
+        } catch {
+            return
+        }
+
+        guard generation == accountGeneration, activeAccountId == userId else { return }
+        do {
+            let state = try await ChatRecoveryClient.shared.state(sessionId: payload.sessionId)
+            switch state {
+            case .processing:
+                return
+            case .failed, .missing:
+                await removeTerminal(
+                    chatId: chatId,
+                    turnId: envelope.turnId,
+                    userId: userId,
+                    sessionId: payload.sessionId
+                )
+                return
+            case .complete:
+                break
+            }
+            guard let token = payload.recoveryToken.fields else { return }
+            let stream = try await ChatRecoveryClient.shared.fetch(
+                sessionId: payload.sessionId,
+                token: token
+            )
+            let response = try await reconstructMessage(
+                stream: stream,
+                turnId: envelope.turnId
+            )
+            let key = turnKey(chatId: chatId, turnId: envelope.turnId)
+            guard generation == accountGeneration,
+                  activeAccountId == userId,
+                  !cancelledTurns.contains(key)
+            else {
+                try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
+                return
+            }
+            try await ChatRecoverySync.shared.mutate(
+                chatId: chatId,
+                userId: userId,
+                mutation: .complete(
+                    envelope: envelope,
+                    response: response,
+                    title: nil,
+                    titleState: nil
+                )
+            )
+            try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
+            postRecoveryUpdate(chatId: chatId)
+        } catch ChatRecoverySyncError.envelopeMissing {
+            try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
+            try? await ChatRecoverySync.shared.refreshFromRemote(
+                chatId: chatId,
+                userId: userId
+            )
+            postRecoveryUpdate(chatId: chatId)
+        } catch ChatRecoveryClientError.state(let state)
+            where state == .failed || state == .missing {
+            await removeTerminal(
+                chatId: chatId,
+                turnId: envelope.turnId,
+                userId: userId,
+                sessionId: payload.sessionId
+            )
+        } catch {
+            return
+        }
+    }
+
+    private func openEnvelope(
+        _ envelope: PendingRecoveryEnvelope,
+        chatId: String,
+        userId: String
+    ) throws -> (
+        payload: ChatRecoveryEnvelopePayload,
+        cek: Data,
+        usedHistoricalKey: Bool
+    ) {
+        let primary = try EncryptionService.shared.getKeyBytesOrThrow()
+        let primaryKeyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: primary)
+        if primaryKeyId == envelope.keyId {
+            let payload = try ChatRecoveryCrypto.decrypt(
+                cek: primary,
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope
+            )
+            return (payload, primary, false)
+        }
+        for key in EncryptionService.shared.getActiveKeys().alternatives {
+            guard let cek = try? EncryptionService.shared.getAlternativeKeyBytes(key),
+                  let keyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek),
+                  keyId == envelope.keyId
+            else {
+                continue
+            }
+            let payload = try ChatRecoveryCrypto.decrypt(
+                cek: cek,
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope
+            )
+            return (payload, cek, true)
+        }
+        throw ChatRecoveryCryptoError.invalidKey
+    }
+
+    private func reconstructMessage(
+        stream: AsyncThrowingStream<ChatStreamResult, Error>,
+        turnId: String
+    ) async throws -> Message {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: true,
+            hapticEnabled: false
+        )
+        var eventState = RecoveredEventState()
+        for try await chunk in stream {
+            let parsed = processor.parse(chunk)
+            for event in parsed.events {
+                eventState.apply(event, processor: processor)
+            }
+            _ = processor.process(parsed)
+        }
+        processor.finishStream()
+        let snapshot = processor.snapshot()
+        var webSearchState = eventState.webSearchState
+        if !snapshot.collectedSources.isEmpty {
+            var state = webSearchState ?? WebSearchState(status: .searching)
+            state.sources = snapshot.collectedSources
+            if state.status == .searching {
+                state.status = .completed
+            }
+            webSearchState = state
+        }
+        var message = Message(
+            role: .assistant,
+            turnId: turnId,
+            content: snapshot.responseContent,
+            thoughts: snapshot.thoughts,
+            isThinking: false,
+            generationTimeSeconds: snapshot.generationTimeSeconds,
+            contentChunks: snapshot.contentChunks,
+            thinkingChunks: snapshot.thinkingChunks,
+            webSearchState: webSearchState
+        )
+        message.thinkingDuration = snapshot.generationTimeSeconds
+        message.segments = snapshot.segments
+        message.webSearches = snapshot.webSearches
+        message.toolCalls = snapshot.toolCalls
+        message.timeline = snapshot.timelineBlocks
+        message.urlFetches = eventState.urlFetches
+        message.annotations = snapshot.collectedAnnotations
+        message.webSearchBeforeThinking = snapshot.webSearchBeforeThinking
+        return message
+    }
+
+    private func removeTerminal(
+        chatId: String,
+        turnId: String,
+        userId: String,
+        sessionId: String?
+    ) async {
+        if let sessionId {
+            try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+        }
+        do {
+            try await ChatRecoverySync.shared.mutate(
+                chatId: chatId,
+                userId: userId,
+                mutation: .remove(turnId: turnId)
+            )
+            postRecoveryUpdate(chatId: chatId)
+        } catch {
+            return
+        }
+    }
+
+    private func randomSessionId() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: Constants.ChatRecovery.sessionIdBytes)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw ChatRecoveryClientError.unavailable
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func turnKey(chatId: String, turnId: String) -> String {
+        "\(chatId)\u{0}\(turnId)"
+    }
+
+    private func postRecoveryUpdate(chatId: String) {
+        NotificationCenter.default.post(
+            name: .chatRecoveryDidUpdate,
+            object: nil,
+            userInfo: ["chatId": chatId]
+        )
+    }
+}
+
+private struct RecoveredEventState {
+    var webSearchState: WebSearchState?
+    var urlFetches: [URLFetchState] = []
+
+    mutating func apply(
+        _ event: TinfoilWebSearchCallEvent,
+        processor: StreamingResponseProcessor
+    ) {
+        if event.action?.type == "open_page", let url = event.action?.url {
+            let fetchId = event.itemId ?? url
+            let status: URLFetchStatus
+            switch event.status {
+            case .inProgress, .searching:
+                status = .fetching
+            case .completed:
+                status = .completed
+            case .failed:
+                status = .failed
+            case .blocked:
+                status = .blocked
+            }
+            if let index = urlFetches.firstIndex(where: { $0.id == fetchId }) {
+                urlFetches[index].status = status
+            } else {
+                urlFetches.append(URLFetchState(id: fetchId, url: url, status: status))
+                processor.appendURLFetchSegment(fetchId)
+            }
+            return
+        }
+
+        let sources = event.sources?.compactMap { source -> WebSearchSource? in
+            guard let url = source.url, !url.isEmpty else { return nil }
+            return WebSearchSource(title: source.title ?? url, url: url)
+        }
+        let existing = processor.findSearchInstance(matching: event.itemId)
+        let id = existing?.id ?? event.itemId ?? processor.allocateSearchId()
+        let status: WebSearchStatus
+        switch event.status {
+        case .inProgress, .searching:
+            status = .searching
+            processor.markWebSearchStarted()
+        case .completed:
+            status = .completed
+        case .failed:
+            status = .failed
+        case .blocked:
+            status = .blocked
+        }
+        let mergedSources = (sources?.isEmpty == false) ? sources : existing?.sources
+        processor.upsertWebSearch(
+            WebSearchInstance(
+                id: id,
+                query: event.action?.query ?? existing?.query,
+                status: status,
+                sources: mergedSources,
+                reason: event.error?.code ?? existing?.reason
+            )
+        )
+        webSearchState = WebSearchState(
+            query: event.action?.query ?? existing?.query,
+            status: status,
+            sources: mergedSources ?? [],
+            reason: event.error?.code
+        )
+    }
+}

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -417,22 +417,41 @@ actor ChatRecoveryCoordinator {
                 }
             }
             guard let token = payload.recoveryToken.fields else { return }
-            let stream = try await ChatRecoveryClient.shared.fetch(
+            let key = turnKey(
+                chatId: chatId,
+                turnId: envelope.turnId,
+                storage: storage
+            )
+            let recovered = try await ChatRecoveryClient.shared.fetch(
                 sessionId: payload.sessionId,
                 token: token
             )
             guard !Task.isCancelled else { return }
+            if !(200..<300).contains(recovered.statusCode) {
+                for try await _ in recovered.stream {}
+                guard generation == accountGeneration,
+                      activeAccountId == userId,
+                      !cancelledTurns.contains(key),
+                      !(await isChatStreaming(chatId)),
+                      !Task.isCancelled
+                else {
+                    return
+                }
+                await removeTerminal(
+                    chatId: chatId,
+                    turnId: envelope.turnId,
+                    userId: userId,
+                    sessionId: payload.sessionId,
+                    storage: storage
+                )
+                return
+            }
             let response = try await reconstructMessage(
-                stream: stream,
+                stream: recovered.stream,
                 chatId: chatId,
                 turnId: envelope.turnId,
                 userId: userId,
                 generation: generation,
-                storage: storage
-            )
-            let key = turnKey(
-                chatId: chatId,
-                turnId: envelope.turnId,
                 storage: storage
             )
             guard generation == accountGeneration,

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -6,12 +6,19 @@ struct ChatRecoveryAttempt: Sendable {
     let chatId: String
     let turnId: String
     let userId: String
+    let storage: ChatRecoveryStorage
     let sessionId: String
     let generation: Int
 }
 
 extension Notification.Name {
     static let chatRecoveryDidUpdate = Notification.Name("chatRecoveryDidUpdate")
+}
+
+enum ChatRecoveryNotificationKey {
+    static let chatId = "chatId"
+    static let userId = "userId"
+    static let storage = "storage"
 }
 
 actor ChatRecoveryCoordinator {
@@ -32,16 +39,22 @@ actor ChatRecoveryCoordinator {
     func begin(
         chatId: String,
         turnId: String,
-        userId: String
+        userId: String,
+        storage: ChatRecoveryStorage
     ) throws -> ChatRecoveryAttempt {
         if activeAccountId != userId {
             reset(accountId: userId)
         }
-        cancelledTurns.remove(turnKey(chatId: chatId, turnId: turnId))
+        cancelledTurns.remove(turnKey(
+            chatId: chatId,
+            turnId: turnId,
+            storage: storage
+        ))
         return ChatRecoveryAttempt(
             chatId: chatId,
             turnId: turnId,
             userId: userId,
+            storage: storage,
             sessionId: try randomSessionId(),
             generation: accountGeneration
         )
@@ -51,14 +64,24 @@ actor ChatRecoveryCoordinator {
         attempt: ChatRecoveryAttempt,
         token: ChatRecoveryTokenPayload
     ) async throws -> PendingRecoveryEnvelope {
-        let key = turnKey(chatId: attempt.chatId, turnId: attempt.turnId)
+        let key = turnKey(
+            chatId: attempt.chatId,
+            turnId: attempt.turnId,
+            storage: attempt.storage
+        )
         if cancelledTurns.contains(key)
             || attempt.generation != accountGeneration
             || activeAccountId != attempt.userId {
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             throw CancellationError()
         }
-        let cek = try EncryptionService.shared.getKeyBytesOrThrow()
+        let cek: Data
+        switch attempt.storage {
+        case .cloud:
+            cek = try EncryptionService.shared.getKeyBytesOrThrow()
+        case .local:
+            cek = try await DeviceEncryptionService.shared.getKeyBytesOrThrow()
+        }
         let envelope = try ChatRecoveryCrypto.encrypt(
             cek: cek,
             userId: attempt.userId,
@@ -71,10 +94,14 @@ actor ChatRecoveryCoordinator {
             try await ChatRecoverySync.shared.mutate(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
+                storage: attempt.storage,
                 mutation: .add(envelope)
             )
         } catch {
             if case ChatRecoverySyncError.pendingLimitReached = error {
+                try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+            } else if attempt.storage == .local,
+                      case ChatRecoverySyncError.chatMissing = error {
                 try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             }
             throw error
@@ -95,7 +122,11 @@ actor ChatRecoveryCoordinator {
         title: String? = nil,
         titleState: Chat.TitleState? = nil
     ) async throws {
-        let key = turnKey(chatId: attempt.chatId, turnId: attempt.turnId)
+        let key = turnKey(
+            chatId: attempt.chatId,
+            turnId: attempt.turnId,
+            storage: attempt.storage
+        )
         guard !cancelledTurns.contains(key),
               attempt.generation == accountGeneration,
               activeAccountId == attempt.userId
@@ -107,6 +138,7 @@ actor ChatRecoveryCoordinator {
             try await ChatRecoverySync.shared.mutate(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
+                storage: attempt.storage,
                 mutation: .complete(
                     envelope: envelope,
                     response: response,
@@ -117,31 +149,48 @@ actor ChatRecoveryCoordinator {
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
         } catch ChatRecoverySyncError.envelopeMissing {
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-            try await ChatRecoverySync.shared.refreshFromRemote(
+            if attempt.storage == .cloud {
+                try await ChatRecoverySync.shared.refreshFromRemote(
+                    chatId: attempt.chatId,
+                    userId: attempt.userId
+                )
+            }
+            postRecoveryUpdate(
                 chatId: attempt.chatId,
-                userId: attempt.userId
+                userId: attempt.userId,
+                storage: attempt.storage
             )
-            postRecoveryUpdate(chatId: attempt.chatId)
         } catch {
             throw error
         }
     }
 
     func cancel(attempt: ChatRecoveryAttempt, response: Message? = nil) async {
-        cancelledTurns.insert(turnKey(chatId: attempt.chatId, turnId: attempt.turnId))
+        cancelledTurns.insert(turnKey(
+            chatId: attempt.chatId,
+            turnId: attempt.turnId,
+            storage: attempt.storage
+        ))
         try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
         do {
             try await ChatRecoverySync.shared.mutate(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
+                storage: attempt.storage,
                 mutation: .cancel(turnId: attempt.turnId, response: response)
             )
         } catch ChatRecoverySyncError.envelopeMissing {
-            try? await ChatRecoverySync.shared.refreshFromRemote(
+            if attempt.storage == .cloud {
+                try? await ChatRecoverySync.shared.refreshFromRemote(
+                    chatId: attempt.chatId,
+                    userId: attempt.userId
+                )
+            }
+            postRecoveryUpdate(
                 chatId: attempt.chatId,
-                userId: attempt.userId
+                userId: attempt.userId,
+                storage: attempt.storage
             )
-            postRecoveryUpdate(chatId: attempt.chatId)
         } catch {
             return
         }
@@ -151,7 +200,7 @@ actor ChatRecoveryCoordinator {
         try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
     }
 
-    func scan(userId: String) async {
+    func scan(userId: String, storages: [ChatRecoveryStorage]) async {
         if activeAccountId != userId {
             reset(accountId: userId)
         }
@@ -159,38 +208,44 @@ actor ChatRecoveryCoordinator {
         isScanning = true
         defer { isScanning = false }
         let generation = accountGeneration
-        let entries = (try? await EncryptedFileStorage.cloud.loadIndex(userId: userId)) ?? []
-        let storedChats = (try? await EncryptedFileStorage.cloud.loadChats(
-            chatIds: entries.map(\.id),
-            userId: userId
-        )) ?? []
-        let work = storedChats.flatMap { chat in
-            (chat.pendingRecoveries ?? []).map { (chat.id, $0) }
+        var work: [(String, PendingRecoveryEnvelope, ChatRecoveryStorage)] = []
+        for storage in storages {
+            guard !Task.isCancelled else { return }
+            let storedChats = (try? await storage.fileStorage.loadChatsWithPendingRecoveries(
+                userId: userId
+            )) ?? []
+            work.append(contentsOf: storedChats.flatMap { chat in
+                (chat.pendingRecoveries ?? []).map { (chat.id, $0, storage) }
+            })
         }
         guard !work.isEmpty else { return }
 
         await withTaskGroup(of: Void.self) { group in
             var iterator = work.makeIterator()
             for _ in 0..<min(Constants.ChatRecovery.maxConcurrentScans, work.count) {
+                guard !Task.isCancelled else { return }
                 if let item = iterator.next() {
                     group.addTask {
                         await self.recover(
                             chatId: item.0,
                             envelope: item.1,
                             userId: userId,
-                            generation: generation
+                            generation: generation,
+                            storage: item.2
                         )
                     }
                 }
             }
             while await group.next() != nil {
+                guard !Task.isCancelled else { return }
                 if let item = iterator.next() {
                     group.addTask {
                         await self.recover(
                             chatId: item.0,
                             envelope: item.1,
                             userId: userId,
-                            generation: generation
+                            generation: generation,
+                            storage: item.2
                         )
                     }
                 }
@@ -202,22 +257,30 @@ actor ChatRecoveryCoordinator {
         chatId: String,
         envelope originalEnvelope: PendingRecoveryEnvelope,
         userId: String,
-        generation: Int
+        generation: Int,
+        storage: ChatRecoveryStorage
     ) async {
-        guard generation == accountGeneration, activeAccountId == userId else { return }
+        guard !Task.isCancelled,
+              generation == accountGeneration,
+              activeAccountId == userId,
+              !(await isChatStreaming(chatId))
+        else {
+            return
+        }
         var envelope = originalEnvelope
         let payload: ChatRecoveryEnvelopePayload
         do {
             if try ChatRecoveryCrypto.isExpired(envelope) {
                 throw ChatRecoveryCryptoError.expired
             }
-            let opened = try openEnvelope(
+            let opened = try await openEnvelope(
                 envelope,
                 chatId: chatId,
-                userId: userId
+                userId: userId,
+                storage: storage
             )
             payload = opened.payload
-            if opened.usedHistoricalKey {
+            if storage == .cloud && opened.usedHistoricalKey {
                 let currentCEK = try EncryptionService.shared.getKeyBytesOrThrow()
                 let rewrapped = try ChatRecoveryCrypto.rewrap(
                     envelope: envelope,
@@ -229,17 +292,23 @@ actor ChatRecoveryCoordinator {
                 try await ChatRecoverySync.shared.mutate(
                     chatId: chatId,
                     userId: userId,
+                    storage: storage,
                     mutation: .replace(old: envelope, new: rewrapped)
                 )
                 envelope = rewrapped
-                postRecoveryUpdate(chatId: chatId)
+                postRecoveryUpdate(
+                    chatId: chatId,
+                    userId: userId,
+                    storage: storage
+                )
             }
         } catch ChatRecoveryCryptoError.expired {
             await removeTerminal(
                 chatId: chatId,
                 turnId: envelope.turnId,
                 userId: userId,
-                sessionId: nil
+                sessionId: nil,
+                storage: storage
             )
             return
         } catch ChatRecoveryCryptoError.invalidEnvelope,
@@ -248,14 +317,20 @@ actor ChatRecoveryCoordinator {
                 chatId: chatId,
                 turnId: envelope.turnId,
                 userId: userId,
-                sessionId: nil
+                sessionId: nil,
+                storage: storage
             )
             return
         } catch {
             return
         }
 
-        guard generation == accountGeneration, activeAccountId == userId else { return }
+        guard !Task.isCancelled,
+              generation == accountGeneration,
+              activeAccountId == userId
+        else {
+            return
+        }
         do {
             let state = try await ChatRecoveryClient.shared.state(sessionId: payload.sessionId)
             switch state {
@@ -266,7 +341,8 @@ actor ChatRecoveryCoordinator {
                     chatId: chatId,
                     turnId: envelope.turnId,
                     userId: userId,
-                    sessionId: payload.sessionId
+                    sessionId: payload.sessionId,
+                    storage: storage
                 )
                 return
             case .complete:
@@ -277,11 +353,16 @@ actor ChatRecoveryCoordinator {
                 sessionId: payload.sessionId,
                 token: token
             )
+            guard !Task.isCancelled else { return }
             let response = try await reconstructMessage(
                 stream: stream,
                 turnId: envelope.turnId
             )
-            let key = turnKey(chatId: chatId, turnId: envelope.turnId)
+            let key = turnKey(
+                chatId: chatId,
+                turnId: envelope.turnId,
+                storage: storage
+            )
             guard generation == accountGeneration,
                   activeAccountId == userId,
                   !cancelledTurns.contains(key)
@@ -289,9 +370,12 @@ actor ChatRecoveryCoordinator {
                 try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
                 return
             }
+            guard !(await isChatStreaming(chatId)) else { return }
+            guard !Task.isCancelled else { return }
             try await ChatRecoverySync.shared.mutate(
                 chatId: chatId,
                 userId: userId,
+                storage: storage,
                 mutation: .complete(
                     envelope: envelope,
                     response: response,
@@ -300,21 +384,32 @@ actor ChatRecoveryCoordinator {
                 )
             )
             try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
-            postRecoveryUpdate(chatId: chatId)
+            postRecoveryUpdate(
+                chatId: chatId,
+                userId: userId,
+                storage: storage
+            )
         } catch ChatRecoverySyncError.envelopeMissing {
             try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
-            try? await ChatRecoverySync.shared.refreshFromRemote(
+            if storage == .cloud {
+                try? await ChatRecoverySync.shared.refreshFromRemote(
+                    chatId: chatId,
+                    userId: userId
+                )
+            }
+            postRecoveryUpdate(
                 chatId: chatId,
-                userId: userId
+                userId: userId,
+                storage: storage
             )
-            postRecoveryUpdate(chatId: chatId)
         } catch ChatRecoveryClientError.state(let state)
             where state == .failed || state == .missing {
             await removeTerminal(
                 chatId: chatId,
                 turnId: envelope.turnId,
                 userId: userId,
-                sessionId: payload.sessionId
+                sessionId: payload.sessionId,
+                storage: storage
             )
         } catch {
             return
@@ -324,12 +419,23 @@ actor ChatRecoveryCoordinator {
     private func openEnvelope(
         _ envelope: PendingRecoveryEnvelope,
         chatId: String,
-        userId: String
-    ) throws -> (
+        userId: String,
+        storage: ChatRecoveryStorage
+    ) async throws -> (
         payload: ChatRecoveryEnvelopePayload,
         cek: Data,
         usedHistoricalKey: Bool
     ) {
+        if storage == .local {
+            let deviceKey = try await DeviceEncryptionService.shared.getKeyBytesOrThrow()
+            let payload = try ChatRecoveryCrypto.decrypt(
+                cek: deviceKey,
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope
+            )
+            return (payload, deviceKey, false)
+        }
         let primary = try EncryptionService.shared.getKeyBytesOrThrow()
         let primaryKeyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: primary)
         if primaryKeyId == envelope.keyId {
@@ -412,7 +518,8 @@ actor ChatRecoveryCoordinator {
         chatId: String,
         turnId: String,
         userId: String,
-        sessionId: String?
+        sessionId: String?,
+        storage: ChatRecoveryStorage
     ) async {
         if let sessionId {
             try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
@@ -421,9 +528,14 @@ actor ChatRecoveryCoordinator {
             try await ChatRecoverySync.shared.mutate(
                 chatId: chatId,
                 userId: userId,
+                storage: storage,
                 mutation: .remove(turnId: turnId)
             )
-            postRecoveryUpdate(chatId: chatId)
+            postRecoveryUpdate(
+                chatId: chatId,
+                userId: userId,
+                storage: storage
+            )
         } catch {
             return
         }
@@ -438,15 +550,33 @@ actor ChatRecoveryCoordinator {
         return bytes.map { String(format: "%02x", $0) }.joined()
     }
 
-    private func turnKey(chatId: String, turnId: String) -> String {
-        "\(chatId)\u{0}\(turnId)"
+    private func isChatStreaming(_ chatId: String) async -> Bool {
+        await MainActor.run {
+            StreamingTracker.shared.isStreaming(chatId)
+        }
     }
 
-    private func postRecoveryUpdate(chatId: String) {
+    private func turnKey(
+        chatId: String,
+        turnId: String,
+        storage: ChatRecoveryStorage
+    ) -> String {
+        "\(storage.rawValue)\u{0}\(chatId)\u{0}\(turnId)"
+    }
+
+    private func postRecoveryUpdate(
+        chatId: String,
+        userId: String,
+        storage: ChatRecoveryStorage
+    ) {
         NotificationCenter.default.post(
             name: .chatRecoveryDidUpdate,
             object: nil,
-            userInfo: ["chatId": chatId]
+            userInfo: [
+                ChatRecoveryNotificationKey.chatId: chatId,
+                ChatRecoveryNotificationKey.userId: userId,
+                ChatRecoveryNotificationKey.storage: storage.rawValue,
+            ]
         )
     }
 }

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -609,14 +609,12 @@ actor ChatRecoveryCoordinator {
                     isStreaming: true
                 )
                 if recoveredMessageIsMeaningful(draft) {
-                    await MainActor.run {
-                        ChatRecoveryDraftStore.shared.replace(
-                            draft,
-                            chatId: chatId,
-                            turnId: turnId,
-                            generation: generation
-                        )
-                    }
+                    try await publishRecoveryDraft(
+                        draft,
+                        chatId: chatId,
+                        turnId: turnId,
+                        generation: generation
+                    )
                 }
             }
         }
@@ -638,16 +636,39 @@ actor ChatRecoveryCoordinator {
         if recoveredMessageIsMeaningful(message) {
             var finalDraft = message
             finalDraft.isStreaming = true
-            await MainActor.run {
-                ChatRecoveryDraftStore.shared.replace(
-                    finalDraft,
-                    chatId: chatId,
-                    turnId: turnId,
-                    generation: generation
-                )
-            }
+            try await publishRecoveryDraft(
+                finalDraft,
+                chatId: chatId,
+                turnId: turnId,
+                generation: generation
+            )
         }
         return message
+    }
+
+    private func publishRecoveryDraft(
+        _ draft: Message,
+        chatId: String,
+        turnId: String,
+        generation: Int
+    ) async throws {
+        let published = await MainActor.run {
+            guard !StreamingTracker.shared.isStreaming(chatId) else {
+                ChatRecoveryDraftStore.shared.clear(
+                    chatId: chatId,
+                    turnId: turnId
+                )
+                return false
+            }
+            ChatRecoveryDraftStore.shared.replace(
+                draft,
+                chatId: chatId,
+                turnId: turnId,
+                generation: generation
+            )
+            return true
+        }
+        guard published else { throw CancellationError() }
     }
 
     private func recoveredMessage(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -23,17 +23,13 @@ enum ChatRecoveryNotificationKey {
 }
 
 enum ChatRecoveryPhase {
-    /// The proxy is still buffering the response because the model has not
-    /// finished generating it. Recovery cannot start yet.
+    /// The proxy is still receiving the response from the model.
     case generating
-    /// The buffered response is complete and is being fetched, decrypted,
-    /// and reconstructed.
+    /// The response is complete and its final state is being restored.
     case restoring
 }
 
-/// Publishes the per-turn recovery phase observed by the coordinator's
-/// status polls so the UI can distinguish "waiting for generation to
-/// finish" from the brief restore step.
+/// Publishes the per-turn recovery phase observed by the coordinator.
 @MainActor
 final class ChatRecoveryPhaseTracker: ObservableObject {
     static let shared = ChatRecoveryPhaseTracker()
@@ -70,13 +66,15 @@ actor ChatRecoveryCoordinator {
     private var activeAccountId: String?
     private var isScanning = false
 
-    func reset(accountId: String?) {
+    func reset(accountId: String?) async {
         accountGeneration += 1
         activeAccountId = accountId
         cancelledTurns.removeAll()
         isScanning = false
-        Task { @MainActor in
+        let generation = accountGeneration
+        await MainActor.run {
             ChatRecoveryPhaseTracker.shared.clearAll()
+            ChatRecoveryDraftStore.shared.reset(generation: generation)
         }
     }
 
@@ -85,15 +83,21 @@ actor ChatRecoveryCoordinator {
         turnId: String,
         userId: String,
         storage: ChatRecoveryStorage
-    ) throws -> ChatRecoveryAttempt {
+    ) async throws -> ChatRecoveryAttempt {
         if activeAccountId != userId {
-            reset(accountId: userId)
+            await reset(accountId: userId)
         }
         cancelledTurns.remove(turnKey(
             chatId: chatId,
             turnId: turnId,
             storage: storage
         ))
+        await MainActor.run {
+            ChatRecoveryDraftStore.shared.allow(
+                chatId: chatId,
+                turnId: turnId
+            )
+        }
         return ChatRecoveryAttempt(
             chatId: chatId,
             turnId: turnId,
@@ -190,6 +194,12 @@ actor ChatRecoveryCoordinator {
                     titleState: titleState
                 )
             )
+            await MainActor.run {
+                ChatRecoveryDraftStore.shared.clear(
+                    chatId: attempt.chatId,
+                    turnId: attempt.turnId
+                )
+            }
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
         } catch ChatRecoverySyncError.envelopeMissing {
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
@@ -217,6 +227,10 @@ actor ChatRecoveryCoordinator {
         ))
         await MainActor.run {
             ChatRecoveryPhaseTracker.shared.clear(turnId: attempt.turnId)
+            ChatRecoveryDraftStore.shared.discard(
+                chatId: attempt.chatId,
+                turnId: attempt.turnId
+            )
         }
         do {
             try await ChatRecoverySync.shared.mutate(
@@ -251,7 +265,7 @@ actor ChatRecoveryCoordinator {
 
     func scan(userId: String, storages: [ChatRecoveryStorage]) async {
         if activeAccountId != userId {
-            reset(accountId: userId)
+            await reset(accountId: userId)
         }
         guard !isScanning else { return }
         isScanning = true
@@ -388,7 +402,6 @@ actor ChatRecoveryCoordinator {
                 await MainActor.run {
                     ChatRecoveryPhaseTracker.shared.setPhase(.generating, turnId: turnId)
                 }
-                return
             case .failed, .missing:
                 await removeTerminal(
                     chatId: chatId,
@@ -411,7 +424,11 @@ actor ChatRecoveryCoordinator {
             guard !Task.isCancelled else { return }
             let response = try await reconstructMessage(
                 stream: stream,
-                turnId: envelope.turnId
+                chatId: chatId,
+                turnId: envelope.turnId,
+                userId: userId,
+                generation: generation,
+                storage: storage
             )
             let key = turnKey(
                 chatId: chatId,
@@ -427,6 +444,37 @@ actor ChatRecoveryCoordinator {
             }
             guard !(await isChatStreaming(chatId)) else { return }
             guard !Task.isCancelled else { return }
+            let finalState = try await ChatRecoveryClient.shared.state(
+                sessionId: payload.sessionId
+            )
+            switch finalState {
+            case .processing:
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.setPhase(.generating, turnId: turnId)
+                }
+                return
+            case .failed, .missing:
+                await removeTerminal(
+                    chatId: chatId,
+                    turnId: envelope.turnId,
+                    userId: userId,
+                    sessionId: payload.sessionId,
+                    storage: storage
+                )
+                return
+            case .complete:
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.setPhase(.restoring, turnId: turnId)
+                }
+            }
+            guard generation == accountGeneration,
+                  activeAccountId == userId,
+                  !cancelledTurns.contains(key),
+                  !(await isChatStreaming(chatId)),
+                  !Task.isCancelled
+            else {
+                return
+            }
             try await ChatRecoverySync.shared.mutate(
                 chatId: chatId,
                 userId: userId,
@@ -528,7 +576,11 @@ actor ChatRecoveryCoordinator {
 
     private func reconstructMessage(
         stream: AsyncThrowingStream<ChatStreamResult, Error>,
-        turnId: String
+        chatId: String,
+        turnId: String,
+        userId: String,
+        generation: Int,
+        storage: ChatRecoveryStorage
     ) async throws -> Message {
         let processor = StreamingResponseProcessor(
             isWebSearchEnabled: true,
@@ -540,10 +592,71 @@ actor ChatRecoveryCoordinator {
             for event in parsed.events {
                 eventState.apply(event, processor: processor)
             }
-            _ = processor.process(parsed)
+            let outcome = processor.process(parsed)
+            if outcome.didMutateState || !parsed.events.isEmpty {
+                try ensureRecoveryIsCurrent(
+                    chatId: chatId,
+                    turnId: turnId,
+                    userId: userId,
+                    generation: generation,
+                    storage: storage
+                )
+                let draft = recoveredMessage(
+                    snapshot: processor.snapshot(),
+                    eventState: eventState,
+                    chatId: chatId,
+                    turnId: turnId,
+                    isStreaming: true
+                )
+                if recoveredMessageIsMeaningful(draft) {
+                    await MainActor.run {
+                        ChatRecoveryDraftStore.shared.replace(
+                            draft,
+                            chatId: chatId,
+                            turnId: turnId,
+                            generation: generation
+                        )
+                    }
+                }
+            }
         }
         processor.finishStream()
-        let snapshot = processor.snapshot()
+        try ensureRecoveryIsCurrent(
+            chatId: chatId,
+            turnId: turnId,
+            userId: userId,
+            generation: generation,
+            storage: storage
+        )
+        let message = recoveredMessage(
+            snapshot: processor.snapshot(),
+            eventState: eventState,
+            chatId: chatId,
+            turnId: turnId,
+            isStreaming: false
+        )
+        if recoveredMessageIsMeaningful(message) {
+            var finalDraft = message
+            finalDraft.isStreaming = true
+            await MainActor.run {
+                ChatRecoveryDraftStore.shared.replace(
+                    finalDraft,
+                    chatId: chatId,
+                    turnId: turnId,
+                    generation: generation
+                )
+            }
+        }
+        return message
+    }
+
+    private func recoveredMessage(
+        snapshot: StreamingResponseProcessor.Snapshot,
+        eventState: RecoveredEventState,
+        chatId: String,
+        turnId: String,
+        isStreaming: Bool
+    ) -> Message {
         var webSearchState = eventState.webSearchState
         if !snapshot.collectedSources.isEmpty {
             var state = webSearchState ?? WebSearchState(status: .searching)
@@ -554,16 +667,18 @@ actor ChatRecoveryCoordinator {
             webSearchState = state
         }
         var message = Message(
+            id: recoveryDraftMessageId(chatId: chatId, turnId: turnId),
             role: .assistant,
             turnId: turnId,
             content: snapshot.responseContent,
             thoughts: snapshot.thoughts,
-            isThinking: false,
+            isThinking: snapshot.isThinking,
             generationTimeSeconds: snapshot.generationTimeSeconds,
             contentChunks: snapshot.contentChunks,
             thinkingChunks: snapshot.thinkingChunks,
             webSearchState: webSearchState
         )
+        message.isStreaming = isStreaming
         message.thinkingDuration = snapshot.generationTimeSeconds
         message.segments = snapshot.segments
         message.webSearches = snapshot.webSearches
@@ -575,6 +690,36 @@ actor ChatRecoveryCoordinator {
         return message
     }
 
+    private func recoveredMessageIsMeaningful(_ message: Message) -> Bool {
+        !message.content.isEmpty
+            || message.thoughts?.isEmpty == false
+            || message.isThinking
+            || message.segments?.isEmpty == false
+            || message.webSearches?.isEmpty == false
+            || message.webSearchState != nil
+            || !message.urlFetches.isEmpty
+            || !message.toolCalls.isEmpty
+            || message.annotations?.isEmpty == false
+            || message.timeline?.isEmpty == false
+    }
+
+    private func ensureRecoveryIsCurrent(
+        chatId: String,
+        turnId: String,
+        userId: String,
+        generation: Int,
+        storage: ChatRecoveryStorage
+    ) throws {
+        let key = turnKey(chatId: chatId, turnId: turnId, storage: storage)
+        guard !Task.isCancelled,
+              generation == accountGeneration,
+              activeAccountId == userId,
+              !cancelledTurns.contains(key)
+        else {
+            throw CancellationError()
+        }
+    }
+
     private func removeTerminal(
         chatId: String,
         turnId: String,
@@ -584,6 +729,10 @@ actor ChatRecoveryCoordinator {
     ) async {
         await MainActor.run {
             ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
+            ChatRecoveryDraftStore.shared.discard(
+                chatId: chatId,
+                turnId: turnId
+            )
         }
         do {
             try await ChatRecoverySync.shared.mutate(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -218,7 +218,6 @@ actor ChatRecoveryCoordinator {
         await MainActor.run {
             ChatRecoveryPhaseTracker.shared.clear(turnId: attempt.turnId)
         }
-        try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
         do {
             try await ChatRecoverySync.shared.mutate(
                 chatId: attempt.chatId,
@@ -226,6 +225,7 @@ actor ChatRecoveryCoordinator {
                 storage: attempt.storage,
                 mutation: .cancel(turnId: attempt.turnId, response: response)
             )
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
         } catch ChatRecoverySyncError.envelopeMissing {
             if attempt.storage == .cloud {
                 try? await ChatRecoverySync.shared.refreshFromRemote(
@@ -233,6 +233,7 @@ actor ChatRecoveryCoordinator {
                     userId: attempt.userId
                 )
             }
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             postRecoveryUpdate(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
@@ -446,7 +447,6 @@ actor ChatRecoveryCoordinator {
                 storage: storage
             )
         } catch ChatRecoverySyncError.envelopeMissing {
-            try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
             await MainActor.run {
                 ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
             }
@@ -456,6 +456,7 @@ actor ChatRecoveryCoordinator {
                     userId: userId
                 )
             }
+            try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
             postRecoveryUpdate(
                 chatId: chatId,
                 userId: userId,
@@ -580,9 +581,6 @@ actor ChatRecoveryCoordinator {
         sessionId: String?,
         storage: ChatRecoveryStorage
     ) async {
-        if let sessionId {
-            try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
-        }
         await MainActor.run {
             ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
         }
@@ -593,6 +591,9 @@ actor ChatRecoveryCoordinator {
                 storage: storage,
                 mutation: .remove(turnId: turnId)
             )
+            if let sessionId {
+                try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+            }
             postRecoveryUpdate(
                 chatId: chatId,
                 userId: userId,

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -240,6 +240,7 @@ actor ChatRecoveryCoordinator {
                 storage: attempt.storage
             )
         } catch {
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             return
         }
     }
@@ -600,6 +601,9 @@ actor ChatRecoveryCoordinator {
                 storage: storage
             )
         } catch {
+            if let sessionId {
+                try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+            }
             return
         }
     }

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -58,19 +58,33 @@ final class ChatRecoveryPhaseTracker: ObservableObject {
     }
 }
 
+func recoveryDraftHasVisibleContent(_ message: Message) -> Bool {
+    !message.content.isEmpty
+        || message.thoughts?.isEmpty == false
+        || message.segments?.isEmpty == false
+        || message.webSearches?.isEmpty == false
+        || message.webSearchState != nil
+        || !message.urlFetches.isEmpty
+        || !message.toolCalls.isEmpty
+        || message.annotations?.isEmpty == false
+        || message.timeline?.isEmpty == false
+}
+
 actor ChatRecoveryCoordinator {
     static let shared = ChatRecoveryCoordinator()
 
     private var accountGeneration = 0
+    private var scanGeneration = 0
     private var cancelledTurns: Set<String> = []
     private var activeAccountId: String?
-    private var isScanning = false
+    private var activeScanGeneration: Int?
 
     func reset(accountId: String?) async {
         accountGeneration += 1
+        scanGeneration += 1
         activeAccountId = accountId
         cancelledTurns.removeAll()
-        isScanning = false
+        activeScanGeneration = nil
         let generation = accountGeneration
         await MainActor.run {
             ChatRecoveryPhaseTracker.shared.clearAll()
@@ -263,17 +277,46 @@ actor ChatRecoveryCoordinator {
         try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
     }
 
-    func scan(userId: String, storages: [ChatRecoveryStorage]) async {
+    func scan(
+        userId: String,
+        storages: [ChatRecoveryStorage],
+        replacingActiveScan: Bool,
+        onProgress: @escaping @Sendable () async -> Void
+    ) async {
         if activeAccountId != userId {
             await reset(accountId: userId)
         }
-        guard !isScanning else { return }
-        isScanning = true
-        defer { isScanning = false }
-        let generation = accountGeneration
+        guard replacingActiveScan || activeScanGeneration == nil else { return }
+        scanGeneration += 1
+        let currentScanGeneration = scanGeneration
+        activeScanGeneration = currentScanGeneration
+        defer {
+            if activeScanGeneration == currentScanGeneration {
+                activeScanGeneration = nil
+            }
+        }
+        let currentAccountGeneration = accountGeneration
+        await MainActor.run {
+            ChatRecoveryDraftStore.shared.beginScan(
+                generation: currentScanGeneration
+            )
+        }
+        guard scanIsCurrent(
+            accountGeneration: currentAccountGeneration,
+            scanGeneration: currentScanGeneration,
+            userId: userId
+        ) else {
+            return
+        }
         var work: [(String, PendingRecoveryEnvelope, ChatRecoveryStorage)] = []
         for storage in storages {
-            guard !Task.isCancelled else { return }
+            guard scanIsCurrent(
+                accountGeneration: currentAccountGeneration,
+                scanGeneration: currentScanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             let storedChats = (try? await storage.fileStorage.loadChatsWithPendingRecoveries(
                 userId: userId
             )) ?? []
@@ -293,8 +336,10 @@ actor ChatRecoveryCoordinator {
                             chatId: item.0,
                             envelope: item.1,
                             userId: userId,
-                            generation: generation,
-                            storage: item.2
+                            accountGeneration: currentAccountGeneration,
+                            scanGeneration: currentScanGeneration,
+                            storage: item.2,
+                            onProgress: onProgress
                         )
                     }
                 }
@@ -307,8 +352,10 @@ actor ChatRecoveryCoordinator {
                             chatId: item.0,
                             envelope: item.1,
                             userId: userId,
-                            generation: generation,
-                            storage: item.2
+                            accountGeneration: currentAccountGeneration,
+                            scanGeneration: currentScanGeneration,
+                            storage: item.2,
+                            onProgress: onProgress
                         )
                     }
                 }
@@ -320,12 +367,16 @@ actor ChatRecoveryCoordinator {
         chatId: String,
         envelope originalEnvelope: PendingRecoveryEnvelope,
         userId: String,
-        generation: Int,
-        storage: ChatRecoveryStorage
+        accountGeneration: Int,
+        scanGeneration: Int,
+        storage: ChatRecoveryStorage,
+        onProgress: @escaping @Sendable () async -> Void
     ) async {
-        guard !Task.isCancelled,
-              generation == accountGeneration,
-              activeAccountId == userId,
+        guard scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ),
               !(await isChatStreaming(chatId))
         else {
             return
@@ -344,6 +395,13 @@ actor ChatRecoveryCoordinator {
             )
             payload = opened.payload
             if storage == .cloud && opened.usedHistoricalKey {
+                guard scanIsCurrent(
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration,
+                    userId: userId
+                ) else {
+                    return
+                }
                 let currentCEK = try EncryptionService.shared.getKeyBytesOrThrow()
                 let rewrapped = try ChatRecoveryCrypto.rewrap(
                     envelope: envelope,
@@ -358,6 +416,13 @@ actor ChatRecoveryCoordinator {
                     storage: storage,
                     mutation: .replace(old: envelope, new: rewrapped)
                 )
+                guard scanIsCurrent(
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration,
+                    userId: userId
+                ) else {
+                    return
+                }
                 envelope = rewrapped
                 postRecoveryUpdate(
                     chatId: chatId,
@@ -366,36 +431,70 @@ actor ChatRecoveryCoordinator {
                 )
             }
         } catch ChatRecoveryCryptoError.expired {
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             await removeTerminal(
                 chatId: chatId,
-                turnId: envelope.turnId,
+                envelope: envelope,
                 userId: userId,
                 sessionId: nil,
-                storage: storage
+                storage: storage,
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration
             )
             return
         } catch ChatRecoveryCryptoError.invalidEnvelope,
                 ChatRecoveryCryptoError.decryptionFailed {
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             await removeTerminal(
                 chatId: chatId,
-                turnId: envelope.turnId,
+                envelope: envelope,
                 userId: userId,
                 sessionId: nil,
-                storage: storage
+                storage: storage,
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration
             )
             return
         } catch {
             return
         }
 
-        guard !Task.isCancelled,
-              generation == accountGeneration,
-              activeAccountId == userId
-        else {
+        guard scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ) else {
             return
         }
         do {
             let state = try await ChatRecoveryClient.shared.state(sessionId: payload.sessionId)
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
+            await onProgress()
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             let turnId = envelope.turnId
             switch state {
             case .processing:
@@ -405,10 +504,12 @@ actor ChatRecoveryCoordinator {
             case .failed, .missing:
                 await removeTerminal(
                     chatId: chatId,
-                    turnId: envelope.turnId,
+                    envelope: envelope,
                     userId: userId,
                     sessionId: payload.sessionId,
-                    storage: storage
+                    storage: storage,
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration
                 )
                 return
             case .complete:
@@ -426,23 +527,33 @@ actor ChatRecoveryCoordinator {
                 sessionId: payload.sessionId,
                 token: token
             )
-            guard !Task.isCancelled else { return }
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             if !(200..<300).contains(recovered.statusCode) {
                 for try await _ in recovered.stream {}
-                guard generation == accountGeneration,
-                      activeAccountId == userId,
+                guard scanIsCurrent(
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration,
+                    userId: userId
+                ),
                       !cancelledTurns.contains(key),
-                      !(await isChatStreaming(chatId)),
-                      !Task.isCancelled
+                      !(await isChatStreaming(chatId))
                 else {
                     return
                 }
                 await removeTerminal(
                     chatId: chatId,
-                    turnId: envelope.turnId,
+                    envelope: envelope,
                     userId: userId,
                     sessionId: payload.sessionId,
-                    storage: storage
+                    storage: storage,
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration
                 )
                 return
             }
@@ -451,21 +562,39 @@ actor ChatRecoveryCoordinator {
                 chatId: chatId,
                 turnId: envelope.turnId,
                 userId: userId,
-                generation: generation,
-                storage: storage
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                storage: storage,
+                onProgress: onProgress
             )
-            guard generation == accountGeneration,
-                  activeAccountId == userId,
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ),
                   !cancelledTurns.contains(key)
             else {
-                try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
                 return
             }
             guard !(await isChatStreaming(chatId)) else { return }
-            guard !Task.isCancelled else { return }
             let finalState = try await ChatRecoveryClient.shared.state(
                 sessionId: payload.sessionId
             )
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
+            await onProgress()
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             switch finalState {
             case .processing:
                 await MainActor.run {
@@ -475,10 +604,12 @@ actor ChatRecoveryCoordinator {
             case .failed, .missing:
                 await removeTerminal(
                     chatId: chatId,
-                    turnId: envelope.turnId,
+                    envelope: envelope,
                     userId: userId,
                     sessionId: payload.sessionId,
-                    storage: storage
+                    storage: storage,
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration
                 )
                 return
             case .complete:
@@ -486,11 +617,13 @@ actor ChatRecoveryCoordinator {
                     ChatRecoveryPhaseTracker.shared.setPhase(.restoring, turnId: turnId)
                 }
             }
-            guard generation == accountGeneration,
-                  activeAccountId == userId,
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ),
                   !cancelledTurns.contains(key),
-                  !(await isChatStreaming(chatId)),
-                  !Task.isCancelled
+                  !(await isChatStreaming(chatId))
             else {
                 return
             }
@@ -505,6 +638,13 @@ actor ChatRecoveryCoordinator {
                     titleState: nil
                 )
             )
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
             await MainActor.run {
                 ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
@@ -515,6 +655,13 @@ actor ChatRecoveryCoordinator {
                 storage: storage
             )
         } catch ChatRecoverySyncError.envelopeMissing {
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             await MainActor.run {
                 ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
             }
@@ -532,12 +679,21 @@ actor ChatRecoveryCoordinator {
             )
         } catch ChatRecoveryClientError.state(let state)
             where state == .failed || state == .missing {
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             await removeTerminal(
                 chatId: chatId,
-                turnId: envelope.turnId,
+                envelope: envelope,
                 userId: userId,
                 sessionId: payload.sessionId,
-                storage: storage
+                storage: storage,
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration
             )
         } catch {
             return
@@ -598,14 +754,17 @@ actor ChatRecoveryCoordinator {
         chatId: String,
         turnId: String,
         userId: String,
-        generation: Int,
-        storage: ChatRecoveryStorage
+        accountGeneration: Int,
+        scanGeneration: Int,
+        storage: ChatRecoveryStorage,
+        onProgress: @escaping @Sendable () async -> Void
     ) async throws -> Message {
         let processor = StreamingResponseProcessor(
             isWebSearchEnabled: true,
             hapticEnabled: false
         )
         var eventState = RecoveredEventState()
+        var lastProgressDraft: Message?
         for try await chunk in stream {
             let parsed = processor.parse(chunk)
             for event in parsed.events {
@@ -617,7 +776,8 @@ actor ChatRecoveryCoordinator {
                     chatId: chatId,
                     turnId: turnId,
                     userId: userId,
-                    generation: generation,
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration,
                     storage: storage
                 )
                 let draft = recoveredMessage(
@@ -627,12 +787,19 @@ actor ChatRecoveryCoordinator {
                     turnId: turnId,
                     isStreaming: true
                 )
-                if recoveredMessageIsMeaningful(draft) {
+                if recoveryDraftHasVisibleContent(draft) {
+                    if draft != lastProgressDraft {
+                        lastProgressDraft = draft
+                        await onProgress()
+                    }
                     try await publishRecoveryDraft(
                         draft,
                         chatId: chatId,
                         turnId: turnId,
-                        generation: generation
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId,
+                        storage: storage
                     )
                 }
             }
@@ -642,7 +809,8 @@ actor ChatRecoveryCoordinator {
             chatId: chatId,
             turnId: turnId,
             userId: userId,
-            generation: generation,
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
             storage: storage
         )
         let message = recoveredMessage(
@@ -652,14 +820,20 @@ actor ChatRecoveryCoordinator {
             turnId: turnId,
             isStreaming: false
         )
-        if recoveredMessageIsMeaningful(message) {
+        if recoveryDraftHasVisibleContent(message) {
+            if message != lastProgressDraft {
+                await onProgress()
+            }
             var finalDraft = message
             finalDraft.isStreaming = true
             try await publishRecoveryDraft(
                 finalDraft,
                 chatId: chatId,
                 turnId: turnId,
-                generation: generation
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId,
+                storage: storage
             )
         }
         return message
@@ -669,8 +843,19 @@ actor ChatRecoveryCoordinator {
         _ draft: Message,
         chatId: String,
         turnId: String,
-        generation: Int
+        accountGeneration: Int,
+        scanGeneration: Int,
+        userId: String,
+        storage: ChatRecoveryStorage
     ) async throws {
+        try ensureRecoveryIsCurrent(
+            chatId: chatId,
+            turnId: turnId,
+            userId: userId,
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            storage: storage
+        )
         let published = await MainActor.run {
             guard !StreamingTracker.shared.isStreaming(chatId) else {
                 ChatRecoveryDraftStore.shared.clear(
@@ -683,10 +868,19 @@ actor ChatRecoveryCoordinator {
                 draft,
                 chatId: chatId,
                 turnId: turnId,
-                generation: generation
+                generation: accountGeneration,
+                scanGeneration: scanGeneration
             )
             return true
         }
+        try ensureRecoveryIsCurrent(
+            chatId: chatId,
+            turnId: turnId,
+            userId: userId,
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            storage: storage
+        )
         guard published else { throw CancellationError() }
     }
 
@@ -713,6 +907,7 @@ actor ChatRecoveryCoordinator {
             content: snapshot.responseContent,
             thoughts: snapshot.thoughts,
             isThinking: snapshot.isThinking,
+            timestamp: .distantPast,
             generationTimeSeconds: snapshot.generationTimeSeconds,
             contentChunks: snapshot.contentChunks,
             thinkingChunks: snapshot.thinkingChunks,
@@ -730,57 +925,81 @@ actor ChatRecoveryCoordinator {
         return message
     }
 
-    private func recoveredMessageIsMeaningful(_ message: Message) -> Bool {
-        !message.content.isEmpty
-            || message.thoughts?.isEmpty == false
-            || message.isThinking
-            || message.segments?.isEmpty == false
-            || message.webSearches?.isEmpty == false
-            || message.webSearchState != nil
-            || !message.urlFetches.isEmpty
-            || !message.toolCalls.isEmpty
-            || message.annotations?.isEmpty == false
-            || message.timeline?.isEmpty == false
-    }
-
     private func ensureRecoveryIsCurrent(
         chatId: String,
         turnId: String,
         userId: String,
-        generation: Int,
+        accountGeneration: Int,
+        scanGeneration: Int,
         storage: ChatRecoveryStorage
     ) throws {
         let key = turnKey(chatId: chatId, turnId: turnId, storage: storage)
-        guard !Task.isCancelled,
-              generation == accountGeneration,
-              activeAccountId == userId,
+        guard scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ),
               !cancelledTurns.contains(key)
         else {
             throw CancellationError()
         }
     }
 
+    private func scanIsCurrent(
+        accountGeneration: Int,
+        scanGeneration: Int,
+        userId: String
+    ) -> Bool {
+        !Task.isCancelled
+            && accountGeneration == self.accountGeneration
+            && scanGeneration == self.scanGeneration
+            && activeAccountId == userId
+    }
+
     private func removeTerminal(
         chatId: String,
-        turnId: String,
+        envelope: PendingRecoveryEnvelope,
         userId: String,
         sessionId: String?,
-        storage: ChatRecoveryStorage
+        storage: ChatRecoveryStorage,
+        accountGeneration: Int,
+        scanGeneration: Int
     ) async {
-        await MainActor.run {
-            ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
-            ChatRecoveryDraftStore.shared.discard(
-                chatId: chatId,
-                turnId: turnId
-            )
+        guard scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ),
+              !(await isChatStreaming(chatId)),
+              scanIsCurrent(
+                  accountGeneration: accountGeneration,
+                  scanGeneration: scanGeneration,
+                  userId: userId
+              )
+        else {
+            return
         }
         do {
             try await ChatRecoverySync.shared.mutate(
                 chatId: chatId,
                 userId: userId,
                 storage: storage,
-                mutation: .remove(turnId: turnId)
+                mutation: .remove(envelope)
             )
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
+            await MainActor.run {
+                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+                ChatRecoveryDraftStore.shared.discard(
+                    chatId: chatId,
+                    turnId: envelope.turnId
+                )
+            }
             if let sessionId {
                 try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
             }
@@ -790,7 +1009,12 @@ actor ChatRecoveryCoordinator {
                 storage: storage
             )
         } catch {
-            if let sessionId {
+            if let sessionId,
+               scanIsCurrent(
+                   accountGeneration: accountGeneration,
+                   scanGeneration: scanGeneration,
+                   userId: userId
+               ) {
                 try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
             }
             return

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -714,22 +714,24 @@ actor ChatRecoveryCoordinator {
                     titleState: nil
                 )
             )
-            await deleteSessionAfterMutation(payload.sessionId)
-            guard scanIsCurrent(
+            if accountIsCurrent(
                 accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
                 userId: userId
-            ) else {
-                return
+            ) {
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
+                    ChatRecoveryDraftStore.shared.clear(
+                        chatId: chatId,
+                        turnId: turnId
+                    )
+                }
+                postRecoveryUpdate(
+                    chatId: chatId,
+                    userId: userId,
+                    storage: storage
+                )
             }
-            await MainActor.run {
-                ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
-            }
-            postRecoveryUpdate(
-                chatId: chatId,
-                userId: userId,
-                storage: storage
-            )
+            await deleteSessionAfterMutation(payload.sessionId)
         } catch ChatRecoverySyncError.envelopeMissing {
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
@@ -1027,8 +1029,18 @@ actor ChatRecoveryCoordinator {
         userId: String
     ) -> Bool {
         !Task.isCancelled
-            && accountGeneration == self.accountGeneration
+            && accountIsCurrent(
+                accountGeneration: accountGeneration,
+                userId: userId
+            )
             && scanGeneration == self.scanGeneration
+    }
+
+    private func accountIsCurrent(
+        accountGeneration: Int,
+        userId: String
+    ) -> Bool {
+        accountGeneration == self.accountGeneration
             && activeAccountId == userId
     }
 
@@ -1062,26 +1074,24 @@ actor ChatRecoveryCoordinator {
                 storage: storage,
                 mutation: .remove(envelope)
             )
-            await deleteSessionAfterMutation(sessionId)
-            guard scanIsCurrent(
+            if accountIsCurrent(
                 accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
                 userId: userId
-            ) else {
-                return
-            }
-            await MainActor.run {
-                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
-                ChatRecoveryDraftStore.shared.discard(
+            ) {
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+                    ChatRecoveryDraftStore.shared.discard(
+                        chatId: chatId,
+                        turnId: envelope.turnId
+                    )
+                }
+                postRecoveryUpdate(
                     chatId: chatId,
-                    turnId: envelope.turnId
+                    userId: userId,
+                    storage: storage
                 )
             }
-            postRecoveryUpdate(
-                chatId: chatId,
-                userId: userId,
-                storage: storage
-            )
+            await deleteSessionAfterMutation(sessionId)
         } catch {
             if let sessionId,
                scanIsCurrent(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -108,6 +108,7 @@ func recoveredTitleMessages(
 actor ChatRecoveryCoordinator {
     private struct ActiveRecoveryTask {
         let id: UUID
+        let turnId: String
         let task: Task<Void, Never>
     }
 
@@ -282,8 +283,11 @@ actor ChatRecoveryCoordinator {
             turnId: attempt.turnId,
             storage: attempt.storage
         ))
+        let shouldClearPhase = !hasActiveRecovery(turnId: attempt.turnId)
         await MainActor.run {
-            ChatRecoveryPhaseTracker.shared.clear(turnId: attempt.turnId)
+            if shouldClearPhase {
+                ChatRecoveryPhaseTracker.shared.clear(turnId: attempt.turnId)
+            }
             ChatRecoveryDraftStore.shared.discard(
                 chatId: attempt.chatId,
                 turnId: attempt.turnId
@@ -332,8 +336,14 @@ actor ChatRecoveryCoordinator {
         defer { cancelledTurns.remove(key) }
         let recoveryTask = activeRecoveryTasks[key]?.task
         recoveryTask?.cancel()
+        let shouldClearPhase = !hasActiveRecovery(
+            turnId: envelope.turnId,
+            excluding: key
+        )
         await MainActor.run {
-            ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+            if shouldClearPhase {
+                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+            }
             ChatRecoveryDraftStore.shared.discard(
                 chatId: chatId,
                 turnId: envelope.turnId
@@ -493,7 +503,11 @@ actor ChatRecoveryCoordinator {
                 onProgress: onProgress
             )
         }
-        activeRecoveryTasks[key] = ActiveRecoveryTask(id: id, task: task)
+        activeRecoveryTasks[key] = ActiveRecoveryTask(
+            id: id,
+            turnId: envelope.turnId,
+            task: task
+        )
         await MainActor.run {
             ChatRecoveryPhaseTracker.shared.setPhase(
                 .generating,
@@ -507,8 +521,10 @@ actor ChatRecoveryCoordinator {
         }
         if activeRecoveryTasks[key]?.id == id {
             activeRecoveryTasks.removeValue(forKey: key)
-            await MainActor.run {
-                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+            if !hasActiveRecovery(turnId: envelope.turnId) {
+                await MainActor.run {
+                    ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+                }
             }
         }
     }
@@ -888,7 +904,6 @@ actor ChatRecoveryCoordinator {
                 userId: userId
             ) {
                 await MainActor.run {
-                    ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
                     ChatRecoveryDraftStore.shared.clear(
                         chatId: chatId,
                         turnId: turnId
@@ -908,9 +923,6 @@ actor ChatRecoveryCoordinator {
                 userId: userId
             ) else {
                 return
-            }
-            await MainActor.run {
-                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
             }
             if storage == .cloud {
                 try? await ChatRecoverySync.shared.refreshFromRemote(
@@ -1248,7 +1260,6 @@ actor ChatRecoveryCoordinator {
                 userId: userId
             ) {
                 await MainActor.run {
-                    ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
                     ChatRecoveryDraftStore.shared.discard(
                         chatId: chatId,
                         turnId: envelope.turnId
@@ -1302,6 +1313,15 @@ actor ChatRecoveryCoordinator {
         storage: ChatRecoveryStorage
     ) -> String {
         "\(storage.rawValue)\u{0}\(chatId)\u{0}\(turnId)"
+    }
+
+    private func hasActiveRecovery(
+        turnId: String,
+        excluding key: String? = nil
+    ) -> Bool {
+        activeRecoveryTasks.contains {
+            $0.key != key && $0.value.turnId == turnId
+        }
     }
 
     private func postRecoveryUpdate(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -494,6 +494,12 @@ actor ChatRecoveryCoordinator {
             )
         }
         activeRecoveryTasks[key] = ActiveRecoveryTask(id: id, task: task)
+        await MainActor.run {
+            ChatRecoveryPhaseTracker.shared.setPhase(
+                .generating,
+                turnId: envelope.turnId
+            )
+        }
         await withTaskCancellationHandler {
             await task.value
         } onCancel: {
@@ -501,6 +507,9 @@ actor ChatRecoveryCoordinator {
         }
         if activeRecoveryTasks[key]?.id == id {
             activeRecoveryTasks.removeValue(forKey: key)
+            await MainActor.run {
+                ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+            }
         }
     }
 
@@ -825,6 +834,16 @@ actor ChatRecoveryCoordinator {
             }
             guard let response else { return }
             let persistedResponse = recoveredResponseForPersistence(response)
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ),
+                  !cancelledTurns.contains(key),
+                  !(await isChatStreaming(chatId))
+            else {
+                return
+            }
             let storedChat = try? await storage.fileStorage.loadChat(
                 chatId: chatId,
                 userId: userId

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -56,6 +56,10 @@ final class ChatRecoveryPhaseTracker: ObservableObject {
         guard !phases.isEmpty else { return }
         phases.removeAll()
     }
+
+    func isActive(turnId: String) -> Bool {
+        phases[turnId] != nil
+    }
 }
 
 func recoveryDraftHasVisibleContent(_ message: Message) -> Bool {
@@ -79,12 +83,40 @@ func recoveredResponseForPersistence(
     return response
 }
 
+func recoveredTitleMessages(
+    titleState: Chat.TitleState,
+    messages: [Message],
+    response: Message,
+    turnId: String
+) -> [Message]? {
+    guard titleState == .placeholder,
+          messages.first(where: { $0.role == .user })?.turnId == turnId
+    else {
+        return nil
+    }
+    var titleMessages = messages
+    if let index = titleMessages.firstIndex(where: {
+        $0.role == .assistant && $0.turnId == turnId
+    }) {
+        titleMessages[index] = response
+    } else {
+        titleMessages.append(response)
+    }
+    return titleMessages
+}
+
 actor ChatRecoveryCoordinator {
+    private struct ActiveRecoveryTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
     static let shared = ChatRecoveryCoordinator()
 
     private var accountGeneration = 0
     private var scanGeneration = 0
     private var cancelledTurns: Set<String> = []
+    private var activeRecoveryTasks: [String: ActiveRecoveryTask] = [:]
     private var activeAccountId: String?
     private var activeScanGeneration: Int?
 
@@ -93,6 +125,8 @@ actor ChatRecoveryCoordinator {
         scanGeneration += 1
         activeAccountId = accountId
         cancelledTurns.removeAll()
+        activeRecoveryTasks.values.forEach { $0.task.cancel() }
+        activeRecoveryTasks.removeAll()
         activeScanGeneration = nil
         let generation = accountGeneration
         await MainActor.run {
@@ -282,6 +316,67 @@ actor ChatRecoveryCoordinator {
         }
     }
 
+    func cancelRecoveredTurn(
+        chatId: String,
+        envelope: PendingRecoveryEnvelope,
+        userId: String,
+        storage: ChatRecoveryStorage
+    ) async {
+        guard activeAccountId == userId else { return }
+        let key = turnKey(
+            chatId: chatId,
+            turnId: envelope.turnId,
+            storage: storage
+        )
+        cancelledTurns.insert(key)
+        defer { cancelledTurns.remove(key) }
+        let recoveryTask = activeRecoveryTasks[key]?.task
+        recoveryTask?.cancel()
+        await MainActor.run {
+            ChatRecoveryPhaseTracker.shared.clear(turnId: envelope.turnId)
+            ChatRecoveryDraftStore.shared.discard(
+                chatId: chatId,
+                turnId: envelope.turnId
+            )
+        }
+        await recoveryTask?.value
+        let openedEnvelope = try? await openEnvelope(
+            envelope,
+            chatId: chatId,
+            userId: userId,
+            storage: storage
+        )
+        let sessionId = openedEnvelope?.payload.sessionId
+        do {
+            try await ChatRecoverySync.shared.mutate(
+                chatId: chatId,
+                userId: userId,
+                storage: storage,
+                mutation: .cancel(turnId: envelope.turnId, response: nil)
+            )
+        } catch ChatRecoverySyncError.envelopeMissing {
+            if storage == .cloud {
+                try? await ChatRecoverySync.shared.refreshFromRemote(
+                    chatId: chatId,
+                    userId: userId
+                )
+            }
+        } catch {
+            if let sessionId {
+                try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+            }
+            return
+        }
+        if let sessionId {
+            try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+        }
+        postRecoveryUpdate(
+            chatId: chatId,
+            userId: userId,
+            storage: storage
+        )
+    }
+
     func deleteSession(attempt: ChatRecoveryAttempt) async {
         try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
     }
@@ -341,7 +436,7 @@ actor ChatRecoveryCoordinator {
                 guard !Task.isCancelled else { return }
                 if let item = iterator.next() {
                     group.addTask {
-                        await self.recover(
+                        await self.performRecovery(
                             chatId: item.0,
                             envelope: item.1,
                             userId: userId,
@@ -357,7 +452,7 @@ actor ChatRecoveryCoordinator {
                 guard !Task.isCancelled else { return }
                 if let item = iterator.next() {
                     group.addTask {
-                        await self.recover(
+                        await self.performRecovery(
                             chatId: item.0,
                             envelope: item.1,
                             userId: userId,
@@ -369,6 +464,43 @@ actor ChatRecoveryCoordinator {
                     }
                 }
             }
+        }
+    }
+
+    private func performRecovery(
+        chatId: String,
+        envelope: PendingRecoveryEnvelope,
+        userId: String,
+        accountGeneration: Int,
+        scanGeneration: Int,
+        storage: ChatRecoveryStorage,
+        onProgress: @escaping @Sendable () async -> Void
+    ) async {
+        let key = turnKey(
+            chatId: chatId,
+            turnId: envelope.turnId,
+            storage: storage
+        )
+        let id = UUID()
+        let task = Task {
+            await recover(
+                chatId: chatId,
+                envelope: envelope,
+                userId: userId,
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                storage: storage,
+                onProgress: onProgress
+            )
+        }
+        activeRecoveryTasks[key] = ActiveRecoveryTask(id: id, task: task)
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        if activeRecoveryTasks[key]?.id == id {
+            activeRecoveryTasks.removeValue(forKey: key)
         }
     }
 
@@ -693,6 +825,24 @@ actor ChatRecoveryCoordinator {
             }
             guard let response else { return }
             let persistedResponse = recoveredResponseForPersistence(response)
+            let storedChat = try? await storage.fileStorage.loadChat(
+                chatId: chatId,
+                userId: userId
+            )
+            let titleMessages = storedChat.flatMap {
+                recoveredTitleMessages(
+                    titleState: $0.titleState,
+                    messages: $0.messages,
+                    response: persistedResponse,
+                    turnId: envelope.turnId
+                )
+            }
+            var generatedTitle: String?
+            if let titleMessages {
+                generatedTitle = await SummarizerService.shared.generateChatTitle(
+                    from: titleMessages
+                )
+            }
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -710,8 +860,8 @@ actor ChatRecoveryCoordinator {
                 mutation: .complete(
                     envelope: envelope,
                     response: persistedResponse,
-                    title: nil,
-                    titleState: nil
+                    title: generatedTitle,
+                    titleState: generatedTitle == nil ? nil : .generated
                 )
             )
             if accountIsCurrent(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -70,6 +70,15 @@ func recoveryDraftHasVisibleContent(_ message: Message) -> Bool {
         || message.timeline?.isEmpty == false
 }
 
+func recoveredResponseForPersistence(
+    _ message: Message,
+    timestamp: Date = Date()
+) -> Message {
+    var response = message
+    response.timestamp = timestamp
+    return response
+}
+
 actor ChatRecoveryCoordinator {
     static let shared = ChatRecoveryCoordinator()
 
@@ -683,6 +692,7 @@ actor ChatRecoveryCoordinator {
                 }
             }
             guard let response else { return }
+            let persistedResponse = recoveredResponseForPersistence(response)
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -699,11 +709,12 @@ actor ChatRecoveryCoordinator {
                 storage: storage,
                 mutation: .complete(
                     envelope: envelope,
-                    response: response,
+                    response: persistedResponse,
                     title: nil,
                     titleState: nil
                 )
             )
+            await deleteSessionAfterMutation(payload.sessionId)
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -711,7 +722,6 @@ actor ChatRecoveryCoordinator {
             ) else {
                 return
             }
-            try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
             await MainActor.run {
                 ChatRecoveryPhaseTracker.shared.clear(turnId: turnId)
             }
@@ -1052,6 +1062,7 @@ actor ChatRecoveryCoordinator {
                 storage: storage,
                 mutation: .remove(envelope)
             )
+            await deleteSessionAfterMutation(sessionId)
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -1065,9 +1076,6 @@ actor ChatRecoveryCoordinator {
                     chatId: chatId,
                     turnId: envelope.turnId
                 )
-            }
-            if let sessionId {
-                try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
             }
             postRecoveryUpdate(
                 chatId: chatId,
@@ -1085,6 +1093,13 @@ actor ChatRecoveryCoordinator {
             }
             return
         }
+    }
+
+    private func deleteSessionAfterMutation(_ sessionId: String?) async {
+        guard let sessionId else { return }
+        await Task {
+            try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
+        }.value
     }
 
     private func randomSessionId() throws -> String {

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -479,7 +479,9 @@ actor ChatRecoveryCoordinator {
             return
         }
         do {
-            let state = try await ChatRecoveryClient.shared.state(sessionId: payload.sessionId)
+            let initialStatus = try await ChatRecoveryClient.shared.status(
+                sessionId: payload.sessionId
+            )
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -496,7 +498,7 @@ actor ChatRecoveryCoordinator {
                 return
             }
             let turnId = envelope.turnId
-            switch state {
+            switch initialStatus.state {
             case .processing:
                 await MainActor.run {
                     ChatRecoveryPhaseTracker.shared.setPhase(.generating, turnId: turnId)
@@ -523,100 +525,164 @@ actor ChatRecoveryCoordinator {
                 turnId: envelope.turnId,
                 storage: storage
             )
-            let recovered = try await ChatRecoveryClient.shared.fetch(
-                sessionId: payload.sessionId,
-                token: token
-            )
-            guard scanIsCurrent(
-                accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
-                userId: userId
-            ) else {
-                return
-            }
-            if !(200..<300).contains(recovered.statusCode) {
-                for try await _ in recovered.stream {}
-                guard scanIsCurrent(
-                    accountGeneration: accountGeneration,
-                    scanGeneration: scanGeneration,
-                    userId: userId
-                ),
-                      !cancelledTurns.contains(key),
-                      !(await isChatStreaming(chatId))
-                else {
-                    return
+            var response: Message?
+            for attempt in 0..<Constants.ChatRecovery.maxStreamAttempts {
+                do {
+                    let recovered = try await ChatRecoveryClient.shared.fetch(
+                        sessionId: payload.sessionId,
+                        token: token
+                    )
+                    guard scanIsCurrent(
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else {
+                        return
+                    }
+                    if !(200..<300).contains(recovered.statusCode) {
+                        for try await _ in recovered.stream {}
+                        guard scanIsCurrent(
+                            accountGeneration: accountGeneration,
+                            scanGeneration: scanGeneration,
+                            userId: userId
+                        ),
+                              !cancelledTurns.contains(key),
+                              !(await isChatStreaming(chatId))
+                        else {
+                            return
+                        }
+                        await removeTerminal(
+                            chatId: chatId,
+                            envelope: envelope,
+                            userId: userId,
+                            sessionId: payload.sessionId,
+                            storage: storage,
+                            accountGeneration: accountGeneration,
+                            scanGeneration: scanGeneration
+                        )
+                        return
+                    }
+                    let recoveredResponse = try await reconstructMessage(
+                        stream: recovered.stream,
+                        chatId: chatId,
+                        turnId: envelope.turnId,
+                        userId: userId,
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        storage: storage,
+                        onProgress: onProgress
+                    )
+                    guard scanIsCurrent(
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ),
+                          !cancelledTurns.contains(key),
+                          !(await isChatStreaming(chatId))
+                    else {
+                        return
+                    }
+                    let finalStatus = try await ChatRecoveryClient.shared.status(
+                        sessionId: payload.sessionId
+                    )
+                    guard scanIsCurrent(
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else {
+                        return
+                    }
+                    await onProgress()
+                    guard scanIsCurrent(
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else {
+                        return
+                    }
+                    switch finalStatus.state {
+                    case .processing:
+                        await MainActor.run {
+                            ChatRecoveryPhaseTracker.shared.setPhase(
+                                .generating,
+                                turnId: turnId
+                            )
+                        }
+                        if attempt + 1 < Constants.ChatRecovery.maxStreamAttempts {
+                            continue
+                        }
+                        return
+                    case .failed, .missing:
+                        await removeTerminal(
+                            chatId: chatId,
+                            envelope: envelope,
+                            userId: userId,
+                            sessionId: payload.sessionId,
+                            storage: storage,
+                            accountGeneration: accountGeneration,
+                            scanGeneration: scanGeneration
+                        )
+                        return
+                    case .complete:
+                        await MainActor.run {
+                            ChatRecoveryPhaseTracker.shared.setPhase(
+                                .restoring,
+                                turnId: turnId
+                            )
+                        }
+                    }
+                    let encryptedByteCount = await recovered.encryptedByteCount()
+                    guard scanIsCurrent(
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else {
+                        return
+                    }
+                    if encryptedByteCount < finalStatus.persistedBytes {
+                        if attempt + 1 < Constants.ChatRecovery.maxStreamAttempts {
+                            continue
+                        }
+                        return
+                    }
+                    response = recoveredResponse
+                    break
+                } catch {
+                    guard scanIsCurrent(
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ),
+                          !cancelledTurns.contains(key),
+                          !(await isChatStreaming(chatId)),
+                          let retryStatus = try? await ChatRecoveryClient.shared.status(
+                              sessionId: payload.sessionId
+                          )
+                    else {
+                        return
+                    }
+                    await onProgress()
+                    switch retryStatus.state {
+                    case .processing, .complete:
+                        guard attempt + 1 < Constants.ChatRecovery.maxStreamAttempts else {
+                            return
+                        }
+                        continue
+                    case .failed, .missing:
+                        await removeTerminal(
+                            chatId: chatId,
+                            envelope: envelope,
+                            userId: userId,
+                            sessionId: payload.sessionId,
+                            storage: storage,
+                            accountGeneration: accountGeneration,
+                            scanGeneration: scanGeneration
+                        )
+                        return
+                    }
                 }
-                await removeTerminal(
-                    chatId: chatId,
-                    envelope: envelope,
-                    userId: userId,
-                    sessionId: payload.sessionId,
-                    storage: storage,
-                    accountGeneration: accountGeneration,
-                    scanGeneration: scanGeneration
-                )
-                return
             }
-            let response = try await reconstructMessage(
-                stream: recovered.stream,
-                chatId: chatId,
-                turnId: envelope.turnId,
-                userId: userId,
-                accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
-                storage: storage,
-                onProgress: onProgress
-            )
-            guard scanIsCurrent(
-                accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
-                userId: userId
-            ),
-                  !cancelledTurns.contains(key)
-            else {
-                return
-            }
-            guard !(await isChatStreaming(chatId)) else { return }
-            let finalState = try await ChatRecoveryClient.shared.state(
-                sessionId: payload.sessionId
-            )
-            guard scanIsCurrent(
-                accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
-                userId: userId
-            ) else {
-                return
-            }
-            await onProgress()
-            guard scanIsCurrent(
-                accountGeneration: accountGeneration,
-                scanGeneration: scanGeneration,
-                userId: userId
-            ) else {
-                return
-            }
-            switch finalState {
-            case .processing:
-                await MainActor.run {
-                    ChatRecoveryPhaseTracker.shared.setPhase(.generating, turnId: turnId)
-                }
-                return
-            case .failed, .missing:
-                await removeTerminal(
-                    chatId: chatId,
-                    envelope: envelope,
-                    userId: userId,
-                    sessionId: payload.sessionId,
-                    storage: storage,
-                    accountGeneration: accountGeneration,
-                    scanGeneration: scanGeneration
-                )
-                return
-            case .complete:
-                await MainActor.run {
-                    ChatRecoveryPhaseTracker.shared.setPhase(.restoring, turnId: turnId)
-                }
-            }
+            guard let response else { return }
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,

--- a/TinfoilChat/Services/ChatRecoveryCrypto.swift
+++ b/TinfoilChat/Services/ChatRecoveryCrypto.swift
@@ -80,7 +80,7 @@ enum ChatRecoveryCrypto {
         try requireLowercaseHex(sessionId, length: Constants.ChatRecovery.sessionIdBytes * 2)
         try requireToken(recoveryToken)
 
-        let keyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
+        let keyId = try recoveryKeyId(cek)
         let formatter = timestampFormatter(fractionalSeconds: true)
         let createdAt = formatter.string(from: now)
         let expiresAt = formatter.string(
@@ -131,7 +131,7 @@ enum ChatRecoveryCrypto {
         try requireIdentifier(userId)
         try requireIdentifier(chatId)
         try validate(envelope)
-        guard try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek) == envelope.keyId else {
+        guard try recoveryKeyId(cek) == envelope.keyId else {
             throw ChatRecoveryCryptoError.invalidKey
         }
         guard let expiry = parseTimestamp(envelope.expiresAt), now < expiry else {
@@ -185,7 +185,7 @@ enum ChatRecoveryCrypto {
             envelope: envelope,
             now: now
         )
-        let keyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: newCEK)
+        let keyId = try recoveryKeyId(newCEK)
         let metadata = PendingRecoveryEnvelope(
             v: envelope.v,
             turnId: envelope.turnId,
@@ -299,6 +299,14 @@ enum ChatRecoveryCrypto {
               value.count <= Constants.ChatRecovery.maxIdentifierLength
         else {
             throw ChatRecoveryCryptoError.invalidIdentifier
+        }
+    }
+
+    private static func recoveryKeyId(_ cek: Data) throws -> String {
+        do {
+            return try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
+        } catch {
+            throw ChatRecoveryCryptoError.invalidKey
         }
     }
 

--- a/TinfoilChat/Services/ChatRecoveryCrypto.swift
+++ b/TinfoilChat/Services/ChatRecoveryCrypto.swift
@@ -1,0 +1,351 @@
+import CryptoKit
+import Foundation
+
+enum ChatRecoveryCryptoError: Error, Equatable {
+    case invalidEnvelope
+    case invalidIdentifier
+    case invalidKey
+    case expired
+    case decryptionFailed
+}
+
+struct ChatRecoveryTokenFields: Codable, Equatable, Sendable {
+    let exportedSecret: String
+    let requestEnc: String
+}
+
+enum ChatRecoveryTokenPayload: Codable, Equatable, Sendable {
+    case serialized(String)
+    case fields(ChatRecoveryTokenFields)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let serialized = try? container.decode(String.self) {
+            self = .serialized(serialized)
+        } else {
+            self = .fields(try container.decode(ChatRecoveryTokenFields.self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .serialized(let value):
+            try container.encode(value)
+        case .fields(let value):
+            try container.encode(value)
+        }
+    }
+
+    var fields: ChatRecoveryTokenFields? {
+        switch self {
+        case .fields(let value):
+            return value
+        case .serialized(let value):
+            guard let data = value.data(using: .utf8) else { return nil }
+            return try? JSONDecoder().decode(ChatRecoveryTokenFields.self, from: data)
+        }
+    }
+}
+
+struct ChatRecoveryEnvelopePayload: Codable, Equatable, Sendable {
+    let sessionId: String
+    let recoveryToken: ChatRecoveryTokenPayload
+}
+
+enum ChatRecoveryCrypto {
+    private static let base64DecodedBlockBytes = 3
+    private static let base64EncodedBlockCharacters = 4
+
+    private static func timestampFormatter(fractionalSeconds: Bool) -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = fractionalSeconds
+            ? [.withInternetDateTime, .withFractionalSeconds]
+            : [.withInternetDateTime]
+        return formatter
+    }
+
+    static func encrypt(
+        cek: Data,
+        userId: String,
+        chatId: String,
+        turnId: String,
+        sessionId: String,
+        recoveryToken: ChatRecoveryTokenPayload,
+        now: Date = Date()
+    ) throws -> PendingRecoveryEnvelope {
+        try requireIdentifier(userId)
+        try requireIdentifier(chatId)
+        try requireIdentifier(turnId)
+        try requireLowercaseHex(sessionId, length: Constants.ChatRecovery.sessionIdBytes * 2)
+        try requireToken(recoveryToken)
+
+        let keyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
+        let formatter = timestampFormatter(fractionalSeconds: true)
+        let createdAt = formatter.string(from: now)
+        let expiresAt = formatter.string(
+            from: now.addingTimeInterval(Constants.ChatRecovery.envelopeLifetimeSeconds)
+        )
+        let metadata = PendingRecoveryEnvelope(
+            v: Constants.ChatRecovery.envelopeVersion,
+            turnId: turnId,
+            keyId: keyId,
+            createdAt: createdAt,
+            expiresAt: expiresAt,
+            nonce: "",
+            ciphertext: ""
+        )
+        let payload = ChatRecoveryEnvelopePayload(
+            sessionId: sessionId,
+            recoveryToken: recoveryToken
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let key = try envelopeKey(cek)
+        let nonce = AES.GCM.Nonce()
+        let sealed = try AES.GCM.seal(
+            plaintext,
+            using: key,
+            nonce: nonce,
+            authenticating: try aad(userId: userId, chatId: chatId, envelope: metadata)
+        )
+        let envelope = PendingRecoveryEnvelope(
+            v: metadata.v,
+            turnId: metadata.turnId,
+            keyId: metadata.keyId,
+            createdAt: metadata.createdAt,
+            expiresAt: metadata.expiresAt,
+            nonce: Data(nonce).base64EncodedString(),
+            ciphertext: (sealed.ciphertext + sealed.tag).base64EncodedString()
+        )
+        try validate(envelope)
+        return envelope
+    }
+
+    static func decrypt(
+        cek: Data,
+        userId: String,
+        chatId: String,
+        envelope: PendingRecoveryEnvelope,
+        now: Date = Date()
+    ) throws -> ChatRecoveryEnvelopePayload {
+        try requireIdentifier(userId)
+        try requireIdentifier(chatId)
+        try validate(envelope)
+        guard try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek) == envelope.keyId else {
+            throw ChatRecoveryCryptoError.invalidKey
+        }
+        guard let expiry = parseTimestamp(envelope.expiresAt), now < expiry else {
+            throw ChatRecoveryCryptoError.expired
+        }
+        guard let nonceData = Data(base64Encoded: envelope.nonce),
+              let combinedCiphertext = Data(base64Encoded: envelope.ciphertext),
+              combinedCiphertext.count > Constants.ChatRecovery.authenticationTagBytes
+        else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+
+        do {
+            let tagStart = combinedCiphertext.count - Constants.ChatRecovery.authenticationTagBytes
+            let sealed = try AES.GCM.SealedBox(
+                nonce: AES.GCM.Nonce(data: nonceData),
+                ciphertext: combinedCiphertext[..<tagStart],
+                tag: combinedCiphertext[tagStart...]
+            )
+            let plaintext = try AES.GCM.open(
+                sealed,
+                using: try envelopeKey(cek),
+                authenticating: try aad(userId: userId, chatId: chatId, envelope: envelope)
+            )
+            let payload = try JSONDecoder().decode(ChatRecoveryEnvelopePayload.self, from: plaintext)
+            try requireLowercaseHex(
+                payload.sessionId,
+                length: Constants.ChatRecovery.sessionIdBytes * 2
+            )
+            try requireToken(payload.recoveryToken)
+            return payload
+        } catch let error as ChatRecoveryCryptoError {
+            throw error
+        } catch {
+            throw ChatRecoveryCryptoError.decryptionFailed
+        }
+    }
+
+    static func rewrap(
+        envelope: PendingRecoveryEnvelope,
+        userId: String,
+        chatId: String,
+        oldCEK: Data,
+        newCEK: Data,
+        now: Date = Date()
+    ) throws -> PendingRecoveryEnvelope {
+        let payload = try decrypt(
+            cek: oldCEK,
+            userId: userId,
+            chatId: chatId,
+            envelope: envelope,
+            now: now
+        )
+        let keyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: newCEK)
+        let metadata = PendingRecoveryEnvelope(
+            v: envelope.v,
+            turnId: envelope.turnId,
+            keyId: keyId,
+            createdAt: envelope.createdAt,
+            expiresAt: envelope.expiresAt,
+            nonce: "",
+            ciphertext: ""
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let nonce = AES.GCM.Nonce()
+        let sealed = try AES.GCM.seal(
+            plaintext,
+            using: try envelopeKey(newCEK),
+            nonce: nonce,
+            authenticating: try aad(userId: userId, chatId: chatId, envelope: metadata)
+        )
+        let rewrapped = PendingRecoveryEnvelope(
+            v: metadata.v,
+            turnId: metadata.turnId,
+            keyId: metadata.keyId,
+            createdAt: metadata.createdAt,
+            expiresAt: metadata.expiresAt,
+            nonce: Data(nonce).base64EncodedString(),
+            ciphertext: (sealed.ciphertext + sealed.tag).base64EncodedString()
+        )
+        try validate(rewrapped)
+        return rewrapped
+    }
+
+    static func validate(_ envelope: PendingRecoveryEnvelope) throws {
+        guard envelope.v == Constants.ChatRecovery.envelopeVersion else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+        try requireIdentifier(envelope.turnId)
+        try requireLowercaseHex(
+            envelope.keyId,
+            length: Constants.ChatRecovery.keyIdHexLength
+        )
+        guard let createdAt = parseTimestamp(envelope.createdAt),
+              let expiresAt = parseTimestamp(envelope.expiresAt),
+              expiresAt > createdAt,
+              expiresAt.timeIntervalSince(createdAt) <= Constants.ChatRecovery.envelopeLifetimeSeconds
+        else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+        guard let nonce = canonicalBase64(
+                  envelope.nonce,
+                  maxDecodedBytes: Constants.ChatRecovery.nonceBytes
+              ),
+              nonce.count == Constants.ChatRecovery.nonceBytes,
+              let ciphertext = canonicalBase64(
+                  envelope.ciphertext,
+                  maxDecodedBytes: Constants.ChatRecovery.maxCiphertextBytes
+              ),
+              ciphertext.count > Constants.ChatRecovery.authenticationTagBytes,
+              ciphertext.count <= Constants.ChatRecovery.maxCiphertextBytes
+        else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+    }
+
+    static func isExpired(
+        _ envelope: PendingRecoveryEnvelope,
+        now: Date = Date()
+    ) throws -> Bool {
+        try validate(envelope)
+        guard let expiry = parseTimestamp(envelope.expiresAt) else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+        return now >= expiry
+    }
+
+    private static func envelopeKey(_ cek: Data) throws -> SymmetricKey {
+        guard cek.count == Constants.ChatRecovery.cekBytes else {
+            throw ChatRecoveryCryptoError.invalidKey
+        }
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: cek),
+            salt: Data(),
+            info: Data(Constants.ChatRecovery.hkdfInfo.utf8),
+            outputByteCount: Constants.ChatRecovery.cekBytes
+        )
+    }
+
+    private static func aad(
+        userId: String,
+        chatId: String,
+        envelope: PendingRecoveryEnvelope
+    ) throws -> Data {
+        try requireIdentifier(userId)
+        try requireIdentifier(chatId)
+        return try JSONSerialization.data(
+            withJSONObject: [
+                Constants.ChatRecovery.aadLabel,
+                userId,
+                chatId,
+                envelope.turnId,
+                envelope.keyId,
+                envelope.v,
+                envelope.createdAt,
+                envelope.expiresAt,
+            ],
+            options: [.withoutEscapingSlashes]
+        )
+    }
+
+    private static func requireIdentifier(_ value: String) throws {
+        guard !value.isEmpty,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              value.count <= Constants.ChatRecovery.maxIdentifierLength
+        else {
+            throw ChatRecoveryCryptoError.invalidIdentifier
+        }
+    }
+
+    private static func requireToken(_ token: ChatRecoveryTokenPayload) throws {
+        guard let fields = token.fields else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+        try requireLowercaseHex(
+            fields.exportedSecret,
+            length: Constants.ChatRecovery.tokenFieldHexLength
+        )
+        try requireLowercaseHex(
+            fields.requestEnc,
+            length: Constants.ChatRecovery.tokenFieldHexLength
+        )
+    }
+
+    private static func requireLowercaseHex(_ value: String, length: Int) throws {
+        guard value.count == length,
+              value.unicodeScalars.allSatisfy({
+                  (48...57).contains(Int($0.value))
+                      || (97...102).contains(Int($0.value))
+              })
+        else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+    }
+
+    private static func canonicalBase64(
+        _ value: String,
+        maxDecodedBytes: Int
+    ) -> Data? {
+        let maxEncodedCharacters = (
+            (maxDecodedBytes + base64DecodedBlockBytes - 1) / base64DecodedBlockBytes
+        ) * base64EncodedBlockCharacters
+        guard !value.isEmpty,
+              value.utf8.count <= maxEncodedCharacters,
+              let data = Data(base64Encoded: value),
+              data.base64EncodedString() == value
+        else {
+            return nil
+        }
+        return data
+    }
+
+    private static func parseTimestamp(_ value: String) -> Date? {
+        timestampFormatter(fractionalSeconds: true).date(from: value)
+            ?? timestampFormatter(fractionalSeconds: false).date(from: value)
+    }
+}

--- a/TinfoilChat/Services/ChatRecoveryDraftStore.swift
+++ b/TinfoilChat/Services/ChatRecoveryDraftStore.swift
@@ -92,8 +92,8 @@ func messagesApplyingRecoveryDrafts(
     drafts: [ChatRecoveryDraftKey: Message]
 ) -> [Message] {
     guard !pendingTurnIds.isEmpty, !drafts.isEmpty else { return messages }
-    let draftsByTurnId = Dictionary(
-        uniqueKeysWithValues: drafts.compactMap { key, draft in
+    let draftsByTurnId: [String: Message] = Dictionary(
+        uniqueKeysWithValues: drafts.compactMap { key, draft -> (String, Message)? in
             guard key.chatId == chatId, pendingTurnIds.contains(key.turnId) else {
                 return nil
             }
@@ -102,7 +102,7 @@ func messagesApplyingRecoveryDrafts(
     )
     guard !draftsByTurnId.isEmpty else { return messages }
 
-    let persistedAssistantTurnIds = Set(messages.compactMap { message in
+    let persistedAssistantTurnIds: Set<String> = Set(messages.compactMap { message -> String? in
         guard message.role == .assistant else { return nil }
         return message.turnId
     })

--- a/TinfoilChat/Services/ChatRecoveryDraftStore.swift
+++ b/TinfoilChat/Services/ChatRecoveryDraftStore.swift
@@ -1,0 +1,182 @@
+import Combine
+import Foundation
+
+struct ChatRecoveryDraftKey: Hashable {
+    let chatId: String
+    let turnId: String
+}
+
+@MainActor
+final class ChatRecoveryDraftStore: ObservableObject {
+    static let shared = ChatRecoveryDraftStore()
+
+    @Published private(set) var drafts: [ChatRecoveryDraftKey: Message] = [:]
+    private var accountGeneration = 0
+    private var discardedChatIds: Set<String> = []
+    private var discardedKeys: Set<ChatRecoveryDraftKey> = []
+
+    init() {}
+
+    func replace(
+        _ draft: Message,
+        chatId: String,
+        turnId: String,
+        generation: Int
+    ) {
+        let key = ChatRecoveryDraftKey(chatId: chatId, turnId: turnId)
+        guard generation == accountGeneration,
+              !discardedChatIds.contains(chatId),
+              !discardedKeys.contains(key)
+        else {
+            return
+        }
+        var streamingDraft = draft
+        streamingDraft.turnId = turnId
+        streamingDraft.isStreaming = true
+        guard drafts[key] != streamingDraft else { return }
+        drafts[key] = streamingDraft
+    }
+
+    func clear(chatId: String, turnId: String) {
+        let key = ChatRecoveryDraftKey(
+            chatId: chatId,
+            turnId: turnId
+        )
+        guard drafts[key] != nil else { return }
+        drafts.removeValue(forKey: key)
+    }
+
+    func prune(chatId: String, retaining turnIds: Set<String>) {
+        let pruned = drafts.filter { key, _ in
+            key.chatId != chatId || turnIds.contains(key.turnId)
+        }
+        guard pruned != drafts else { return }
+        drafts = pruned
+    }
+
+    func reset(generation: Int) {
+        guard generation >= accountGeneration else { return }
+        accountGeneration = generation
+        discardedChatIds.removeAll()
+        discardedKeys.removeAll()
+        clearAll()
+    }
+
+    func discard(chatId: String) {
+        discardedChatIds.insert(chatId)
+        prune(chatId: chatId, retaining: [])
+    }
+
+    func discard(chatId: String, turnId: String) {
+        let key = ChatRecoveryDraftKey(chatId: chatId, turnId: turnId)
+        discardedKeys.insert(key)
+        clear(chatId: chatId, turnId: turnId)
+    }
+
+    func allow(chatId: String, turnId: String) {
+        discardedKeys.remove(
+            ChatRecoveryDraftKey(chatId: chatId, turnId: turnId)
+        )
+    }
+
+    func clearAll() {
+        guard !drafts.isEmpty else { return }
+        drafts.removeAll()
+    }
+}
+
+func messagesApplyingRecoveryDrafts(
+    _ messages: [Message],
+    chatId: String,
+    pendingTurnIds: Set<String>,
+    drafts: [ChatRecoveryDraftKey: Message]
+) -> [Message] {
+    guard !pendingTurnIds.isEmpty, !drafts.isEmpty else { return messages }
+    let draftsByTurnId = Dictionary(
+        uniqueKeysWithValues: drafts.compactMap { key, draft in
+            guard key.chatId == chatId, pendingTurnIds.contains(key.turnId) else {
+                return nil
+            }
+            return (key.turnId, draft)
+        }
+    )
+    guard !draftsByTurnId.isEmpty else { return messages }
+
+    let persistedAssistantTurnIds = Set(messages.compactMap { message in
+        guard message.role == .assistant else { return nil }
+        return message.turnId
+    })
+    var result: [Message] = []
+    result.reserveCapacity(messages.count + draftsByTurnId.count)
+
+    for message in messages {
+        guard let turnId = message.turnId,
+              let draft = draftsByTurnId[turnId]
+        else {
+            result.append(message)
+            continue
+        }
+
+        if message.role == .assistant {
+            result.append(recoveryDraftPresentationMessage(
+                draft,
+                id: message.id,
+                timestamp: message.timestamp
+            ))
+        } else {
+            result.append(message)
+            if message.role == .user,
+               !persistedAssistantTurnIds.contains(turnId) {
+                result.append(recoveryDraftPresentationMessage(
+                    draft,
+                    id: recoveryDraftMessageId(chatId: chatId, turnId: turnId),
+                    timestamp: message.timestamp
+                ))
+            }
+        }
+    }
+    return result
+}
+
+func recoveryDraftMessageId(chatId: String, turnId: String) -> String {
+    "recovery-draft:\(chatId):\(turnId)"
+}
+
+private func recoveryDraftPresentationMessage(
+    _ draft: Message,
+    id: String,
+    timestamp: Date
+) -> Message {
+    var message = Message(
+        id: id,
+        role: .assistant,
+        turnId: draft.turnId,
+        content: draft.content,
+        thoughts: draft.thoughts,
+        isThinking: draft.isThinking,
+        timestamp: timestamp,
+        isCollapsed: draft.isCollapsed,
+        generationTimeSeconds: draft.generationTimeSeconds,
+        contentChunks: draft.contentChunks,
+        thinkingChunks: draft.thinkingChunks,
+        webSearchState: draft.webSearchState,
+        attachments: draft.attachments
+    )
+    message.isStreaming = true
+    message.streamError = draft.streamError
+    message.isRequestError = draft.isRequestError
+    message.isRateLimitError = draft.isRateLimitError
+    message.isHourlyLimitError = draft.isHourlyLimitError
+    message.isConnectionError = draft.isConnectionError
+    message.urlFetches = draft.urlFetches
+    message.thinkingDuration = draft.thinkingDuration
+    message.isError = draft.isError
+    message.webSearchBeforeThinking = draft.webSearchBeforeThinking
+    message.annotations = draft.annotations
+    message.searchReasoning = draft.searchReasoning
+    message.segments = draft.segments
+    message.webSearches = draft.webSearches
+    message.toolCalls = draft.toolCalls
+    message.timeline = draft.timeline
+    return message
+}

--- a/TinfoilChat/Services/ChatRecoveryDraftStore.swift
+++ b/TinfoilChat/Services/ChatRecoveryDraftStore.swift
@@ -12,6 +12,7 @@ final class ChatRecoveryDraftStore: ObservableObject {
 
     @Published private(set) var drafts: [ChatRecoveryDraftKey: Message] = [:]
     private var accountGeneration = 0
+    private var scanGeneration = 0
     private var discardedChatIds: Set<String> = []
     private var discardedKeys: Set<ChatRecoveryDraftKey> = []
 
@@ -21,10 +22,12 @@ final class ChatRecoveryDraftStore: ObservableObject {
         _ draft: Message,
         chatId: String,
         turnId: String,
-        generation: Int
+        generation: Int,
+        scanGeneration: Int? = nil
     ) {
         let key = ChatRecoveryDraftKey(chatId: chatId, turnId: turnId)
         guard generation == accountGeneration,
+              scanGeneration == nil || scanGeneration == self.scanGeneration,
               !discardedChatIds.contains(chatId),
               !discardedKeys.contains(key)
         else {
@@ -35,6 +38,11 @@ final class ChatRecoveryDraftStore: ObservableObject {
         streamingDraft.isStreaming = true
         guard drafts[key] != streamingDraft else { return }
         drafts[key] = streamingDraft
+    }
+
+    func beginScan(generation: Int) {
+        guard generation >= scanGeneration else { return }
+        scanGeneration = generation
     }
 
     func clear(chatId: String, turnId: String) {
@@ -57,6 +65,7 @@ final class ChatRecoveryDraftStore: ObservableObject {
     func reset(generation: Int) {
         guard generation >= accountGeneration else { return }
         accountGeneration = generation
+        scanGeneration = 0
         discardedChatIds.removeAll()
         discardedKeys.removeAll()
         clearAll()

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -1,0 +1,304 @@
+import ClerkKit
+import Foundation
+
+enum ChatRecoverySyncError: Error {
+    case chatMissing
+    case envelopeMissing
+    case pendingLimitReached
+    case conflict
+}
+
+actor ChatRecoverySync {
+    static let shared = ChatRecoverySync()
+
+    enum Mutation {
+        case add(PendingRecoveryEnvelope)
+        case remove(turnId: String)
+        case cancel(turnId: String, response: Message?)
+        case replace(old: PendingRecoveryEnvelope, new: PendingRecoveryEnvelope)
+        case complete(
+            envelope: PendingRecoveryEnvelope,
+            response: Message,
+            title: String?,
+            titleState: Chat.TitleState?
+        )
+    }
+
+    func mutate(
+        chatId: String,
+        userId: String,
+        mutation: Mutation
+    ) async throws {
+        var lastError: Error = ChatRecoverySyncError.conflict
+        for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            do {
+                guard await Clerk.shared.user?.id == userId else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
+                guard let remote = try await CloudStorageService.shared.downloadChat(chatId) else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
+                let local = try? await EncryptedFileStorage.cloud.loadChat(
+                    chatId: chatId,
+                    userId: userId
+                )
+                guard let remoteChat = await MainActor.run(body: { remote.toChat() }) else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
+                var candidate = preferredBase(local: local, remote: remoteChat)
+                try apply(mutation, to: &candidate, authoritativeRemote: remoteChat)
+                candidate.syncVersion = remote.syncVersion
+                stampEdit(&candidate, observedRemote: remoteChat)
+                candidate.locallyModified = true
+
+                guard await Clerk.shared.user?.id == userId else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
+                let result = try await CloudStorageService.shared.uploadChat(
+                    StoredChat(from: candidate, syncVersion: remote.syncVersion),
+                    idempotencyKey: UUID().uuidString.lowercased()
+                )
+                applyAttachmentRewrites(result.rewrites, to: &candidate)
+                candidate.syncVersion = result.syncVersion ?? remote.syncVersion + 1
+                candidate.syncedAt = Date()
+                candidate.locallyModified = false
+                candidate.clockVersion = candidate.syncVersion
+                guard await Clerk.shared.user?.id == userId else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
+                await applyLocally(
+                    candidate,
+                    mutation: mutation,
+                    userId: userId,
+                    expectedBaselineUpdatedAt: local?.updatedAt
+                )
+                return
+            } catch let error as SyncEnclaveError
+                where EnclaveErrorRecovery.isVersionConflict(error) {
+                lastError = error
+                continue
+            } catch {
+                throw error
+            }
+        }
+        throw lastError
+    }
+
+    func refreshFromRemote(chatId: String, userId: String) async throws {
+        for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            guard await Clerk.shared.user?.id == userId,
+                  let remote = try await CloudStorageService.shared.downloadChat(chatId),
+                  var chat = await MainActor.run(body: { remote.toChat() }),
+                  !chat.decryptionFailed,
+                  !chat.dataCorrupted
+            else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            let local = try? await EncryptedFileStorage.cloud.loadChat(
+                chatId: chatId,
+                userId: userId
+            )
+            guard local?.locallyModified != true else {
+                throw ChatRecoverySyncError.conflict
+            }
+            guard await Clerk.shared.user?.id == userId else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            chat.syncedAt = Date()
+            chat.locallyModified = false
+            if try await EncryptedFileStorage.cloud.applyRemoteChatIfFresh(
+                chat,
+                userId: userId,
+                expectedLocalUpdatedAt: local?.updatedAt
+            ) {
+                return
+            }
+        }
+        throw ChatRecoverySyncError.conflict
+    }
+
+    private func preferredBase(local: Chat?, remote: Chat) -> Chat {
+        guard let local else { return remote }
+        let localClock = trustedClock(local)
+        let remoteClock = trustedClock(remote)
+        let remoteWins = SyncConflictResolver.remoteWins(
+            localClock: localClock,
+            remoteClock: remoteClock,
+            localUpdatedAt: local.updatedAt,
+            remoteUpdatedAt: remote.updatedAt
+        )
+        return remoteWins ? remote : local
+    }
+
+    private func trustedClock(_ chat: Chat) -> EditClock? {
+        guard let clock = chat.clock,
+              let writer = chat.writer,
+              chat.clockVersion == chat.syncVersion
+        else {
+            return nil
+        }
+        return EditClock(v: clock, w: writer)
+    }
+
+    private func applyAttachmentRewrites(
+        _ rewrites: [CloudStorageService.AttachmentRewrite],
+        to chat: inout Chat
+    ) {
+        let byClientId = Dictionary(
+            rewrites.map { ($0.clientId, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for messageIndex in chat.messages.indices {
+            for attachmentIndex in chat.messages[messageIndex].attachments.indices {
+                let clientId = chat.messages[messageIndex].attachments[attachmentIndex].id
+                guard let rewrite = byClientId[clientId] else { continue }
+                chat.messages[messageIndex].attachments[attachmentIndex].id = rewrite.serverId
+                chat.messages[messageIndex].attachments[attachmentIndex].encryptionKey =
+                    rewrite.encryptionKey
+                chat.messages[messageIndex].attachments[attachmentIndex].base64 = nil
+            }
+        }
+    }
+
+    private func apply(
+        _ mutation: Mutation,
+        to chat: inout Chat,
+        authoritativeRemote: Chat
+    ) throws {
+        var pending = chat.pendingRecoveries ?? []
+        switch mutation {
+        case .add(let envelope):
+            pending.removeAll { $0.turnId == envelope.turnId }
+            pending.removeAll { envelopeIsExpired($0) }
+            guard pending.count < Constants.ChatRecovery.maxPendingPerChat else {
+                throw ChatRecoverySyncError.pendingLimitReached
+            }
+            pending.append(envelope)
+        case .remove(let turnId):
+            pending.removeAll { $0.turnId == turnId }
+        case .cancel(let turnId, let response):
+            guard authoritativeRemote.pendingRecoveries?.contains(where: {
+                $0.turnId == turnId
+            }) == true else {
+                throw ChatRecoverySyncError.envelopeMissing
+            }
+            pending.removeAll { $0.turnId == turnId }
+            if let response,
+               let index = chat.messages.firstIndex(where: {
+                   $0.role == .assistant && $0.turnId == turnId
+               }) {
+                chat.messages[index] = response
+            }
+        case .replace(let old, let new):
+            guard authoritativeRemote.pendingRecoveries?.contains(old) == true
+                    || authoritativeRemote.pendingRecoveries?.contains(new) == true,
+                  let index = pending.firstIndex(of: old)
+            else {
+                throw ChatRecoverySyncError.envelopeMissing
+            }
+            pending[index] = new
+        case .complete(let envelope, let response, let title, let titleState):
+            let alreadyCompleted = authoritativeRemote.messages.contains {
+                sameRecoveredResponse($0, response)
+            }
+            guard (authoritativeRemote.pendingRecoveries?.contains(envelope) == true
+                    || alreadyCompleted),
+                  (pending.contains(envelope) || alreadyCompleted)
+            else {
+                throw ChatRecoverySyncError.envelopeMissing
+            }
+            pending.removeAll { $0.turnId == envelope.turnId }
+            if let index = chat.messages.firstIndex(where: {
+                $0.role == .assistant && $0.turnId == envelope.turnId
+            }) {
+                chat.messages[index] = response
+            } else {
+                chat.messages.append(response)
+            }
+            if let title {
+                chat.title = title
+            }
+            if let titleState {
+                chat.titleState = titleState
+            }
+        }
+        chat.pendingRecoveries = pending.isEmpty ? nil : pending
+    }
+
+    private func sameRecoveredResponse(_ lhs: Message, _ rhs: Message) -> Bool {
+        lhs.role == .assistant
+            && lhs.turnId == rhs.turnId
+            && lhs.content == rhs.content
+            && lhs.thoughts == rhs.thoughts
+            && lhs.generationTimeSeconds == rhs.generationTimeSeconds
+            && lhs.segments == rhs.segments
+            && lhs.webSearches == rhs.webSearches
+            && lhs.webSearchState == rhs.webSearchState
+            && lhs.urlFetches == rhs.urlFetches
+            && lhs.toolCalls == rhs.toolCalls
+            && lhs.timeline == rhs.timeline
+            && lhs.annotations == rhs.annotations
+    }
+
+    private func stampEdit(_ chat: inout Chat, observedRemote: Chat) {
+        EditClockStore.observe(chat.clock)
+        EditClockStore.observe(observedRemote.clock)
+        let clock = EditClockStore.nextClock(
+            observedMax: max(chat.clock ?? 0, observedRemote.clock ?? 0)
+        )
+        chat.clock = clock.v
+        chat.writer = clock.w
+        chat.clockVersion = chat.syncVersion + 1
+        chat.updatedAt = Date()
+    }
+
+    private func applyLocally(
+        _ uploaded: Chat,
+        mutation: Mutation,
+        userId: String,
+        expectedBaselineUpdatedAt: Date?
+    ) async {
+        for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            let loaded = try? await EncryptedFileStorage.cloud.loadChat(
+                chatId: uploaded.id,
+                userId: userId
+            )
+            let expectedUpdatedAt = loaded?.updatedAt
+            var candidate: Chat
+            if loaded?.updatedAt == expectedBaselineUpdatedAt {
+                candidate = uploaded
+            } else if var local = loaded {
+                do {
+                    try apply(mutation, to: &local, authoritativeRemote: uploaded)
+                } catch {
+                    return
+                }
+                local.syncVersion = uploaded.syncVersion
+                stampEdit(&local, observedRemote: uploaded)
+                local.locallyModified = true
+                candidate = local
+            } else {
+                return
+            }
+            let applied = (try? await EncryptedFileStorage.cloud.applyRemoteChatIfFresh(
+                candidate,
+                userId: userId,
+                expectedLocalUpdatedAt: expectedUpdatedAt,
+                allowLocallyModified: true
+            )) ?? false
+            if applied {
+                if candidate.locallyModified {
+                    await CloudSyncService.shared.backupChat(candidate.id)
+                }
+                return
+            }
+        }
+    }
+
+    private func envelopeIsExpired(_ envelope: PendingRecoveryEnvelope) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: envelope.expiresAt).map { $0 <= Date() } ?? true
+    }
+
+}

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -8,8 +8,27 @@ enum ChatRecoverySyncError: Error {
     case conflict
 }
 
+enum ChatRecoveryStorage: String, Sendable {
+    case cloud
+    case local
+
+    var fileStorage: EncryptedFileStorage {
+        switch self {
+        case .cloud:
+            return .cloud
+        case .local:
+            return .local
+        }
+    }
+}
+
 actor ChatRecoverySync {
     static let shared = ChatRecoverySync()
+    private let expiryFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
 
     enum Mutation {
         case add(PendingRecoveryEnvelope)
@@ -27,8 +46,18 @@ actor ChatRecoverySync {
     func mutate(
         chatId: String,
         userId: String,
+        storage: ChatRecoveryStorage,
         mutation: Mutation
     ) async throws {
+        if storage == .local {
+            try await mutateLocal(
+                chatId: chatId,
+                userId: userId,
+                mutation: mutation
+            )
+            return
+        }
+
         var lastError: Error = ChatRecoverySyncError.conflict
         for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
             do {
@@ -38,12 +67,18 @@ actor ChatRecoverySync {
                 guard let remote = try await CloudStorageService.shared.downloadChat(chatId) else {
                     throw ChatRecoverySyncError.chatMissing
                 }
-                let local = try? await EncryptedFileStorage.cloud.loadChat(
+                let loadedLocal = try? await EncryptedFileStorage.cloud.loadChat(
                     chatId: chatId,
                     userId: userId
                 )
                 guard let remoteChat = await MainActor.run(body: { remote.toChat() }) else {
                     throw ChatRecoverySyncError.chatMissing
+                }
+                guard !remoteChat.decryptionFailed, !remoteChat.dataCorrupted else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
+                let local = loadedLocal.flatMap {
+                    $0.decryptionFailed || $0.dataCorrupted ? nil : $0
                 }
                 var candidate = preferredBase(local: local, remote: remoteChat)
                 try apply(mutation, to: &candidate, authoritativeRemote: remoteChat)
@@ -82,6 +117,39 @@ actor ChatRecoverySync {
             }
         }
         throw lastError
+    }
+
+    private func mutateLocal(
+        chatId: String,
+        userId: String,
+        mutation: Mutation
+    ) async throws {
+        for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            guard await Clerk.shared.user?.id == userId,
+                  let local = try await EncryptedFileStorage.local.loadChat(
+                      chatId: chatId,
+                      userId: userId
+                  )
+            else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            var candidate = local
+            try apply(mutation, to: &candidate, authoritativeRemote: local)
+            candidate.updatedAt = Date()
+            candidate.locallyModified = true
+            guard await Clerk.shared.user?.id == userId else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            if try await EncryptedFileStorage.local.applyRemoteChatIfFresh(
+                candidate,
+                userId: userId,
+                expectedLocalUpdatedAt: local.updatedAt,
+                allowLocallyModified: true
+            ) {
+                return
+            }
+        }
+        throw ChatRecoverySyncError.conflict
     }
 
     func refreshFromRemote(chatId: String, userId: String) async throws {
@@ -190,6 +258,9 @@ actor ChatRecoverySync {
                 chat.messages[index] = response
             }
         case .replace(let old, let new):
+            if pending.contains(new) {
+                break
+            }
             guard authoritativeRemote.pendingRecoveries?.contains(old) == true
                     || authoritativeRemote.pendingRecoveries?.contains(new) == true,
                   let index = pending.firstIndex(of: old)
@@ -296,9 +367,7 @@ actor ChatRecoverySync {
     }
 
     private func envelopeIsExpired(_ envelope: PendingRecoveryEnvelope) -> Bool {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.date(from: envelope.expiresAt).map { $0 <= Date() } ?? true
+        expiryFormatter.date(from: envelope.expiresAt).map { $0 <= Date() } ?? true
     }
 
 }

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -32,7 +32,7 @@ actor ChatRecoverySync {
 
     enum Mutation {
         case add(PendingRecoveryEnvelope)
-        case remove(turnId: String)
+        case remove(PendingRecoveryEnvelope)
         case cancel(turnId: String, response: Message?)
         case replace(old: PendingRecoveryEnvelope, new: PendingRecoveryEnvelope)
         case complete(
@@ -49,6 +49,7 @@ actor ChatRecoverySync {
         storage: ChatRecoveryStorage,
         mutation: Mutation
     ) async throws {
+        try Task.checkCancellation()
         if storage == .local {
             try await mutateLocal(
                 chatId: chatId,
@@ -61,19 +62,23 @@ actor ChatRecoverySync {
         var lastError: Error = ChatRecoverySyncError.conflict
         for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
             do {
+                try Task.checkCancellation()
                 guard await Clerk.shared.user?.id == userId else {
                     throw ChatRecoverySyncError.chatMissing
                 }
                 guard let remote = try await CloudStorageService.shared.downloadChat(chatId) else {
                     throw ChatRecoverySyncError.chatMissing
                 }
+                try Task.checkCancellation()
                 let loadedLocal = try? await EncryptedFileStorage.cloud.loadChat(
                     chatId: chatId,
                     userId: userId
                 )
+                try Task.checkCancellation()
                 guard let remoteChat = await MainActor.run(body: { remote.toChat() }) else {
                     throw ChatRecoverySyncError.chatMissing
                 }
+                try Task.checkCancellation()
                 guard !remoteChat.decryptionFailed, !remoteChat.dataCorrupted else {
                     throw ChatRecoverySyncError.chatMissing
                 }
@@ -89,10 +94,12 @@ actor ChatRecoverySync {
                 guard await Clerk.shared.user?.id == userId else {
                     throw ChatRecoverySyncError.chatMissing
                 }
+                try Task.checkCancellation()
                 let result = try await CloudStorageService.shared.uploadChat(
                     StoredChat(from: candidate, syncVersion: remote.syncVersion),
                     idempotencyKey: UUID().uuidString.lowercased()
                 )
+                try Task.checkCancellation()
                 applyAttachmentRewrites(result.rewrites, to: &candidate)
                 candidate.syncVersion = result.syncVersion ?? remote.syncVersion + 1
                 candidate.syncedAt = Date()
@@ -101,6 +108,7 @@ actor ChatRecoverySync {
                 guard await Clerk.shared.user?.id == userId else {
                     throw ChatRecoverySyncError.chatMissing
                 }
+                try Task.checkCancellation()
                 await applyLocally(
                     candidate,
                     mutation: mutation,
@@ -125,6 +133,7 @@ actor ChatRecoverySync {
         mutation: Mutation
     ) async throws {
         for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            try Task.checkCancellation()
             guard await Clerk.shared.user?.id == userId,
                   let local = try await EncryptedFileStorage.local.loadChat(
                       chatId: chatId,
@@ -133,6 +142,7 @@ actor ChatRecoverySync {
             else {
                 throw ChatRecoverySyncError.chatMissing
             }
+            try Task.checkCancellation()
             var candidate = local
             try apply(mutation, to: &candidate, authoritativeRemote: local)
             candidate.updatedAt = Date()
@@ -140,6 +150,7 @@ actor ChatRecoverySync {
             guard await Clerk.shared.user?.id == userId else {
                 throw ChatRecoverySyncError.chatMissing
             }
+            try Task.checkCancellation()
             if try await EncryptedFileStorage.local.applyRemoteChatIfFresh(
                 candidate,
                 userId: userId,
@@ -242,8 +253,13 @@ actor ChatRecoverySync {
                 throw ChatRecoverySyncError.pendingLimitReached
             }
             pending.append(envelope)
-        case .remove(let turnId):
-            pending.removeAll { $0.turnId == turnId }
+        case .remove(let envelope):
+            guard authoritativeRemote.pendingRecoveries?.contains(envelope) == true,
+                  let index = pending.firstIndex(of: envelope)
+            else {
+                throw ChatRecoverySyncError.envelopeMissing
+            }
+            pending.remove(at: index)
         case .cancel(let turnId, let response):
             guard authoritativeRemote.pendingRecoveries?.contains(where: {
                 $0.turnId == turnId
@@ -330,6 +346,7 @@ actor ChatRecoverySync {
         expectedBaselineUpdatedAt: Date?
     ) async {
         for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            guard !Task.isCancelled else { return }
             let loaded = try? await EncryptedFileStorage.cloud.loadChat(
                 chatId: uploaded.id,
                 userId: userId
@@ -357,6 +374,7 @@ actor ChatRecoverySync {
                 expectedLocalUpdatedAt: expectedUpdatedAt,
                 allowLocallyModified: true
             )) ?? false
+            guard !Task.isCancelled else { return }
             if applied {
                 if candidate.locallyModified {
                     await CloudSyncService.shared.backupChat(candidate.id)

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -299,11 +299,18 @@ actor ChatRecoverySync {
             } else {
                 chat.messages.append(response)
             }
-            if let title {
-                chat.title = title
-            }
-            if let titleState {
-                chat.titleState = titleState
+            let canApplyGeneratedTitle = titleState != .generated
+                || (
+                    authoritativeRemote.titleState == .placeholder
+                        && chat.titleState == .placeholder
+                )
+            if canApplyGeneratedTitle {
+                if let title {
+                    chat.title = title
+                }
+                if let titleState {
+                    chat.titleState = titleState
+                }
             }
         }
         chat.pendingRecoveries = pending.isEmpty ? nil : pending

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -99,22 +99,19 @@ actor ChatRecoverySync {
                     StoredChat(from: candidate, syncVersion: remote.syncVersion),
                     idempotencyKey: UUID().uuidString.lowercased()
                 )
-                try Task.checkCancellation()
                 applyAttachmentRewrites(result.rewrites, to: &candidate)
                 candidate.syncVersion = result.syncVersion ?? remote.syncVersion + 1
                 candidate.syncedAt = Date()
                 candidate.locallyModified = false
                 candidate.clockVersion = candidate.syncVersion
-                guard await Clerk.shared.user?.id == userId else {
-                    throw ChatRecoverySyncError.chatMissing
-                }
-                try Task.checkCancellation()
-                await applyLocally(
-                    candidate,
-                    mutation: mutation,
-                    userId: userId,
-                    expectedBaselineUpdatedAt: local?.updatedAt
-                )
+                await Task {
+                    await self.applyLocally(
+                        candidate,
+                        mutation: mutation,
+                        userId: userId,
+                        expectedBaselineUpdatedAt: local?.updatedAt
+                    )
+                }.value
                 return
             } catch let error as SyncEnclaveError
                 where EnclaveErrorRecovery.isVersionConflict(error) {
@@ -346,7 +343,6 @@ actor ChatRecoverySync {
         expectedBaselineUpdatedAt: Date?
     ) async {
         for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
-            guard !Task.isCancelled else { return }
             let loaded = try? await EncryptedFileStorage.cloud.loadChat(
                 chatId: uploaded.id,
                 userId: userId
@@ -374,7 +370,6 @@ actor ChatRecoverySync {
                 expectedLocalUpdatedAt: expectedUpdatedAt,
                 allowLocallyModified: true
             )) ?? false
-            guard !Task.isCancelled else { return }
             if applied {
                 if candidate.locallyModified {
                     await CloudSyncService.shared.backupChat(candidate.id)

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -114,10 +114,7 @@ class CloudStorageService: ObservableObject {
     @discardableResult
     func uploadChat(_ chat: StoredChat, idempotencyKey: String) async throws -> UploadChatResult {
         var chatToUpload = chat
-        let rewrites = try await encryptAndUploadAttachments(
-            &chatToUpload,
-            idempotencyKey: idempotencyKey
-        )
+        let rewrites = try await encryptAndUploadAttachments(&chatToUpload)
         stripBase64FromMessages(&chatToUpload.messages)
 
         let plaintext = try JSONEncoder().encode(chatToUpload)
@@ -157,14 +154,11 @@ class CloudStorageService: ObservableObject {
     }
 
     private func encryptAndUploadAttachments(
-        _ chat: inout StoredChat,
-        idempotencyKey: String
+        _ chat: inout StoredChat
     ) async throws -> [AttachmentRewrite] {
         var rewrites: [AttachmentRewrite] = []
-        var attachmentIndex = 0
         for msgIdx in chat.messages.indices {
             for attIdx in chat.messages[msgIdx].attachments.indices {
-                defer { attachmentIndex += 1 }
                 let att = chat.messages[msgIdx].attachments[attIdx]
                 guard att.type == .image,
                       let base64 = att.base64,
@@ -173,8 +167,9 @@ class CloudStorageService: ObservableObject {
                     continue
                 }
                 let attIdemKey = attachmentIdempotencyKey(
-                    uploadKey: idempotencyKey,
-                    attachmentIndex: attachmentIndex
+                    chatId: chat.id,
+                    clientId: att.id,
+                    plaintext: raw
                 )
                 // The enclave mints both the durable attachment id
                 // and a fresh per-attachment AES-256 key. The chat
@@ -211,10 +206,16 @@ class CloudStorageService: ObservableObject {
         }
     }
 
-    private func attachmentIdempotencyKey(uploadKey: String, attachmentIndex: Int) -> String {
-        let input = "attachment:\(uploadKey):\(attachmentIndex)"
-        let digest = SHA256.hash(data: Data(input.utf8))
-        return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+    private func attachmentIdempotencyKey(
+        chatId: String,
+        clientId: String,
+        plaintext: Data
+    ) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("attachment:\(chatId):\(clientId):".utf8))
+        hasher.update(data: plaintext)
+        let digest = hasher.finalize()
+        return dataToHex(Data(digest.prefix(16)))
     }
 
     // MARK: - Download

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -444,8 +444,7 @@ class CloudSyncService: ObservableObject {
                   ),
                   chat.messages.contains(where: {
                       $0.role == .user && $0.turnId == requiredTurnId
-                  }),
-                  !streamingTracker.isStreaming(chatId)
+                  })
             else {
                 throw SyncEnclaveError(message: "required chat turn is not ready for backup")
             }
@@ -458,7 +457,7 @@ class CloudSyncService: ObservableObject {
                     throw SyncEnclaveError(message: "account changed during cloud backup")
                 }
                 let newVersion = result.syncVersion ?? chat.syncVersion + 1
-                _ = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
+                let fullySynced = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
                     chatId: chat.id,
                     userId: userId,
                     expectedUpdatedAt: chat.updatedAt,
@@ -471,6 +470,9 @@ class CloudSyncService: ObservableObject {
                         )
                     }
                 )
+                if fullySynced {
+                    SyncHealthStore.shared.reportChatSynced(chat.id)
+                }
                 return
             } catch let error as SyncEnclaveError
                 where EnclaveErrorRecovery.isVersionConflict(error) {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -425,6 +425,92 @@ class CloudSyncService: ObservableObject {
         }
     }
 
+    func backupChatAndWait(_ chatId: String, requiredTurnId: String) async throws {
+        let generation = accountGeneration
+        guard let userId = await getCurrentUserId(),
+              await cloudStorage.isAuthenticated(), await canWriteToCloud(),
+              generation == accountGeneration
+        else {
+            throw SyncEnclaveError(message: "chat is not ready for cloud backup")
+        }
+
+        beginPendingUpload(chatId)
+        defer { endPendingUpload(chatId, generation: generation) }
+        for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            guard generation == accountGeneration,
+                  let chat = try? await EncryptedFileStorage.cloud.loadChat(
+                      chatId: chatId,
+                      userId: userId
+                  ),
+                  chat.messages.contains(where: {
+                      $0.role == .user && $0.turnId == requiredTurnId
+                  }),
+                  !streamingTracker.isStreaming(chatId)
+            else {
+                throw SyncEnclaveError(message: "required chat turn is not ready for backup")
+            }
+            do {
+                let result = try await cloudStorage.uploadChat(
+                    StoredChat(from: chat, syncVersion: chat.syncVersion),
+                    idempotencyKey: newSyncEnclaveIdempotencyKey()
+                )
+                guard generation == accountGeneration else {
+                    throw SyncEnclaveError(message: "account changed during cloud backup")
+                }
+                let newVersion = result.syncVersion ?? chat.syncVersion + 1
+                _ = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
+                    chatId: chat.id,
+                    userId: userId,
+                    expectedUpdatedAt: chat.updatedAt,
+                    syncVersion: newVersion,
+                    attachmentRewrites: result.rewrites.map {
+                        (
+                            clientId: $0.clientId,
+                            serverId: $0.serverId,
+                            encryptionKey: $0.encryptionKey
+                        )
+                    }
+                )
+                return
+            } catch let error as SyncEnclaveError
+                where EnclaveErrorRecovery.isVersionConflict(error) {
+                guard let remote = try await cloudStorage.downloadChat(chatId),
+                      let remoteChat = await convertStoredChat(remote)
+                else {
+                    throw error
+                }
+                let localClock = trustedChatClock(chat)
+                let remoteClock = trustedChatClock(remoteChat)
+                guard !SyncConflictResolver.remoteWins(
+                    localClock: localClock,
+                    remoteClock: remoteClock,
+                    localUpdatedAt: chat.updatedAt,
+                    remoteUpdatedAt: remoteChat.updatedAt
+                ) else {
+                    throw error
+                }
+                try await EncryptedFileStorage.cloud.updateSyncMetadata(
+                    chatId: chatId,
+                    userId: userId,
+                    syncVersion: remote.syncVersion,
+                    syncedAt: chat.syncedAt ?? Date(),
+                    locallyModified: true
+                )
+            }
+        }
+        throw SyncEnclaveError(message: "required chat turn could not be backed up")
+    }
+
+    private func trustedChatClock(_ chat: Chat) -> EditClock? {
+        guard let clock = chat.clock,
+              let writer = chat.writer,
+              chat.clockVersion == chat.syncVersion
+        else {
+            return nil
+        }
+        return EditClock(v: clock, w: writer)
+    }
+
     private func beginPendingUpload(_ chatId: String) {
         pendingUploadCounts[chatId, default: 0] += 1
         pendingUploadChatIds.insert(chatId)

--- a/TinfoilChat/Services/DeviceEncryptionService.swift
+++ b/TinfoilChat/Services/DeviceEncryptionService.swift
@@ -37,8 +37,13 @@ actor DeviceEncryptionService: ChatEncryptor {
     }
 
     func decryptData(_ encrypted: EncryptedData) async throws -> Data {
-        let key = try getOrCreateKey()
+        let key = try getExistingKey()
         return try AESGCMHelper.open(encrypted, using: key)
+    }
+
+    func getKeyBytesOrThrow() throws -> Data {
+        let key = try getExistingKey()
+        return key.withUnsafeBytes { Data($0) }
     }
 
     // MARK: - Key Management
@@ -51,18 +56,24 @@ actor DeviceEncryptionService: ChatEncryptor {
 
     // MARK: - Private
 
-    private func getOrCreateKey() throws -> SymmetricKey {
+    private func getExistingKey() throws -> SymmetricKey {
         if let key = cachedKey { return key }
-
-        if let existing = loadKeyFromKeychain() {
-            cachedKey = existing
-            return existing
+        guard let key = loadKeyFromKeychain() else {
+            throw EncryptionError.keyNotInitialized
         }
+        cachedKey = key
+        return key
+    }
 
-        let newKey = SymmetricKey(size: .bits256)
-        try saveKeyToKeychain(newKey)
-        cachedKey = newKey
-        return newKey
+    private func getOrCreateKey() throws -> SymmetricKey {
+        do {
+            return try getExistingKey()
+        } catch EncryptionError.keyNotInitialized {
+            let newKey = SymmetricKey(size: .bits256)
+            try saveKeyToKeychain(newKey)
+            cachedKey = newKey
+            return newKey
+        }
     }
 
     private func loadKeyFromKeychain() -> SymmetricKey? {

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -587,6 +587,14 @@ actor EncryptedFileStorage {
         return try await loadChats(chatIds: entries.map(\.id), userId: userId)
     }
 
+    func loadChatsWithPendingRecoveries(userId: String) async throws -> [Chat] {
+        let entries = try await loadIndex(userId: userId)
+        let chatIds = entries.compactMap {
+            $0.hasPendingRecoveries == true ? $0.id : nil
+        }
+        return try await loadChats(chatIds: chatIds, userId: userId)
+    }
+
     // MARK: - Error Recovery
 
     func rebuildIndex(userId: String) async throws -> [ChatIndexEntry] {

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -242,7 +242,8 @@ class ProfileSyncService: ObservableObject {
         do {
             let result = try await pushAtVersion(profile.version ?? 0)
             return (result.success, result.version, nil)
-        } catch let error as SyncEnclaveError where Self.isStaleBlobConflict(error) {
+        } catch let error as SyncEnclaveError
+            where EnclaveErrorRecovery.isVersionConflict(error) {
             // Optimistic-concurrency conflict: the server holds a
             // version our push was not based on. Re-read it and merge
             // field by field so neither device's edits are lost, then
@@ -312,15 +313,6 @@ class ProfileSyncService: ObservableObject {
             for: unknownFieldsKey,
             service: unknownFieldsService
         )
-    }
-
-    /// A STALE_BLOB (HTTP 412) push means our If-Match version no longer
-    /// matches the server: either the row advanced under another writer
-    /// or we tried to create a profile that already exists.
-    private static func isStaleBlobConflict(_ error: SyncEnclaveError) -> Bool {
-        error.code == WireCodes.staleBlob
-            || error.status == 412
-            || (error.status == 409 && error.code == WireCodes.syncConflict)
     }
 
     /// Re-attempt a profile fetch after a key change. The enclave

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -234,26 +234,25 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         if isWebSearchEnabled, let annotations = chunk.choices.first?.delta.annotations {
             var didCollectNewSource = false
             for annotation in annotations where annotation.type == "url_citation" {
-                if let citation = annotation.urlCitation {
-                    let source = WebSearchSource(
-                        title: citation.title ?? citation.url,
-                        url: citation.url
-                    )
-                    collectedSources.append(source)
-                    collectedAnnotations.append(
-                        Annotation(
-                            type: "url_citation",
-                            url_citation: URLCitation(
-                                title: citation.title ?? citation.url,
-                                url: citation.url,
-                                start_index: nil,
-                                end_index: nil
-                            )
+                let citation = annotation.urlCitation
+                let source = WebSearchSource(
+                    title: citation.title ?? citation.url,
+                    url: citation.url
+                )
+                collectedSources.append(source)
+                collectedAnnotations.append(
+                    Annotation(
+                        type: "url_citation",
+                        url_citation: URLCitation(
+                            title: citation.title ?? citation.url,
+                            url: citation.url,
+                            start_index: nil,
+                            end_index: nil
                         )
                     )
-                    didCollectNewSource = true
-                    outcome.didMutateState = true
-                }
+                )
+                didCollectNewSource = true
+                outcome.didMutateState = true
             }
             // Mirror the running sources onto the most recent WebSearchInstance.
             // When the router sent `.completed` before any sources, we held the

--- a/TinfoilChat/Services/SummarizerService.swift
+++ b/TinfoilChat/Services/SummarizerService.swift
@@ -79,9 +79,10 @@ actor SummarizerService {
         }
 
         let truncatedContent = assistantMessage.content
-            .split(separator: " ", omittingEmptySubsequences: true)
+            .split(whereSeparator: \.isWhitespace)
             .prefix(Constants.TitleGeneration.wordThreshold)
             .joined(separator: " ")
+        guard !truncatedContent.isEmpty else { return nil }
 
         guard let title = try? await summarize(
             content: truncatedContent,

--- a/TinfoilChat/Services/SummarizerService.swift
+++ b/TinfoilChat/Services/SummarizerService.swift
@@ -71,6 +71,26 @@ actor SummarizerService {
         let decoded = try JSONDecoder().decode(SummarizeResponse.self, from: response.body)
         return decoded.summary
     }
+
+    func generateChatTitle(from messages: [Message]) async -> String? {
+        guard let assistantMessage = messages.first(where: { $0.role == .assistant }),
+              !assistantMessage.content.isEmpty else {
+            return nil
+        }
+
+        let truncatedContent = assistantMessage.content
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .prefix(Constants.TitleGeneration.wordThreshold)
+            .joined(separator: " ")
+
+        guard let title = try? await summarize(
+            content: truncatedContent,
+            style: .titleSummary
+        ), !title.isEmpty else {
+            return nil
+        }
+        return title
+    }
 }
 
 // MARK: - Models

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -101,8 +101,10 @@ struct RecoveryDecision: Equatable {
 
 enum EnclaveErrorRecovery {
     static func isVersionConflict(_ error: SyncEnclaveError) -> Bool {
-        error.code == WireCodes.staleBlob
-            || (error.code == nil && error.status == 412)
+        let isUncodedPrecondition = error.status == 412
+            && (error.code == nil || error.usesHTTPStatusFallbackCode)
+        return error.code == WireCodes.staleBlob
+            || isUncodedPrecondition
             || (error.status == 409 && error.code == WireCodes.syncConflict)
     }
 

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -101,10 +101,10 @@ struct RecoveryDecision: Equatable {
 
 enum EnclaveErrorRecovery {
     static func isVersionConflict(_ error: SyncEnclaveError) -> Bool {
-        let isUncodedPrecondition = error.status == 412
+        let isUncodedVersionConflict = (error.status == 409 || error.status == 412)
             && (error.code == nil || error.usesHTTPStatusFallbackCode)
         return error.code == WireCodes.staleBlob
-            || isUncodedPrecondition
+            || isUncodedVersionConflict
             || (error.status == 409 && error.code == WireCodes.syncConflict)
     }
 

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -100,6 +100,12 @@ struct RecoveryDecision: Equatable {
 }
 
 enum EnclaveErrorRecovery {
+    static func isVersionConflict(_ error: SyncEnclaveError) -> Bool {
+        error.code == WireCodes.staleBlob
+            || (error.code == nil && error.status == 412)
+            || (error.status == 409 && error.code == WireCodes.syncConflict)
+    }
+
     /// Decide the recovery action for any thrown value from a sync
     /// enclave call. Idempotent and pure — safe to call inside a
     /// catch block before any side effects.

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -213,19 +213,83 @@ enum LegacyBlobMigration {
     /// Drop the local alternative-keys list once the migration
     /// report confirms every observed row has been re-sealed.
     @discardableResult
-    static func finalizeAlternativesIfMigrated(_ report: MigrationReport) -> Bool {
+    static func finalizeAlternativesIfMigrated(_ report: MigrationReport) async -> Bool {
         guard report.fullyMigrated else { return false }
+        guard let userId = await Clerk.shared.user?.id,
+              let primary = try? EncryptionService.shared.getKeyBytesOrThrow(),
+              let primaryKeyId = try? SyncEnclaveKeyBundle.deriveKeyIdHex(cek: primary)
+        else {
+            return false
+        }
+        guard let entries = try? await EncryptedFileStorage.cloud.loadIndex(userId: userId)
+        else {
+            return false
+        }
+        for entry in entries {
+            guard let chat = try? await EncryptedFileStorage.cloud.loadChat(
+                chatId: entry.id,
+                userId: userId
+            ) else {
+                return false
+            }
+            if chat.pendingRecoveries?.contains(where: { $0.keyId != primaryKeyId }) == true {
+                return false
+            }
+        }
+        guard await remoteRecoveriesUseOnlyPrimary(
+            userId: userId,
+            primaryKeyId: primaryKeyId
+        ) else {
+            return false
+        }
         EncryptionService.shared.clearFallbackKeys()
         return true
     }
 
     static func runAndFinalize() async -> MigrationReport {
         let report = await run()
-        _ = finalizeAlternativesIfMigrated(report)
+        _ = await finalizeAlternativesIfMigrated(report)
         return report
     }
 
     // MARK: - Private
+
+    private static func remoteRecoveriesUseOnlyPrimary(
+        userId: String,
+        primaryKeyId: String
+    ) async -> Bool {
+        var cursor: String?
+        var seenCursors: Set<String> = []
+        repeat {
+            guard await Clerk.shared.user?.id == userId,
+                  let page = try? await CloudStorageService.shared.listChats(
+                      limit: Constants.SyncEnclave.listStatusPageLimit,
+                      continuationToken: cursor,
+                      includeContent: true
+                  )
+            else {
+                return false
+            }
+            for remote in page.conversations {
+                guard let content = remote.content,
+                      let data = content.data(using: .utf8),
+                      let chat = try? JSONDecoder().decode(StoredChat.self, from: data)
+                else {
+                    return false
+                }
+                if chat.pendingRecoveries?.contains(where: {
+                    $0.keyId != primaryKeyId
+                }) == true {
+                    return false
+                }
+            }
+            cursor = page.nextContinuationToken
+            if let cursor, !cursor.isEmpty, !seenCursors.insert(cursor).inserted {
+                return false
+            }
+        } while cursor?.isEmpty == false
+        return true
+    }
 
     /// Stable, non-secret fingerprint of the migration candidate key set
     /// (primary plus alternatives) the way `CEKEncoding.migrationKeys()`

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
@@ -25,6 +25,14 @@ struct SyncEnclaveError: LocalizedError, Equatable {
     let details: [String: AnyCodable]?
 
     var errorDescription: String? { message }
+    var usesHTTPStatusFallbackCode: Bool {
+        guard let status else { return false }
+        return code == Self.httpStatusFallbackCode(status)
+    }
+
+    static func httpStatusFallbackCode(_ status: Int) -> String {
+        "HTTP_\(status)"
+    }
 
     static func == (lhs: SyncEnclaveError, rhs: SyncEnclaveError) -> Bool {
         lhs.message == rhs.message && lhs.status == rhs.status && lhs.code == rhs.code
@@ -264,7 +272,7 @@ actor SyncEnclaveClient {
 
     private static func parseError(response: SecureResponse) -> SyncEnclaveError {
         var message = "Sync enclave request failed: HTTP \(response.statusCode)"
-        var code: String? = "HTTP_\(response.statusCode)"
+        var code: String? = SyncEnclaveError.httpStatusFallbackCode(response.statusCode)
         var details: [String: AnyCodable]? = nil
         if !response.body.isEmpty,
            let parsed = try? JSONDecoder.enclave.decode([String: AnyCodable].self, from: response.body) {

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -250,8 +250,6 @@ class AuthManager: ObservableObject {
         // device. This runs before isAuthenticated is cleared below so the
         // view model can still resolve the signing-out user's id for the wipe.
         await ProfileManager.shared.clearLocalProfileForAccountRemoval()
-        EncryptionService.shared.clearKey()
-        await DeviceEncryptionService.shared.clearKey()
         if let chatViewModel {
             await chatViewModel.wipeLocalChatsForSignOut()
         } else {
@@ -260,6 +258,8 @@ class AuthManager: ObservableObject {
             // outlive the account on a shared device.
             await Chat.deleteAllChatsFromStorage(userId: localUserId)
         }
+        EncryptionService.shared.clearKey()
+        await DeviceEncryptionService.shared.clearKey()
         SettingsManager.shared.clearAllSettings()
 
         localUserData = nil

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -244,6 +244,7 @@ class AuthManager: ObservableObject {
         // Handle chat state BEFORE clearing auth so the view model can still
         // save the current chat (hasChatAccess depends on isAuthenticated).
         await chatViewModel?.handleSignOut()
+        await ChatRecoveryCoordinator.shared.reset(accountId: nil)
 
         // Sign-out performs a full local wipe so that no content, encryption
         // keys, or personalization bleed into the next account on a shared

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -61,6 +61,12 @@ func shouldBlockMessageSendForRecovery(
     !isStreaming && !pendingRecoveries.isEmpty
 }
 
+func recoveryScanHasStalled(lastProgressAt: Date?, now: Date) -> Bool {
+    guard let lastProgressAt else { return false }
+    return now.timeIntervalSince(lastProgressAt)
+        >= Constants.ChatRecovery.scanStallTimeoutSeconds
+}
+
 @MainActor
 class ChatViewModel: ObservableObject {
     // Published properties for UI updates
@@ -299,6 +305,7 @@ class ChatViewModel: ObservableObject {
     private var recoveryScanTimer: Timer?
     private var recoveryScanTask: Task<Void, Never>?
     private var recoveryScanGeneration = 0
+    private var recoveryScanLastProgressAt: Date?
     private var recoveryScansSuspended = false
     private var recoveryRescanRequested = false
     private var didBecomeActiveObserver: NSObjectProtocol?
@@ -663,16 +670,15 @@ class ChatViewModel: ObservableObject {
         autoSyncTimer?.invalidate()
         recoveryScanTimer?.invalidate()
         recoveryScanTimer = nil
+        setupRecoveryScanTimer()
 
         // Do not start auto-sync when cloud sync is disabled
         if !SettingsManager.shared.isCloudSyncEnabled {
-            setupRecoveryScanTimer()
             return
         }
 
         // Do not start auto-sync until encryption key is set up
         if !EncryptionService.shared.hasEncryptionKey() {
-            setupRecoveryScanTimer()
             return
         }
 
@@ -852,10 +858,24 @@ class ChatViewModel: ObservableObject {
     private func scanPendingRecoveries() {
         guard let userId = currentUserId else { return }
         guard !recoveryScansSuspended else { return }
-        if recoveryScanTask != nil {
+        if let activeTask = recoveryScanTask {
             recoveryRescanRequested = true
-            return
+            guard recoveryScanHasStalled(
+                lastProgressAt: recoveryScanLastProgressAt,
+                now: Date()
+            ) else {
+                return
+            }
+            recoveryRescanRequested = false
+            activeTask.cancel()
+            recoveryScanTask = nil
+            startRecoveryScan(userId: userId, replacingActiveScan: true)
+        } else {
+            startRecoveryScan(userId: userId, replacingActiveScan: false)
         }
+    }
+
+    private func startRecoveryScan(userId: String, replacingActiveScan: Bool) {
         var storages: [ChatRecoveryStorage] = [.local]
         if SettingsManager.shared.isCloudSyncEnabled,
            EncryptionService.shared.hasEncryptionKey() {
@@ -864,13 +884,19 @@ class ChatViewModel: ObservableObject {
         recoveryScanGeneration += 1
         let generation = recoveryScanGeneration
         let storagesToScan = storages
+        recoveryScanLastProgressAt = Date()
         recoveryScanTask = Task { [weak self] in
             await ChatRecoveryCoordinator.shared.scan(
                 userId: userId,
-                storages: storagesToScan
+                storages: storagesToScan,
+                replacingActiveScan: replacingActiveScan,
+                onProgress: { [weak self] in
+                    await self?.recordRecoveryScanProgress(generation: generation)
+                }
             )
             guard let self, self.recoveryScanGeneration == generation else { return }
             self.recoveryScanTask = nil
+            self.recoveryScanLastProgressAt = nil
             if self.recoveryRescanRequested {
                 self.recoveryRescanRequested = false
                 self.scanPendingRecoveries()
@@ -884,8 +910,18 @@ class ChatViewModel: ObservableObject {
         recoveryScanGeneration += 1
         let task = recoveryScanTask
         recoveryScanTask = nil
+        recoveryScanLastProgressAt = nil
         task?.cancel()
         await task?.value
+    }
+
+    private func recordRecoveryScanProgress(generation: Int) {
+        guard recoveryScanGeneration == generation,
+              recoveryScanTask != nil
+        else {
+            return
+        }
+        recoveryScanLastProgressAt = Date()
     }
 
     func resumeRecoveryScans() {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1640,7 +1640,6 @@ class ChatViewModel: ObservableObject {
 
         let userId = currentUserId
         discardMessageQueue(chatId: id)
-        ChatRecoveryDraftStore.shared.discard(chatId: id)
         let canceledStreamTask = cancelGeneration(
             chatId: id,
             announce: false
@@ -1664,6 +1663,7 @@ class ChatViewModel: ObservableObject {
             }
 
             await Chat.deleteChatFromStorage(chatId: id, userId: userId)
+            ChatRecoveryDraftStore.shared.discard(chatId: id)
 
             if let index = localChats.firstIndex(where: { $0.id == id }) {
                 localChats.remove(at: index)
@@ -2122,6 +2122,7 @@ class ChatViewModel: ObservableObject {
             recoveryStorage = nil
         }
         streamingTracker.startStreaming(streamChatId)
+        ChatRecoveryDraftStore.shared.prune(chatId: streamChatId, retaining: [])
         let streamModel = currentModel
         let streamProject = activeProject
         let streamProjectDocuments = projectDocuments

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -54,6 +54,13 @@ struct ChatStreamState {
     }
 }
 
+func shouldBlockMessageSendForRecovery(
+    pendingRecoveries: [PendingRecoveryEnvelope],
+    isStreaming: Bool
+) -> Bool {
+    !isStreaming && !pendingRecoveries.isEmpty
+}
+
 @MainActor
 class ChatViewModel: ObservableObject {
     // Published properties for UI updates
@@ -349,6 +356,13 @@ class ChatViewModel: ObservableObject {
         return streamState.isStreaming(chatId: chatId)
     }
 
+    var hasPendingResponseRecovery: Bool {
+        shouldBlockMessageSendForRecovery(
+            pendingRecoveries: currentChat?.pendingRecoveries ?? [],
+            isStreaming: isLoading
+        )
+    }
+
     /// Whether the given chat has a response currently being generated,
     /// regardless of which chat is on screen.
     func isChatStreaming(_ chatId: String) -> Bool {
@@ -610,6 +624,7 @@ class ChatViewModel: ObservableObject {
                 self.replaceChat(recovered)
                 if self.currentChat?.id == chatId {
                     self.currentChat = recovered
+                    self.scheduleMessageQueueDrain(chatId: chatId)
                 }
             }
         }
@@ -1800,6 +1815,7 @@ class ChatViewModel: ObservableObject {
         let hasAttachments = !pendingAttachments.isEmpty
         guard hasText || hasAttachments else { return false }
         guard attachmentsAreReadyToSend(pendingAttachments) else { return false }
+        guard !hasPendingResponseRecovery else { return false }
 
         if isLoading {
             guard !isMessageQueueFull else { return false }
@@ -1905,6 +1921,7 @@ class ChatViewModel: ObservableObject {
     private func drainMessageQueue(chatId: String) {
         guard currentChat?.id == chatId,
               !streamState.isStreaming(chatId: chatId),
+              !hasPendingResponseRecovery,
               var queue = messageQueues[chatId],
               !queue.isEmpty else { return }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -621,6 +621,10 @@ class ChatViewModel: ObservableObject {
                 else {
                     return
                 }
+                ChatRecoveryDraftStore.shared.prune(
+                    chatId: chatId,
+                    retaining: Set((recovered.pendingRecoveries ?? []).map(\.turnId))
+                )
                 self.replaceChat(recovered)
                 if self.currentChat?.id == chatId {
                     self.currentChat = recovered
@@ -1636,6 +1640,7 @@ class ChatViewModel: ObservableObject {
 
         let userId = currentUserId
         discardMessageQueue(chatId: id)
+        ChatRecoveryDraftStore.shared.discard(chatId: id)
         let canceledStreamTask = cancelGeneration(
             chatId: id,
             announce: false
@@ -3652,6 +3657,7 @@ class ChatViewModel: ObservableObject {
         await suspendRecoveryScans()
 
         // Clear all chats from memory
+        ChatRecoveryDraftStore.shared.clearAll()
         chats.removeAll()
         localChats.removeAll()
         currentChat = nil

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3068,7 +3068,7 @@ class ChatViewModel: ObservableObject {
 
         let streamTask = streamTasks[chatId]
         let recoveryAttempt = recoveryAttempts.removeValue(forKey: chatId)
-        let stoppedResponse = recoveryAttempt.flatMap { attempt in
+        let stoppedResponse = recoveryAttempt.flatMap { attempt -> Message? in
             guard let location = findChatLocation(chatId) else { return nil }
             return chat(at: location).messages.last {
                 $0.role == .assistant && $0.turnId == attempt.turnId

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -370,9 +370,11 @@ class ChatViewModel: ObservableObject {
         )
     }
 
-    var activeRecoveryEnvelope: PendingRecoveryEnvelope? {
+    func activeRecoveryEnvelope(
+        trackedBy phaseTracker: ChatRecoveryPhaseTracker = .shared
+    ) -> PendingRecoveryEnvelope? {
         (currentChat?.pendingRecoveries ?? []).first {
-            ChatRecoveryPhaseTracker.shared.isActive(turnId: $0.turnId)
+            phaseTracker.isActive(turnId: $0.turnId)
         }
     }
 
@@ -3130,7 +3132,7 @@ class ChatViewModel: ObservableObject {
         guard let chat = currentChat,
               chat.id == chatId,
               let userId = currentUserId,
-              let envelope = activeRecoveryEnvelope
+              let envelope = activeRecoveryEnvelope()
         else {
             return
         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -280,11 +280,13 @@ class ChatViewModel: ObservableObject {
     // Private properties
     private var client: TinfoilAI?
     private var streamTasks: [String: Task<Void, Never>] = [:]
+    private var recoveryAttempts: [String: ChatRecoveryAttempt] = [:]
     private var thinkingSummaryServices: [String: ThinkingSummaryService] = [:]
     private var autoSyncTimer: Timer?
     private var didBecomeActiveObserver: NSObjectProtocol?
     private var willResignActiveObserver: NSObjectProtocol?
     private var sharedSettingsObserver: NSObjectProtocol?
+    private var chatRecoveryObserver: NSObjectProtocol?
     private var networkStatusCancellable: AnyCancellable?
     private var streamUpdateTimers: [String: Timer] = [:]
     private var pendingStreamUpdates: [String: Chat] = [:]
@@ -504,6 +506,7 @@ class ChatViewModel: ObservableObject {
         // Setup app lifecycle observers
         setupAppLifecycleObservers()
         setupSharedSettingsObserver()
+        setupChatRecoveryObserver()
 
         // Setup network status observer for automatic retry on reconnection
         setupNetworkStatusObserver()
@@ -552,6 +555,40 @@ class ChatViewModel: ObservableObject {
         }
         if let observer = sharedSettingsObserver {
             NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = chatRecoveryObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func setupChatRecoveryObserver() {
+        chatRecoveryObserver = NotificationCenter.default.addObserver(
+            forName: .chatRecoveryDidUpdate,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in
+                guard let self,
+                      let chatId = notification.userInfo?["chatId"] as? String,
+                      let userId = self.currentUserId,
+                      !self.streamingTracker.isStreaming(chatId),
+                      let recovered = try? await EncryptedFileStorage.cloud.loadChat(
+                          chatId: chatId,
+                          userId: userId
+                      )
+                else {
+                    return
+                }
+                guard self.currentUserId == userId,
+                      !self.streamingTracker.isStreaming(chatId)
+                else {
+                    return
+                }
+                self.replaceChat(recovered)
+                if self.currentChat?.id == chatId {
+                    self.currentChat = recovered
+                }
+            }
         }
     }
 
@@ -642,6 +679,7 @@ class ChatViewModel: ObservableObject {
                     }
 
                 }
+                self.scanPendingRecoveries()
 
                 // Also backup current chat if it has changes
                 if let currentChat = await MainActor.run(body: { self.currentChat }),
@@ -702,6 +740,7 @@ class ChatViewModel: ObservableObject {
                         if syncResult.downloaded > 0 || syncResult.deleted > 0 {
                             await self?.updateChatsAfterSync()
                         }
+                        self?.scanPendingRecoveries()
                     }
                 }
             }
@@ -735,6 +774,7 @@ class ChatViewModel: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] isConnected in
                 guard let self = self, isConnected else { return }
+                self.scanPendingRecoveries()
 
                 // Only retry if verification failed (has error) and not currently initializing
                 guard self.verificationError != nil && !self.isVerifying && !self.isClientInitializing else { return }
@@ -744,6 +784,18 @@ class ChatViewModel: ObservableObject {
                     self?.retryClientSetup()
                 }
             }
+    }
+
+    private func scanPendingRecoveries() {
+        guard let userId = currentUserId,
+              SettingsManager.shared.isCloudSyncEnabled,
+              EncryptionService.shared.hasEncryptionKey()
+        else {
+            return
+        }
+        Task {
+            await ChatRecoveryCoordinator.shared.scan(userId: userId)
+        }
     }
 
     private func setupTinfoilClient() {
@@ -1925,8 +1977,23 @@ class ChatViewModel: ObservableObject {
 
         AccessibilityAnnouncer.announce(Constants.Accessibility.generatingResponse)
 
+        let turnId = UUID().uuidString.lowercased()
+        var turnChat = initialChat
+        turnChat.hasActiveStream = true
+        if let userIndex = turnChat.messages.lastIndex(where: { $0.role == .user }) {
+            turnChat.messages[userIndex].turnId = turnId
+            turnChat.locallyModified = true
+            turnChat.updatedAt = Date()
+            updateChat(turnChat)
+        }
+
         // Create initial empty assistant message as a placeholder
-        let assistantMessage = Message(role: .assistant, content: "", isCollapsed: true)
+        let assistantMessage = Message(
+            role: .assistant,
+            turnId: turnId,
+            content: "",
+            isCollapsed: true
+        )
         addMessage(assistantMessage)
 
         guard var updatedStreamChat = currentChat else { return }
@@ -1935,9 +2002,13 @@ class ChatViewModel: ObservableObject {
         updateChat(updatedStreamChat)
         let streamChat = updatedStreamChat
         streamState.start(chatId: streamChatId)
-        streamingTracker.startStreaming(streamChatId)
 
         let conversationMessages = streamChat.messages
+        let recoveryUserId = currentUserId
+        let recoveryEnabled = recoveryUserId != nil
+            && SettingsManager.shared.isCloudSyncEnabled
+            && !streamChat.isLocalOnly
+            && !streamChat.isTemporary
         let streamModel = currentModel
         let streamProject = activeProject
         let streamProjectDocuments = projectDocuments
@@ -1966,8 +2037,20 @@ class ChatViewModel: ObservableObject {
             }
             
             var hasRetriedWithFreshKey = false
+            var recoveryAttempt: ChatRecoveryAttempt?
 
             retryLoop: do {
+                if !hasRetriedWithFreshKey {
+                    if recoveryEnabled {
+                        await self.drainPendingSaves()
+                        try await self.cloudSync.backupChatAndWait(
+                            streamChatId,
+                            requiredTurnId: turnId
+                        )
+                    }
+                    self.streamingTracker.startStreaming(streamChatId)
+                }
+
                 // Wait for client initialization if needed
                 if client == nil || isClientInitializing {
                     // If client setup hasn't started, start it
@@ -2152,7 +2235,47 @@ class ChatViewModel: ObservableObject {
                 // TinfoilEventParser; the SDK-level callback variant is
                 // no longer needed because the router emits nothing
                 // auxiliary on the chat stream.
-                let stream: AsyncThrowingStream<ChatStreamResult, Error> = client.chatsStream(query: chatQuery)
+                let stream: AsyncThrowingStream<ChatStreamResult, Error>
+                var recoveryEnvelope: PendingRecoveryEnvelope?
+                if recoveryEnabled, let userId = recoveryUserId {
+                    let bearerToken = SessionTokenManager.shared.currentToken
+                    guard !bearerToken.isEmpty else {
+                        throw NSError(
+                            domain: "TinfoilChat",
+                            code: 401,
+                            userInfo: [NSLocalizedDescriptionKey: "Authentication token unavailable."]
+                        )
+                    }
+                    let attempt = try await ChatRecoveryCoordinator.shared.begin(
+                        chatId: streamChatId,
+                        turnId: turnId,
+                        userId: userId
+                    )
+                    recoveryAttempt = attempt
+                    recoveryAttempts[streamChatId] = attempt
+                    let recoverable = try await ChatRecoveryClient.shared.start(
+                        query: chatQuery,
+                        sessionId: attempt.sessionId,
+                        bearerToken: bearerToken,
+                        userId: userId
+                    )
+                    let envelope = try await ChatRecoveryCoordinator.shared.register(
+                        attempt: attempt,
+                        token: recoverable.token
+                    )
+                    recoveryEnvelope = envelope
+                    if let location = findChatLocation(streamChatId) {
+                        var chat = self.chat(at: location)
+                        var pending = chat.pendingRecoveries ?? []
+                        pending.removeAll { $0.turnId == turnId }
+                        pending.append(envelope)
+                        chat.pendingRecoveries = pending
+                        updateChat(chat)
+                    }
+                    stream = recoverable.stream
+                } else {
+                    stream = client.chatsStream(query: chatQuery)
+                }
 
                 // Applies one decoded marker event to the current chat.
                 // Mirrors the behavior the legacy SDK onWebSearchEvent
@@ -2459,6 +2582,34 @@ class ChatViewModel: ObservableObject {
                     }
                 }
 
+                if let attempt = recoveryAttempt,
+                   let envelope = recoveryEnvelope,
+                   let response = finalizedChat?.messages.last(where: {
+                       $0.role == .assistant && $0.turnId == turnId
+                   }) {
+                    do {
+                        try await ChatRecoveryCoordinator.shared.complete(
+                            attempt: attempt,
+                            envelope: envelope,
+                            response: response,
+                            title: finalizedChat?.title,
+                            titleState: finalizedChat?.titleState
+                        )
+                    } catch {
+                        recoveryAttempts.removeValue(forKey: streamChatId)
+                        recoveryAttempt = nil
+                        throw error
+                    }
+                    if var chat = finalizedChat {
+                        chat.pendingRecoveries?.removeAll { $0.turnId == turnId }
+                        if chat.pendingRecoveries?.isEmpty == true {
+                            chat.pendingRecoveries = nil
+                        }
+                        finalizedChat = chat
+                    }
+                    recoveryAttempts.removeValue(forKey: streamChatId)
+                }
+
                 guard !Task.isCancelled else { return }
 
                 // Save with the resolved title and trigger cloud backup
@@ -2492,6 +2643,19 @@ class ChatViewModel: ObservableObject {
 
                 if shouldRetry {
                     hasRetriedWithFreshKey = true
+                    if let attempt = recoveryAttempt {
+                        await ChatRecoveryCoordinator.shared.cancel(attempt: attempt)
+                        recoveryAttempt = nil
+                        recoveryAttempts.removeValue(forKey: streamChatId)
+                        if let location = findChatLocation(streamChatId) {
+                            var chat = self.chat(at: location)
+                            chat.pendingRecoveries?.removeAll { $0.turnId == turnId }
+                            if chat.pendingRecoveries?.isEmpty == true {
+                                chat.pendingRecoveries = nil
+                            }
+                            updateChat(chat)
+                        }
+                    }
                     // The token is reminted by acquireTokenForSend at the top of
                     // the retry pass (forceRefresh), so no separate refresh here.
                     if await MainActor.run(body: { self.client != nil }) {
@@ -2626,6 +2790,19 @@ class ChatViewModel: ObservableObject {
         if nsError.domain == "TinfoilChat" && nsError.code == 401 {
             return "Authentication error. Please sign in again."
         }
+
+        if case ChatRecoveryClientError.httpStatus(let statusCode) = error {
+            switch statusCode {
+            case 401:
+                return "Authentication error. Please sign in again."
+            case 429:
+                return "You've reached your daily limit of free requests. Your limit will reset tomorrow, or you can upgrade to Premium for unlimited access."
+            case 500...599:
+                return "The service is having trouble right now. Please try again in a moment, or switch to a different model."
+            default:
+                return "The model couldn't process this request. Please try again, or start a new chat if the problem persists."
+            }
+        }
         
         // HTTP status errors from the OpenAI SDK. Handle every code here so
         // the raw enum dump (including the NSHTTPURLResponse description)
@@ -2719,6 +2896,9 @@ class ChatViewModel: ObservableObject {
 
     /// Checks if an error indicates the user has hit their rate limit
     static func isRateLimitError(_ error: Error) -> Bool {
+        if case ChatRecoveryClientError.httpStatus(429) = error {
+            return true
+        }
         if case OpenAIError.statusError(_, let statusCode) = error, statusCode == 429 {
             return true
         }
@@ -2734,6 +2914,10 @@ class ChatViewModel: ObservableObject {
 
     /// Checks if an error is a client request error (4xx, excluding 401 which is handled by retry)
     private func isRequestError(_ error: Error) -> Bool {
+        if case ChatRecoveryClientError.httpStatus(let statusCode) = error,
+           (400...499).contains(statusCode), statusCode != 401 {
+            return true
+        }
         if case OpenAIError.statusError(_, let statusCode) = error,
            (400...499).contains(statusCode), statusCode != 401 {
             return true
@@ -2747,6 +2931,9 @@ class ChatViewModel: ObservableObject {
 
     /// Checks if an error is an authentication error (401)
     static func isAuthenticationError(_ error: Error) -> Bool {
+        if case ChatRecoveryClientError.httpStatus(401) = error {
+            return true
+        }
         // Streaming path: the SDK checks the HTTP status code before reading the body
         // and throws OpenAIError.statusError with the original status code
         if case OpenAIError.statusError(_, let statusCode) = error,
@@ -2786,11 +2973,34 @@ class ChatViewModel: ObservableObject {
         guard streamState.isStreaming(chatId: chatId) else { return nil }
 
         let streamTask = streamTasks[chatId]
+        let recoveryAttempt = recoveryAttempts.removeValue(forKey: chatId)
+        let stoppedResponse = recoveryAttempt.flatMap { attempt in
+            guard let location = findChatLocation(chatId) else { return nil }
+            return chat(at: location).messages.last {
+                $0.role == .assistant && $0.turnId == attempt.turnId
+            }
+        }
+        let recoveryCleanup = recoveryAttempt.map { attempt in
+            Task.detached(priority: .userInitiated) {
+                await ChatRecoveryCoordinator.shared.cancel(
+                    attempt: attempt,
+                    response: stoppedResponse
+                )
+            }
+        }
         streamTask?.cancel()
         flushPendingStreamUpdate(chatId: chatId)
         if let location = findChatLocation(chatId) {
             var chat = chat(at: location)
             chat.hasActiveStream = false
+            if let recoveryAttempt {
+                chat.pendingRecoveries?.removeAll {
+                    $0.turnId == recoveryAttempt.turnId
+                }
+                if chat.pendingRecoveries?.isEmpty == true {
+                    chat.pendingRecoveries = nil
+                }
+            }
             updateChat(chat)
             streamingTracker.endStreaming(chat.id)
         } else {
@@ -2801,7 +3011,15 @@ class ChatViewModel: ObservableObject {
         if announce {
             AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
         }
-        return streamTask
+        return Task {
+            await recoveryCleanup?.value
+            await streamTask?.value
+            if let recoveryAttempt {
+                await ChatRecoveryCoordinator.shared.deleteSession(
+                    attempt: recoveryAttempt
+                )
+            }
+        }
     }
 
     private func cancelAllGenerations() -> [Task<Void, Never>] {
@@ -3219,6 +3437,10 @@ class ChatViewModel: ObservableObject {
         if authStateChanged {
             // Clear cached session token and reinitialize client only when auth changes
             SessionTokenManager.shared.clearSessionToken()
+            let accountId = isAuthenticated ? authManager?.localUserId : nil
+            Task {
+                await ChatRecoveryCoordinator.shared.reset(accountId: accountId)
+            }
             setupTinfoilClient()
         }
 
@@ -3247,6 +3469,7 @@ class ChatViewModel: ObservableObject {
                 }
 
                 self.ensureBlankChatAtTop()
+                self.scanPendingRecoveries()
             }
         }
     }
@@ -3705,6 +3928,7 @@ class ChatViewModel: ObservableObject {
             
             // Setup pagination token
             await setupPaginationForAppRestart()
+            scanPendingRecoveries()
         } catch {
             await MainActor.run {
                 self.syncErrors.append(error.localizedDescription)
@@ -3819,6 +4043,7 @@ class ChatViewModel: ObservableObject {
                 self.chats = result.chats
                 normalizeChatsArray()
             }
+            scanPendingRecoveries()
         } catch {
             #if DEBUG
             print("Failed to perform initial sync: \(error)")
@@ -4035,6 +4260,7 @@ class ChatViewModel: ObservableObject {
             self.paginationToken = savedPaginationToken
             self.isPaginationActive = savedIsPaginationActive
         }
+        scanPendingRecoveries()
     }
     
     /// Reset pagination and reload all chats from storage (used after sync)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -158,7 +158,13 @@ class ChatViewModel: ObservableObject {
         }
     }
     @Published var syncErrors: [String] = []
-    private var encryptionKey: String?  // Keep private for security
+    private var encryptionKey: String? {  // Keep private for security
+        didSet {
+            if encryptionKey != nil, authManager?.isAuthenticated == true {
+                setupAutoSyncTimer()
+            }
+        }
+    }
     @Published var isFirstTimeUser: Bool = false
     @Published var showEncryptionSetup: Bool = false
     @Published var shouldShowKeyImport: Bool = false
@@ -283,6 +289,11 @@ class ChatViewModel: ObservableObject {
     private var recoveryAttempts: [String: ChatRecoveryAttempt] = [:]
     private var thinkingSummaryServices: [String: ThinkingSummaryService] = [:]
     private var autoSyncTimer: Timer?
+    private var recoveryScanTimer: Timer?
+    private var recoveryScanTask: Task<Void, Never>?
+    private var recoveryScanGeneration = 0
+    private var recoveryScansSuspended = false
+    private var recoveryRescanRequested = false
     private var didBecomeActiveObserver: NSObjectProtocol?
     private var willResignActiveObserver: NSObjectProtocol?
     private var sharedSettingsObserver: NSObjectProtocol?
@@ -532,9 +543,12 @@ class ChatViewModel: ObservableObject {
     }
     
     deinit {
-        // Stop auto-sync timer
+        // Stop sync timers
         autoSyncTimer?.invalidate()
         autoSyncTimer = nil
+        recoveryScanTimer?.invalidate()
+        recoveryScanTimer = nil
+        recoveryScanTask?.cancel()
 
         // Stop stream update timers
         streamUpdateTimers.values.forEach { $0.invalidate() }
@@ -569,10 +583,19 @@ class ChatViewModel: ObservableObject {
         ) { [weak self] notification in
             Task { @MainActor in
                 guard let self,
-                      let chatId = notification.userInfo?["chatId"] as? String,
-                      let userId = self.currentUserId,
+                      let chatId = notification.userInfo?[
+                          ChatRecoveryNotificationKey.chatId
+                      ] as? String,
+                      let userId = notification.userInfo?[
+                          ChatRecoveryNotificationKey.userId
+                      ] as? String,
+                      self.currentUserId == userId,
+                      let storageValue = notification.userInfo?[
+                          ChatRecoveryNotificationKey.storage
+                      ] as? String,
+                      let storage = ChatRecoveryStorage(rawValue: storageValue),
                       !self.streamingTracker.isStreaming(chatId),
-                      let recovered = try? await EncryptedFileStorage.cloud.loadChat(
+                      let recovered = try? await storage.fileStorage.loadChat(
                           chatId: chatId,
                           userId: userId
                       )
@@ -619,14 +642,18 @@ class ChatViewModel: ObservableObject {
     private func setupAutoSyncTimer() {
         // Invalidate existing timer if any
         autoSyncTimer?.invalidate()
+        recoveryScanTimer?.invalidate()
+        recoveryScanTimer = nil
 
         // Do not start auto-sync when cloud sync is disabled
         if !SettingsManager.shared.isCloudSyncEnabled {
+            setupRecoveryScanTimer()
             return
         }
 
         // Do not start auto-sync until encryption key is set up
         if !EncryptionService.shared.hasEncryptionKey() {
+            setupRecoveryScanTimer()
             return
         }
 
@@ -697,6 +724,21 @@ class ChatViewModel: ObservableObject {
             RunLoop.main.add(timer, forMode: .common)
         }
     }
+
+    private func setupRecoveryScanTimer() {
+        guard authManager?.isAuthenticated == true else { return }
+        recoveryScanTimer = Timer.scheduledTimer(
+            withTimeInterval: Constants.Sync.chatSyncIntervalSeconds,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.scanPendingRecoveries()
+            }
+        }
+        if let timer = recoveryScanTimer {
+            RunLoop.main.add(timer, forMode: .common)
+        }
+    }
     
     /// Setup observers for app lifecycle events
     private func setupAppLifecycleObservers() {
@@ -721,28 +763,28 @@ class ChatViewModel: ObservableObject {
                 self?.retryClientSetup()
             }
             
-            // Resume auto-sync timer if authenticated and cloud sync is enabled
+            // Resume cloud sync or local recovery polling
             Task { @MainActor in
-                if self?.authManager?.isAuthenticated == true && SettingsManager.shared.isCloudSyncEnabled {
-                    // Skip sync if no encryption key is set
-                    if !EncryptionService.shared.hasEncryptionKey() {
-                        return
-                    }
+                guard let self, self.authManager?.isAuthenticated == true else { return }
+                self.setupAutoSyncTimer()
+                self.scanPendingRecoveries()
 
-                    self?.setupAutoSyncTimer()
-
-                    // Perform immediate sync when returning from background
-                    if let syncResult = await self?.cloudSync.syncAllChats() {
-                        // Update last sync date
-                        self?.lastSyncDate = Date()
-
-                        // Update chats if needed
-                        if syncResult.downloaded > 0 || syncResult.deleted > 0 {
-                            await self?.updateChatsAfterSync()
-                        }
-                        self?.scanPendingRecoveries()
-                    }
+                guard SettingsManager.shared.isCloudSyncEnabled,
+                      EncryptionService.shared.hasEncryptionKey()
+                else {
+                    return
                 }
+
+                // Perform immediate sync when returning from background
+                let syncResult = await self.cloudSync.syncAllChats()
+                // Update last sync date
+                self.lastSyncDate = Date()
+
+                // Update chats if needed
+                if syncResult.downloaded > 0 || syncResult.deleted > 0 {
+                    await self.updateChatsAfterSync()
+                }
+                self.scanPendingRecoveries()
             }
         }
         
@@ -753,9 +795,11 @@ class ChatViewModel: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                // Pause auto-sync timer
+                // Pause sync timers
                 self?.autoSyncTimer?.invalidate()
                 self?.autoSyncTimer = nil
+                self?.recoveryScanTimer?.invalidate()
+                self?.recoveryScanTimer = nil
                 
                 // Do one final sync before going to background
                 if self?.authManager?.isAuthenticated == true && SettingsManager.shared.isCloudSyncEnabled {
@@ -787,15 +831,47 @@ class ChatViewModel: ObservableObject {
     }
 
     private func scanPendingRecoveries() {
-        guard let userId = currentUserId,
-              SettingsManager.shared.isCloudSyncEnabled,
-              EncryptionService.shared.hasEncryptionKey()
-        else {
+        guard let userId = currentUserId else { return }
+        guard !recoveryScansSuspended else { return }
+        if recoveryScanTask != nil {
+            recoveryRescanRequested = true
             return
         }
-        Task {
-            await ChatRecoveryCoordinator.shared.scan(userId: userId)
+        var storages: [ChatRecoveryStorage] = [.local]
+        if SettingsManager.shared.isCloudSyncEnabled,
+           EncryptionService.shared.hasEncryptionKey() {
+            storages.append(.cloud)
         }
+        recoveryScanGeneration += 1
+        let generation = recoveryScanGeneration
+        let storagesToScan = storages
+        recoveryScanTask = Task { [weak self] in
+            await ChatRecoveryCoordinator.shared.scan(
+                userId: userId,
+                storages: storagesToScan
+            )
+            guard let self, self.recoveryScanGeneration == generation else { return }
+            self.recoveryScanTask = nil
+            if self.recoveryRescanRequested {
+                self.recoveryRescanRequested = false
+                self.scanPendingRecoveries()
+            }
+        }
+    }
+
+    private func suspendRecoveryScans() async {
+        recoveryScansSuspended = true
+        recoveryRescanRequested = false
+        recoveryScanGeneration += 1
+        let task = recoveryScanTask
+        recoveryScanTask = nil
+        task?.cancel()
+        await task?.value
+    }
+
+    func resumeRecoveryScans() {
+        recoveryScansSuspended = false
+        scanPendingRecoveries()
     }
 
     private func setupTinfoilClient() {
@@ -1244,6 +1320,14 @@ class ChatViewModel: ObservableObject {
         let wasCurrent = currentChat?.id == chatId
         guard var chat = chatForProjectMove(chatId) else { return }
         let wasLocal = chat.isLocalOnly
+        let hasPendingLocalRecovery = wasLocal && (
+            recoveryAttempts[chatId] != nil || chat.pendingRecoveries?.isEmpty == false
+        )
+        guard !streamingTracker.isStreaming(chatId),
+              !hasPendingLocalRecovery
+        else {
+            return
+        }
 
         chat.projectId = projectId
         chat.isLocalOnly = false
@@ -2005,10 +2089,17 @@ class ChatViewModel: ObservableObject {
 
         let conversationMessages = streamChat.messages
         let recoveryUserId = currentUserId
-        let recoveryEnabled = recoveryUserId != nil
-            && SettingsManager.shared.isCloudSyncEnabled
-            && !streamChat.isLocalOnly
-            && !streamChat.isTemporary
+        let recoveryStorage: ChatRecoveryStorage?
+        if recoveryUserId == nil || streamChat.isTemporary {
+            recoveryStorage = nil
+        } else if streamChat.isLocalOnly {
+            recoveryStorage = .local
+        } else if SettingsManager.shared.isCloudSyncEnabled {
+            recoveryStorage = .cloud
+        } else {
+            recoveryStorage = nil
+        }
+        streamingTracker.startStreaming(streamChatId)
         let streamModel = currentModel
         let streamProject = activeProject
         let streamProjectDocuments = projectDocuments
@@ -2041,14 +2132,15 @@ class ChatViewModel: ObservableObject {
 
             retryLoop: do {
                 if !hasRetriedWithFreshKey {
-                    if recoveryEnabled {
+                    if let recoveryStorage {
                         await self.drainPendingSaves()
-                        try await self.cloudSync.backupChatAndWait(
-                            streamChatId,
-                            requiredTurnId: turnId
-                        )
+                        if recoveryStorage == .cloud {
+                            try await self.cloudSync.backupChatAndWait(
+                                streamChatId,
+                                requiredTurnId: turnId
+                            )
+                        }
                     }
-                    self.streamingTracker.startStreaming(streamChatId)
                 }
 
                 // Wait for client initialization if needed
@@ -2237,7 +2329,7 @@ class ChatViewModel: ObservableObject {
                 // auxiliary on the chat stream.
                 let stream: AsyncThrowingStream<ChatStreamResult, Error>
                 var recoveryEnvelope: PendingRecoveryEnvelope?
-                if recoveryEnabled, let userId = recoveryUserId {
+                if let recoveryStorage, let userId = recoveryUserId {
                     let bearerToken = SessionTokenManager.shared.currentToken
                     guard !bearerToken.isEmpty else {
                         throw NSError(
@@ -2249,7 +2341,8 @@ class ChatViewModel: ObservableObject {
                     let attempt = try await ChatRecoveryCoordinator.shared.begin(
                         chatId: streamChatId,
                         turnId: turnId,
-                        userId: userId
+                        userId: userId,
+                        storage: recoveryStorage
                     )
                     recoveryAttempt = attempt
                     recoveryAttempts[streamChatId] = attempt
@@ -2662,6 +2755,7 @@ class ChatViewModel: ObservableObject {
                         continue retryLoop
                     }
                 }
+                recoveryAttempts.removeValue(forKey: streamChatId)
 
                 // Handle error
                 await MainActor.run {
@@ -3482,9 +3576,12 @@ class ChatViewModel: ObservableObject {
         let canceledStreamTasks = cancelAllGenerations()
         await drainStreamTasks(canceledStreamTasks)
 
-        // Stop auto-sync timer when signing out
+        // Stop sync timers when signing out
         autoSyncTimer?.invalidate()
         autoSyncTimer = nil
+        recoveryScanTimer?.invalidate()
+        recoveryScanTimer = nil
+        await suspendRecoveryScans()
 
         // Save all local chats with content to disk before clearing in-memory state.
         // This is called while isAuthenticated is still true (see clearAuthState ordering)
@@ -3533,8 +3630,9 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Clear all local chats and reset to fresh state
-    func clearAllChatsFromDevice() async {
+    func clearAllChatsFromDevice(resumeRecoveryScans: Bool = true) async {
         let canceledStreamTasks = cancelAllGenerations()
+        await suspendRecoveryScans()
 
         // Clear all chats from memory
         chats.removeAll()
@@ -3562,6 +3660,9 @@ class ChatViewModel: ObservableObject {
         
         // Clear encryption key reference
         encryptionKey = nil
+        if resumeRecoveryScans {
+            recoveryScansSuspended = false
+        }
     }
 
     /// Erase on-disk chats for the signed-out user during sign-out cleanup.
@@ -3603,6 +3704,7 @@ class ChatViewModel: ObservableObject {
 
     /// Handle sign-in by loading user's saved chats and triggering sync
     func handleSignIn() {
+        recoveryScansSuspended = false
         #if DEBUG
         print("handleSignIn called")
         #endif
@@ -3698,6 +3800,7 @@ class ChatViewModel: ObservableObject {
                             SettingsManager.shared.isLocalOnlyModeEnabled = true
                         }
                     }
+                    self.scanPendingRecoveries()
 
                     // If no cloud key exists, try passkey recovery before falling back
                     if !EncryptionService.shared.hasEncryptionKey() {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -731,8 +731,6 @@ class ChatViewModel: ObservableObject {
                     }
 
                 }
-                self.scanPendingRecoveries()
-
                 // Also backup current chat if it has changes
                 if let currentChat = await MainActor.run(body: { self.currentChat }),
                    !currentChat.messages.isEmpty,

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -370,6 +370,12 @@ class ChatViewModel: ObservableObject {
         )
     }
 
+    var activeRecoveryEnvelope: PendingRecoveryEnvelope? {
+        (currentChat?.pendingRecoveries ?? []).first {
+            ChatRecoveryPhaseTracker.shared.isActive(turnId: $0.turnId)
+        }
+    }
+
     /// Whether the given chat has a response currently being generated,
     /// regardless of which chat is on screen.
     func isChatStreaming(_ chatId: String) -> Bool {
@@ -2720,7 +2726,9 @@ class ChatViewModel: ObservableObject {
 
                 // Generate title before save to avoid uploading placeholder title
                 if var chat = finalizedChat, chat.needsGeneratedTitle && chat.messages.count >= 2 {
-                    if let generated = await self.generateLLMTitle(from: chat.messages) {
+                    if let generated = await SummarizerService.shared.generateChatTitle(
+                        from: chat.messages
+                    ) {
                         chat.title = generated
                         chat.titleState = .generated
                         chat.locallyModified = true
@@ -3112,8 +3120,29 @@ class ChatViewModel: ObservableObject {
     /// Cancels the current message generation
     func cancelGeneration() {
         guard let chatId = currentChat?.id else { return }
-        _ = cancelGeneration(chatId: chatId, announce: true)
+        if cancelGeneration(chatId: chatId, announce: true) == nil {
+            cancelRecoveredGeneration(chatId: chatId)
+        }
         self.showVerifierSheet = false
+    }
+
+    private func cancelRecoveredGeneration(chatId: String) {
+        guard let chat = currentChat,
+              chat.id == chatId,
+              let userId = currentUserId,
+              let envelope = activeRecoveryEnvelope
+        else {
+            return
+        }
+        let storage: ChatRecoveryStorage = chat.isLocalOnly ? .local : .cloud
+        Task {
+            await ChatRecoveryCoordinator.shared.cancelRecoveredTurn(
+                chatId: chatId,
+                envelope: envelope,
+                userId: userId,
+                storage: storage
+            )
+        }
     }
 
     @discardableResult
@@ -4620,35 +4649,7 @@ class ChatViewModel: ObservableObject {
     }
 }
 
-// MARK: - LLM Title Generation
 extension ChatViewModel {
-    /// Generates a concise chat title using the title model, based on the assistant's first response.
-    fileprivate func generateLLMTitle(from messages: [Message]) async -> String? {
-        // Find the first assistant message
-        guard let assistantMessage = messages.first(where: { $0.role == .assistant }),
-              !assistantMessage.content.isEmpty else {
-            return nil
-        }
-
-        // Truncate content to word threshold
-        let words = assistantMessage.content.split(separator: " ", omittingEmptySubsequences: true)
-        let truncatedContent = words
-            .prefix(Constants.TitleGeneration.wordThreshold)
-            .joined(separator: " ")
-
-        do {
-            let title = try await SummarizerService.shared.summarize(
-                content: truncatedContent,
-                style: .titleSummary
-            )
-
-            guard !title.isEmpty else { return nil }
-            return title
-        } catch {
-            return nil
-        }
-    }
-
     // MARK: - Audio Recording
 
     /// Check if audio input is available (premium feature with audio model)

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -55,10 +55,19 @@ struct ChatListView: View {
     /// refreshed only when the conversation, model, or message count changes
     /// instead of on every body evaluation during streaming.
     private func refreshArchivedMessagesStartIndex() {
-        archivedMessagesStartIndex = TokenEstimation.findContextStartIndex(
-            messages: viewModel.messages,
+        let persistedMessages = viewModel.messages
+        let persistedStartIndex = TokenEstimation.findContextStartIndex(
+            messages: persistedMessages,
             budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
         )
+        guard persistedMessages.indices.contains(persistedStartIndex) else {
+            archivedMessagesStartIndex = 0
+            return
+        }
+        let boundaryMessageId = persistedMessages[persistedStartIndex].id
+        archivedMessagesStartIndex = messages.firstIndex {
+            $0.id == boundaryMessageId
+        } ?? persistedStartIndex
     }
 
     var body: some View {

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -13,6 +13,7 @@ struct ChatListView: View {
     let onRequestSignIn: () -> Void
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
     @Binding var messageText: String
+    @ObservedObject private var recoveryDraftStore = ChatRecoveryDraftStore.shared
 
     @State private var isAtBottom = true
     @State private var userHasScrolled = false
@@ -25,8 +26,29 @@ struct ChatListView: View {
     @State private var tableOpacity = 1.0
     @State private var archivedMessagesStartIndex = 0
 
+    private var pendingRecoveryTurnIds: Set<String> {
+        Set((viewModel.currentChat?.pendingRecoveries ?? []).map(\.turnId))
+    }
+
+    private var recoveryDraftTurnIds: Set<String> {
+        let chatId = viewModel.currentChat?.id
+        return Set(recoveryDraftStore.drafts.keys.compactMap { key in
+            key.chatId == chatId && pendingRecoveryTurnIds.contains(key.turnId)
+                ? key.turnId
+                : nil
+        })
+    }
+
     private var messages: [Message] {
-        viewModel.messages
+        guard let chatId = viewModel.currentChat?.id else {
+            return viewModel.messages
+        }
+        return messagesApplyingRecoveryDrafts(
+            viewModel.messages,
+            chatId: chatId,
+            pendingTurnIds: pendingRecoveryTurnIds,
+            drafts: recoveryDraftStore.drafts
+        )
     }
 
     /// Token estimation walks every message, so the result is cached and
@@ -34,13 +56,15 @@ struct ChatListView: View {
     /// instead of on every body evaluation during streaming.
     private func refreshArchivedMessagesStartIndex() {
         archivedMessagesStartIndex = TokenEstimation.findContextStartIndex(
-            messages: messages,
+            messages: viewModel.messages,
             budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
         )
     }
 
     var body: some View {
         MessageTableView(
+            messages: messages,
+            recoveryDraftTurnIds: recoveryDraftTurnIds,
             archivedMessagesStartIndex: archivedMessagesStartIndex,
             isDarkMode: isDarkMode,
             isLoading: isLoading,
@@ -137,6 +161,7 @@ struct ChatListView: View {
         .onAppear {
             setupKeyboardObservers()
             refreshArchivedMessagesStartIndex()
+            pruneRecoveryDrafts()
         }
         .onDisappear {
             removeKeyboardObservers()
@@ -163,8 +188,12 @@ struct ChatListView: View {
                 }
             }
         }
+        .onChange(of: pendingRecoveryTurnIds) { _, _ in
+            pruneRecoveryDrafts()
+        }
         .onChange(of: viewModel.currentChat?.createdAt) { _, _ in
             refreshArchivedMessagesStartIndex()
+            pruneRecoveryDrafts()
             userHasScrolled = false
             viewModel.isScrollInteractionActive = false
 
@@ -208,5 +237,13 @@ struct ChatListView: View {
     private func removeKeyboardObservers() {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    private func pruneRecoveryDrafts() {
+        guard let chatId = viewModel.currentChat?.id else { return }
+        recoveryDraftStore.prune(
+            chatId: chatId,
+            retaining: pendingRecoveryTurnIds
+        )
     }
 }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -24,6 +24,16 @@ func cameraPermissionAction(for status: AVAuthorizationStatus) -> CameraPermissi
     }
 }
 
+func shouldShowMessageStopAction(
+    isStreaming: Bool,
+    hasActiveRecovery: Bool,
+    hasSubmittableContent: Bool,
+    isMessageQueueFull: Bool
+) -> Bool {
+    hasActiveRecovery
+        || (isStreaming && (!hasSubmittableContent || isMessageQueueFull))
+}
+
 /// Input area for typing messages, including attachments and send button
 struct MessageInputView: View {
     // MARK: - Constants
@@ -44,6 +54,7 @@ struct MessageInputView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @EnvironmentObject private var authManager: AuthManager
+    @ObservedObject private var recoveryPhaseTracker = ChatRecoveryPhaseTracker.shared
     @State private var textHeight: CGFloat = Layout.defaultHeight
     /// Reflects whether the editor has grown beyond a single line, so callers
     /// can hide content that would otherwise be pushed off-screen.
@@ -90,7 +101,12 @@ struct MessageInputView: View {
     /// submittable, or the queue already full, it reverts to a stop button
     /// so the stream can always be cancelled. Mirrors the webapp.
     private var showStopAction: Bool {
-        viewModel.isLoading && (!hasSubmittableContent || viewModel.isMessageQueueFull)
+        shouldShowMessageStopAction(
+            isStreaming: viewModel.isLoading,
+            hasActiveRecovery: viewModel.activeRecoveryEnvelope != nil,
+            hasSubmittableContent: hasSubmittableContent,
+            isMessageQueueFull: viewModel.isMessageQueueFull
+        )
     }
 
     private enum TrailingAction {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -103,7 +103,9 @@ struct MessageInputView: View {
     private var showStopAction: Bool {
         shouldShowMessageStopAction(
             isStreaming: viewModel.isLoading,
-            hasActiveRecovery: viewModel.activeRecoveryEnvelope != nil,
+            hasActiveRecovery: viewModel.activeRecoveryEnvelope(
+                trackedBy: recoveryPhaseTracker
+            ) != nil,
             hasSubmittableContent: hasSubmittableContent,
             isMessageQueueFull: viewModel.isMessageQueueFull
         )

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -138,12 +138,14 @@ struct MessageInputView: View {
     }
 
     /// The send action greys out while a draft can't be dispatched because
-    /// an attachment is still processing; voice greys out while a recording
-    /// is being transcribed.
+    /// an attachment is still processing or the previous response is being
+    /// recovered; voice greys out while a recording is being transcribed.
     private var isTrailingActionDisabled: Bool {
         switch trailingAction {
         case .voice: return viewModel.isTranscribing
-        case .send: return !attachmentsAreReadyToSend(viewModel.pendingAttachments)
+        case .send:
+            return viewModel.hasPendingResponseRecovery
+                || !attachmentsAreReadyToSend(viewModel.pendingAttachments)
         case .stop: return false
         }
     }

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -10,6 +10,8 @@ import Textual
 import ObjectiveC
 
 struct MessageTableView: UIViewRepresentable {
+    let messages: [Message]
+    let recoveryDraftTurnIds: Set<String>
     let archivedMessagesStartIndex: Int
     let isDarkMode: Bool
     let isLoading: Bool
@@ -21,10 +23,6 @@ struct MessageTableView: UIViewRepresentable {
     let scrollToUserTrigger: UUID
     @Binding var tableOpacity: Double
     let keyboardHeight: CGFloat
-
-    private var messages: [Message] {
-        viewModel.messages
-    }
 
     func makeUIView(context: Context) -> UITableView {
         let tableView = UITableView(frame: .zero, style: .plain)
@@ -85,7 +83,7 @@ struct MessageTableView: UIViewRepresentable {
 
         // Detect ID conversion (temp → permanent) by checking if message IDs match
         // This is more reliable than checking wrappers since wrappers only exist for rendered cells
-        let currentMessageIds = Set(viewModel.messages.map { $0.id })
+        let currentMessageIds = Set(messages.map { $0.id })
         let isIdConversion = chatIdChanged && !currentMessageIds.isEmpty &&
             currentMessageIds == context.coordinator.lastMessageIds
 
@@ -218,6 +216,9 @@ struct MessageTableView: UIViewRepresentable {
                         isDarkMode: coordinator.parent.isDarkMode,
                         isLastMessage: true,
                         isLoading: coordinator.parent.isLoading,
+                        hasRecoveryDraft: currentMessage.turnId.map {
+                            coordinator.parent.recoveryDraftTurnIds.contains($0)
+                        } ?? false,
                         isArchived: isArchived,
                         showArchiveSeparator: showArchiveSeparator,
                         messageIndex: coordinator.parent.messages.count - 1
@@ -229,6 +230,25 @@ struct MessageTableView: UIViewRepresentable {
                         tableView.endUpdates()
                     }
                 }
+            }
+        } else {
+            for (index, message) in messages.enumerated() {
+                guard let wrapper = context.coordinator.messageWrappers[message.id] else {
+                    continue
+                }
+                wrapper.update(
+                    message: message,
+                    isDarkMode: isDarkMode,
+                    isLastMessage: index == messages.count - 1,
+                    isLoading: false,
+                    hasRecoveryDraft: message.turnId.map {
+                        recoveryDraftTurnIds.contains($0)
+                    } ?? false,
+                    isArchived: index < archivedMessagesStartIndex,
+                    showArchiveSeparator: index == archivedMessagesStartIndex
+                        && archivedMessagesStartIndex > 0,
+                    messageIndex: index
+                )
             }
         }
 
@@ -261,6 +281,9 @@ struct MessageTableView: UIViewRepresentable {
                     isDarkMode: isDarkMode,
                     isLastMessage: true,
                     isLoading: false,
+                    hasRecoveryDraft: lastMessage.turnId.map {
+                        recoveryDraftTurnIds.contains($0)
+                    } ?? false,
                     isArchived: isArchived,
                     showArchiveSeparator: showArchiveSeparator,
                     messageIndex: messages.count - 1
@@ -401,16 +424,16 @@ struct MessageTableView: UIViewRepresentable {
             self.parent = parent
         }
 
-        func getOrCreateWrapper(for message: Message, isDarkMode: Bool, isLastMessage: Bool, isLoading: Bool, isArchived: Bool, showArchiveSeparator: Bool, messageIndex: Int) -> ObservableMessageWrapper {
+        func getOrCreateWrapper(for message: Message, isDarkMode: Bool, isLastMessage: Bool, isLoading: Bool, hasRecoveryDraft: Bool, isArchived: Bool, showArchiveSeparator: Bool, messageIndex: Int) -> ObservableMessageWrapper {
             if let existing = messageWrappers[message.id] {
-                existing.update(message: message, isDarkMode: isDarkMode, isLastMessage: isLastMessage, isLoading: isLoading, isArchived: isArchived, showArchiveSeparator: showArchiveSeparator, messageIndex: messageIndex)
+                existing.update(message: message, isDarkMode: isDarkMode, isLastMessage: isLastMessage, isLoading: isLoading, hasRecoveryDraft: hasRecoveryDraft, isArchived: isArchived, showArchiveSeparator: showArchiveSeparator, messageIndex: messageIndex)
                 // Never re-animate existing messages
                 existing.shouldAnimateAppearance = false
                 return existing
             } else {
                 let isFirstTimeShown = !shownMessageIds.contains(message.id)
                 shownMessageIds.insert(message.id)
-                let wrapper = ObservableMessageWrapper(message: message, isDarkMode: isDarkMode, isLastMessage: isLastMessage, isLoading: isLoading, isArchived: isArchived, showArchiveSeparator: showArchiveSeparator, shouldAnimateAppearance: isFirstTimeShown, messageIndex: messageIndex)
+                let wrapper = ObservableMessageWrapper(message: message, isDarkMode: isDarkMode, isLastMessage: isLastMessage, isLoading: isLoading, hasRecoveryDraft: hasRecoveryDraft, isArchived: isArchived, showArchiveSeparator: showArchiveSeparator, shouldAnimateAppearance: isFirstTimeShown, messageIndex: messageIndex)
                 messageWrappers[message.id] = wrapper
                 return wrapper
             }
@@ -488,6 +511,9 @@ struct MessageTableView: UIViewRepresentable {
                     isDarkMode: parent.isDarkMode,
                     isLastMessage: isLastMessage,
                     isLoading: parent.isLoading && isLastMessage,
+                    hasRecoveryDraft: message.turnId.map {
+                        parent.recoveryDraftTurnIds.contains($0)
+                    } ?? false,
                     isArchived: isArchived,
                     showArchiveSeparator: showArchiveSeparator,
                     messageIndex: indexPath.row
@@ -827,6 +853,7 @@ class ObservableMessageWrapper: ObservableObject {
     @Published var isDarkMode: Bool
     @Published var isLastMessage: Bool
     @Published var isLoading: Bool
+    @Published var hasRecoveryDraft: Bool
     @Published var isArchived: Bool
     @Published var showArchiveSeparator: Bool
     var shouldAnimateAppearance: Bool = false
@@ -836,18 +863,19 @@ class ObservableMessageWrapper: ObservableObject {
     var cachedHeight: CGFloat?
     var cachedHeightKey: Int?
 
-    init(message: Message, isDarkMode: Bool, isLastMessage: Bool, isLoading: Bool, isArchived: Bool, showArchiveSeparator: Bool, shouldAnimateAppearance: Bool = true, messageIndex: Int = 0) {
+    init(message: Message, isDarkMode: Bool, isLastMessage: Bool, isLoading: Bool, hasRecoveryDraft: Bool = false, isArchived: Bool, showArchiveSeparator: Bool, shouldAnimateAppearance: Bool = true, messageIndex: Int = 0) {
         self.message = message
         self.isDarkMode = isDarkMode
         self.isLastMessage = isLastMessage
         self.isLoading = isLoading
+        self.hasRecoveryDraft = hasRecoveryDraft
         self.isArchived = isArchived
         self.showArchiveSeparator = showArchiveSeparator
         self.shouldAnimateAppearance = shouldAnimateAppearance
         self.messageIndex = messageIndex
     }
 
-    func update(message: Message, isDarkMode: Bool, isLastMessage: Bool, isLoading: Bool, isArchived: Bool, showArchiveSeparator: Bool, messageIndex: Int) {
+    func update(message: Message, isDarkMode: Bool, isLastMessage: Bool, isLoading: Bool, hasRecoveryDraft: Bool, isArchived: Bool, showArchiveSeparator: Bool, messageIndex: Int) {
         let contentChanged = self.message.content != message.content ||
                             self.message.thoughts != message.thoughts ||
                             self.message.contentChunks != message.contentChunks ||
@@ -860,10 +888,15 @@ class ObservableMessageWrapper: ObservableObject {
                             self.message.urlFetches != message.urlFetches ||
                             self.message.segments != message.segments ||
                             self.message.webSearches != message.webSearches ||
+                            self.message.toolCalls != message.toolCalls ||
+                            self.message.timeline != message.timeline ||
+                            self.message.annotations != message.annotations ||
+                            self.message.webSearchBeforeThinking != message.webSearchBeforeThinking ||
                             self.isDarkMode != isDarkMode
 
         let metadataChanged = self.isLastMessage != isLastMessage ||
                               self.isLoading != isLoading ||
+                              self.hasRecoveryDraft != hasRecoveryDraft ||
                               self.isArchived != isArchived ||
                               self.showArchiveSeparator != showArchiveSeparator ||
                               self.messageIndex != messageIndex
@@ -885,6 +918,7 @@ class ObservableMessageWrapper: ObservableObject {
             self.isDarkMode = isDarkMode
             self.isLastMessage = isLastMessage
             self.isLoading = isLoading
+            self.hasRecoveryDraft = hasRecoveryDraft
             self.isArchived = isArchived
             self.showArchiveSeparator = showArchiveSeparator
             self.messageIndex = messageIndex
@@ -974,6 +1008,7 @@ struct ObservableMessageCell: View {
                     isDarkMode: wrapper.isDarkMode,
                     isLastMessage: wrapper.isLastMessage,
                     isLoading: wrapper.isLoading,
+                    hasRecoveryDraft: wrapper.hasRecoveryDraft,
                     messageIndex: wrapper.messageIndex
                 )
                 .environmentObject(viewModel)

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -829,7 +829,7 @@ class ObservableMessageWrapper: ObservableObject {
     @Published var isLoading: Bool
     @Published var isArchived: Bool
     @Published var showArchiveSeparator: Bool
-    @Published var shouldAnimateAppearance: Bool = false
+    var shouldAnimateAppearance: Bool = false
     @Published var messageIndex: Int
     var bufferMultiplier: CGFloat = Constants.StreamingBuffer.initialMultiplier
     var actualContentHeight: CGFloat = 0

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -199,6 +199,7 @@ struct MessageTableView: UIViewRepresentable {
             // During streaming, update the last message wrapper directly
             if let lastMessage = messages.last,
                let wrapper = context.coordinator.messageWrappers[lastMessage.id] {
+                let lastMessageId = lastMessage.id
                 if hasRecoveryDraft(lastMessage) {
                     context.coordinator.heightCache.removeValue(
                         forKey: IndexPath(row: messages.count - 1, section: 0)
@@ -229,7 +230,12 @@ struct MessageTableView: UIViewRepresentable {
                     // stale wrapper or recalculating heights against the old row
                     // set would desync the table from its datasource.
                     guard coordinator.lastChatId == currentChatId,
-                          let currentMessage = coordinator.parent.messages.last else { return }
+                          coordinator.streamingMessageId == lastMessageId,
+                          let currentMessage = coordinator.parent.messages.last,
+                          currentMessage.id == lastMessageId
+                    else {
+                        return
+                    }
 
                     wrapper.update(
                         message: currentMessage,

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -24,6 +24,15 @@ struct MessageTableView: UIViewRepresentable {
     @Binding var tableOpacity: Double
     let keyboardHeight: CGFloat
 
+    private func hasRecoveryDraft(_ message: Message) -> Bool {
+        message.turnId.map { recoveryDraftTurnIds.contains($0) } ?? false
+    }
+
+    private var usesStreamingLayout: Bool {
+        guard let lastMessage = messages.last else { return isLoading }
+        return isLoading || hasRecoveryDraft(lastMessage)
+    }
+
     func makeUIView(context: Context) -> UITableView {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.backgroundColor = .clear
@@ -97,9 +106,9 @@ struct MessageTableView: UIViewRepresentable {
         // collapsed height immediately and can't overlap the rows added after
         // it. The stale wrapper's buffer state and cached height go with it.
         let previousStreamingMessageId = context.coordinator.streamingMessageId
-        context.coordinator.streamingMessageId = isLoading ? messages.last?.id : nil
+        context.coordinator.streamingMessageId = usesStreamingLayout ? messages.last?.id : nil
         if let staleId = previousStreamingMessageId,
-           staleId != messages.last?.id,
+           staleId != context.coordinator.streamingMessageId,
            let staleWrapper = context.coordinator.messageWrappers[staleId] {
             staleWrapper.resetBuffer()
             context.coordinator.messageHeightCache.removeValue(forKey: staleId)
@@ -118,7 +127,7 @@ struct MessageTableView: UIViewRepresentable {
                 // the same conversation stays on screen with its wrappers
                 // retained, so a stream that ends across the conversion must
                 // still collapse its buffer through the normal path.
-                context.coordinator.lastIsLoading = isLoading
+                context.coordinator.lastUsesStreamingLayout = usesStreamingLayout
                 context.coordinator.messageWrappers.removeAll()
                 context.coordinator.shownMessageIds.removeAll()
 
@@ -186,10 +195,21 @@ struct MessageTableView: UIViewRepresentable {
             context.coordinator.lastMessageCount = messages.count
             context.coordinator.heightCache.removeAll()
             tableView.reloadData()
-        } else if isLoading && !messages.isEmpty {
+        } else if usesStreamingLayout && !messages.isEmpty {
             // During streaming, update the last message wrapper directly
             if let lastMessage = messages.last,
                let wrapper = context.coordinator.messageWrappers[lastMessage.id] {
+                if hasRecoveryDraft(lastMessage) {
+                    context.coordinator.heightCache.removeValue(
+                        forKey: IndexPath(row: messages.count - 1, section: 0)
+                    )
+                    context.coordinator.messageHeightCache.removeValue(
+                        forKey: lastMessage.id
+                    )
+                    context.coordinator.contentEstimateCache.removeValue(
+                        forKey: lastMessage.id
+                    )
+                }
 
                 let isArchived = messages.count - 1 < archivedMessagesStartIndex
                 let showArchiveSeparator = messages.count - 1 == archivedMessagesStartIndex && archivedMessagesStartIndex > 0
@@ -216,9 +236,7 @@ struct MessageTableView: UIViewRepresentable {
                         isDarkMode: coordinator.parent.isDarkMode,
                         isLastMessage: true,
                         isLoading: coordinator.parent.isLoading,
-                        hasRecoveryDraft: currentMessage.turnId.map {
-                            coordinator.parent.recoveryDraftTurnIds.contains($0)
-                        } ?? false,
+                        hasRecoveryDraft: coordinator.parent.hasRecoveryDraft(currentMessage),
                         isArchived: isArchived,
                         showArchiveSeparator: showArchiveSeparator,
                         messageIndex: coordinator.parent.messages.count - 1
@@ -231,19 +249,47 @@ struct MessageTableView: UIViewRepresentable {
                     }
                 }
             }
+            for (index, message) in messages.dropLast().enumerated() {
+                guard hasRecoveryDraft(message),
+                      let wrapper = context.coordinator.messageWrappers[message.id]
+                else {
+                    continue
+                }
+                context.coordinator.heightCache.removeValue(
+                    forKey: IndexPath(row: index, section: 0)
+                )
+                context.coordinator.messageHeightCache.removeValue(forKey: message.id)
+                context.coordinator.contentEstimateCache.removeValue(forKey: message.id)
+                wrapper.update(
+                    message: message,
+                    isDarkMode: isDarkMode,
+                    isLastMessage: false,
+                    isLoading: false,
+                    hasRecoveryDraft: true,
+                    isArchived: index < archivedMessagesStartIndex,
+                    showArchiveSeparator: index == archivedMessagesStartIndex
+                        && archivedMessagesStartIndex > 0,
+                    messageIndex: index
+                )
+            }
         } else {
             for (index, message) in messages.enumerated() {
                 guard let wrapper = context.coordinator.messageWrappers[message.id] else {
                     continue
+                }
+                if hasRecoveryDraft(message) {
+                    context.coordinator.heightCache.removeValue(
+                        forKey: IndexPath(row: index, section: 0)
+                    )
+                    context.coordinator.messageHeightCache.removeValue(forKey: message.id)
+                    context.coordinator.contentEstimateCache.removeValue(forKey: message.id)
                 }
                 wrapper.update(
                     message: message,
                     isDarkMode: isDarkMode,
                     isLastMessage: index == messages.count - 1,
                     isLoading: false,
-                    hasRecoveryDraft: message.turnId.map {
-                        recoveryDraftTurnIds.contains($0)
-                    } ?? false,
+                    hasRecoveryDraft: hasRecoveryDraft(message),
                     isArchived: index < archivedMessagesStartIndex,
                     showArchiveSeparator: index == archivedMessagesStartIndex
                         && archivedMessagesStartIndex > 0,
@@ -252,10 +298,11 @@ struct MessageTableView: UIViewRepresentable {
             }
         }
 
-        let isLoadingChanged = context.coordinator.lastIsLoading != isLoading
-        context.coordinator.lastIsLoading = isLoading
+        let streamingLayoutChanged =
+            context.coordinator.lastUsesStreamingLayout != usesStreamingLayout
+        context.coordinator.lastUsesStreamingLayout = usesStreamingLayout
 
-        if isLoadingChanged && !isLoading {
+        if streamingLayoutChanged && !usesStreamingLayout {
             let preservedOffset = tableView.contentOffset.y
             context.coordinator.preservedOffsetAfterStreaming = preservedOffset
             context.coordinator.isCollapsingStreamingBuffer = true
@@ -281,9 +328,7 @@ struct MessageTableView: UIViewRepresentable {
                     isDarkMode: isDarkMode,
                     isLastMessage: true,
                     isLoading: false,
-                    hasRecoveryDraft: lastMessage.turnId.map {
-                        recoveryDraftTurnIds.contains($0)
-                    } ?? false,
+                    hasRecoveryDraft: hasRecoveryDraft(lastMessage),
                     isArchived: isArchived,
                     showArchiveSeparator: showArchiveSeparator,
                     messageIndex: messages.count - 1
@@ -395,7 +440,7 @@ struct MessageTableView: UIViewRepresentable {
         var lastScrollTrigger: UUID?
         var lastScrollToUserTrigger: UUID?
         var lastMessageCount: Int = 0
-        var lastIsLoading: Bool = false
+        var lastUsesStreamingLayout: Bool = false
         var cellReuseIdentifierSuffix: String = ""
         var lastKeyboardHeight: CGFloat = 0
         var lastIsDarkMode: Bool = false
@@ -511,9 +556,7 @@ struct MessageTableView: UIViewRepresentable {
                     isDarkMode: parent.isDarkMode,
                     isLastMessage: isLastMessage,
                     isLoading: parent.isLoading && isLastMessage,
-                    hasRecoveryDraft: message.turnId.map {
-                        parent.recoveryDraftTurnIds.contains($0)
-                    } ?? false,
+                    hasRecoveryDraft: parent.hasRecoveryDraft(message),
                     isArchived: isArchived,
                     showArchiveSeparator: showArchiveSeparator,
                     messageIndex: indexPath.row
@@ -649,11 +692,14 @@ struct MessageTableView: UIViewRepresentable {
             // appended rows behind it) can still render its buffer this tick.
             // Trust the wrapper's claim wherever the row sits so that inflated
             // frame never enters the height caches.
+            if parent.hasRecoveryDraft(message) {
+                return true
+            }
             if let wrapper = messageWrappers[message.id], wrapper.isLoading, wrapper.isLastMessage {
                 return true
             }
             guard indexPath.row == parent.messages.count - 1 else { return false }
-            return parent.isLoading
+            return parent.usesStreamingLayout
         }
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -670,7 +716,7 @@ struct MessageTableView: UIViewRepresentable {
 
             let targetInset: CGFloat
 
-            if parent.isLoading, let lastMessage = parent.messages.last,
+            if parent.usesStreamingLayout, let lastMessage = parent.messages.last,
                let wrapper = messageWrappers[lastMessage.id], wrapper.actualContentHeight > 0 {
 
                 let screenHeight = UIScreen.main.bounds.height
@@ -684,7 +730,7 @@ struct MessageTableView: UIViewRepresentable {
                 } else {
                     targetInset = streamingInset
                 }
-            } else if parent.isLoading && isUserMessageScrollMode {
+            } else if parent.usesStreamingLayout && isUserMessageScrollMode {
                 targetInset = insetForUserMessageAtTop(tableView)
             } else if isUserMessageScrollMode {
                 // Streaming has ended but the user is still reading with their
@@ -973,7 +1019,7 @@ struct ObservableMessageCell: View {
     /// is measuring cells (queued dispatch landing at stream end). Requiring
     /// the coordinator's synchronous id keeps the buffer off such rows.
     private var showsStreamingBuffer: Bool {
-        wrapper.isLoading && wrapper.isLastMessage
+        (wrapper.isLoading || wrapper.hasRecoveryDraft) && wrapper.isLastMessage
             && coordinator?.streamingMessageId == wrapper.message.id
     }
 

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -19,12 +19,13 @@ struct IdentifiedGroup<T>: Identifiable {
     let items: [T]
 }
 
-func shouldShowPendingResponseRecovery(
+private func messageHasPendingRecovery(
     message: Message,
+    role: MessageRole,
     pendingRecoveries: [PendingRecoveryEnvelope],
     activeTurnId: String?
 ) -> Bool {
-    guard message.role == .user,
+    guard message.role == role,
           let turnId = message.turnId,
           turnId != activeTurnId
     else {
@@ -33,18 +34,30 @@ func shouldShowPendingResponseRecovery(
     return pendingRecoveries.contains { $0.turnId == turnId }
 }
 
+func shouldShowPendingResponseRecovery(
+    message: Message,
+    pendingRecoveries: [PendingRecoveryEnvelope],
+    activeTurnId: String?
+) -> Bool {
+    messageHasPendingRecovery(
+        message: message,
+        role: .user,
+        pendingRecoveries: pendingRecoveries,
+        activeTurnId: activeTurnId
+    )
+}
+
 func shouldHidePendingResponseAssistant(
     message: Message,
     pendingRecoveries: [PendingRecoveryEnvelope],
     activeTurnId: String?
 ) -> Bool {
-    guard message.role == .assistant,
-          let turnId = message.turnId,
-          turnId != activeTurnId
-    else {
-        return false
-    }
-    return pendingRecoveries.contains { $0.turnId == turnId }
+    messageHasPendingRecovery(
+        message: message,
+        role: .assistant,
+        pendingRecoveries: pendingRecoveries,
+        activeTurnId: activeTurnId
+    )
 }
 
 func pendingResponseRecoveryDetail(phase: ChatRecoveryPhase) -> String {
@@ -116,21 +129,28 @@ struct MessageView: View {
         return message.content.count <= Constants.Rendering.maxInlineSelectionCharacters
     }
 
+    private var recoveryContext: (pendingRecoveries: [PendingRecoveryEnvelope], activeTurnId: String?) {
+        (
+            pendingRecoveries: viewModel.currentChat?.pendingRecoveries ?? [],
+            activeTurnId: viewModel.isLoading ? viewModel.messages.last?.turnId : nil
+        )
+    }
+
     private var showsPendingResponseRecovery: Bool {
-        let activeTurnId = viewModel.isLoading ? viewModel.messages.last?.turnId : nil
+        let context = recoveryContext
         return shouldShowPendingResponseRecovery(
             message: message,
-            pendingRecoveries: viewModel.currentChat?.pendingRecoveries ?? [],
-            activeTurnId: activeTurnId
+            pendingRecoveries: context.pendingRecoveries,
+            activeTurnId: context.activeTurnId
         )
     }
 
     private var hidesPendingResponseAssistant: Bool {
-        let activeTurnId = viewModel.isLoading ? viewModel.messages.last?.turnId : nil
+        let context = recoveryContext
         return shouldHidePendingResponseAssistant(
             message: message,
-            pendingRecoveries: viewModel.currentChat?.pendingRecoveries ?? [],
-            activeTurnId: activeTurnId
+            pendingRecoveries: context.pendingRecoveries,
+            activeTurnId: context.activeTurnId
         )
     }
 

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -74,18 +74,19 @@ private struct PendingResponseRecoveryView: View {
     let phase: ChatRecoveryPhase
 
     var body: some View {
-        HStack(alignment: .center, spacing: Constants.ChatRecovery.indicatorSpacing) {
-            ProgressView()
-                .controlSize(.small)
-                .tint(isDarkMode ? .white.opacity(0.65) : .black.opacity(0.65))
+        VStack(alignment: .leading, spacing: Constants.ChatRecovery.indicatorTextSpacing) {
+            HStack(alignment: .center, spacing: Constants.ChatRecovery.indicatorSpacing) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(isDarkMode ? .white.opacity(0.65) : .black.opacity(0.65))
 
-            VStack(alignment: .leading, spacing: Constants.ChatRecovery.indicatorTextSpacing) {
                 Text(Constants.ChatRecovery.indicatorTitle)
                     .font(.subheadline.weight(.medium))
-                Text(pendingResponseRecoveryDetail(phase: phase))
-                    .font(.caption)
-                    .foregroundColor(isDarkMode ? .white.opacity(0.55) : .black.opacity(0.55))
             }
+
+            Text(pendingResponseRecoveryDetail(phase: phase))
+                .font(.caption)
+                .foregroundColor(isDarkMode ? .white.opacity(0.55) : .black.opacity(0.55))
         }
         .foregroundColor(isDarkMode ? .white : .black)
         .padding(.vertical, Constants.ChatRecovery.indicatorVerticalPadding)

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -19,6 +19,63 @@ struct IdentifiedGroup<T>: Identifiable {
     let items: [T]
 }
 
+func shouldShowPendingResponseRecovery(
+    message: Message,
+    pendingRecoveries: [PendingRecoveryEnvelope],
+    activeTurnId: String?
+) -> Bool {
+    guard message.role == .user,
+          let turnId = message.turnId,
+          turnId != activeTurnId
+    else {
+        return false
+    }
+    return pendingRecoveries.contains { $0.turnId == turnId }
+}
+
+private struct PendingResponseRecoveryView: View {
+    let isDarkMode: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Constants.ChatRecovery.indicatorSpacing) {
+            Image(systemName: "arrow.clockwise")
+                .font(.body.weight(.medium))
+                .foregroundColor(isDarkMode ? .white.opacity(0.65) : .black.opacity(0.65))
+
+            VStack(alignment: .leading, spacing: Constants.ChatRecovery.indicatorTextSpacing) {
+                HStack(spacing: Constants.ChatRecovery.indicatorTextSpacing) {
+                    Text(Constants.ChatRecovery.indicatorTitle)
+                        .font(.subheadline.weight(.medium))
+                    InlineLoadingDotsView(isDarkMode: isDarkMode)
+                        .accessibilityHidden(true)
+                }
+                Text(Constants.ChatRecovery.indicatorDetail)
+                    .font(.caption)
+                    .foregroundColor(isDarkMode ? .white.opacity(0.55) : .black.opacity(0.55))
+            }
+        }
+        .foregroundColor(isDarkMode ? .white : .black)
+        .padding(.horizontal, Constants.ChatRecovery.indicatorHorizontalPadding)
+        .padding(.vertical, Constants.ChatRecovery.indicatorVerticalPadding)
+        .frame(maxWidth: Constants.ChatRecovery.indicatorMaxWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: Constants.ChatRecovery.indicatorCornerRadius)
+                .fill(isDarkMode ? Color.white.opacity(0.06) : Color.black.opacity(0.04))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Constants.ChatRecovery.indicatorCornerRadius)
+                .stroke(
+                    isDarkMode ? Color.white.opacity(0.12) : Color.black.opacity(0.10),
+                    lineWidth: Constants.ChatRecovery.indicatorBorderWidth
+                )
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(Constants.ChatRecovery.indicatorTitle). \(Constants.ChatRecovery.indicatorDetail)"
+        )
+    }
+}
+
 struct MessageView: View {
     let message: Message
     let isDarkMode: Bool
@@ -49,6 +106,15 @@ struct MessageView: View {
     private var inlineAssistantTextSelectionEnabled: Bool {
         guard !(isLoading && isLastMessage) else { return false }
         return message.content.count <= Constants.Rendering.maxInlineSelectionCharacters
+    }
+
+    private var showsPendingResponseRecovery: Bool {
+        let activeTurnId = viewModel.isLoading ? viewModel.messages.last?.turnId : nil
+        return shouldShowPendingResponseRecovery(
+            message: message,
+            pendingRecoveries: viewModel.currentChat?.pendingRecoveries ?? [],
+            activeTurnId: activeTurnId
+        )
     }
 
     /// Runs of adjacent segments collapsed for inline rendering. Adjacent
@@ -728,6 +794,12 @@ struct MessageView: View {
                         isEditMode = true
                         viewModel.editRequestedForMessageIndex = nil
                     }
+                }
+
+                if showsPendingResponseRecovery {
+                    PendingResponseRecoveryView(isDarkMode: isDarkMode)
+                        .padding(.top, Constants.ChatRecovery.indicatorTopPadding)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
             }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -37,9 +37,10 @@ private func messageHasPendingRecovery(
 func shouldShowPendingResponseRecovery(
     message: Message,
     pendingRecoveries: [PendingRecoveryEnvelope],
-    activeTurnId: String?
+    activeTurnId: String?,
+    hasRecoveryDraft: Bool = false
 ) -> Bool {
-    messageHasPendingRecovery(
+    !hasRecoveryDraft && messageHasPendingRecovery(
         message: message,
         role: .user,
         pendingRecoveries: pendingRecoveries,
@@ -50,9 +51,10 @@ func shouldShowPendingResponseRecovery(
 func shouldHidePendingResponseAssistant(
     message: Message,
     pendingRecoveries: [PendingRecoveryEnvelope],
-    activeTurnId: String?
+    activeTurnId: String?,
+    hasRecoveryDraft: Bool = false
 ) -> Bool {
-    messageHasPendingRecovery(
+    !hasRecoveryDraft && messageHasPendingRecovery(
         message: message,
         role: .assistant,
         pendingRecoveries: pendingRecoveries,
@@ -102,6 +104,7 @@ struct MessageView: View {
     let isDarkMode: Bool
     let isLastMessage: Bool
     let isLoading: Bool
+    let hasRecoveryDraft: Bool
     let messageIndex: Int
     @EnvironmentObject var viewModel: TinfoilChat.ChatViewModel
     @ObservedObject private var recoveryPhaseTracker = ChatRecoveryPhaseTracker.shared
@@ -126,8 +129,12 @@ struct MessageView: View {
     }
 
     private var inlineAssistantTextSelectionEnabled: Bool {
-        guard !(isLoading && isLastMessage) else { return false }
+        guard !isRenderingStream else { return false }
         return message.content.count <= Constants.Rendering.maxInlineSelectionCharacters
+    }
+
+    private var isRenderingStream: Bool {
+        (isLoading && isLastMessage) || (hasRecoveryDraft && message.isStreaming)
     }
 
     private var recoveryContext: (pendingRecoveries: [PendingRecoveryEnvelope], activeTurnId: String?) {
@@ -142,7 +149,8 @@ struct MessageView: View {
         return shouldShowPendingResponseRecovery(
             message: message,
             pendingRecoveries: context.pendingRecoveries,
-            activeTurnId: context.activeTurnId
+            activeTurnId: context.activeTurnId,
+            hasRecoveryDraft: hasRecoveryDraft
         )
     }
 
@@ -151,7 +159,8 @@ struct MessageView: View {
         return shouldHidePendingResponseAssistant(
             message: message,
             pendingRecoveries: context.pendingRecoveries,
-            activeTurnId: context.activeTurnId
+            activeTurnId: context.activeTurnId,
+            hasRecoveryDraft: hasRecoveryDraft
         )
     }
 
@@ -318,7 +327,7 @@ struct MessageView: View {
             ForEach(runs) { identifiedRun in
                 switch identifiedRun.run {
                 case .text(let text, let isTrailing):
-                    let isStreamingText = isTrailing && isLoading && isLastMessage
+                    let isStreamingText = isTrailing && isRenderingStream
                     LaTeXMarkdownView(
                         content: text,
                         isDarkMode: isDarkMode,
@@ -335,20 +344,23 @@ struct MessageView: View {
                     CollapsibleThinkingBox(
                         thinkingText: content,
                         isDarkMode: isDarkMode,
-                        isStreaming: isThinking && isLoading && isLastMessage,
+                        isStreaming: isThinking && isRenderingStream,
                         generationTimeSeconds: duration,
-                        thinkingSummary: isLastMessage && isThinking ? viewModel.thinkingSummary : nil,
+                        thinkingSummary: isLoading && isLastMessage && isThinking
+                            ? viewModel.thinkingSummary
+                            : nil,
                         onTap: { showThoughtsSheet = true }
                     )
                 case .webSearches(let group):
                     let aggregate = aggregatedState(for: group)
                     let isSearchInFlight = aggregate.status == .searching
-                        && isLoading
-                        && isLastMessage
+                        && isRenderingStream
                     WebSearchBox(
                         webSearchState: aggregate,
                         isDarkMode: isDarkMode,
-                        webSearchSummary: isSearchInFlight ? viewModel.webSearchSummary : nil,
+                        webSearchSummary: isLoading && isLastMessage && isSearchInFlight
+                            ? viewModel.webSearchSummary
+                            : nil,
                         groupSize: group.count,
                         onTap: {
                             if group.count > 1 {
@@ -370,7 +382,7 @@ struct MessageView: View {
                 case .toolCall(let toolCall, let isTrailing):
                     GenUIToolCallView(
                         toolCall: toolCall,
-                        isStreaming: isTrailing && isLoading && isLastMessage,
+                        isStreaming: isTrailing && isRenderingStream,
                         isDarkMode: isDarkMode,
                         resolution: message.genUIResolution(for: toolCall.id),
                         onRetry: nil
@@ -447,8 +459,7 @@ struct MessageView: View {
                     message.thoughts == nil &&
                     !message.isThinking &&
                     (message.segments?.isEmpty ?? true) &&
-                    isLoading &&
-                    isLastMessage {
+                    isRenderingStream {
                     VStack(alignment: .leading, spacing: 4) {
                         if !message.urlFetches.isEmpty {
                             URLFetchBox(urlFetches: message.urlFetches, isDarkMode: isDarkMode, onTap: { showURLFetchSheet = true })
@@ -459,7 +470,9 @@ struct MessageView: View {
                             WebSearchBox(
                                 webSearchState: webSearchState,
                                 isDarkMode: isDarkMode,
-                                webSearchSummary: viewModel.webSearchSummary,
+                                webSearchSummary: isLoading && isLastMessage
+                                    ? viewModel.webSearchSummary
+                                    : nil,
                                 onTap: { showSourcesSheet = true }
                             )
                         }
@@ -491,9 +504,11 @@ struct MessageView: View {
                         CollapsibleThinkingBox(
                             thinkingText: message.thoughts ?? "",
                             isDarkMode: isDarkMode,
-                            isStreaming: message.isThinking && isLoading && isLastMessage,
+                            isStreaming: message.isThinking && isRenderingStream,
                             generationTimeSeconds: message.generationTimeSeconds,
-                            thinkingSummary: isLastMessage && message.isThinking ? viewModel.thinkingSummary : nil,
+                            thinkingSummary: isLoading && isLastMessage && message.isThinking
+                                ? viewModel.thinkingSummary
+                                : nil,
                             onTap: { showThoughtsSheet = true }
                         )
 
@@ -508,7 +523,9 @@ struct MessageView: View {
                                 WebSearchBox(
                                     webSearchState: webSearchState,
                                     isDarkMode: isDarkMode,
-                                    webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
+                                    webSearchSummary: isLoading && isLastMessage
+                                        ? viewModel.webSearchSummary
+                                        : nil,
                                     onTap: { showSourcesSheet = true }
                                 )
                             }
@@ -518,7 +535,7 @@ struct MessageView: View {
                                     ChunkedContentView(
                                         chunks: message.contentChunks,
                                         isDarkMode: isDarkMode,
-                                        isStreaming: isLoading && isLastMessage,
+                                        isStreaming: isRenderingStream,
                                         textSelectionEnabled: inlineAssistantTextSelectionEnabled,
                                         citationUrls: citationUrls
                                     )
@@ -528,7 +545,7 @@ struct MessageView: View {
                                     LaTeXMarkdownView(
                                         content: message.content,
                                         isDarkMode: isDarkMode,
-                                        isStreaming: isLoading && isLastMessage,
+                                        isStreaming: isRenderingStream,
                                         textSelectionEnabled: inlineAssistantTextSelectionEnabled,
                                         citationUrls: citationUrls
                                     )
@@ -549,9 +566,13 @@ struct MessageView: View {
                         CollapsibleThinkingBox(
                             thinkingText: parsed.thinkingText,
                             isDarkMode: isDarkMode,
-                            isStreaming: isLoading && isLastMessage,
+                            isStreaming: isRenderingStream,
                             generationTimeSeconds: message.generationTimeSeconds,
-                            thinkingSummary: isLastMessage && !message.content.contains("</think>") ? viewModel.thinkingSummary : nil,
+                            thinkingSummary: isLoading
+                                && isLastMessage
+                                && !message.content.contains("</think>")
+                                ? viewModel.thinkingSummary
+                                : nil,
                             onTap: { showThoughtsSheet = true }
                         )
                         
@@ -560,7 +581,7 @@ struct MessageView: View {
                             LaTeXMarkdownView(
                                 content: parsed.remainderText,
                                 isDarkMode: isDarkMode,
-                                isStreaming: isLoading && isLastMessage,
+                                isStreaming: isRenderingStream,
                                 textSelectionEnabled: inlineAssistantTextSelectionEnabled,
                                 citationUrls: citationUrls
                             )
@@ -627,7 +648,9 @@ struct MessageView: View {
                                 WebSearchBox(
                                     webSearchState: webSearchState,
                                     isDarkMode: isDarkMode,
-                                    webSearchSummary: isLastMessage ? viewModel.webSearchSummary : nil,
+                                    webSearchSummary: isLoading && isLastMessage
+                                        ? viewModel.webSearchSummary
+                                        : nil,
                                     onTap: { showSourcesSheet = true }
                                 )
                             }
@@ -636,7 +659,7 @@ struct MessageView: View {
                                 ChunkedContentView(
                                     chunks: message.contentChunks,
                                     isDarkMode: isDarkMode,
-                                    isStreaming: isLoading && isLastMessage,
+                                    isStreaming: isRenderingStream,
                                     textSelectionEnabled: inlineAssistantTextSelectionEnabled,
                                     citationUrls: citationUrls
                                 )
@@ -646,7 +669,7 @@ struct MessageView: View {
                                 LaTeXMarkdownView(
                                     content: message.content,
                                     isDarkMode: isDarkMode,
-                                    isStreaming: isLoading && isLastMessage,
+                                    isStreaming: isRenderingStream,
                                     textSelectionEnabled: inlineAssistantTextSelectionEnabled,
                                     citationUrls: citationUrls
                                 )
@@ -682,8 +705,7 @@ struct MessageView: View {
                 // initial content has started arriving so we don't double up
                 // with the initial `LoadingDotsView` placeholder above.
                 if message.role == .assistant &&
-                   isLoading &&
-                   isLastMessage &&
+                   isRenderingStream &&
                    (!message.content.isEmpty || message.thoughts != nil || message.isThinking ||
                     !(message.segments?.isEmpty ?? true)) {
                     StreamingIndicatorDot(isDarkMode: isDarkMode)
@@ -709,7 +731,7 @@ struct MessageView: View {
                 // Add action buttons for assistant messages (only when not streaming)
                 if message.role == .assistant &&
                    (!message.content.isEmpty || message.thoughts != nil) &&
-                   !(isLoading && isLastMessage) {
+                   !isRenderingStream {
                     HStack(spacing: 16) {
                         // Sources button - only show if we have web search sources
                         if let webSearchState = message.webSearchState,

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -33,45 +33,52 @@ func shouldShowPendingResponseRecovery(
     return pendingRecoveries.contains { $0.turnId == turnId }
 }
 
+func shouldHidePendingResponseAssistant(
+    message: Message,
+    pendingRecoveries: [PendingRecoveryEnvelope],
+    activeTurnId: String?
+) -> Bool {
+    guard message.role == .assistant,
+          let turnId = message.turnId,
+          turnId != activeTurnId
+    else {
+        return false
+    }
+    return pendingRecoveries.contains { $0.turnId == turnId }
+}
+
+func pendingResponseRecoveryDetail(phase: ChatRecoveryPhase) -> String {
+    switch phase {
+    case .generating:
+        return Constants.ChatRecovery.indicatorDetailGenerating
+    case .restoring:
+        return Constants.ChatRecovery.indicatorDetailRestoring
+    }
+}
+
 private struct PendingResponseRecoveryView: View {
     let isDarkMode: Bool
+    let phase: ChatRecoveryPhase
 
     var body: some View {
-        HStack(alignment: .top, spacing: Constants.ChatRecovery.indicatorSpacing) {
-            Image(systemName: "arrow.clockwise")
-                .font(.body.weight(.medium))
-                .foregroundColor(isDarkMode ? .white.opacity(0.65) : .black.opacity(0.65))
+        HStack(alignment: .center, spacing: Constants.ChatRecovery.indicatorSpacing) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(isDarkMode ? .white.opacity(0.65) : .black.opacity(0.65))
 
             VStack(alignment: .leading, spacing: Constants.ChatRecovery.indicatorTextSpacing) {
-                HStack(spacing: Constants.ChatRecovery.indicatorTextSpacing) {
-                    Text(Constants.ChatRecovery.indicatorTitle)
-                        .font(.subheadline.weight(.medium))
-                    InlineLoadingDotsView(isDarkMode: isDarkMode)
-                        .accessibilityHidden(true)
-                }
-                Text(Constants.ChatRecovery.indicatorDetail)
+                Text(Constants.ChatRecovery.indicatorTitle)
+                    .font(.subheadline.weight(.medium))
+                Text(pendingResponseRecoveryDetail(phase: phase))
                     .font(.caption)
                     .foregroundColor(isDarkMode ? .white.opacity(0.55) : .black.opacity(0.55))
             }
         }
         .foregroundColor(isDarkMode ? .white : .black)
-        .padding(.horizontal, Constants.ChatRecovery.indicatorHorizontalPadding)
         .padding(.vertical, Constants.ChatRecovery.indicatorVerticalPadding)
-        .frame(maxWidth: Constants.ChatRecovery.indicatorMaxWidth, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: Constants.ChatRecovery.indicatorCornerRadius)
-                .fill(isDarkMode ? Color.white.opacity(0.06) : Color.black.opacity(0.04))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: Constants.ChatRecovery.indicatorCornerRadius)
-                .stroke(
-                    isDarkMode ? Color.white.opacity(0.12) : Color.black.opacity(0.10),
-                    lineWidth: Constants.ChatRecovery.indicatorBorderWidth
-                )
-        )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(
-            "\(Constants.ChatRecovery.indicatorTitle). \(Constants.ChatRecovery.indicatorDetail)"
+            "\(Constants.ChatRecovery.indicatorTitle). \(pendingResponseRecoveryDetail(phase: phase))"
         )
     }
 }
@@ -83,6 +90,7 @@ struct MessageView: View {
     let isLoading: Bool
     let messageIndex: Int
     @EnvironmentObject var viewModel: TinfoilChat.ChatViewModel
+    @ObservedObject private var recoveryPhaseTracker = ChatRecoveryPhaseTracker.shared
     @State private var showCopyFeedback = false
     @State private var cachedParsedContent: (thinkingText: String, remainderText: String, contentHash: Int)? = nil
     @State private var showLongMessageSheet = false
@@ -111,6 +119,15 @@ struct MessageView: View {
     private var showsPendingResponseRecovery: Bool {
         let activeTurnId = viewModel.isLoading ? viewModel.messages.last?.turnId : nil
         return shouldShowPendingResponseRecovery(
+            message: message,
+            pendingRecoveries: viewModel.currentChat?.pendingRecoveries ?? [],
+            activeTurnId: activeTurnId
+        )
+    }
+
+    private var hidesPendingResponseAssistant: Bool {
+        let activeTurnId = viewModel.isLoading ? viewModel.messages.last?.turnId : nil
+        return shouldHidePendingResponseAssistant(
             message: message,
             pendingRecoveries: viewModel.currentChat?.pendingRecoveries ?? [],
             activeTurnId: activeTurnId
@@ -797,7 +814,10 @@ struct MessageView: View {
                 }
 
                 if showsPendingResponseRecovery {
-                    PendingResponseRecoveryView(isDarkMode: isDarkMode)
+                    PendingResponseRecoveryView(
+                        isDarkMode: isDarkMode,
+                        phase: recoveryPhaseTracker.phase(forTurnId: message.turnId)
+                    )
                         .padding(.top, Constants.ChatRecovery.indicatorTopPadding)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -902,6 +922,13 @@ struct MessageView: View {
             }
             return .systemAction
         })
+        .if(hidesPendingResponseAssistant) { view in
+            view
+                .hidden()
+                .frame(height: 0)
+                .clipped()
+                .accessibilityHidden(true)
+        }
     }
 
     private func copyMessagePart(_ text: String) {

--- a/TinfoilChat/Views/OptimizedChatListView.swift
+++ b/TinfoilChat/Views/OptimizedChatListView.swift
@@ -325,6 +325,7 @@ struct UIKitScrollView: UIViewRepresentable {
                                 isDarkMode: isDarkMode,
                                 isLastMessage: actualIndex == messages.count - 1,
                                 isLoading: false,
+                                hasRecoveryDraft: false,
                                 messageIndex: actualIndex
                             )
                             .markdownStyleHost(isDarkMode: isDarkMode)
@@ -464,6 +465,7 @@ struct StreamingMessageContainer: View {
                 isDarkMode: isDarkMode,
                 isLastMessage: true,
                 isLoading: isLoading,
+                hasRecoveryDraft: false,
                 messageIndex: messageIndex
             )
             .markdownStyleHost(isDarkMode: isDarkMode)

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -356,10 +356,11 @@ struct SettingsView: View {
     /// Shared destructive cleanup used by both "Delete Everything" and "Delete Account".
     private func performFullDataCleanup() async {
         await ProfileManager.shared.clearLocalProfileForAccountRemoval()
+        await chatViewModel.clearAllChatsFromDevice(resumeRecoveryScans: false)
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()
+        chatViewModel.resumeRecoveryScans()
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.hasLaunchedBefore)
-        await chatViewModel.clearAllChatsFromDevice()
         settings.clearAllSettings()
     }
 

--- a/TinfoilChatTests/ChatRecoveryClientTests.swift
+++ b/TinfoilChatTests/ChatRecoveryClientTests.swift
@@ -1,0 +1,44 @@
+@preconcurrency import EHBP
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Chat recovery client")
+struct ChatRecoveryClientTests {
+    @Test("plain conflict is not treated as processing")
+    func plainConflict() throws {
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://example.com/recovery/session")!,
+            statusCode: 409,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        do {
+            _ = try recoveryResponseNonce(from: response)
+            Issue.record("Expected a plain conflict to fail")
+        } catch ChatRecoveryClientError.httpStatus(let statusCode) {
+            #expect(statusCode == 409)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("authenticated upstream conflict preserves its nonce")
+    func authenticatedConflict() throws {
+        let nonceHex = String(
+            repeating: "a",
+            count: EHBPConstants.responseNonceLength * 2
+        )
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://example.com/recovery/session")!,
+            statusCode: 409,
+            httpVersion: nil,
+            headerFields: [EHBPProtocol.responseNonceHeader: nonceHex]
+        ))
+
+        let nonce = try recoveryResponseNonce(from: response)
+
+        #expect(nonce.count == EHBPConstants.responseNonceLength)
+    }
+}

--- a/TinfoilChatTests/ChatRecoveryClientTests.swift
+++ b/TinfoilChatTests/ChatRecoveryClientTests.swift
@@ -5,6 +5,32 @@ import Testing
 
 @Suite("Chat recovery client")
 struct ChatRecoveryClientTests {
+    @Test("status decodes persisted encrypted bytes")
+    func statusBytes() throws {
+        let status = try JSONDecoder().decode(
+            ChatRecoveryStatus.self,
+            from: Data(#"{"status":"processing","bytes":128}"#.utf8)
+        )
+
+        #expect(status.state == .processing)
+        #expect(status.persistedBytes == 128)
+    }
+
+    @Test("status rejects invalid persisted encrypted bytes", arguments: [
+        #"{"status":"complete"}"#,
+        #"{"status":"complete","bytes":-1}"#,
+        #"{"status":"complete","bytes":"128"}"#,
+    ])
+    func invalidStatusBytes(json: String) {
+        do {
+            _ = try JSONDecoder().decode(
+                ChatRecoveryStatus.self,
+                from: Data(json.utf8)
+            )
+            Issue.record("Expected invalid persisted bytes to fail")
+        } catch {}
+    }
+
     @Test("plain conflict is not treated as processing")
     func plainConflict() throws {
         let response = try #require(HTTPURLResponse(

--- a/TinfoilChatTests/ChatRecoveryCryptoTests.swift
+++ b/TinfoilChatTests/ChatRecoveryCryptoTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Chat recovery envelope crypto")
+struct ChatRecoveryCryptoTests {
+    private let userId = "user_123"
+    private let chatId = "chat_123"
+    private let turnId = "turn_123"
+    private let sessionId = "0123456789abcdef0123456789abcdef"
+    private let now = ISO8601DateFormatter().date(from: "2026-07-20T12:00:00Z")!
+
+    private var token: ChatRecoveryTokenFields {
+        ChatRecoveryTokenFields(
+            exportedSecret: String(repeating: "a", count: 64),
+            requestEnc: String(repeating: "b", count: 64)
+        )
+    }
+
+    @Test("round trips structured and serialized tokens")
+    func roundTrip() throws {
+        for payload in [
+            ChatRecoveryTokenPayload.fields(token),
+            .serialized(String(data: try JSONEncoder().encode(token), encoding: .utf8)!),
+        ] {
+            let envelope = try ChatRecoveryCrypto.encrypt(
+                cek: Data(repeating: 1, count: 32),
+                userId: userId,
+                chatId: chatId,
+                turnId: turnId,
+                sessionId: sessionId,
+                recoveryToken: payload,
+                now: now
+            )
+            let opened = try ChatRecoveryCrypto.decrypt(
+                cek: Data(repeating: 1, count: 32),
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope,
+                now: now
+            )
+            #expect(opened.sessionId == sessionId)
+            #expect(opened.recoveryToken.fields == token)
+        }
+    }
+
+    @Test("binds ciphertext to account and turn metadata")
+    func authenticatedMetadata() throws {
+        let envelope = try makeEnvelope()
+        #expect(throws: ChatRecoveryCryptoError.self) {
+            try ChatRecoveryCrypto.decrypt(
+                cek: Data(repeating: 1, count: 32),
+                userId: "another_user",
+                chatId: chatId,
+                envelope: envelope,
+                now: now
+            )
+        }
+        let tampered = PendingRecoveryEnvelope(
+            v: envelope.v,
+            turnId: "another_turn",
+            keyId: envelope.keyId,
+            createdAt: envelope.createdAt,
+            expiresAt: envelope.expiresAt,
+            nonce: envelope.nonce,
+            ciphertext: envelope.ciphertext
+        )
+        #expect(throws: ChatRecoveryCryptoError.self) {
+            try ChatRecoveryCrypto.decrypt(
+                cek: Data(repeating: 1, count: 32),
+                userId: userId,
+                chatId: chatId,
+                envelope: tampered,
+                now: now
+            )
+        }
+    }
+
+    @Test("rewrap preserves lifetime and requires the new key")
+    func rewrap() throws {
+        let envelope = try makeEnvelope()
+        let rewrapped = try ChatRecoveryCrypto.rewrap(
+            envelope: envelope,
+            userId: userId,
+            chatId: chatId,
+            oldCEK: Data(repeating: 1, count: 32),
+            newCEK: Data(repeating: 2, count: 32),
+            now: now
+        )
+        #expect(rewrapped.createdAt == envelope.createdAt)
+        #expect(rewrapped.expiresAt == envelope.expiresAt)
+        #expect(rewrapped.keyId != envelope.keyId)
+        #expect(throws: ChatRecoveryCryptoError.self) {
+            try ChatRecoveryCrypto.decrypt(
+                cek: Data(repeating: 1, count: 32),
+                userId: userId,
+                chatId: chatId,
+                envelope: rewrapped,
+                now: now
+            )
+        }
+        let opened = try ChatRecoveryCrypto.decrypt(
+            cek: Data(repeating: 2, count: 32),
+            userId: userId,
+            chatId: chatId,
+            envelope: rewrapped,
+            now: now
+        )
+        #expect(opened.recoveryToken.fields == token)
+    }
+
+    @Test("rejects expired envelopes")
+    func expiry() throws {
+        let envelope = try makeEnvelope()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let expiry = formatter.date(from: envelope.expiresAt)!
+        #expect(try ChatRecoveryCrypto.isExpired(envelope, now: expiry))
+        #expect(throws: ChatRecoveryCryptoError.expired) {
+            try ChatRecoveryCrypto.decrypt(
+                cek: Data(repeating: 1, count: 32),
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope,
+                now: expiry
+            )
+        }
+    }
+
+    @Test("rejects oversized ciphertext")
+    func oversizedCiphertext() throws {
+        let envelope = try makeEnvelope()
+        let oversized = PendingRecoveryEnvelope(
+            v: envelope.v,
+            turnId: envelope.turnId,
+            keyId: envelope.keyId,
+            createdAt: envelope.createdAt,
+            expiresAt: envelope.expiresAt,
+            nonce: envelope.nonce,
+            ciphertext: Data(
+                repeating: 0,
+                count: Constants.ChatRecovery.maxCiphertextBytes + 1
+            ).base64EncodedString()
+        )
+        #expect(throws: ChatRecoveryCryptoError.invalidEnvelope) {
+            try ChatRecoveryCrypto.validate(oversized)
+        }
+    }
+
+    @Test("round trips cross-device turn metadata")
+    func modelRoundTrip() throws {
+        let message = Message(
+            role: .user,
+            turnId: turnId,
+            content: "hello"
+        )
+        let decodedMessage = try JSONDecoder().decode(
+            Message.self,
+            from: JSONEncoder().encode(message)
+        )
+        #expect(decodedMessage.turnId == turnId)
+
+        let envelope = try makeEnvelope()
+        let decodedEnvelope = try JSONDecoder().decode(
+            PendingRecoveryEnvelope.self,
+            from: JSONEncoder().encode(envelope)
+        )
+        #expect(decodedEnvelope == envelope)
+    }
+
+    private func makeEnvelope() throws -> PendingRecoveryEnvelope {
+        try ChatRecoveryCrypto.encrypt(
+            cek: Data(repeating: 1, count: 32),
+            userId: userId,
+            chatId: chatId,
+            turnId: turnId,
+            sessionId: sessionId,
+            recoveryToken: .fields(token),
+            now: now
+        )
+    }
+}

--- a/TinfoilChatTests/ChatRecoveryCryptoTests.swift
+++ b/TinfoilChatTests/ChatRecoveryCryptoTests.swift
@@ -24,7 +24,7 @@ struct ChatRecoveryCryptoTests {
             .serialized(String(data: try JSONEncoder().encode(token), encoding: .utf8)!),
         ] {
             let envelope = try ChatRecoveryCrypto.encrypt(
-                cek: Data(repeating: 1, count: 32),
+                cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
                 userId: userId,
                 chatId: chatId,
                 turnId: turnId,
@@ -33,7 +33,7 @@ struct ChatRecoveryCryptoTests {
                 now: now
             )
             let opened = try ChatRecoveryCrypto.decrypt(
-                cek: Data(repeating: 1, count: 32),
+                cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
                 userId: userId,
                 chatId: chatId,
                 envelope: envelope,
@@ -49,7 +49,7 @@ struct ChatRecoveryCryptoTests {
         let envelope = try makeEnvelope()
         #expect(throws: ChatRecoveryCryptoError.self) {
             try ChatRecoveryCrypto.decrypt(
-                cek: Data(repeating: 1, count: 32),
+                cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
                 userId: "another_user",
                 chatId: chatId,
                 envelope: envelope,
@@ -67,7 +67,7 @@ struct ChatRecoveryCryptoTests {
         )
         #expect(throws: ChatRecoveryCryptoError.self) {
             try ChatRecoveryCrypto.decrypt(
-                cek: Data(repeating: 1, count: 32),
+                cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
                 userId: userId,
                 chatId: chatId,
                 envelope: tampered,
@@ -83,8 +83,8 @@ struct ChatRecoveryCryptoTests {
             envelope: envelope,
             userId: userId,
             chatId: chatId,
-            oldCEK: Data(repeating: 1, count: 32),
-            newCEK: Data(repeating: 2, count: 32),
+            oldCEK: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
+            newCEK: Data(repeating: 2, count: SyncEnclaveKeyBundle.cekByteCount),
             now: now
         )
         #expect(rewrapped.createdAt == envelope.createdAt)
@@ -92,7 +92,7 @@ struct ChatRecoveryCryptoTests {
         #expect(rewrapped.keyId != envelope.keyId)
         #expect(throws: ChatRecoveryCryptoError.self) {
             try ChatRecoveryCrypto.decrypt(
-                cek: Data(repeating: 1, count: 32),
+                cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
                 userId: userId,
                 chatId: chatId,
                 envelope: rewrapped,
@@ -100,13 +100,60 @@ struct ChatRecoveryCryptoTests {
             )
         }
         let opened = try ChatRecoveryCrypto.decrypt(
-            cek: Data(repeating: 2, count: 32),
+            cek: Data(repeating: 2, count: SyncEnclaveKeyBundle.cekByteCount),
             userId: userId,
             chatId: chatId,
             envelope: rewrapped,
             now: now
         )
         #expect(opened.recoveryToken.fields == token)
+    }
+
+    @Test("binds local recovery envelopes to the device key")
+    func localDeviceKey() throws {
+        let deviceKey = Data(
+            repeating: 3,
+            count: SyncEnclaveKeyBundle.cekByteCount
+        )
+        let cloudKey = Data(
+            repeating: 4,
+            count: SyncEnclaveKeyBundle.cekByteCount
+        )
+        let envelope = try makeEnvelope(cek: deviceKey)
+        #expect(throws: ChatRecoveryCryptoError.invalidKey) {
+            try ChatRecoveryCrypto.decrypt(
+                cek: cloudKey,
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope,
+                now: now
+            )
+        }
+        let opened = try ChatRecoveryCrypto.decrypt(
+            cek: deviceKey,
+            userId: userId,
+            chatId: chatId,
+            envelope: envelope,
+            now: now
+        )
+        #expect(opened.recoveryToken.fields == token)
+    }
+
+    @Test("normalizes malformed recovery keys")
+    func malformedKey() throws {
+        let envelope = try makeEnvelope()
+        #expect(throws: ChatRecoveryCryptoError.invalidKey) {
+            try ChatRecoveryCrypto.decrypt(
+                cek: Data(
+                    repeating: 1,
+                    count: SyncEnclaveKeyBundle.cekByteCount - 1
+                ),
+                userId: userId,
+                chatId: chatId,
+                envelope: envelope,
+                now: now
+            )
+        }
     }
 
     @Test("rejects expired envelopes")
@@ -118,7 +165,7 @@ struct ChatRecoveryCryptoTests {
         #expect(try ChatRecoveryCrypto.isExpired(envelope, now: expiry))
         #expect(throws: ChatRecoveryCryptoError.expired) {
             try ChatRecoveryCrypto.decrypt(
-                cek: Data(repeating: 1, count: 32),
+                cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
                 userId: userId,
                 chatId: chatId,
                 envelope: envelope,
@@ -168,9 +215,11 @@ struct ChatRecoveryCryptoTests {
         #expect(decodedEnvelope == envelope)
     }
 
-    private func makeEnvelope() throws -> PendingRecoveryEnvelope {
+    private func makeEnvelope(
+        cek: Data = Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount)
+    ) throws -> PendingRecoveryEnvelope {
         try ChatRecoveryCrypto.encrypt(
-            cek: Data(repeating: 1, count: 32),
+            cek: cek,
             userId: userId,
             chatId: chatId,
             turnId: turnId,

--- a/TinfoilChatTests/ChatRecoveryDraftStoreTests.swift
+++ b/TinfoilChatTests/ChatRecoveryDraftStoreTests.swift
@@ -50,6 +50,38 @@ struct ChatRecoveryDraftStoreTests {
         #expect(stored?.isStreaming == true)
     }
 
+    @Test func rejectsDraftsFromSupersededScans() {
+        let store = ChatRecoveryDraftStore()
+        store.reset(generation: 1)
+        store.beginScan(generation: 4)
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Current"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 1,
+            scanGeneration: 4
+        )
+
+        store.beginScan(generation: 5)
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Stale"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 1,
+            scanGeneration: 4
+        )
+        #expect(store.drafts.values.first?.content == "Current")
+
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Fresh"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 1,
+            scanGeneration: 5
+        )
+        #expect(store.drafts.values.first?.content == "Fresh")
+    }
+
     @Test func prunesByChatAndResetClearsEveryDraft() {
         let store = ChatRecoveryDraftStore()
         let drafts = [

--- a/TinfoilChatTests/ChatRecoveryDraftStoreTests.swift
+++ b/TinfoilChatTests/ChatRecoveryDraftStoreTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@MainActor
+struct ChatRecoveryDraftStoreTests {
+    @Test func replacesWholeSnapshotsAndRejectsStaleGenerations() {
+        let store = ChatRecoveryDraftStore()
+        store.reset(generation: 3)
+        var first = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "First",
+            thoughts: "Reasoning"
+        )
+        first.urlFetches = [
+            URLFetchState(id: "fetch-1", url: "https://example.com", status: .fetching)
+        ]
+        store.replace(
+            first,
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 3
+        )
+
+        let replacement = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Replacement"
+        )
+        store.replace(
+            replacement,
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 3
+        )
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Stale"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 2
+        )
+
+        let stored = store.drafts[
+            ChatRecoveryDraftKey(chatId: "chat-1", turnId: "turn-1")
+        ]
+        #expect(stored?.content == "Replacement")
+        #expect(stored?.thoughts == nil)
+        #expect(stored?.urlFetches.isEmpty == true)
+        #expect(stored?.isStreaming == true)
+    }
+
+    @Test func prunesByChatAndResetClearsEveryDraft() {
+        let store = ChatRecoveryDraftStore()
+        let drafts = [
+            ("chat-1", "turn-1"),
+            ("chat-1", "turn-2"),
+            ("chat-2", "turn-1"),
+        ]
+        for (chatId, turnId) in drafts {
+            store.replace(
+                Message(role: .assistant, turnId: turnId, content: turnId),
+                chatId: chatId,
+                turnId: turnId,
+                generation: 0
+            )
+        }
+
+        store.prune(chatId: "chat-1", retaining: ["turn-2"])
+
+        #expect(store.drafts.keys.contains(
+            ChatRecoveryDraftKey(chatId: "chat-1", turnId: "turn-2")
+        ))
+        #expect(!store.drafts.keys.contains(
+            ChatRecoveryDraftKey(chatId: "chat-1", turnId: "turn-1")
+        ))
+        #expect(store.drafts.keys.contains(
+            ChatRecoveryDraftKey(chatId: "chat-2", turnId: "turn-1")
+        ))
+
+        store.reset(generation: 1)
+        #expect(store.drafts.isEmpty)
+    }
+
+    @Test func discardedChatRejectsLateDraftsUntilReset() {
+        let store = ChatRecoveryDraftStore()
+        store.discard(chatId: "chat-1")
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Late"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 0
+        )
+        #expect(store.drafts.isEmpty)
+
+        store.reset(generation: 1)
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Current"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 1
+        )
+        #expect(store.drafts.count == 1)
+    }
+
+    @Test func discardedTurnRejectsLateDraftsUntilAllowed() {
+        let store = ChatRecoveryDraftStore()
+        store.discard(chatId: "chat-1", turnId: "turn-1")
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Late"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 0
+        )
+        #expect(store.drafts.isEmpty)
+
+        store.allow(chatId: "chat-1", turnId: "turn-1")
+        store.replace(
+            Message(role: .assistant, turnId: "turn-1", content: "Current"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            generation: 0
+        )
+        #expect(store.drafts.count == 1)
+    }
+
+    @Test func substitutesPersistedAssistantWithoutChangingTimelineIdentity() {
+        let timestamp = Date(timeIntervalSince1970: 1_000)
+        let user = Message(
+            id: "user-id",
+            role: .user,
+            turnId: "turn-1",
+            content: "Question"
+        )
+        let partial = Message(
+            id: "assistant-id",
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Old partial",
+            timestamp: timestamp
+        )
+        var draft = Message(
+            id: "ephemeral-id",
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered answer",
+            thoughts: "Recovered reasoning"
+        )
+        draft.toolCalls = [
+            GenUIToolCall(id: "call-1", name: "example", arguments: "{}")
+        ]
+
+        let presented = messagesApplyingRecoveryDrafts(
+            [user, partial],
+            chatId: "chat-1",
+            pendingTurnIds: ["turn-1"],
+            drafts: [
+                ChatRecoveryDraftKey(chatId: "chat-1", turnId: "turn-1"): draft
+            ]
+        )
+
+        #expect(presented.count == 2)
+        #expect(presented[1].id == "assistant-id")
+        #expect(presented[1].timestamp == timestamp)
+        #expect(presented[1].content == "Recovered answer")
+        #expect(presented[1].thoughts == "Recovered reasoning")
+        #expect(presented[1].toolCalls == draft.toolCalls)
+        #expect(presented[1].isStreaming)
+    }
+
+    @Test func insertsStableAssistantImmediatelyAfterMatchingUser() {
+        let timestamp = Date(timeIntervalSince1970: 1_000)
+        let user = Message(
+            id: "user-id",
+            role: .user,
+            turnId: "turn-1",
+            content: "Question",
+            timestamp: timestamp
+        )
+        let later = Message(
+            id: "later-id",
+            role: .user,
+            turnId: "turn-2",
+            content: "Later"
+        )
+        let draft = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered"
+        )
+        let drafts = [
+            ChatRecoveryDraftKey(chatId: "chat-1", turnId: "turn-1"): draft
+        ]
+
+        let first = messagesApplyingRecoveryDrafts(
+            [user, later],
+            chatId: "chat-1",
+            pendingTurnIds: ["turn-1"],
+            drafts: drafts
+        )
+        let second = messagesApplyingRecoveryDrafts(
+            [user, later],
+            chatId: "chat-1",
+            pendingTurnIds: ["turn-1"],
+            drafts: drafts
+        )
+
+        #expect(first.map(\.id) == [
+            "user-id",
+            recoveryDraftMessageId(chatId: "chat-1", turnId: "turn-1"),
+            "later-id",
+        ])
+        #expect(first[1].id == second[1].id)
+        #expect(first[1].timestamp == timestamp)
+        #expect(first[1].role == .assistant)
+        #expect(first[1].isStreaming)
+    }
+
+    @Test func ignoresDraftsOutsideThePendingChatTurn() {
+        let user = Message(
+            role: .user,
+            turnId: "turn-1",
+            content: "Question"
+        )
+        let draft = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered"
+        )
+
+        let presented = messagesApplyingRecoveryDrafts(
+            [user],
+            chatId: "chat-1",
+            pendingTurnIds: ["turn-2"],
+            drafts: [
+                ChatRecoveryDraftKey(chatId: "chat-2", turnId: "turn-1"): draft
+            ]
+        )
+
+        #expect(presented == [user])
+    }
+}

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ChatRecoverySchedulingTests {
+    @Test func emptyThinkingStateKeepsRecoveryIndicatorVisible() {
+        let emptyThinking = Message(
+            role: .assistant,
+            content: "",
+            isThinking: true
+        )
+        let recoveredThought = Message(
+            role: .assistant,
+            content: "",
+            thoughts: "Recovered reasoning",
+            isThinking: true
+        )
+
+        #expect(!recoveryDraftHasVisibleContent(emptyThinking))
+        #expect(recoveryDraftHasVisibleContent(recoveredThought))
+    }
+
+    @Test func replacesOnlyScansThatHaveStoppedMakingProgress() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let freshProgress = now.addingTimeInterval(
+            -Constants.ChatRecovery.scanStallTimeoutSeconds + 1
+        )
+        let staleProgress = now.addingTimeInterval(
+            -Constants.ChatRecovery.scanStallTimeoutSeconds
+        )
+
+        #expect(!recoveryScanHasStalled(lastProgressAt: nil, now: now))
+        #expect(!recoveryScanHasStalled(lastProgressAt: freshProgress, now: now))
+        #expect(recoveryScanHasStalled(lastProgressAt: staleProgress, now: now))
+    }
+}

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import TinfoilChat
 
 struct ChatRecoverySchedulingTests {
-    @Test func emptyThinkingStateKeepsRecoveryIndicatorVisible() {
+    @Test func emptyThinkingDraftDoesNotReplaceRecoveryIndicator() {
         let emptyThinking = Message(
             role: .assistant,
             content: "",
@@ -18,6 +18,23 @@ struct ChatRecoverySchedulingTests {
 
         #expect(!recoveryDraftHasVisibleContent(emptyThinking))
         #expect(recoveryDraftHasVisibleContent(recoveredThought))
+    }
+
+    @Test func persistedRecoveryUsesCompletionTimestamp() {
+        let draft = Message(
+            role: .assistant,
+            content: "Recovered response",
+            timestamp: .distantPast
+        )
+        let completionTimestamp = Date(timeIntervalSince1970: 1_000)
+
+        let persisted = recoveredResponseForPersistence(
+            draft,
+            timestamp: completionTimestamp
+        )
+
+        #expect(draft.timestamp == .distantPast)
+        #expect(persisted.timestamp == completionTimestamp)
     }
 
     @Test func replacesOnlyScansThatHaveStoppedMakingProgress() {

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -37,6 +37,40 @@ struct ChatRecoverySchedulingTests {
         #expect(persisted.timestamp == completionTimestamp)
     }
 
+    @Test func recoveredFirstResponseCanGenerateAChatTitle() throws {
+        let user = Message(
+            role: .user,
+            turnId: "turn-1",
+            content: "Question"
+        )
+        let partial = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Partial"
+        )
+        let recovered = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered response"
+        )
+
+        let messages = try #require(recoveredTitleMessages(
+            titleState: .placeholder,
+            messages: [user, partial],
+            response: recovered,
+            turnId: "turn-1"
+        ))
+
+        #expect(messages.count == 2)
+        #expect(messages[1].content == "Recovered response")
+        #expect(recoveredTitleMessages(
+            titleState: .manual,
+            messages: [user, partial],
+            response: recovered,
+            turnId: "turn-1"
+        ) == nil)
+    }
+
     @Test func replacesOnlyScansThatHaveStoppedMakingProgress() {
         let now = Date(timeIntervalSince1970: 1_000)
         let freshProgress = now.addingTimeInterval(

--- a/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
+++ b/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
@@ -113,6 +113,16 @@ struct EnclaveErrorRecoveryTests {
             SyncEnclaveError(message: "stale blob", status: 412)
         ))
         #expect(EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(message: "conflict", status: 409)
+        ))
+        #expect(EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(
+                message: "conflict",
+                status: 409,
+                code: SyncEnclaveError.httpStatusFallbackCode(409)
+            )
+        ))
+        #expect(EnclaveErrorRecovery.isVersionConflict(
             SyncEnclaveError(
                 message: "stale blob",
                 status: 412,

--- a/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
+++ b/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
@@ -112,6 +112,13 @@ struct EnclaveErrorRecoveryTests {
         #expect(EnclaveErrorRecovery.isVersionConflict(
             SyncEnclaveError(message: "stale blob", status: 412)
         ))
+        #expect(EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(
+                message: "stale blob",
+                status: 412,
+                code: SyncEnclaveError.httpStatusFallbackCode(412)
+            )
+        ))
         #expect(!EnclaveErrorRecovery.isVersionConflict(
             SyncEnclaveError(
                 message: "stale key",

--- a/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
+++ b/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
@@ -101,6 +101,33 @@ struct EnclaveErrorRecoveryTests {
         #expect(decision.classification.kind == .terminal)
     }
 
+    @Test func versionConflictExcludesStaleKey() {
+        #expect(EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(
+                message: "conflict",
+                status: 409,
+                code: WireCodes.syncConflict
+            )
+        ))
+        #expect(EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(message: "stale blob", status: 412)
+        ))
+        #expect(!EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(
+                message: "stale key",
+                status: 409,
+                code: WireCodes.staleKey
+            )
+        ))
+        #expect(!EnclaveErrorRecovery.isVersionConflict(
+            SyncEnclaveError(
+                message: "unknown key",
+                status: 412,
+                code: WireCodes.unknownKey
+            )
+        ))
+    }
+
     // MARK: - Non-SyncEnclaveError fallback
 
     @Test func wrappedVerificationFailureMapsToBlockAllSync() {

--- a/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
+++ b/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
@@ -47,4 +47,47 @@ struct PendingResponseRecoveryPresentationTests {
             activeTurnId: "turn-1"
         ))
     }
+
+    @Test func hidesInterruptedAssistantWhileRecoveryIsPending() {
+        let interrupted = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "",
+            thoughts: "Partial reasoning",
+            isThinking: true
+        )
+
+        #expect(shouldHidePendingResponseAssistant(
+            message: interrupted,
+            pendingRecoveries: [recovery],
+            activeTurnId: nil
+        ))
+        #expect(!shouldHidePendingResponseAssistant(
+            message: interrupted,
+            pendingRecoveries: [recovery],
+            activeTurnId: "turn-1"
+        ))
+    }
+
+    @Test func describesRecoveryPhases() {
+        #expect(pendingResponseRecoveryDetail(phase: .generating)
+            == "This may take a few minutes")
+        #expect(pendingResponseRecoveryDetail(phase: .restoring)
+            == "This may take a few minutes")
+    }
+
+    @Test func blocksSendingOnlyAfterAnInterruptedRecoverableTurn() {
+        #expect(shouldBlockMessageSendForRecovery(
+            pendingRecoveries: [recovery],
+            isStreaming: false
+        ))
+        #expect(!shouldBlockMessageSendForRecovery(
+            pendingRecoveries: [recovery],
+            isStreaming: true
+        ))
+        #expect(!shouldBlockMessageSendForRecovery(
+            pendingRecoveries: [],
+            isStreaming: false
+        ))
+    }
 }

--- a/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
+++ b/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
@@ -69,6 +69,28 @@ struct PendingResponseRecoveryPresentationTests {
         ))
     }
 
+    @Test func draftSuppressesPlaceholderAndRevealsAssistant() {
+        let user = Message(role: .user, turnId: "turn-1", content: "Question")
+        let assistant = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered partial"
+        )
+
+        #expect(!shouldShowPendingResponseRecovery(
+            message: user,
+            pendingRecoveries: [recovery],
+            activeTurnId: nil,
+            hasRecoveryDraft: true
+        ))
+        #expect(!shouldHidePendingResponseAssistant(
+            message: assistant,
+            pendingRecoveries: [recovery],
+            activeTurnId: nil,
+            hasRecoveryDraft: true
+        ))
+    }
+
     @Test func describesRecoveryPhases() {
         #expect(pendingResponseRecoveryDetail(phase: .generating)
             == "This may take a few minutes")

--- a/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
+++ b/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import TinfoilChat
+
+struct PendingResponseRecoveryPresentationTests {
+    private let recovery = PendingRecoveryEnvelope(
+        v: 1,
+        turnId: "turn-1",
+        keyId: String(repeating: "0", count: 32),
+        createdAt: "2026-07-21T00:00:00.000Z",
+        expiresAt: "2026-07-22T00:00:00.000Z",
+        nonce: "nonce",
+        ciphertext: "ciphertext"
+    )
+
+    @Test func showsRecoveryForMatchingUserTurn() {
+        let message = Message(role: .user, turnId: "turn-1", content: "Question")
+
+        #expect(shouldShowPendingResponseRecovery(
+            message: message,
+            pendingRecoveries: [recovery],
+            activeTurnId: nil
+        ))
+    }
+
+    @Test func hidesRecoveryForAssistantAndUnrelatedTurns() {
+        let assistant = Message(role: .assistant, turnId: "turn-1", content: "")
+        let otherUser = Message(role: .user, turnId: "turn-2", content: "Question")
+
+        #expect(!shouldShowPendingResponseRecovery(
+            message: assistant,
+            pendingRecoveries: [recovery],
+            activeTurnId: nil
+        ))
+        #expect(!shouldShowPendingResponseRecovery(
+            message: otherUser,
+            pendingRecoveries: [recovery],
+            activeTurnId: nil
+        ))
+    }
+
+    @Test func hidesRecoveryForActiveStreamingTurn() {
+        let message = Message(role: .user, turnId: "turn-1", content: "Question")
+
+        #expect(!shouldShowPendingResponseRecovery(
+            message: message,
+            pendingRecoveries: [recovery],
+            activeTurnId: "turn-1"
+        ))
+    }
+}

--- a/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
+++ b/TinfoilChatTests/PendingResponseRecoveryPresentationTests.swift
@@ -112,4 +112,19 @@ struct PendingResponseRecoveryPresentationTests {
             isStreaming: false
         ))
     }
+
+    @Test func activeRecoveredResponseShowsStopAction() {
+        #expect(shouldShowMessageStopAction(
+            isStreaming: false,
+            hasActiveRecovery: true,
+            hasSubmittableContent: false,
+            isMessageQueueFull: false
+        ))
+        #expect(!shouldShowMessageStopAction(
+            isStreaming: false,
+            hasActiveRecovery: false,
+            hasSubmittableContent: false,
+            isMessageQueueFull: false
+        ))
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds cross-device and same-device recovery for interrupted chat streams. Streams recovered responses live (including local-only chats), shows progress, keeps scans moving, and finalizes recovered conversations more reliably.

- **New Features**
  - Add `turnId` on messages and `pendingRecoveries` on chats; surface `hasPendingRecoveries` in `ChatIndexEntry`; sync in cloud `StoredChat`.
  - Start recoverable streams via `ChatRecoveryClient` using `EHBP`; capture a session and per-turn recovery token.
  - Encrypt and authenticate envelopes with `ChatRecoveryCrypto` (HKDF + AES-GCM; scoped to user/chat/turn; TTLs and size/identifier limits).
  - Coordinate scans and lifecycle with `ChatRecoveryCoordinator`/`ChatRecoverySync`; recover local and cloud chats; fast-path load chats with pending recoveries; ensure the user turn is uploaded before cloud recovery via `CloudSyncService.backupChatAndWait`.
  - UI: stream recovered responses under the matching user turn; hide the overlapping assistant bubble; block send while a prior response is recovering; show progress by received token counts; use streaming layout for recovery drafts.
  - Recover interrupted local-only chats when envelopes are stored on device.
  - Update dependencies: `EHBP` 0.3.0 and `openai-swift` 0.0.11.

- **Bug Fixes**
  - Detect stalled recovery scans and restart only those that stop making progress; enforce request/scan timeouts.
  - Clean up failed/missing sessions and remove envelopes; reset on sign-out; safely resume after destructive cleanup; make cleanup durable by clearing recovered state first.
  - Recognize sync conflicts without error codes (409/412) using HTTP fallback; unify detection in `EnclaveErrorRecovery.isVersionConflict`.
  - Require an existing device key for local decryption; finalize legacy key migration by pruning alternatives after re-seal.
  - Replay recovered responses from the beginning to avoid truncation and ensure consistent reconstruction.
  - Tighten recovered conversation completion: persist the upstream completion timestamp and finalize titles only after content is stored.
  - Prevent stale recovery updates and avoid publishing during layout; polish UI (e.g., align recovery spinner with title text); authenticate recovered upstream errors.

<sup>Written for commit 14ced69c43f5c7d0be27ad9ca1493f55d677bfd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

