### PR TITLE
chore: rename agent instructions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .sentryclirc
 TinfoilChat.xcodeproj/project.xcworkspace/xcuserdata
 TinfoilChat.xcodeproj/xcuserdata/*
-CLAUDE.md
 .build/
 *.noindex/
 TinfoilChat-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Building and Running
+
+NEVER build or run the project using xcodebuild or any other compilation commands. Only make code changes and let the user handle building, running, and testing in Xcode.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the agent instructions to `AGENTS.md` and ensured it is tracked by Git (removed from `.gitignore`). Clarifies that contributors should not build or run the project; only make code changes and let users build/test in Xcode.

<sup>Written for commit 2e103a43756a852fd61299e9a279616b0fbea04f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

