### PR TITLE
Cross device recovery hardening

### DIFF
--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/encrypted-http-body-protocol.git",
       "state" : {
-        "revision" : "1bb648e9212739de454657f9a9e3eee762c86e8e",
-        "version" : "0.3.0"
+        "revision" : "93cc1fa1ad61e19f9a34fb23cb5b5d5635d3edb0",
+        "version" : "0.3.1"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "54ba387ef14557b43a6d9dea763af76f0adaccb0",
-        "version" : "0.6.5"
+        "revision" : "f3194e56338ef72a3afd206ba0dbfbb1b6db9059",
+        "version" : "0.6.6"
       }
     }
   ],

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -171,7 +171,8 @@ enum Constants {
         static let maxPendingPerChat = 8
         static let maxConcurrentScans = 3
         static let maxMutationAttempts = 4
-        static let maxStreamAttempts = 2
+        static let retryBaseDelayNanoseconds: UInt64 = 100_000_000
+        static let retryMaxDelayNanoseconds: UInt64 = 10_000_000_000
         static let maxCiphertextBytes = 4_096
         static let maxIdentifierLength = 256
         static let sessionIdBytes = 16

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -57,6 +57,48 @@ enum SyncConflictResolver {
 
 // MARK: - Sync Models
 
+private struct ValidatedPendingRecoveries: Decodable {
+    let envelopes: [PendingRecoveryEnvelope]
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        if let count = container.count,
+           count > Constants.ChatRecovery.maxPendingPerChat {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Too many pending recovery envelopes"
+            )
+        }
+        var envelopes: [PendingRecoveryEnvelope] = []
+        var turnIds: Set<String> = []
+        while !container.isAtEnd {
+            guard envelopes.count < Constants.ChatRecovery.maxPendingPerChat else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Too many pending recovery envelopes"
+                )
+            }
+            let envelope = try container.decode(PendingRecoveryEnvelope.self)
+            do {
+                try ChatRecoveryCrypto.validate(envelope)
+            } catch {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid pending recovery envelope"
+                )
+            }
+            guard turnIds.insert(envelope.turnId).inserted else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Duplicate pending recovery turn"
+                )
+            }
+            envelopes.append(envelope)
+        }
+        self.envelopes = envelopes
+    }
+}
+
 /// Extended chat model with sync metadata
 struct StoredChat: Codable {
     let id: String
@@ -277,7 +319,10 @@ struct StoredChat: Codable {
         title = try container.decode(String.self, forKey: .title)
         titleState = try container.decodeIfPresent(Chat.TitleState.self, forKey: .titleState)
         messages = try container.decode([Message].self, forKey: .messages)
-        pendingRecoveries = try container.decodeIfPresent([PendingRecoveryEnvelope].self, forKey: .pendingRecoveries)
+        pendingRecoveries = try container.decodeIfPresent(
+            ValidatedPendingRecoveries.self,
+            forKey: .pendingRecoveries
+        )?.envelopes
         
         // Dates from ISO strings - configure formatter to handle fractional seconds
         let isoFormatter = ISO8601DateFormatter()

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -121,27 +121,7 @@ func mergingRecoveredResponse(
     return messages
 }
 
-func recoveredResponsesMatch(_ lhs: Message, _ rhs: Message) -> Bool {
-    lhs.role == .assistant
-        && lhs.role == rhs.role
-        && lhs.turnId == rhs.turnId
-        && lhs.content == rhs.content
-        && lhs.thoughts == rhs.thoughts
-        && lhs.isThinking == rhs.isThinking
-        && lhs.thinkingDuration == rhs.thinkingDuration
-        && lhs.generationTimeSeconds == rhs.generationTimeSeconds
-        && lhs.segments == rhs.segments
-        && lhs.webSearches == rhs.webSearches
-        && lhs.webSearchState == rhs.webSearchState
-        && lhs.urlFetches == rhs.urlFetches
-        && lhs.toolCalls == rhs.toolCalls
-        && lhs.timeline == rhs.timeline
-        && lhs.annotations == rhs.annotations
-        && lhs.searchReasoning == rhs.searchReasoning
-        && lhs.webSearchBeforeThinking == rhs.webSearchBeforeThinking
-}
-
-func recoveryReplayCheckpointMatches(_ lhs: Message, _ rhs: Message) -> Bool {
+func recoveryResponsePayloadMatches(_ lhs: Message, _ rhs: Message) -> Bool {
     lhs.role == .assistant
         && lhs.role == rhs.role
         && lhs.turnId == rhs.turnId
@@ -165,6 +145,26 @@ func chatRecoveryRetryDelayNanoseconds(attempt: Int) -> UInt64 {
         delay = next
     }
     return delay
+}
+
+func recoveryRetryDeadlineReached(
+    _ envelope: PendingRecoveryEnvelope,
+    now: Date = Date()
+) -> Bool {
+    (try? ChatRecoveryCrypto.isExpired(envelope, now: now)) ?? true
+}
+
+func registrationFailureDefinitelyDidNotPersist(_ error: Error) -> Bool {
+    if let syncError = error as? ChatRecoverySyncError {
+        switch syncError {
+        case .chatMissing, .envelopeMissing, .pendingLimitReached, .conflict:
+            return true
+        }
+    }
+    if let enclaveError = error as? SyncEnclaveError {
+        return EnclaveErrorRecovery.isVersionConflict(enclaveError)
+    }
+    return false
 }
 
 actor ChatRecoveryCoordinator {
@@ -260,6 +260,15 @@ actor ChatRecoveryCoordinator {
                 sessionId: attempt.sessionId,
                 recoveryToken: token
             )
+        } catch {
+            Task {
+                try? await ChatRecoveryClient.shared.delete(
+                    sessionId: attempt.sessionId
+                )
+            }
+            throw error
+        }
+        do {
             try await ChatRecoverySync.shared.mutate(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
@@ -267,10 +276,12 @@ actor ChatRecoveryCoordinator {
                 mutation: .add(envelope)
             )
         } catch {
-            Task {
-                try? await ChatRecoveryClient.shared.delete(
-                    sessionId: attempt.sessionId
-                )
+            if registrationFailureDefinitelyDidNotPersist(error) {
+                Task {
+                    try? await ChatRecoveryClient.shared.delete(
+                        sessionId: attempt.sessionId
+                    )
+                }
             }
             throw error
         }
@@ -794,6 +805,18 @@ actor ChatRecoveryCoordinator {
             }
             var response: Message?
             for attempt in 0... {
+                if recoveryRetryDeadlineReached(envelope) {
+                    await removeTerminal(
+                        chatId: chatId,
+                        envelope: envelope,
+                        userId: userId,
+                        sessionId: payload.sessionId,
+                        storage: storage,
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration
+                    )
+                    return
+                }
                 do {
                     await MainActor.run {
                         ChatRecoveryDraftStore.shared.beginReplayAttempt(

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -1063,7 +1063,7 @@ actor ChatRecoveryCoordinator {
                 }
             }
         }
-        processor.finishStream()
+        try processor.finishStream()
         try ensureRecoveryIsCurrent(
             chatId: chatId,
             turnId: turnId,

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -94,15 +94,77 @@ func recoveredTitleMessages(
     else {
         return nil
     }
-    var titleMessages = messages
-    if let index = titleMessages.firstIndex(where: {
+    return mergingRecoveredResponse(
+        response,
+        into: messages,
+        turnId: turnId
+    )
+}
+
+func mergingRecoveredResponse(
+    _ response: Message,
+    into messages: [Message],
+    turnId: String
+) -> [Message] {
+    var messages = messages
+    if let existingIndex = messages.firstIndex(where: {
         $0.role == .assistant && $0.turnId == turnId
     }) {
-        titleMessages[index] = response
+        messages[existingIndex] = response
+    } else if let userIndex = messages.lastIndex(where: {
+        $0.role == .user && $0.turnId == turnId
+    }) {
+        messages.insert(response, at: messages.index(after: userIndex))
     } else {
-        titleMessages.append(response)
+        messages.append(response)
     }
-    return titleMessages
+    return messages
+}
+
+func recoveredResponsesMatch(_ lhs: Message, _ rhs: Message) -> Bool {
+    lhs.role == .assistant
+        && lhs.role == rhs.role
+        && lhs.turnId == rhs.turnId
+        && lhs.content == rhs.content
+        && lhs.thoughts == rhs.thoughts
+        && lhs.isThinking == rhs.isThinking
+        && lhs.thinkingDuration == rhs.thinkingDuration
+        && lhs.generationTimeSeconds == rhs.generationTimeSeconds
+        && lhs.segments == rhs.segments
+        && lhs.webSearches == rhs.webSearches
+        && lhs.webSearchState == rhs.webSearchState
+        && lhs.urlFetches == rhs.urlFetches
+        && lhs.toolCalls == rhs.toolCalls
+        && lhs.timeline == rhs.timeline
+        && lhs.annotations == rhs.annotations
+        && lhs.searchReasoning == rhs.searchReasoning
+        && lhs.webSearchBeforeThinking == rhs.webSearchBeforeThinking
+}
+
+func recoveryReplayCheckpointMatches(_ lhs: Message, _ rhs: Message) -> Bool {
+    lhs.role == .assistant
+        && lhs.role == rhs.role
+        && lhs.turnId == rhs.turnId
+        && lhs.content == rhs.content
+        && lhs.thoughts == rhs.thoughts
+        && lhs.isThinking == rhs.isThinking
+        && lhs.webSearchState == rhs.webSearchState
+        && lhs.urlFetches == rhs.urlFetches
+        && lhs.toolCalls == rhs.toolCalls
+        && (lhs.annotations ?? []) == (rhs.annotations ?? [])
+        && lhs.webSearchBeforeThinking == rhs.webSearchBeforeThinking
+}
+
+func chatRecoveryRetryDelayNanoseconds(attempt: Int) -> UInt64 {
+    var delay = Constants.ChatRecovery.retryBaseDelayNanoseconds
+    for _ in 0..<max(0, attempt) {
+        let (next, overflow) = delay.multipliedReportingOverflow(by: 2)
+        if overflow || next >= Constants.ChatRecovery.retryMaxDelayNanoseconds {
+            return Constants.ChatRecovery.retryMaxDelayNanoseconds
+        }
+        delay = next
+    }
+    return delay
 }
 
 actor ChatRecoveryCoordinator {
@@ -181,22 +243,23 @@ actor ChatRecoveryCoordinator {
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             throw CancellationError()
         }
-        let cek: Data
-        switch attempt.storage {
-        case .cloud:
-            cek = try EncryptionService.shared.getKeyBytesOrThrow()
-        case .local:
-            cek = try await DeviceEncryptionService.shared.getKeyBytesOrThrow()
-        }
-        let envelope = try ChatRecoveryCrypto.encrypt(
-            cek: cek,
-            userId: attempt.userId,
-            chatId: attempt.chatId,
-            turnId: attempt.turnId,
-            sessionId: attempt.sessionId,
-            recoveryToken: token
-        )
+        let envelope: PendingRecoveryEnvelope
         do {
+            let cek: Data
+            switch attempt.storage {
+            case .cloud:
+                cek = try EncryptionService.shared.getKeyBytesOrThrow()
+            case .local:
+                cek = try await DeviceEncryptionService.shared.getKeyBytesOrThrow()
+            }
+            envelope = try ChatRecoveryCrypto.encrypt(
+                cek: cek,
+                userId: attempt.userId,
+                chatId: attempt.chatId,
+                turnId: attempt.turnId,
+                sessionId: attempt.sessionId,
+                recoveryToken: token
+            )
             try await ChatRecoverySync.shared.mutate(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
@@ -204,11 +267,10 @@ actor ChatRecoveryCoordinator {
                 mutation: .add(envelope)
             )
         } catch {
-            if case ChatRecoverySyncError.pendingLimitReached = error {
-                try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-            } else if attempt.storage == .local,
-                      case ChatRecoverySyncError.chatMissing = error {
-                try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+            Task {
+                try? await ChatRecoveryClient.shared.delete(
+                    sessionId: attempt.sessionId
+                )
             }
             throw error
         }
@@ -604,11 +666,34 @@ actor ChatRecoveryCoordinator {
             ) else {
                 return
             }
+            let cleanupDate = try? ChatRecoveryCrypto.dateImmediatelyBeforeExpiry(
+                envelope
+            )
+            let sessionId: String?
+            if let cleanupDate,
+               let opened = try? await openEnvelope(
+                   envelope,
+                   chatId: chatId,
+                   userId: userId,
+                   storage: storage,
+                   now: cleanupDate
+               ) {
+                sessionId = opened.payload.sessionId
+            } else {
+                sessionId = nil
+            }
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             await removeTerminal(
                 chatId: chatId,
                 envelope: envelope,
                 userId: userId,
-                sessionId: nil,
+                sessionId: sessionId,
                 storage: storage,
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration
@@ -656,6 +741,7 @@ actor ChatRecoveryCoordinator {
                 return
             }
             await onProgress()
+            var highestPersistedBytes = initialStatus.persistedBytes
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -691,9 +777,32 @@ actor ChatRecoveryCoordinator {
                 turnId: envelope.turnId,
                 storage: storage
             )
+            let persistedCheckpoint = (
+                try? await storage.fileStorage.loadChat(
+                    chatId: chatId,
+                    userId: userId
+                )
+            )?.messages.first(where: {
+                $0.role == .assistant && $0.turnId == envelope.turnId
+            })
+            guard scanIsCurrent(
+                accountGeneration: accountGeneration,
+                scanGeneration: scanGeneration,
+                userId: userId
+            ) else {
+                return
+            }
             var response: Message?
-            for attempt in 0..<Constants.ChatRecovery.maxStreamAttempts {
+            for attempt in 0... {
                 do {
+                    await MainActor.run {
+                        ChatRecoveryDraftStore.shared.beginReplayAttempt(
+                            chatId: chatId,
+                            turnId: envelope.turnId,
+                            sessionId: payload.sessionId,
+                            fallbackCheckpoint: persistedCheckpoint
+                        )
+                    }
                     let recovered = try await ChatRecoveryClient.shared.fetch(
                         sessionId: payload.sessionId,
                         token: token
@@ -732,6 +841,7 @@ actor ChatRecoveryCoordinator {
                         stream: recovered.stream,
                         chatId: chatId,
                         turnId: envelope.turnId,
+                        sessionId: payload.sessionId,
                         userId: userId,
                         accountGeneration: accountGeneration,
                         scanGeneration: scanGeneration,
@@ -758,7 +868,10 @@ actor ChatRecoveryCoordinator {
                     ) else {
                         return
                     }
-                    await onProgress()
+                    if finalStatus.persistedBytes > highestPersistedBytes {
+                        highestPersistedBytes = finalStatus.persistedBytes
+                        await onProgress()
+                    }
                     guard scanIsCurrent(
                         accountGeneration: accountGeneration,
                         scanGeneration: scanGeneration,
@@ -774,10 +887,8 @@ actor ChatRecoveryCoordinator {
                                 turnId: turnId
                             )
                         }
-                        if attempt + 1 < Constants.ChatRecovery.maxStreamAttempts {
-                            continue
-                        }
-                        return
+                        try await waitForRecoveryRetry(attempt: attempt)
+                        continue
                     case .failed, .missing:
                         await removeTerminal(
                             chatId: chatId,
@@ -806,10 +917,8 @@ actor ChatRecoveryCoordinator {
                         return
                     }
                     if encryptedByteCount < finalStatus.persistedBytes {
-                        if attempt + 1 < Constants.ChatRecovery.maxStreamAttempts {
-                            continue
-                        }
-                        return
+                        try await waitForRecoveryRetry(attempt: attempt)
+                        continue
                     }
                     response = recoveredResponse
                     break
@@ -827,12 +936,13 @@ actor ChatRecoveryCoordinator {
                     else {
                         return
                     }
-                    await onProgress()
+                    if retryStatus.persistedBytes > highestPersistedBytes {
+                        highestPersistedBytes = retryStatus.persistedBytes
+                        await onProgress()
+                    }
                     switch retryStatus.state {
                     case .processing, .complete:
-                        guard attempt + 1 < Constants.ChatRecovery.maxStreamAttempts else {
-                            return
-                        }
+                        try await waitForRecoveryRetry(attempt: attempt)
                         continue
                     case .failed, .missing:
                         await removeTerminal(
@@ -963,7 +1073,8 @@ actor ChatRecoveryCoordinator {
         _ envelope: PendingRecoveryEnvelope,
         chatId: String,
         userId: String,
-        storage: ChatRecoveryStorage
+        storage: ChatRecoveryStorage,
+        now: Date = Date()
     ) async throws -> (
         payload: ChatRecoveryEnvelopePayload,
         cek: Data,
@@ -975,7 +1086,8 @@ actor ChatRecoveryCoordinator {
                 cek: deviceKey,
                 userId: userId,
                 chatId: chatId,
-                envelope: envelope
+                envelope: envelope,
+                now: now
             )
             return (payload, deviceKey, false)
         }
@@ -986,7 +1098,8 @@ actor ChatRecoveryCoordinator {
                 cek: primary,
                 userId: userId,
                 chatId: chatId,
-                envelope: envelope
+                envelope: envelope,
+                now: now
             )
             return (payload, primary, false)
         }
@@ -1001,17 +1114,25 @@ actor ChatRecoveryCoordinator {
                 cek: cek,
                 userId: userId,
                 chatId: chatId,
-                envelope: envelope
+                envelope: envelope,
+                now: now
             )
             return (payload, cek, true)
         }
         throw ChatRecoveryCryptoError.invalidKey
     }
 
+    private func waitForRecoveryRetry(attempt: Int) async throws {
+        try await Task<Never, Never>.sleep(
+            nanoseconds: chatRecoveryRetryDelayNanoseconds(attempt: attempt)
+        )
+    }
+
     private func reconstructMessage(
         stream: AsyncThrowingStream<ChatStreamResult, Error>,
         chatId: String,
         turnId: String,
+        sessionId: String,
         userId: String,
         accountGeneration: Int,
         scanGeneration: Int,
@@ -1047,19 +1168,20 @@ actor ChatRecoveryCoordinator {
                     isStreaming: true
                 )
                 if recoveryDraftHasVisibleContent(draft) {
-                    if draft != lastProgressDraft {
-                        lastProgressDraft = draft
-                        await onProgress()
-                    }
-                    try await publishRecoveryDraft(
+                    let published = try await publishRecoveryDraft(
                         draft,
                         chatId: chatId,
                         turnId: turnId,
+                        sessionId: sessionId,
                         accountGeneration: accountGeneration,
                         scanGeneration: scanGeneration,
                         userId: userId,
                         storage: storage
                     )
+                    if published && draft != lastProgressDraft {
+                        lastProgressDraft = draft
+                        await onProgress()
+                    }
                 }
             }
         }
@@ -1080,20 +1202,21 @@ actor ChatRecoveryCoordinator {
             isStreaming: false
         )
         if recoveryDraftHasVisibleContent(message) {
-            if message != lastProgressDraft {
-                await onProgress()
-            }
             var finalDraft = message
             finalDraft.isStreaming = true
-            try await publishRecoveryDraft(
+            let published = try await publishRecoveryDraft(
                 finalDraft,
                 chatId: chatId,
                 turnId: turnId,
+                sessionId: sessionId,
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
                 userId: userId,
                 storage: storage
             )
+            if published && message != lastProgressDraft {
+                await onProgress()
+            }
         }
         return message
     }
@@ -1102,11 +1225,12 @@ actor ChatRecoveryCoordinator {
         _ draft: Message,
         chatId: String,
         turnId: String,
+        sessionId: String,
         accountGeneration: Int,
         scanGeneration: Int,
         userId: String,
         storage: ChatRecoveryStorage
-    ) async throws {
+    ) async throws -> Bool {
         try ensureRecoveryIsCurrent(
             chatId: chatId,
             turnId: turnId,
@@ -1115,22 +1239,22 @@ actor ChatRecoveryCoordinator {
             scanGeneration: scanGeneration,
             storage: storage
         )
-        let published = await MainActor.run {
+        let published = await MainActor.run { () -> Bool? in
             guard !StreamingTracker.shared.isStreaming(chatId) else {
                 ChatRecoveryDraftStore.shared.clear(
                     chatId: chatId,
                     turnId: turnId
                 )
-                return false
+                return nil
             }
-            ChatRecoveryDraftStore.shared.replace(
+            return ChatRecoveryDraftStore.shared.replaceDuringReplay(
                 draft,
                 chatId: chatId,
                 turnId: turnId,
+                sessionId: sessionId,
                 generation: accountGeneration,
                 scanGeneration: scanGeneration
             )
-            return true
         }
         try ensureRecoveryIsCurrent(
             chatId: chatId,
@@ -1140,7 +1264,8 @@ actor ChatRecoveryCoordinator {
             scanGeneration: scanGeneration,
             storage: storage
         )
-        guard published else { throw CancellationError() }
+        guard let published else { throw CancellationError() }
+        return published
     }
 
     private func recoveredMessage(

--- a/TinfoilChat/Services/ChatRecoveryCrypto.swift
+++ b/TinfoilChat/Services/ChatRecoveryCrypto.swift
@@ -259,6 +259,19 @@ enum ChatRecoveryCrypto {
         return now >= expiry
     }
 
+    static func dateImmediatelyBeforeExpiry(
+        _ envelope: PendingRecoveryEnvelope
+    ) throws -> Date {
+        try validate(envelope)
+        guard let expiry = parseTimestamp(envelope.expiresAt) else {
+            throw ChatRecoveryCryptoError.invalidEnvelope
+        }
+        return Date(
+            timeIntervalSinceReferenceDate:
+                expiry.timeIntervalSinceReferenceDate.nextDown
+        )
+    }
+
     private static func envelopeKey(_ cek: Data) throws -> SymmetricKey {
         guard cek.count == Constants.ChatRecovery.cekBytes else {
             throw ChatRecoveryCryptoError.invalidKey

--- a/TinfoilChat/Services/ChatRecoveryDraftStore.swift
+++ b/TinfoilChat/Services/ChatRecoveryDraftStore.swift
@@ -8,9 +8,16 @@ struct ChatRecoveryDraftKey: Hashable {
 
 @MainActor
 final class ChatRecoveryDraftStore: ObservableObject {
+    private struct ReplayState {
+        let sessionId: String
+        let checkpoint: Message?
+        var checkpointReached: Bool
+    }
+
     static let shared = ChatRecoveryDraftStore()
 
     @Published private(set) var drafts: [ChatRecoveryDraftKey: Message] = [:]
+    private var replayStates: [ChatRecoveryDraftKey: ReplayState] = [:]
     private var accountGeneration = 0
     private var scanGeneration = 0
     private var discardedChatIds: Set<String> = []
@@ -40,6 +47,65 @@ final class ChatRecoveryDraftStore: ObservableObject {
         drafts[key] = streamingDraft
     }
 
+    func beginReplayAttempt(
+        chatId: String,
+        turnId: String,
+        sessionId: String,
+        fallbackCheckpoint: Message?
+    ) {
+        let key = ChatRecoveryDraftKey(chatId: chatId, turnId: turnId)
+        if let replay = replayStates[key],
+           replay.sessionId != sessionId {
+            drafts.removeValue(forKey: key)
+        }
+        let checkpoint = drafts[key] ?? fallbackCheckpoint
+        replayStates[key] = ReplayState(
+            sessionId: sessionId,
+            checkpoint: checkpoint,
+            checkpointReached: checkpoint == nil
+        )
+    }
+
+    func replaceDuringReplay(
+        _ draft: Message,
+        chatId: String,
+        turnId: String,
+        sessionId: String,
+        generation: Int,
+        scanGeneration: Int
+    ) -> Bool? {
+        let key = ChatRecoveryDraftKey(chatId: chatId, turnId: turnId)
+        guard generation == accountGeneration,
+              scanGeneration == self.scanGeneration,
+              !discardedChatIds.contains(chatId),
+              !discardedKeys.contains(key),
+              var replay = replayStates[key],
+              replay.sessionId == sessionId
+        else {
+            return nil
+        }
+        if !replay.checkpointReached {
+            if let checkpoint = replay.checkpoint,
+               recoveryReplayCheckpointMatches(checkpoint, draft) {
+                replay.checkpointReached = true
+                replayStates[key] = replay
+            }
+            return false
+        }
+        var streamingDraft = draft
+        streamingDraft.turnId = turnId
+        streamingDraft.isStreaming = true
+        let changed = drafts[key] != streamingDraft
+        replace(
+            draft,
+            chatId: chatId,
+            turnId: turnId,
+            generation: generation,
+            scanGeneration: scanGeneration
+        )
+        return changed
+    }
+
     func beginScan(generation: Int) {
         guard generation >= scanGeneration else { return }
         scanGeneration = generation
@@ -50,16 +116,23 @@ final class ChatRecoveryDraftStore: ObservableObject {
             chatId: chatId,
             turnId: turnId
         )
-        guard drafts[key] != nil else { return }
+        guard drafts[key] != nil || replayStates[key] != nil else { return }
         drafts.removeValue(forKey: key)
+        replayStates.removeValue(forKey: key)
     }
 
     func prune(chatId: String, retaining turnIds: Set<String>) {
         let pruned = drafts.filter { key, _ in
             key.chatId != chatId || turnIds.contains(key.turnId)
         }
-        guard pruned != drafts else { return }
+        let prunedReplayStates = replayStates.filter { key, _ in
+            key.chatId != chatId || turnIds.contains(key.turnId)
+        }
+        guard pruned != drafts || prunedReplayStates.count != replayStates.count else {
+            return
+        }
         drafts = pruned
+        replayStates = prunedReplayStates
     }
 
     func reset(generation: Int) {
@@ -89,8 +162,9 @@ final class ChatRecoveryDraftStore: ObservableObject {
     }
 
     func clearAll() {
-        guard !drafts.isEmpty else { return }
+        guard !drafts.isEmpty || !replayStates.isEmpty else { return }
         drafts.removeAll()
+        replayStates.removeAll()
     }
 }
 

--- a/TinfoilChat/Services/ChatRecoveryDraftStore.swift
+++ b/TinfoilChat/Services/ChatRecoveryDraftStore.swift
@@ -86,7 +86,7 @@ final class ChatRecoveryDraftStore: ObservableObject {
         }
         if !replay.checkpointReached {
             if let checkpoint = replay.checkpoint,
-               recoveryReplayCheckpointMatches(checkpoint, draft) {
+               recoveryResponsePayloadMatches(checkpoint, draft) {
                 replay.checkpointReached = true
                 replayStates[key] = replay
             }
@@ -96,13 +96,9 @@ final class ChatRecoveryDraftStore: ObservableObject {
         streamingDraft.turnId = turnId
         streamingDraft.isStreaming = true
         let changed = drafts[key] != streamingDraft
-        replace(
-            draft,
-            chatId: chatId,
-            turnId: turnId,
-            generation: generation,
-            scanGeneration: scanGeneration
-        )
+        if changed {
+            drafts[key] = streamingDraft
+        }
         return changed
     }
 

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -283,7 +283,7 @@ actor ChatRecoverySync {
             pending[index] = new
         case .complete(let envelope, let response, let title, let titleState):
             let alreadyCompleted = authoritativeRemote.messages.contains {
-                sameRecoveredResponse($0, response)
+                recoveredResponsesMatch($0, response)
             }
             guard (authoritativeRemote.pendingRecoveries?.contains(envelope) == true
                     || alreadyCompleted),
@@ -292,13 +292,11 @@ actor ChatRecoverySync {
                 throw ChatRecoverySyncError.envelopeMissing
             }
             pending.removeAll { $0.turnId == envelope.turnId }
-            if let index = chat.messages.firstIndex(where: {
-                $0.role == .assistant && $0.turnId == envelope.turnId
-            }) {
-                chat.messages[index] = response
-            } else {
-                chat.messages.append(response)
-            }
+            chat.messages = mergingRecoveredResponse(
+                response,
+                into: chat.messages,
+                turnId: envelope.turnId
+            )
             let canApplyGeneratedTitle = titleState != .generated
                 || (
                     authoritativeRemote.titleState == .placeholder
@@ -314,21 +312,6 @@ actor ChatRecoverySync {
             }
         }
         chat.pendingRecoveries = pending.isEmpty ? nil : pending
-    }
-
-    private func sameRecoveredResponse(_ lhs: Message, _ rhs: Message) -> Bool {
-        lhs.role == .assistant
-            && lhs.turnId == rhs.turnId
-            && lhs.content == rhs.content
-            && lhs.thoughts == rhs.thoughts
-            && lhs.generationTimeSeconds == rhs.generationTimeSeconds
-            && lhs.segments == rhs.segments
-            && lhs.webSearches == rhs.webSearches
-            && lhs.webSearchState == rhs.webSearchState
-            && lhs.urlFetches == rhs.urlFetches
-            && lhs.toolCalls == rhs.toolCalls
-            && lhs.timeline == rhs.timeline
-            && lhs.annotations == rhs.annotations
     }
 
     private func stampEdit(_ chat: inout Chat, observedRemote: Chat) {

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -283,7 +283,7 @@ actor ChatRecoverySync {
             pending[index] = new
         case .complete(let envelope, let response, let title, let titleState):
             let alreadyCompleted = authoritativeRemote.messages.contains {
-                recoveredResponsesMatch($0, response)
+                recoveryResponsePayloadMatches($0, response)
             }
             guard (authoritativeRemote.pendingRecoveries?.contains(envelope) == true
                     || alreadyCompleted),

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -7,6 +7,10 @@
 import Foundation
 import OpenAI
 
+enum StreamingResponseProcessorError: Error {
+    case incompleteResponse
+}
+
 /// Owns all per-chunk parsing state for one streaming response (event
 /// markers, thinking state machine, chunkers, tool calls, web search
 /// bookkeeping) so the stream can be consumed off the main actor. The main
@@ -109,6 +113,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     private var responseContent: String
     private var currentThoughts: String?
     private var generationTimeSeconds: TimeInterval?
+    private var receivedFinishReason = false
 
     private let isWebSearchEnabled: Bool
     private let hapticEnabled: Bool
@@ -175,6 +180,9 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     /// the main actor before `process` runs so segment ordering matches the
     /// order in which markers arrived relative to the surrounding text.
     func parse(_ chunk: ChatStreamResult) -> ParsedChunk {
+        if chunk.choices.contains(where: { $0.finishReason != nil }) {
+            receivedFinishReason = true
+        }
         var content = chunk.choices.first?.delta.content ?? ""
         var events: [TinfoilWebSearchCallEvent] = []
         if !content.isEmpty {
@@ -457,10 +465,13 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         return outcome
     }
 
-    /// Runs once after the stream ends (completed or cancelled, not thrown):
-    /// drains parser tails, closes any open thinking state, and finalizes the
-    /// chunkers so `snapshot()` reflects the completed response.
-    func finishStream() {
+    /// Runs once after a completed stream ends: validates application-level
+    /// completion, drains parser tails, closes any open thinking state, and
+    /// finalizes the chunkers so `snapshot()` reflects the completed response.
+    func finishStream() throws {
+        guard receivedFinishReason else {
+            throw StreamingResponseProcessorError.incompleteResponse
+        }
         // Drain any bytes the tinfoil-event parser is still
         // holding back at the stream boundary. Anything in the
         // tail is either an unterminated marker body (router

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2650,7 +2650,7 @@ class ChatViewModel: ObservableObject {
                         }
                     }
 
-                    processor.finishStream()
+                    try processor.finishStream()
                 }
 
                 // Propagate cancellation from cancelGeneration (which cancels

--- a/TinfoilChatTests/ChatRecoveryCryptoTests.swift
+++ b/TinfoilChatTests/ChatRecoveryCryptoTests.swift
@@ -162,6 +162,18 @@ struct ChatRecoveryCryptoTests {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let expiry = formatter.date(from: envelope.expiresAt)!
+        let cleanupDate = try ChatRecoveryCrypto.dateImmediatelyBeforeExpiry(
+            envelope
+        )
+        let payload = try ChatRecoveryCrypto.decrypt(
+            cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
+            userId: userId,
+            chatId: chatId,
+            envelope: envelope,
+            now: cleanupDate
+        )
+        #expect(cleanupDate < expiry)
+        #expect(payload.sessionId == sessionId)
         #expect(try ChatRecoveryCrypto.isExpired(envelope, now: expiry))
         #expect(throws: ChatRecoveryCryptoError.expired) {
             try ChatRecoveryCrypto.decrypt(

--- a/TinfoilChatTests/ChatRecoveryCryptoTests.swift
+++ b/TinfoilChatTests/ChatRecoveryCryptoTests.swift
@@ -174,6 +174,8 @@ struct ChatRecoveryCryptoTests {
         )
         #expect(cleanupDate < expiry)
         #expect(payload.sessionId == sessionId)
+        #expect(!recoveryRetryDeadlineReached(envelope, now: cleanupDate))
+        #expect(recoveryRetryDeadlineReached(envelope, now: expiry))
         #expect(try ChatRecoveryCrypto.isExpired(envelope, now: expiry))
         #expect(throws: ChatRecoveryCryptoError.expired) {
             try ChatRecoveryCrypto.decrypt(

--- a/TinfoilChatTests/ChatRecoveryDraftStoreTests.swift
+++ b/TinfoilChatTests/ChatRecoveryDraftStoreTests.swift
@@ -82,6 +82,76 @@ struct ChatRecoveryDraftStoreTests {
         #expect(store.drafts.values.first?.content == "Fresh")
     }
 
+    @Test func replayNeverRegressesTheVisibleDraft() {
+        let store = ChatRecoveryDraftStore()
+        store.reset(generation: 1)
+        store.beginScan(generation: 4)
+        var checkpoint = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Partial",
+            generationTimeSeconds: 1
+        )
+        checkpoint.thinkingDuration = 1
+        checkpoint.timeline = [.string("platform-derived")]
+        checkpoint.searchReasoning = "platform-derived"
+        var replayCheckpoint = checkpoint
+        replayCheckpoint.generationTimeSeconds = 2
+        replayCheckpoint.thinkingDuration = 2
+        replayCheckpoint.segments = []
+        replayCheckpoint.webSearches = []
+        replayCheckpoint.timeline = []
+        replayCheckpoint.annotations = []
+        replayCheckpoint.searchReasoning = nil
+        store.beginReplayAttempt(
+            chatId: "chat-1",
+            turnId: "turn-1",
+            sessionId: "session-1",
+            fallbackCheckpoint: checkpoint
+        )
+
+        #expect(store.replaceDuringReplay(
+            Message(role: .assistant, turnId: "turn-1", content: "Part"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            sessionId: "session-1",
+            generation: 1,
+            scanGeneration: 4
+        ) == false)
+        #expect(store.replaceDuringReplay(
+            replayCheckpoint,
+            chatId: "chat-1",
+            turnId: "turn-1",
+            sessionId: "session-1",
+            generation: 1,
+            scanGeneration: 4
+        ) == false)
+        #expect(store.replaceDuringReplay(
+            Message(role: .assistant, turnId: "turn-1", content: "Partial response"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            sessionId: "session-1",
+            generation: 1,
+            scanGeneration: 4
+        ) == true)
+
+        store.beginReplayAttempt(
+            chatId: "chat-1",
+            turnId: "turn-1",
+            sessionId: "session-1",
+            fallbackCheckpoint: checkpoint
+        )
+        #expect(store.replaceDuringReplay(
+            Message(role: .assistant, turnId: "turn-1", content: "Part"),
+            chatId: "chat-1",
+            turnId: "turn-1",
+            sessionId: "session-1",
+            generation: 1,
+            scanGeneration: 4
+        ) == false)
+        #expect(store.drafts.values.first?.content == "Partial response")
+    }
+
     @Test func prunesByChatAndResetClearsEveryDraft() {
         let store = ChatRecoveryDraftStore()
         let drafts = [

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -71,6 +71,33 @@ struct ChatRecoverySchedulingTests {
         ) == nil)
     }
 
+    @Test func insertsRecoveredResponseAfterItsUserTurn() {
+        let firstUser = Message(
+            role: .user,
+            turnId: "turn-1",
+            content: "First question"
+        )
+        let secondUser = Message(
+            role: .user,
+            turnId: "turn-2",
+            content: "Second question"
+        )
+        let recovered = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered response"
+        )
+
+        let messages = mergingRecoveredResponse(
+            recovered,
+            into: [firstUser, secondUser],
+            turnId: "turn-1"
+        )
+
+        #expect(messages.map(\.turnId) == ["turn-1", "turn-1", "turn-2"])
+        #expect(messages.map(\.role) == [.user, .assistant, .user])
+    }
+
     @Test func replacesOnlyScansThatHaveStoppedMakingProgress() {
         let now = Date(timeIntervalSince1970: 1_000)
         let freshProgress = now.addingTimeInterval(
@@ -83,5 +110,20 @@ struct ChatRecoverySchedulingTests {
         #expect(!recoveryScanHasStalled(lastProgressAt: nil, now: now))
         #expect(!recoveryScanHasStalled(lastProgressAt: freshProgress, now: now))
         #expect(recoveryScanHasStalled(lastProgressAt: staleProgress, now: now))
+    }
+
+    @Test func retryDelayUsesACappedExponentialBackoff() {
+        #expect(
+            chatRecoveryRetryDelayNanoseconds(attempt: 0)
+                == Constants.ChatRecovery.retryBaseDelayNanoseconds
+        )
+        #expect(
+            chatRecoveryRetryDelayNanoseconds(attempt: 1)
+                == Constants.ChatRecovery.retryBaseDelayNanoseconds * 2
+        )
+        #expect(
+            chatRecoveryRetryDelayNanoseconds(attempt: 100)
+                == Constants.ChatRecovery.retryMaxDelayNanoseconds
+        )
     }
 }

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -126,4 +126,55 @@ struct ChatRecoverySchedulingTests {
                 == Constants.ChatRecovery.retryMaxDelayNanoseconds
         )
     }
+
+    @Test func recoveredPayloadComparisonIgnoresDerivedMetadata() {
+        var persisted = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered response",
+            generationTimeSeconds: 1
+        )
+        persisted.thinkingDuration = 1
+        persisted.timeline = [.string("platform-derived")]
+        persisted.searchReasoning = "platform-derived"
+        var reconstructed = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered response",
+            generationTimeSeconds: 2
+        )
+        reconstructed.thinkingDuration = 2
+        reconstructed.segments = []
+        reconstructed.webSearches = []
+        reconstructed.timeline = []
+        reconstructed.annotations = []
+
+        #expect(recoveryResponsePayloadMatches(persisted, reconstructed))
+        reconstructed.content = "Different response"
+        #expect(!recoveryResponsePayloadMatches(persisted, reconstructed))
+    }
+
+    @Test func registrationCleanupRequiresADefinitePreCommitFailure() {
+        #expect(registrationFailureDefinitelyDidNotPersist(
+            ChatRecoverySyncError.chatMissing
+        ))
+        #expect(registrationFailureDefinitelyDidNotPersist(
+            ChatRecoverySyncError.pendingLimitReached
+        ))
+        #expect(registrationFailureDefinitelyDidNotPersist(
+            ChatRecoverySyncError.conflict
+        ))
+        #expect(registrationFailureDefinitelyDidNotPersist(
+            SyncEnclaveError(message: "conflict", status: 409, code: nil)
+        ))
+        #expect(!registrationFailureDefinitelyDidNotPersist(
+            CancellationError()
+        ))
+        #expect(!registrationFailureDefinitelyDidNotPersist(
+            NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNetworkConnectionLost
+            )
+        ))
+    }
 }

--- a/TinfoilChatTests/CloudSyncRecoveryValidationTests.swift
+++ b/TinfoilChatTests/CloudSyncRecoveryValidationTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Cloud recovery validation")
+struct CloudSyncRecoveryValidationTests {
+    @Test func acceptsValidRecoveryEnvelopes() throws {
+        let envelope = try makeEnvelope()
+
+        let chat = try JSONDecoder().decode(
+            StoredChat.self,
+            from: storedChatData(pendingRecoveries: [envelope])
+        )
+
+        #expect(chat.pendingRecoveries == [envelope])
+    }
+
+    @Test func rejectsDuplicateRecoveryTurns() throws {
+        let envelope = try makeEnvelope()
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(
+                StoredChat.self,
+                from: storedChatData(
+                    pendingRecoveries: [envelope, envelope]
+                )
+            )
+        }
+    }
+
+    @Test func rejectsTooManyRecoveryEnvelopes() throws {
+        let envelope = try makeEnvelope()
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(
+                StoredChat.self,
+                from: storedChatData(
+                    pendingRecoveries: Array(
+                        repeating: envelope,
+                        count: Constants.ChatRecovery.maxPendingPerChat + 1
+                    )
+                )
+            )
+        }
+    }
+
+    @Test func rejectsInvalidRecoveryMetadata() throws {
+        let envelope = try makeEnvelope()
+        let invalid = PendingRecoveryEnvelope(
+            v: envelope.v,
+            turnId: "",
+            keyId: envelope.keyId,
+            createdAt: envelope.createdAt,
+            expiresAt: envelope.expiresAt,
+            nonce: envelope.nonce,
+            ciphertext: envelope.ciphertext
+        )
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(
+                StoredChat.self,
+                from: storedChatData(pendingRecoveries: [invalid])
+            )
+        }
+    }
+
+    private func makeEnvelope() throws -> PendingRecoveryEnvelope {
+        try ChatRecoveryCrypto.encrypt(
+            cek: Data(repeating: 1, count: SyncEnclaveKeyBundle.cekByteCount),
+            userId: "user_123",
+            chatId: "chat_123",
+            turnId: "turn_123",
+            sessionId: "0123456789abcdef0123456789abcdef",
+            recoveryToken: .fields(ChatRecoveryTokenFields(
+                exportedSecret: String(repeating: "a", count: 64),
+                requestEnc: String(repeating: "b", count: 64)
+            )),
+            now: ISO8601DateFormatter().date(
+                from: "2026-07-20T12:00:00Z"
+            )!
+        )
+    }
+
+    private func storedChatData(
+        pendingRecoveries: [PendingRecoveryEnvelope]
+    ) throws -> Data {
+        let pendingData = try JSONEncoder().encode(pendingRecoveries)
+        let pendingJSON = try JSONSerialization.jsonObject(with: pendingData)
+        return try JSONSerialization.data(withJSONObject: [
+            "id": "chat_123",
+            "title": "Chat",
+            "messages": [],
+            "pendingRecoveries": pendingJSON,
+            "createdAt": "2026-07-20T12:00:00.000Z",
+            "updatedAt": "2026-07-20T12:00:00.000Z",
+            "syncVersion": 1,
+            "locallyModified": false,
+        ])
+    }
+}

--- a/TinfoilChatTests/StreamingResponseProcessorTests.swift
+++ b/TinfoilChatTests/StreamingResponseProcessorTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import OpenAI
+import Testing
+@testable import TinfoilChat
+
+@Suite("Streaming response completion")
+struct StreamingResponseProcessorTests {
+    @Test("rejects a response without a finish reason")
+    func rejectsIncompleteResponse() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        let parsed = processor.parse(try chunk(content: "partial"))
+        _ = processor.process(parsed)
+
+        #expect(throws: StreamingResponseProcessorError.self) {
+            try processor.finishStream()
+        }
+    }
+
+    @Test("accepts authenticated finish reasons", arguments: [
+        "stop",
+        "length",
+        "content_filter",
+        "tool_calls",
+        "function_call",
+    ])
+    func acceptsFinishReason(_ finishReason: String) throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        let content = processor.parse(try chunk(content: "complete"))
+        _ = processor.process(content)
+        let terminal = processor.parse(
+            try chunk(content: "", finishReason: finishReason)
+        )
+        _ = processor.process(terminal)
+
+        try processor.finishStream()
+
+        #expect(processor.snapshot().responseContent == "complete")
+    }
+
+    private func chunk(
+        content: String,
+        finishReason: String? = nil
+    ) throws -> ChatStreamResult {
+        var choice: [String: Any] = [
+            "index": 0,
+            "delta": ["content": content],
+        ]
+        choice["finish_reason"] = finishReason.map { $0 as Any } ?? NSNull()
+        let data = try JSONSerialization.data(withJSONObject: [
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-oss-120b",
+            "choices": [choice],
+        ])
+        return try JSONDecoder().decode(ChatStreamResult.self, from: data)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens cross-device chat recovery by validating pending recovery data, requiring complete streaming responses, and keeping recovery alive with capped exponential backoff. Also preserves visible drafts with session-scoped replay checkpoints and correct response placement to avoid UI regressions.

- **Bug Fixes**
  - Validate pending recovery envelopes during cloud sync; reject invalid, duplicate, or over-limit entries.
  - Require a finish reason in streaming responses; reject incomplete streams.
  - Replace fixed retry limit with capped exponential backoff; keep retrying until expiry and only report progress when persisted bytes increase.
  - Preserve recoverable chat state with session-scoped replay checkpoints; never regress the visible draft and only publish when the draft actually changed.
  - Insert recovered assistant messages right after their user turn or replace an existing one; compare payloads while ignoring derived metadata to avoid duplicates.
  - On expiry, decrypt just before expiry to recover the session ID for cleanup; only delete remote sessions on definite pre-commit failures.

- **Dependencies**
  - Bump `encrypted-http-body-protocol` to `0.3.1`.
  - Bump `tinfoil-swift` to `0.6.6`.

<sup>Written for commit 828453c0ee2fd43ace4d7e937963c135c5229272. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

