### PR TITLE
Fix misc UI and UX issues

### DIFF
--- a/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/StatCardsWidget.swift
@@ -74,7 +74,7 @@ private struct StatCardsView: View {
                     Text(stat.label)
                         .font(.caption.weight(.medium))
                         .foregroundColor(GenUIStyle.mutedText(isDarkMode))
-                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
 
                     HStack(spacing: 6) {
                         Text(stat.value.stringValue)

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -102,13 +102,17 @@ struct MessageInputView: View {
     /// The trailing button doubles as voice input while the draft is empty
     /// and becomes the send button once the user enters text or attaches
     /// files; while a stream with nothing submittable is in flight it turns
-    /// into a stop button. An active recording or transcription pins the
-    /// voice role so the microphone can always be stopped.
+    /// into a stop button. An active recording pins the voice role so the
+    /// microphone can always be stopped, but a pending transcription yields
+    /// to stop so an in-flight stream stays cancellable.
     private var trailingAction: TrailingAction {
-        if showAudioButton && (viewModel.isRecording || viewModel.isTranscribing) {
+        if showAudioButton && viewModel.isRecording {
             return .voice
         }
         if showStopAction { return .stop }
+        if showAudioButton && viewModel.isTranscribing {
+            return .voice
+        }
         if showAudioButton,
            messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
            viewModel.pendingAttachments.isEmpty {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -93,10 +93,78 @@ struct MessageInputView: View {
         viewModel.isLoading && (!hasSubmittableContent || viewModel.isMessageQueueFull)
     }
 
-    /// The send button greys out while a draft can't be dispatched because
-    /// an attachment is still processing.
-    private var isSendActionDisabled: Bool {
-        !showStopAction && !attachmentsAreReadyToSend(viewModel.pendingAttachments)
+    private enum TrailingAction {
+        case voice
+        case send
+        case stop
+    }
+
+    /// The trailing button doubles as voice input while the draft is empty
+    /// and becomes the send button once the user enters text or attaches
+    /// files; while a stream with nothing submittable is in flight it turns
+    /// into a stop button. An active recording or transcription pins the
+    /// voice role so the microphone can always be stopped.
+    private var trailingAction: TrailingAction {
+        if showAudioButton && (viewModel.isRecording || viewModel.isTranscribing) {
+            return .voice
+        }
+        if showStopAction { return .stop }
+        if showAudioButton,
+           messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           viewModel.pendingAttachments.isEmpty {
+            return .voice
+        }
+        return .send
+    }
+
+    private var trailingActionIconName: String {
+        switch trailingAction {
+        case .voice: return viewModel.isRecording ? "stop.fill" : "mic.fill"
+        case .send: return "arrow.up"
+        case .stop: return "stop.fill"
+        }
+    }
+
+    private var trailingActionAccessibilityLabel: String {
+        switch trailingAction {
+        case .voice: return viewModel.isRecording ? "Stop recording" : "Voice input"
+        case .send: return "Send message"
+        case .stop: return "Stop generating"
+        }
+    }
+
+    /// The send action greys out while a draft can't be dispatched because
+    /// an attachment is still processing; voice greys out while a recording
+    /// is being transcribed.
+    private var isTrailingActionDisabled: Bool {
+        switch trailingAction {
+        case .voice: return viewModel.isTranscribing
+        case .send: return !attachmentsAreReadyToSend(viewModel.pendingAttachments)
+        case .stop: return false
+        }
+    }
+
+    private var trailingActionForegroundColor: Color {
+        if viewModel.isRecording { return .white }
+        return isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight
+    }
+
+    private var trailingActionBackgroundColor: Color {
+        if viewModel.isRecording { return .red }
+        return isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight
+    }
+
+    /// Icon content shared by both input layouts' trailing action button.
+    @ViewBuilder
+    private var trailingActionIcon: some View {
+        if trailingAction == .voice && viewModel.isTranscribing {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle(tint: trailingActionForegroundColor))
+                .scaleEffect(0.8)
+        } else {
+            Image(systemName: trailingActionIconName)
+                .font(.system(size: 16, weight: .semibold))
+        }
     }
 
     // Attachment picker state
@@ -430,60 +498,27 @@ struct MessageInputView: View {
 
                     Spacer()
 
-                    // Microphone button
-                    if showAudioButton {
-                        Button(action: handleAudioButtonTap) {
-                            ZStack {
-                                if viewModel.isRecording {
-                                    // Pulsating background when recording
-                                    Circle()
-                                        .fill(Color.red.opacity(0.2))
-                                        .frame(width: 44, height: 44)
-                                        .scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 1.1 : 0.9))
-                                        .animation(
-                                            reduceMotion ? nil : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
-                                            value: isPulsing
-                                        )
-                                }
-
-                                Group {
-                                    if viewModel.isTranscribing {
-                                        ProgressView()
-                                            .progressViewStyle(CircularProgressViewStyle(tint: .secondary))
-                                            .scaleEffect(0.8)
-                                    } else {
-                                        Image(systemName: viewModel.isRecording ? "stop.fill" : "mic.fill")
-                                            .font(.system(size: 20))
-                                    }
-                                }
-                                .frame(width: 32, height: 32)
-                                .foregroundColor(viewModel.isRecording ? .red : .secondary)
-                            }
-                            .frame(width: 32, height: 32)
-                        }
-                        .onChange(of: viewModel.isRecording) { _, isRecording in
-                            isPulsing = isRecording
-                        }
-                        .disabled(viewModel.isLoading || viewModel.isTranscribing)
-                        .accessibleHitTarget()
-                        .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Voice input")
-                        .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
-                        .padding(.trailing, 4)
-                    }
-
-                    Button(action: sendOrCancelMessage) {
-                        Image(systemName: showStopAction ? "stop.fill" : "arrow.up")
-                            .font(.system(size: 16, weight: .semibold))
+                    Button(action: handleTrailingActionTap) {
+                        trailingActionIcon
                             .frame(width: 24, height: 24)
-                            .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
+                            .foregroundColor(trailingActionForegroundColor)
                     }
                     .buttonStyle(.borderedProminent)
                     .buttonBorderShape(.circle)
                     .glassEffect(.regular.interactive(), in: .circle)
                     .clipShape(.circle)
-                    .tint(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
-                    .disabled(isSendActionDisabled)
-                    .accessibilityLabel(showStopAction ? "Stop generating" : "Send message")
+                    .tint(trailingActionBackgroundColor)
+                    .scaleEffect(reduceMotion || !isPulsing ? 1.0 : 1.1)
+                    .animation(
+                        reduceMotion ? nil : (isPulsing ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true) : .easeInOut(duration: 0.2)),
+                        value: isPulsing
+                    )
+                    .onChange(of: viewModel.isRecording) { _, isRecording in
+                        isPulsing = isRecording
+                    }
+                    .disabled(isTrailingActionDisabled)
+                    .accessibilityLabel(trailingActionAccessibilityLabel)
+                    .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
                     .padding(.trailing, 8)
                 }
                 .padding(.vertical, 8)
@@ -531,60 +566,27 @@ struct MessageInputView: View {
 
                     Spacer()
 
-                    // Microphone button
-                    if showAudioButton {
-                        Button(action: handleAudioButtonTap) {
-                            ZStack {
-                                if viewModel.isRecording {
-                                    // Pulsating background when recording
-                                    Circle()
-                                        .fill(Color.red.opacity(0.2))
-                                        .frame(width: 44, height: 44)
-                                        .scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 1.1 : 0.9))
-                                        .animation(
-                                            reduceMotion ? nil : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
-                                            value: isPulsing
-                                        )
-                                }
-
-                                Group {
-                                    if viewModel.isTranscribing {
-                                        ProgressView()
-                                            .progressViewStyle(CircularProgressViewStyle(tint: .secondary))
-                                            .scaleEffect(0.8)
-                                    } else {
-                                        Image(systemName: viewModel.isRecording ? "stop.fill" : "mic.fill")
-                                            .font(.system(size: 20))
-                                    }
-                                }
-                                .frame(width: 32, height: 32)
-                                .foregroundColor(viewModel.isRecording ? .red : .secondary)
-                            }
-                            .frame(width: 32, height: 32)
-                        }
-                        .onChange(of: viewModel.isRecording) { _, isRecording in
-                            isPulsing = isRecording
-                        }
-                        .disabled(viewModel.isLoading || viewModel.isTranscribing)
-                        .accessibleHitTarget()
-                        .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Voice input")
-                        .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
-                        .padding(.trailing, 4)
-                    }
-
-                    Button(action: sendOrCancelMessage) {
+                    Button(action: handleTrailingActionTap) {
                         ZStack {
                             Circle()
-                                .fill(isDarkMode ? Color.sendButtonBackgroundDark : Color.sendButtonBackgroundLight)
+                                .fill(trailingActionBackgroundColor)
                                 .frame(width: 32, height: 32)
 
-                            Image(systemName: showStopAction ? "stop.fill" : "arrow.up")
-                                .font(.system(size: 16, weight: .semibold))
-                                .foregroundColor(isDarkMode ? Color.sendButtonForegroundDark : Color.sendButtonForegroundLight)
+                            trailingActionIcon
+                                .foregroundColor(trailingActionForegroundColor)
                         }
                     }
-                    .disabled(isSendActionDisabled)
-                    .accessibilityLabel(showStopAction ? "Stop generating" : "Send message")
+                    .scaleEffect(reduceMotion || !isPulsing ? 1.0 : 1.1)
+                    .animation(
+                        reduceMotion ? nil : (isPulsing ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true) : .easeInOut(duration: 0.2)),
+                        value: isPulsing
+                    )
+                    .onChange(of: viewModel.isRecording) { _, isRecording in
+                        isPulsing = isRecording
+                    }
+                    .disabled(isTrailingActionDisabled)
+                    .accessibilityLabel(trailingActionAccessibilityLabel)
+                    .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
                     .accessibleHitTarget()
                     .padding(.trailing, 8)
                 }
@@ -648,6 +650,14 @@ struct MessageInputView: View {
         .accessibilityValue(viewModel.currentModel.displayName)
         .accessibilityHint("Changes the AI model")
         .padding(.leading, 4)
+    }
+
+    private func handleTrailingActionTap() {
+        if trailingAction == .voice {
+            handleAudioButtonTap()
+        } else {
+            sendOrCancelMessage()
+        }
     }
 
     private func sendOrCancelMessage() {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -523,6 +523,7 @@ struct MessageInputView: View {
                     .disabled(isTrailingActionDisabled)
                     .accessibilityLabel(trailingActionAccessibilityLabel)
                     .accessibilityValue(viewModel.isTranscribing ? "Transcribing" : "")
+                    .accessibleHitTarget()
                     .padding(.trailing, 8)
                 }
                 .padding(.vertical, 8)

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -123,7 +123,7 @@ struct MessageInputView: View {
 
     private var trailingActionIconName: String {
         switch trailingAction {
-        case .voice: return viewModel.isRecording ? "stop.fill" : "mic.fill"
+        case .voice: return viewModel.isRecording ? "stop.fill" : "waveform"
         case .send: return "arrow.up"
         case .stop: return "stop.fill"
         }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -360,8 +360,9 @@ struct MessageView: View {
                             )
                         }
 
-                        // Show loading dots when there's no web search, or when search has completed with sources
-                        if message.webSearchState == nil || (message.webSearchState?.status == .completed && !(message.webSearchState?.sources.isEmpty ?? true)) {
+                        // Show loading dots unless a web search is actively in
+                        // flight, in which case the search box itself pulses
+                        if message.webSearchState?.status != .searching {
                             LoadingDotsView(isDarkMode: isDarkMode)
                                 .padding(.horizontal)
                         }
@@ -579,7 +580,8 @@ struct MessageView: View {
                 if message.role == .assistant &&
                    isLoading &&
                    isLastMessage &&
-                   (!message.content.isEmpty || message.thoughts != nil || message.isThinking) {
+                   (!message.content.isEmpty || message.thoughts != nil || message.isThinking ||
+                    !(message.segments?.isEmpty ?? true)) {
                     StreamingIndicatorDot(isDarkMode: isDarkMode)
                         .padding(.top, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the trailing action smart and easier to tap: voice (waveform) when empty, send when ready, stop during generation or while transcribing. Also keep loading indicators visible and let stat card labels wrap.

- **New Features**
  - Send button doubles as voice input while the draft is empty; becomes stop during generation and while transcribing if a response is in flight, with unified behavior across input layouts.
  - Adds a recording pulse, transcription spinner, waveform icon, larger tap target, accurate disabled states, and clear accessibility labels.

- **Bug Fixes**
  - Loading dots stay visible during tool use and after web search unless a search is actively running; streaming dot shows when segments are present.
  - Stat cards expand to fit longer labels without truncation.

<sup>Written for commit 7bd09eb45e267628660e3cdc9559c321ff376f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

