### PR TITLE
fix: preserve chat snapshots through sync retries

### DIFF
--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -121,7 +121,7 @@ class CloudStorageService: ObservableObject {
         let rewrites = try await encryptAndUploadAttachments(&chatToUpload)
         stripBase64FromMessages(&chatToUpload.messages)
 
-        let plaintext = try JSONEncoder().encode(chatToUpload)
+        let plaintext = try Self.encodeChatPlaintext(chatToUpload)
         let keyB64 = try CEKEncoding.requirePrimaryKeyB64()
 
         var metadata: [String: AnyCodable] = [
@@ -181,7 +181,7 @@ class CloudStorageService: ObservableObject {
                       let raw = Data(base64Encoded: base64) else {
                     continue
                 }
-                let attIdemKey = attachmentIdempotencyKey(
+                let attIdemKey = Self.attachmentIdempotencyKey(
                     chatId: chat.id,
                     clientId: att.id,
                     plaintext: raw
@@ -221,7 +221,13 @@ class CloudStorageService: ObservableObject {
         }
     }
 
-    private func attachmentIdempotencyKey(
+    static func encodeChatPlaintext(_ chat: StoredChat) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(chat)
+    }
+
+    static func attachmentIdempotencyKey(
         chatId: String,
         clientId: String,
         plaintext: Data

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -41,7 +41,7 @@ private func parseISODate(_ dateString: String) -> Date? {
 /// snapshot and returns this closure; every retry replays it, so the
 /// bytes pushed to the enclave are identical across attempts and the
 /// enclave can de-duplicate them into a single committed effect.
-private typealias UploadAttempt = @MainActor @Sendable () async throws -> Void
+typealias UploadAttempt = @MainActor @Sendable () async throws -> Void
 
 /// Coalesces rapid upload requests per chat into single uploads with exponential backoff retry.
 /// Uses a dirty-flag + worker-loop pattern to batch rapid successive writes.
@@ -54,7 +54,7 @@ private typealias UploadAttempt = @MainActor @Sendable () async throws -> Void
 /// re-read a chat edited between attempts would replay different
 /// bytes under the same key and fail with 409 IDEMPOTENCY_CONFLICT
 /// instead of deduping.
-private actor UploadCoalescer {
+actor UploadCoalescer {
     private struct ChatUploadState {
         var dirty: Bool = false
         var workerRunning: Bool = false
@@ -66,9 +66,20 @@ private actor UploadCoalescer {
     private var states: [String: ChatUploadState] = [:]
     private var generation = 0
     private let prepareUpload: @Sendable (String, String) async throws -> UploadAttempt?
+    private let waitBeforeRetry: @Sendable (Int) async -> Void
 
-    init(prepareUpload: @escaping @Sendable (String, String) async throws -> UploadAttempt?) {
+    init(
+        prepareUpload: @escaping @Sendable (String, String) async throws -> UploadAttempt?,
+        waitBeforeRetry: @escaping @Sendable (Int) async -> Void = { attempt in
+            let delay = min(
+                Constants.Sync.uploadBaseDelaySeconds * pow(2.0, Double(attempt)),
+                Constants.Sync.uploadMaxDelaySeconds
+            )
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+    ) {
         self.prepareUpload = prepareUpload
+        self.waitBeforeRetry = waitBeforeRetry
     }
 
     func enqueue(_ chatId: String) {
@@ -192,19 +203,9 @@ private actor UploadCoalescer {
                     break
                 }
 
-                let delay = min(
-                    Constants.Sync.uploadBaseDelaySeconds * pow(2.0, Double(attempt)),
-                    Constants.Sync.uploadMaxDelaySeconds
-                )
-                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                await waitBeforeRetry(attempt)
                 guard workerGeneration == generation else {
                     return CancellationError()
-                }
-
-                // If dirty was set during backoff, return early to upload fresh data
-                let isDirty = states[chatId]?.dirty ?? false
-                if isDirty {
-                    return nil
                 }
             }
         }
@@ -226,6 +227,18 @@ private actor UploadCoalescer {
 @MainActor
 class CloudSyncService: ObservableObject {
     static let shared = CloudSyncService()
+
+    private struct UploadAccount: Equatable {
+        let generation: Int
+        let userId: String
+    }
+
+    private struct PreparedChatUpload {
+        let chat: StoredChat
+        let expectedUpdatedAt: Date
+        let idempotencyKey: String
+        let account: UploadAccount
+    }
     
     // MARK: - Published Properties
     @Published var isSyncing = false
@@ -572,8 +585,9 @@ class CloudSyncService: ObservableObject {
     private func doBackupChat(_ chatId: String, idempotencyKey: String) async throws -> UploadAttempt? {
         let generation = accountGeneration
         guard let userId = await getCurrentUserId() else { return nil }
+        let account = UploadAccount(generation: generation, userId: userId)
         guard await canWriteToCloud() else { return nil }
-        guard generation == accountGeneration else { return nil }
+        guard await isCurrentUploadAccount(account) else { return nil }
 
         // Check if chat is currently streaming
         if streamingTracker.isStreaming(chatId) {
@@ -609,7 +623,7 @@ class CloudSyncService: ObservableObject {
         ) else {
             return nil // Chat might have been deleted
         }
-        guard generation == accountGeneration else { return nil }
+        guard await isCurrentUploadAccount(account) else { return nil }
         
         
         // Don't sync blank, empty, decryption-failure, or local-only chats.
@@ -623,23 +637,30 @@ class CloudSyncService: ObservableObject {
         if streamingTracker.isStreaming(chatId) {
             return nil
         }
+
+        let preparedUpload = PreparedChatUpload(
+            chat: StoredChat(from: chat, syncVersion: chat.syncVersion),
+            expectedUpdatedAt: chat.updatedAt,
+            idempotencyKey: idempotencyKey,
+            account: account
+        )
         
         return { [weak self] in
-            guard let self else { return }
+            guard let self else { throw CancellationError() }
+            guard await self.isCurrentUploadAccount(preparedUpload.account) else {
+                throw CancellationError()
+            }
             do {
-                try await self.uploadAndMarkSynced(
-                    chat,
-                    idempotencyKey: idempotencyKey,
-                    generation: generation,
-                    userId: userId
-                )
+                try await self.uploadAndMarkSynced(preparedUpload)
             } catch {
-                guard generation == self.accountGeneration else { return }
+                guard await self.isCurrentUploadAccount(preparedUpload.account) else {
+                    throw CancellationError()
+                }
                 try await self.handleUploadFailure(
                     chatId: chatId,
                     error: error,
-                    generation: generation,
-                    userId: userId
+                    generation: preparedUpload.account.generation,
+                    userId: preparedUpload.account.userId
                 )
             }
         }
@@ -2412,17 +2433,50 @@ class CloudSyncService: ObservableObject {
         guard !streamingTracker.isStreaming(chat.id) else { return }
 
         let storedChat = StoredChat(from: chat, syncVersion: chat.syncVersion)
-        let result = try await cloudStorage.uploadChat(
+        let account = UploadAccount(generation: generation, userId: userId)
+        try await uploadAndMarkSynced(
             storedChat,
+            expectedUpdatedAt: chat.updatedAt,
+            idempotencyKey: idempotencyKey,
+            account: account,
+            restoreDeleted: restoreDeleted
+        )
+    }
+
+    private func uploadAndMarkSynced(_ upload: PreparedChatUpload) async throws {
+        // Streaming is an eligibility check only while preparing. Once frozen,
+        // this operation must finish while newer streaming edits stay dirty.
+        try await uploadAndMarkSynced(
+            upload.chat,
+            expectedUpdatedAt: upload.expectedUpdatedAt,
+            idempotencyKey: upload.idempotencyKey,
+            account: upload.account
+        )
+    }
+
+    private func uploadAndMarkSynced(
+        _ chat: StoredChat,
+        expectedUpdatedAt: Date,
+        idempotencyKey: String,
+        account: UploadAccount,
+        restoreDeleted: Bool = false
+    ) async throws {
+        guard await isCurrentUploadAccount(account) else {
+            throw CancellationError()
+        }
+        let result = try await cloudStorage.uploadChat(
+            chat,
             idempotencyKey: idempotencyKey,
             restoreDeleted: restoreDeleted
         )
-        guard generation == accountGeneration else { return }
+        guard await isCurrentUploadAccount(account) else {
+            throw CancellationError()
+        }
         let newVersion = result.syncVersion ?? chat.syncVersion + 1
         let fullySynced = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
             chatId: chat.id,
-            userId: userId,
-            expectedUpdatedAt: chat.updatedAt,
+            userId: account.userId,
+            expectedUpdatedAt: expectedUpdatedAt,
             syncVersion: newVersion,
             attachmentRewrites: result.rewrites.map {
                 (
@@ -2432,9 +2486,17 @@ class CloudSyncService: ObservableObject {
                 )
             }
         )
+        guard await isCurrentUploadAccount(account) else {
+            throw CancellationError()
+        }
         if fullySynced {
             SyncHealthStore.shared.reportChatSynced(chat.id)
         }
+    }
+
+    private func isCurrentUploadAccount(_ account: UploadAccount) async -> Bool {
+        guard account.generation == accountGeneration else { return false }
+        return await getCurrentUserId() == account.userId
     }
 
     /// Rebase the local chat's sync version onto the server's current
@@ -2788,5 +2850,3 @@ class CloudSyncService: ObservableObject {
     }
 
 }
-
-

--- a/TinfoilChatTests/CloudSyncUploadRetryTests.swift
+++ b/TinfoilChatTests/CloudSyncUploadRetryTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+private enum UploadRetryTestError: Error {
+    case transient
+}
+
+private actor RetryBackoffGate {
+    private var entered = false
+    private var released = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func pause() async {
+        entered = true
+        entryWaiters.forEach { $0.resume() }
+        entryWaiters.removeAll()
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiter = continuation
+        }
+    }
+
+    func release() {
+        released = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+}
+
+private actor UploadRetryProbe {
+    struct Snapshot: Sendable {
+        let preparedKeys: [String]
+        let executedKeys: [String]
+    }
+
+    private var preparedKeys: [String] = []
+    private var executedKeys: [String] = []
+
+    func prepare(key: String) -> Int {
+        preparedKeys.append(key)
+        return preparedKeys.count
+    }
+
+    func execute(key: String, preparation: Int) throws {
+        executedKeys.append(key)
+        if preparation == 1 && executedKeys.count == 1 {
+            throw UploadRetryTestError.transient
+        }
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(preparedKeys: preparedKeys, executedKeys: executedKeys)
+    }
+}
+
+struct CloudSyncUploadRetryTests {
+    @Test
+    func dirtyWriteDoesNotReplacePreparedRetry() async throws {
+        let backoff = RetryBackoffGate()
+        let probe = UploadRetryProbe()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { _, key in
+                let preparation = await probe.prepare(key: key)
+                return {
+                    try await probe.execute(key: key, preparation: preparation)
+                }
+            },
+            waitBeforeRetry: { _ in await backoff.pause() }
+        )
+
+        await coalescer.enqueue("chat")
+        await backoff.waitUntilEntered()
+        await coalescer.enqueue("chat")
+        await backoff.release()
+        await coalescer.waitForUpload("chat")
+
+        let snapshot = await probe.snapshot()
+        try #require(snapshot.preparedKeys.count == 2)
+        try #require(snapshot.executedKeys.count == 3)
+        #expect(snapshot.executedKeys[0] == snapshot.preparedKeys[0])
+        #expect(snapshot.executedKeys[1] == snapshot.preparedKeys[0])
+        #expect(snapshot.executedKeys[2] == snapshot.preparedKeys[1])
+        #expect(snapshot.preparedKeys[0] != snapshot.preparedKeys[1])
+    }
+
+    @Test
+    func clearDuringBackoffCancelsWaiterAndPreventsFrozenRetry() async {
+        let backoff = RetryBackoffGate()
+        let probe = UploadRetryProbe()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { _, key in
+                let preparation = await probe.prepare(key: key)
+                return {
+                    try await probe.execute(key: key, preparation: preparation)
+                }
+            },
+            waitBeforeRetry: { _ in await backoff.pause() }
+        )
+        let clearTask = Task {
+            await backoff.waitUntilEntered()
+            await coalescer.clear()
+            await backoff.release()
+        }
+        var waiterCancelled = false
+
+        do {
+            try await coalescer.enqueueAndWait("chat")
+            Issue.record("Expected clear to cancel the upload waiter")
+        } catch is CancellationError {
+            waiterCancelled = true
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+        await clearTask.value
+        await coalescer.waitForUpload("chat")
+
+        let snapshot = await probe.snapshot()
+        #expect(waiterCancelled)
+        #expect(snapshot.preparedKeys.count == 1)
+        #expect(snapshot.executedKeys.count == 1)
+    }
+
+    @Test @MainActor
+    func frozenChatEncodingIsCanonical() throws {
+        var chat = Chat(modelType: uploadRetryTestModel)
+        chat.title = "Frozen"
+        let frozen = StoredChat(from: chat, syncVersion: chat.syncVersion)
+
+        let first = try CloudStorageService.encodeChatPlaintext(frozen)
+        chat.title = "Newer edit"
+        let replay = try CloudStorageService.encodeChatPlaintext(frozen)
+
+        #expect(first == replay)
+        #expect(String(decoding: first, as: UTF8.self).hasPrefix("{\"createdAt\":"))
+    }
+
+    @Test
+    func attachmentIdempotencyKeyUsesFrozenIdentityAndBytes() {
+        let plaintext = Data("image bytes".utf8)
+        let first = CloudStorageService.attachmentIdempotencyKey(
+            chatId: "chat",
+            clientId: "attachment",
+            plaintext: plaintext
+        )
+        let replay = CloudStorageService.attachmentIdempotencyKey(
+            chatId: "chat",
+            clientId: "attachment",
+            plaintext: plaintext
+        )
+        let newerAttachment = CloudStorageService.attachmentIdempotencyKey(
+            chatId: "chat",
+            clientId: "attachment-2",
+            plaintext: plaintext
+        )
+
+        #expect(first == replay)
+        #expect(first != newerAttachment)
+    }
+}
+
+private let uploadRetryTestModel = ModelType(
+    from: AppModelConfig(
+        modelName: "gpt-oss-120b",
+        image: "openai.png",
+        name: "GPT OSS 120B",
+        nameShort: "GPT OSS",
+        description: "",
+        details: "",
+        parameters: "",
+        contextWindow: "64k tokens",
+        type: "chat",
+        chat: true,
+        paid: false,
+        multimodal: false,
+        toolCalling: nil,
+        attributes: nil,
+        reasoningConfig: nil
+    )
+)


### PR DESCRIPTION
## Summary
- finish frozen retries before uploading newer dirty chat state
- canonicalize chat payload encoding and preserve prepared uploads across streaming changes
- prevent prepared uploads from crossing account generations and add focused retry tests

## Testing
- Not run locally; repository instructions require running tests in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves frozen chat upload snapshots across retries so we replay identical bytes and don’t overwrite them with newer edits. Adds deterministic encoding and account scoping to prevent idempotency conflicts and cross-account replays.

- **Bug Fixes**
  - Finish frozen retries before uploading newer dirty state to keep idempotency keys valid.
  - Use canonical chat JSON (sorted keys) and stable attachment idempotency keys for identical bytes across retries.
  - Scope prepared uploads to the current account (generation + userId) to block cross-account replays.
  - Keep prepared uploads intact during streaming; newer edits stay dirty and sync after the retry completes.
  - Finalize with the frozen snapshot’s expectedUpdatedAt to avoid races with fresh edits.

- **Refactors**
  - Injected retry backoff via `waitBeforeRetry`; removed “drop retry if dirty during backoff” path.
  - Introduced `PreparedChatUpload` and account checks; added `encodeChatPlaintext` and made `attachmentIdempotencyKey` static.
  - Exposed `UploadCoalescer` and `UploadAttempt` for tests and added focused retry tests.

<sup>Written for commit e6b5935c24e0ab012dbf5ec35c28c5273906da5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

