### PR TITLE
fix: reliably remove chats deleted on other devices

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -423,6 +423,12 @@ enum Constants {
         enum Sync {
             static let chatStatus = "tinfoil-sync-chat-status"
             static let allChatsStatus = "tinfoil-sync-all-chats-status"
+            /// Server timestamp up to which chat delete tombstones have been
+            /// fetched AND applied locally. Kept separate from `chatStatus`:
+            /// the status cache is a disposable freshness snapshot, while
+            /// this watermark encodes durable reconciliation progress and
+            /// must never advance past an unapplied tombstone.
+            static let chatDeletesWatermark = "tinfoil-sync-chat-deletes-watermark"
             static let projectChatStatusPrefix = "tinfoil-sync-project-chat-status-"
 
             static func projectChatStatus(projectId: String) -> String {

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -436,9 +436,21 @@ struct ChatListResponse: Codable {
     }
 }
 
-/// Response from deleted-since API
-struct DeletedChatsResponse: Codable {
-    let deletedIds: [String]
+/// Row-update and delete-tombstone event streams collected from one
+/// list-status walk. The deletion reconciliation pass needs both from
+/// the same walk so it can arbitrate a tombstone against a later
+/// re-create of the same row.
+struct ChatEventsSinceResponse {
+    struct Update {
+        let id: String
+        let updatedAt: String
+    }
+    struct Delete {
+        let id: String
+        let deletedAt: String
+    }
+    let updates: [Update]
+    let deletes: [Delete]
 }
 
 /// Remote chat metadata from API

--- a/TinfoilChat/Services/ChatDeletesWatermark.swift
+++ b/TinfoilChat/Services/ChatDeletesWatermark.swift
@@ -55,7 +55,6 @@ enum ChatDeletesWatermark {
     /// value.
     static func advance(latestEventAt: Date, defaults: UserDefaults = .standard) {
         let candidate = latestEventAt.addingTimeInterval(-overlapSeconds)
-        guard candidate.timeIntervalSince1970 > 0 else { return }
         if let current = formatter.date(from: load(defaults: defaults)),
            candidate <= current {
             return

--- a/TinfoilChat/Services/ChatDeletesWatermark.swift
+++ b/TinfoilChat/Services/ChatDeletesWatermark.swift
@@ -1,0 +1,72 @@
+//
+//  ChatDeletesWatermark.swift
+//  TinfoilChat
+//
+//  Durable cursor for the remote-deletion reconciliation pass, persisted
+//  in UserDefaults. It records the server timestamp up to which chat
+//  tombstones have been fetched AND applied locally.
+//
+//  Deliberately independent from the sync-status cache: that cache is a
+//  disposable freshness snapshot (cleared on account change, cache
+//  misses) that advances whenever any sync pass completes. Reusing its
+//  `lastUpdated` as the deletion cursor meant a single skipped or failed
+//  deletion pass permanently hid the missed tombstones, leaving deleted
+//  chats resurrectable on this device. Mirrors
+//  `services/cloud/chat-deletes-watermark.ts` in the webapp.
+//
+
+import Foundation
+
+enum ChatDeletesWatermark {
+    /// Seed for devices with no persisted watermark. The first pass
+    /// replays every retained tombstone, which is idempotent:
+    /// already-deleted chats are absent locally and only refresh the
+    /// in-memory tracker.
+    static let epoch = "1970-01-01T00:00:00.000Z"
+
+    /// Safety overlap subtracted from the newest observed server
+    /// timestamp before persisting. Tombstones written concurrently with
+    /// a pass (same-millisecond ties, replication lag) are re-listed by
+    /// the next pass instead of being skipped; re-applying a tombstone is
+    /// a no-op.
+    static let overlapSeconds: TimeInterval = 5
+
+    private static var storageKey: String {
+        Constants.StorageKeys.Sync.chatDeletesWatermark
+    }
+
+    private static let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static func load(defaults: UserDefaults = .standard) -> String {
+        if let stored = defaults.string(forKey: storageKey),
+           formatter.date(from: stored) != nil {
+            return stored
+        }
+        return epoch
+    }
+
+    /// Persist a new watermark derived from the newest event timestamp
+    /// observed in a fully reconciled pass. Monotonic: a stale candidate
+    /// (overlap window, concurrent passes) never regresses the stored
+    /// value.
+    static func advance(latestEventAt: Date, defaults: UserDefaults = .standard) {
+        let candidate = latestEventAt.addingTimeInterval(-overlapSeconds)
+        guard candidate.timeIntervalSince1970 > 0 else { return }
+        if let current = formatter.date(from: load(defaults: defaults)),
+           candidate <= current {
+            return
+        }
+        defaults.set(
+            formatter.string(from: candidate),
+            forKey: storageKey
+        )
+    }
+
+    static func clear(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: storageKey)
+    }
+}

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -112,7 +112,11 @@ class CloudStorageService: ObservableObject {
     /// the caller can persist them against the freshest local copy
     /// without mutating the chat object passed in.
     @discardableResult
-    func uploadChat(_ chat: StoredChat, idempotencyKey: String) async throws -> UploadChatResult {
+    func uploadChat(
+        _ chat: StoredChat,
+        idempotencyKey: String,
+        restoreDeleted: Bool = false
+    ) async throws -> UploadChatResult {
         var chatToUpload = chat
         let rewrites = try await encryptAndUploadAttachments(&chatToUpload)
         stripBase64FromMessages(&chatToUpload.messages)
@@ -132,10 +136,21 @@ class CloudStorageService: ObservableObject {
         } else {
             metadata["projectId"] = AnyCodable(NSNull())
         }
+        if restoreDeleted {
+            metadata["restoreDeleted"] = AnyCodable(true)
+        }
 
-        let ifMatch: String? = chatToUpload.syncVersion > 0
-            ? String(chatToUpload.syncVersion)
-            : "0"
+        // A restore re-creates a row whose server copy is gone, so there
+        // is no etag to CAS against; `if_match=null` is the enclave's
+        // create-new sentinel.
+        let ifMatch: String?
+        if restoreDeleted {
+            ifMatch = nil
+        } else {
+            ifMatch = chatToUpload.syncVersion > 0
+                ? String(chatToUpload.syncVersion)
+                : "0"
+        }
         let response = try await SyncEnclaveAPI.push(
             EnclavePushRequest(
                 scope: .chat,
@@ -412,19 +427,25 @@ class CloudStorageService: ObservableObject {
         return ChatSyncStatus(count: count, lastUpdated: lastUpdated)
     }
 
-    func getDeletedChatsSince(since: String) async throws -> DeletedChatsResponse {
-        var deletedIds: [String] = []
+    /// Walk the list-status pages once and return both event streams
+    /// since `since`: row updates and delete tombstones.
+    func listChatEventsSince(since: String) async throws -> ChatEventsSinceResponse {
+        var updates: [ChatEventsSinceResponse.Update] = []
+        var deletes: [ChatEventsSinceResponse.Delete] = []
         var cursor: String? = since
         repeat {
             let status = try await SyncEnclaveAPI.listStatus(
                 EnclaveListStatusRequest(scope: .chat, cursor: cursor, limit: Constants.SyncEnclave.listStatusPageLimit, projectId: nil)
             )
+            for entry in status.updates {
+                updates.append(.init(id: entry.id, updatedAt: entry.updatedAt))
+            }
             for entry in status.deletes {
-                deletedIds.append(entry.id)
+                deletes.append(.init(id: entry.id, deletedAt: entry.deletedAt))
             }
             cursor = status.nextCursor
         } while hasNextCursor(cursor)
-        return DeletedChatsResponse(deletedIds: deletedIds)
+        return ChatEventsSinceResponse(updates: updates, deletes: deletes)
     }
 
     // MARK: - Delete

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -720,6 +720,22 @@ class CloudSyncService: ObservableObject {
                       !deletedChatsTracker.isDeleted(chatId) else {
                     return
                 }
+                // The row may have been tombstoned after the last pass
+                // fetched its deletion window, in which case the tracker
+                // doesn't know about it yet. Reconcile deletions now so a
+                // fresh tombstone is applied and recorded rather than
+                // overwritten by the restore below; a failed pass skips
+                // the restore and the next sync retries the upload (and
+                // this arbitration) from scratch.
+                let deletions = await reconcileRemoteDeletions(
+                    generation: generation,
+                    userId: userId
+                )
+                guard generation == accountGeneration else { return }
+                guard !deletions.failed,
+                      !deletedChatsTracker.isDeleted(chatId) else {
+                    return
+                }
                 try await uploadAndMarkSynced(
                     localChat,
                     idempotencyKey: newSyncEnclaveIdempotencyKey(),
@@ -2459,7 +2475,11 @@ class CloudSyncService: ObservableObject {
                     // A tombstone whose timestamp cannot be parsed cannot
                     // be arbitrated or applied. Hold the watermark behind
                     // it so the next pass replays it, instead of advancing
-                    // past the deletion and skipping it forever.
+                    // past the deletion and skipping it forever. Record it
+                    // in the tracker too, so ingestion and the gone-row
+                    // restore path won't resurrect a dirty local copy
+                    // while arbitration is impossible.
+                    deletedChatsTracker.markAsDeleted(tombstone.id)
                     allResolved = false
                     continue
                 }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -2452,14 +2452,21 @@ class CloudSyncService: ObservableObject {
                 latestEventAt = max(latestEventAt ?? at, at)
                 latestUpdateAt[update.id] = max(latestUpdateAt[update.id] ?? .distantPast, at)
             }
+            var allResolved = true
             var latestDeleteAt: [String: Date] = [:]
             for tombstone in events.deletes {
-                guard let at = parseISODate(tombstone.deletedAt) else { continue }
+                guard let at = parseISODate(tombstone.deletedAt) else {
+                    // A tombstone whose timestamp cannot be parsed cannot
+                    // be arbitrated or applied. Hold the watermark behind
+                    // it so the next pass replays it, instead of advancing
+                    // past the deletion and skipping it forever.
+                    allResolved = false
+                    continue
+                }
                 latestEventAt = max(latestEventAt ?? at, at)
                 latestDeleteAt[tombstone.id] = max(latestDeleteAt[tombstone.id] ?? .distantPast, at)
             }
 
-            var allResolved = true
             for (id, deletedAt) in latestDeleteAt {
                 guard generation == accountGeneration else {
                     outcome.failed = true
@@ -2482,10 +2489,22 @@ class CloudSyncService: ObservableObject {
                 // phantom deletion and trigger a needless UI reload. A
                 // local-only chat lives outside cloud storage, so loadChat
                 // returns nil and it is preserved.
-                let existing = try? await EncryptedFileStorage.cloud.loadChat(
-                    chatId: id,
-                    userId: userId
-                )
+                let existing: Chat?
+                do {
+                    existing = try await EncryptedFileStorage.cloud.loadChat(
+                        chatId: id,
+                        userId: userId
+                    )
+                } catch {
+                    // A transient read/decryption failure is not proof of
+                    // absence: treating it as absent would advance the
+                    // watermark past a tombstone that was never applied.
+                    // Hold the watermark so the next pass re-checks it.
+                    // Not `failed`: an unreadable row cannot be uploaded,
+                    // so it carries no resurrection risk.
+                    allResolved = false
+                    continue
+                }
                 guard generation == accountGeneration else {
                     outcome.failed = true
                     return outcome

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -683,6 +683,9 @@ class CloudSyncService: ObservableObject {
     ///   snapshot. Rebase the local row onto the server's current
     ///   version (so the next upload's CAS base matches) and re-upload,
     ///   letting local win instead of looping on STALE_BLOB forever.
+    /// - Remote row is gone entirely (deleted on another device): a
+    ///   locally modified copy wins by re-creating the row through the
+    ///   restore path, unless its tombstone is already being applied.
     ///
     /// If the pull itself fails the chat stays locallyModified and the
     /// next sync cycle retries.
@@ -692,18 +695,43 @@ class CloudSyncService: ObservableObject {
         userId: String
     ) async {
         do {
-            guard var downloadedChat = try await cloudStorage.downloadChat(chatId) else {
-                return
-            }
+            let remoteChat = try await cloudStorage.downloadChat(chatId)
             guard generation == accountGeneration else { return }
-            if downloadedChat.modelType == nil {
-                downloadedChat.modelType = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first
-            }
 
             let localChat = try? await EncryptedFileStorage.cloud.loadChat(
                 chatId: chatId,
                 userId: userId
             )
+            guard generation == accountGeneration else { return }
+
+            // The remote row vanished (concurrent delete). A clean local
+            // copy is removed by the deletion reconciliation pass. A
+            // locally modified copy carries writes the server never saw;
+            // there is no etag left to CAS against, so a plain re-upload
+            // would loop on STALE_BLOB forever. The newer local content
+            // wins by re-creating the row through the explicit restore
+            // path — unless the reconciliation pass has already recorded
+            // the tombstone, in which case the deletion is being applied
+            // right now and wins.
+            guard var downloadedChat = remoteChat else {
+                guard let localChat,
+                      localChat.locallyModified,
+                      !localChat.isLocalOnly,
+                      !deletedChatsTracker.isDeleted(chatId) else {
+                    return
+                }
+                try await uploadAndMarkSynced(
+                    localChat,
+                    idempotencyKey: newSyncEnclaveIdempotencyKey(),
+                    generation: generation,
+                    userId: userId,
+                    restoreDeleted: true
+                )
+                return
+            }
+            if downloadedChat.modelType == nil {
+                downloadedChat.modelType = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first
+            }
 
             // A chat's edit clock is trusted only when it was maintained
             // at the row's current synced version; otherwise a
@@ -1147,26 +1175,33 @@ class CloudSyncService: ObservableObject {
         var result = SyncResult()
 
         // Delete local chats that were deleted on another device
-        var deletedCount = 0
-        if let cachedStatus = getCachedSyncStatus(),
-           let lastUpdated = cachedStatus.lastUpdated {
-            deletedCount = await deleteRemotelyDeletedChats(
-                since: lastUpdated,
-                generation: generation,
-                userId: userId
-            )
-        }
+        let deletions = await reconcileRemoteDeletions(
+            generation: generation,
+            userId: userId
+        )
         guard generation == accountGeneration else { return SyncResult() }
 
-        // First, backup any unsynced local changes
-        let backupResult = await backupUnsyncedChats()
-        guard generation == accountGeneration else { return SyncResult() }
-        result = SyncResult(
-            uploaded: backupResult.uploaded,
-            downloaded: 0,
-            deleted: deletedCount,
-            errors: backupResult.errors
-        )
+        if deletions.failed {
+            // Uploading dirty chats before deletions reconcile can
+            // resurrect chats deleted on another device, so keep local
+            // changes queued until a pass succeeds.
+            result = SyncResult(
+                uploaded: 0,
+                downloaded: 0,
+                deleted: deletions.removed,
+                errors: ["Skipped uploading local changes: remote deletions could not be reconciled"]
+            )
+        } else {
+            // First, backup any unsynced local changes
+            let backupResult = await backupUnsyncedChats()
+            guard generation == accountGeneration else { return SyncResult() }
+            result = SyncResult(
+                uploaded: backupResult.uploaded,
+                downloaded: 0,
+                deleted: deletions.removed,
+                errors: backupResult.errors
+            )
+        }
 
         // Then, get list of remote chats with content
         do {
@@ -1439,22 +1474,33 @@ class CloudSyncService: ObservableObject {
         var result = SyncResult()
 
         // Delete local chats that were deleted on another device
-        let deletedCount = await deleteRemotelyDeletedChats(
-            since: since,
+        let deletions = await reconcileRemoteDeletions(
             generation: generation,
             userId: userId
         )
         guard generation == accountGeneration else { return SyncResult() }
 
-        // Backup any unsynced local changes first (matches doSyncAllChats behavior)
-        let backupResult = await backupUnsyncedChats()
-        guard generation == accountGeneration else { return SyncResult() }
-        result = SyncResult(
-            uploaded: backupResult.uploaded,
-            downloaded: 0,
-            deleted: deletedCount,
-            errors: backupResult.errors
-        )
+        if deletions.failed {
+            // Uploading dirty chats before deletions reconcile can
+            // resurrect chats deleted on another device, so keep local
+            // changes queued until a pass succeeds.
+            result = SyncResult(
+                uploaded: 0,
+                downloaded: 0,
+                deleted: deletions.removed,
+                errors: ["Skipped uploading local changes: remote deletions could not be reconciled"]
+            )
+        } else {
+            // Backup any unsynced local changes first (matches doSyncAllChats behavior)
+            let backupResult = await backupUnsyncedChats()
+            guard generation == accountGeneration else { return SyncResult() }
+            result = SyncResult(
+                uploaded: backupResult.uploaded,
+                downloaded: 0,
+                deleted: deletions.removed,
+                errors: backupResult.errors
+            )
+        }
 
         do {
             _ = try? await encryptionService.initialize()
@@ -1612,18 +1658,15 @@ class CloudSyncService: ObservableObject {
             // was missed locally, after which the count gate never reopens and
             // the orphan lingers until a full reload. Re-run the tombstone
             // reconciliation here so a missed deletion self-heals on the next
-            // tick. The pass is idempotent and only reports chats actually
-            // removed locally, so it triggers a UI reload only when needed.
-            if let cachedStatus = getCachedSyncStatus(),
-               let lastUpdated = cachedStatus.lastUpdated {
-                let reconciled = await deleteRemotelyDeletedChats(
-                    since: lastUpdated,
-                    generation: generation,
-                    userId: userId
-                )
-                if reconciled > 0 {
-                    return SyncResult(deleted: reconciled)
-                }
+            // tick. The pass resumes from its own durable watermark, is
+            // idempotent, and only reports chats actually removed locally,
+            // so it triggers a UI reload only when needed.
+            let deletions = await reconcileRemoteDeletions(
+                generation: generation,
+                userId: userId
+            )
+            if deletions.removed > 0 {
+                return SyncResult(deleted: deletions.removed)
             }
             return SyncResult()
         }
@@ -2011,6 +2054,10 @@ class CloudSyncService: ObservableObject {
             where key.hasPrefix(Constants.StorageKeys.Sync.projectChatStatusPrefix) {
             UserDefaults.standard.removeObject(forKey: key)
         }
+        // The deletes watermark is scoped to the account's tombstone
+        // history, so the next account (or re-login) must replay from
+        // epoch rather than resume at the previous account's position.
+        ChatDeletesWatermark.clear()
         // Drop any in-flight key registration so the next signed-in user
         // never awaits a task started under the previous user's key.
         emptyRemoteRegistration?.cancel()
@@ -2303,12 +2350,17 @@ class CloudSyncService: ObservableObject {
         _ chat: Chat,
         idempotencyKey: String,
         generation: Int,
-        userId: String
+        userId: String,
+        restoreDeleted: Bool = false
     ) async throws {
         guard !streamingTracker.isStreaming(chat.id) else { return }
 
         let storedChat = StoredChat(from: chat, syncVersion: chat.syncVersion)
-        let result = try await cloudStorage.uploadChat(storedChat, idempotencyKey: idempotencyKey)
+        let result = try await cloudStorage.uploadChat(
+            storedChat,
+            idempotencyKey: idempotencyKey,
+            restoreDeleted: restoreDeleted
+        )
         guard generation == accountGeneration else { return }
         let newVersion = result.syncVersion ?? chat.syncVersion + 1
         let fullySynced = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
@@ -2357,23 +2409,73 @@ class CloudSyncService: ObservableObject {
         )
     }
 
-    /// Delete local chats that were deleted on another device since `since` timestamp.
-    /// Returns the number of chats deleted locally.
-    @discardableResult
-    private func deleteRemotelyDeletedChats(
-        since: String,
+    /// Outcome of one remote-deletion reconciliation pass.
+    struct RemoteDeletionsOutcome {
+        /// Chats removed locally by this pass.
+        var removed: Int = 0
+        /// Every tombstone in the fetched window was resolved: applied
+        /// locally, already absent, or superseded by a newer remote
+        /// write. Only a reconciled pass advances the durable watermark.
+        var reconciled: Bool = false
+        /// The tombstone fetch errored. Local state cannot yet be
+        /// trusted against remote deletions, so callers must not upload
+        /// dirty chats (a re-upload would resurrect a chat deleted
+        /// elsewhere).
+        var failed: Bool = false
+    }
+
+    /// Delete local chats whose remote rows carry deletion tombstones,
+    /// resuming from the durable deletes watermark. The watermark only
+    /// advances after a fully reconciled pass so a failed or interrupted
+    /// pass replays the same window next time.
+    private func reconcileRemoteDeletions(
         generation: Int,
         userId: String
-    ) async -> Int {
+    ) async -> RemoteDeletionsOutcome {
+        var outcome = RemoteDeletionsOutcome()
         do {
-            let deleted = try await cloudStorage.getDeletedChatsSince(since: since)
-            guard generation == accountGeneration,
-                  !deleted.deletedIds.isEmpty else {
-                return 0
+            let since = ChatDeletesWatermark.load()
+            let events = try await cloudStorage.listChatEventsSince(since: since)
+            guard generation == accountGeneration else {
+                outcome.failed = true
+                return outcome
             }
-            var removedCount = 0
-            for id in deleted.deletedIds {
-                guard generation == accountGeneration else { break }
+
+            // Newest server-side write per chat in this window. A
+            // tombstone is only authoritative when no later write exists:
+            // a row re-created after its tombstone (restore, or an upload
+            // that raced the delete) must survive.
+            var latestUpdateAt: [String: Date] = [:]
+            var latestEventAt: Date?
+            for update in events.updates {
+                guard let at = parseISODate(update.updatedAt) else { continue }
+                latestEventAt = max(latestEventAt ?? at, at)
+                latestUpdateAt[update.id] = max(latestUpdateAt[update.id] ?? .distantPast, at)
+            }
+            var latestDeleteAt: [String: Date] = [:]
+            for tombstone in events.deletes {
+                guard let at = parseISODate(tombstone.deletedAt) else { continue }
+                latestEventAt = max(latestEventAt ?? at, at)
+                latestDeleteAt[tombstone.id] = max(latestDeleteAt[tombstone.id] ?? .distantPast, at)
+            }
+
+            var allResolved = true
+            for (id, deletedAt) in latestDeleteAt {
+                guard generation == accountGeneration else {
+                    outcome.failed = true
+                    return outcome
+                }
+                if let updatedAt = latestUpdateAt[id], updatedAt > deletedAt {
+                    // The row was re-created after the tombstone; the live
+                    // row wins. Unblock ingestion in case an earlier pass
+                    // recorded the tombstone. On a same-timestamp tie
+                    // deletion wins instead: a live row wrongly deleted
+                    // locally is re-downloaded once the tracker entry
+                    // expires with the session, while a dead row wrongly
+                    // kept local would never be cleaned up.
+                    deletedChatsTracker.removeFromDeleted(id)
+                    continue
+                }
                 // Skip chats already absent locally (a prior reconciliation
                 // pass handled them, or they were never stored here). This
                 // keeps repeated passes idempotent so they never report a
@@ -2384,6 +2486,10 @@ class CloudSyncService: ObservableObject {
                     chatId: id,
                     userId: userId
                 )
+                guard generation == accountGeneration else {
+                    outcome.failed = true
+                    return outcome
+                }
                 guard let expectedUpdatedAt = existing?.updatedAt else { continue }
                 let removed = (try? await EncryptedFileStorage.cloud.deleteChatIfEvictable(
                     chatId: id,
@@ -2391,16 +2497,34 @@ class CloudSyncService: ObservableObject {
                     shouldEvict: { $0.updatedAt == expectedUpdatedAt },
                     shouldEvictOnLoadError: { _ in false }
                 )) ?? false
-                guard generation == accountGeneration else { break }
+                guard generation == accountGeneration else {
+                    outcome.failed = true
+                    return outcome
+                }
                 if removed {
                     deletedChatsTracker.markAsDeleted(id)
-                    removedCount += 1
+                    outcome.removed += 1
+                } else {
+                    // The row changed under us (an in-flight local edit) or
+                    // could not be verified. Leave it for the conflict path
+                    // to arbitrate and hold the watermark behind this
+                    // tombstone so the next pass re-checks it. Not `failed`:
+                    // a row that cannot be loaded cannot be uploaded either,
+                    // so it carries no resurrection risk.
+                    allResolved = false
                 }
             }
-            return removedCount
+
+            outcome.reconciled = allResolved
+            if allResolved, let latestEventAt, generation == accountGeneration {
+                ChatDeletesWatermark.advance(latestEventAt: latestEventAt)
+            }
+            return outcome
         } catch {
-            // Non-fatal: continue even if deletion check fails
-            return 0
+            // Without the tombstone window we cannot know which local
+            // chats are stale; report failed so upload legs hold off.
+            outcome.failed = true
+            return outcome
         }
     }
 

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1185,6 +1185,35 @@ class CloudSyncService: ObservableObject {
         return result
     }
 
+    private static let uploadsSkippedUnreconciledDeletionsError =
+        "Skipped uploading local changes: remote deletions could not be reconciled"
+
+    /// Upload leg shared by the full and delta sync paths. Uploading
+    /// dirty chats before deletions reconcile can resurrect chats
+    /// deleted on another device, so a failed pass keeps local changes
+    /// queued until a pass succeeds.
+    private func backupUnsyncedChatsAfterDeletions(
+        _ deletions: RemoteDeletionsOutcome,
+        generation: Int
+    ) async -> SyncResult {
+        if deletions.failed {
+            return SyncResult(
+                uploaded: 0,
+                downloaded: 0,
+                deleted: deletions.removed,
+                errors: [Self.uploadsSkippedUnreconciledDeletionsError]
+            )
+        }
+        let backupResult = await backupUnsyncedChats()
+        guard generation == accountGeneration else { return SyncResult() }
+        return SyncResult(
+            uploaded: backupResult.uploaded,
+            downloaded: 0,
+            deleted: deletions.removed,
+            errors: backupResult.errors
+        )
+    }
+
     private func doSyncAllChats() async -> SyncResult {
         let generation = accountGeneration
         guard let userId = await getCurrentUserId() else { return SyncResult() }
@@ -1197,27 +1226,11 @@ class CloudSyncService: ObservableObject {
         )
         guard generation == accountGeneration else { return SyncResult() }
 
-        if deletions.failed {
-            // Uploading dirty chats before deletions reconcile can
-            // resurrect chats deleted on another device, so keep local
-            // changes queued until a pass succeeds.
-            result = SyncResult(
-                uploaded: 0,
-                downloaded: 0,
-                deleted: deletions.removed,
-                errors: ["Skipped uploading local changes: remote deletions could not be reconciled"]
-            )
-        } else {
-            // First, backup any unsynced local changes
-            let backupResult = await backupUnsyncedChats()
-            guard generation == accountGeneration else { return SyncResult() }
-            result = SyncResult(
-                uploaded: backupResult.uploaded,
-                downloaded: 0,
-                deleted: deletions.removed,
-                errors: backupResult.errors
-            )
-        }
+        result = await backupUnsyncedChatsAfterDeletions(
+            deletions,
+            generation: generation
+        )
+        guard generation == accountGeneration else { return SyncResult() }
 
         // Then, get list of remote chats with content
         do {
@@ -1496,27 +1509,11 @@ class CloudSyncService: ObservableObject {
         )
         guard generation == accountGeneration else { return SyncResult() }
 
-        if deletions.failed {
-            // Uploading dirty chats before deletions reconcile can
-            // resurrect chats deleted on another device, so keep local
-            // changes queued until a pass succeeds.
-            result = SyncResult(
-                uploaded: 0,
-                downloaded: 0,
-                deleted: deletions.removed,
-                errors: ["Skipped uploading local changes: remote deletions could not be reconciled"]
-            )
-        } else {
-            // Backup any unsynced local changes first (matches doSyncAllChats behavior)
-            let backupResult = await backupUnsyncedChats()
-            guard generation == accountGeneration else { return SyncResult() }
-            result = SyncResult(
-                uploaded: backupResult.uploaded,
-                downloaded: 0,
-                deleted: deletions.removed,
-                errors: backupResult.errors
-            )
-        }
+        result = await backupUnsyncedChatsAfterDeletions(
+            deletions,
+            generation: generation
+        )
+        guard generation == accountGeneration else { return SyncResult() }
 
         do {
             _ = try? await encryptionService.initialize()

--- a/TinfoilChatTests/ChatDeletesWatermarkTests.swift
+++ b/TinfoilChatTests/ChatDeletesWatermarkTests.swift
@@ -1,0 +1,65 @@
+//
+//  ChatDeletesWatermarkTests.swift
+//  TinfoilChatTests
+//
+
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ChatDeletesWatermarkTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "chat-deletes-watermark-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    @Test func loadDefaultsToEpochWhenUnsetOrCorrupt() {
+        let defaults = makeDefaults()
+        #expect(ChatDeletesWatermark.load(defaults: defaults) == ChatDeletesWatermark.epoch)
+
+        defaults.set("not-a-timestamp", forKey: Constants.StorageKeys.Sync.chatDeletesWatermark)
+        #expect(ChatDeletesWatermark.load(defaults: defaults) == ChatDeletesWatermark.epoch)
+    }
+
+    @Test func advanceSubtractsOverlapAndPersists() {
+        let defaults = makeDefaults()
+        let eventAt = formatter.date(from: "2026-01-01T00:00:20.000Z")!
+
+        ChatDeletesWatermark.advance(latestEventAt: eventAt, defaults: defaults)
+
+        let expected = eventAt.addingTimeInterval(-ChatDeletesWatermark.overlapSeconds)
+        #expect(ChatDeletesWatermark.load(defaults: defaults) == formatter.string(from: expected))
+    }
+
+    @Test func advanceIsMonotonic() {
+        let defaults = makeDefaults()
+        let newer = formatter.date(from: "2026-01-01T00:01:00.000Z")!
+        let older = formatter.date(from: "2026-01-01T00:00:30.000Z")!
+
+        ChatDeletesWatermark.advance(latestEventAt: newer, defaults: defaults)
+        let persisted = ChatDeletesWatermark.load(defaults: defaults)
+
+        ChatDeletesWatermark.advance(latestEventAt: older, defaults: defaults)
+        #expect(ChatDeletesWatermark.load(defaults: defaults) == persisted)
+    }
+
+    @Test func clearResetsToEpoch() {
+        let defaults = makeDefaults()
+        ChatDeletesWatermark.advance(
+            latestEventAt: formatter.date(from: "2026-01-01T00:00:20.000Z")!,
+            defaults: defaults
+        )
+
+        ChatDeletesWatermark.clear(defaults: defaults)
+
+        #expect(ChatDeletesWatermark.load(defaults: defaults) == ChatDeletesWatermark.epoch)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make deletions reliable across devices by reconciling server tombstones before any uploads and tracking progress with a durable watermark. Also allow restoring a locally edited chat when its remote row was deleted, with a pre-restore reconciliation to avoid racing recent deletes.

- **Bug Fixes**
  - Added a durable deletes watermark in `UserDefaults` with a 5s safety overlap; advances only after a fully reconciled pass.
  - Replaced the deleted-only fetch with a single list-status walk that collects both updates and tombstones; apply a tombstone only if no newer remote update exists, and never advance past tombstones that can’t be verified (parse/read errors).
  - Block uploads when tombstone fetch/reconciliation fails to prevent resurrecting remotely deleted chats; gating is shared across full and delta sync paths and re-run on periodic ticks.
  - Prevent restoring a chat that was just deleted elsewhere by reconciling immediately before restore and skipping if the tombstone is present or reconciliation fails.
  - Clear the deletes watermark on account switch.

- **New Features**
  - Support restoring a locally modified chat whose remote row was deleted by uploading with `restoreDeleted` (uses `if_match=null`).
  - New `listChatEventsSince` returns updates and deletes from the same walk for correct arbitration.
  - Added tests for the watermark’s defaults, overlap, monotonic advance, and clear.

<sup>Written for commit afc39d468a9883cf41bf1567caf9ea363a2ba11e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

