### PR TITLE
chore: xcode package resolve

### DIFF
--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/clerk/clerk-ios",
       "state" : {
-        "revision" : "38a14dfb7f2e5be689975b0f3d6dfe347c425770",
-        "version" : "1.3.3"
+        "revision" : "9b6c83e780c48af3a5cb8c40305674d9d8cb0fc6",
+        "version" : "1.2.4"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/encrypted-http-body-protocol.git",
       "state" : {
-        "revision" : "93cc1fa1ad61e19f9a34fb23cb5b5d5635d3edb0",
-        "version" : "0.3.1"
+        "revision" : "1bb648e9212739de454657f9a9e3eee762c86e8e",
+        "version" : "0.3.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit",
       "state" : {
-        "revision" : "575bda0cd71186372e2ecb1352b91d7853bce048",
-        "version" : "5.0.5"
+        "revision" : "ebde4c008bad416588627d83ac07b991c204f72b",
+        "version" : "5.0.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm.git",
       "state" : {
-        "revision" : "5d8667fc283993e7a791f28c6b5e5071ed2cc70c",
-        "version" : "5.81.2"
+        "revision" : "629a56ecef190469914b8f0914bf0446363eb09f",
+        "version" : "5.78.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa/",
       "state" : {
-        "revision" : "afa7510e05b99f35c1febe47566bfd868fa53fb9",
-        "version" : "9.23.0"
+        "revision" : "2c420d31d0c31b525fa9e7c552ef0fc9d924befc",
+        "version" : "9.17.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
-        "version" : "1.4.1"
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "f3194e56338ef72a3afd206ba0dbfbb1b6db9059",
-        "version" : "0.6.6"
+        "revision" : "54ba387ef14557b43a6d9dea763af76f0adaccb0",
+        "version" : "0.6.5"
       }
     }
   ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sync SwiftPM lockfile with Xcode’s resolution to ensure reproducible builds. Rolls back several packages to previously stable versions.

- **Dependencies**
  - `clerk-ios`: 1.3.3 → 1.2.4
  - `encrypted-http-body-protocol`: 0.3.1 → 0.3.0
  - `PhoneNumberKit`: 5.0.5 → 5.0.2
  - `purchases-ios-spm`: 5.81.2 → 5.78.0
  - `sentry-cocoa`: 9.23.0 → 9.17.1
  - `swift-concurrency-extras`: 1.4.1 → 1.4.0
  - `tinfoil-swift`: 0.6.6 → 0.6.5

<sup>Written for commit fba1fa5a0a66c7750c3858248459607e60e19447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

