### PR TITLE
Avoid metadata requests for favicon-only UI

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -312,8 +312,7 @@ enum Constants {
     enum Metadata {
         static let enclaveURL = "https://opengraph-metadata.tinfoil.sh"
         static let configRepo = "tinfoilsh/confidential-website-metadata-fetcher"
-        /// Cap on cached link-metadata entries; favicon bytes ride along
-        /// in each entry, so an unbounded cache would grow steadily.
+        /// Cap on cached metadata and favicon entries.
         static let cacheEntryLimit = 200
     }
 

--- a/TinfoilChat/Services/LinkMetadataService.swift
+++ b/TinfoilChat/Services/LinkMetadataService.swift
@@ -2,11 +2,10 @@
 //  LinkMetadataService.swift
 //  TinfoilChat
 //
-//  Fetches OpenGraph metadata (title/description/site_name/image/favicon)
+//  Fetches OpenGraph metadata and favicons
 //  for a URL from the `opengraph-metadata.tinfoil.sh` enclave through an
 //  attested `SecureClient`. Mirrors the webapp's `metadata-client.ts` so
-//  the iOS link-preview widget surfaces the same rich card (hero image
-//  + favicon + title + description) as the web build.
+//  the iOS link-preview widget surfaces the same rich card as the web build.
 //
 //  In-flight requests for the same URL are deduplicated so multiple
 //  `LinkPreviewView` instances rendering the same link share a single
@@ -21,7 +20,6 @@ struct LinkMetadata: Equatable, Sendable {
     let description: String?
     let siteName: String?
     let image: String?
-    let faviconBytes: Data?
     let cached: Bool
 }
 
@@ -35,8 +33,11 @@ private struct MetadataResponse: Decodable {
     let description: String?
     let site_name: String?
     let image: String?
-    let favicon_bytes: Data?
     let cached: Bool?
+}
+
+private struct FaviconResponse: Decodable {
+    let favicon_bytes: Data
 }
 
 enum LinkMetadataError: Error {
@@ -49,11 +50,11 @@ actor LinkMetadataService {
     static let shared = LinkMetadataService()
 
     private var cache: [String: LinkMetadata] = [:]
-    /// Insertion order of cache keys, oldest first, so the cache can
-    /// evict instead of growing without bound (entries carry raw
-    /// favicon bytes).
     private var cacheOrder: [String] = []
     private var inFlight: [String: Task<LinkMetadata, Error>] = [:]
+    private var faviconCache: [String: Data] = [:]
+    private var faviconCacheOrder: [String] = []
+    private var faviconInFlight: [String: Task<Data, Error>] = [:]
 
     private var client: SecureClient?
     private var verificationTask: Task<SecureClient, Error>?
@@ -105,6 +106,24 @@ actor LinkMetadataService {
         return result
     }
 
+    func favicon(for url: String) async throws -> Data {
+        guard let host = URL(string: url)?.host?.lowercased() else {
+            throw LinkMetadataError.invalidURL
+        }
+        if let cached = faviconCache[host] { return cached }
+        if let existing = faviconInFlight[host] { return try await existing.value }
+
+        let task = Task<Data, Error> {
+            try await self.fetchFavicon(url: url)
+        }
+        faviconInFlight[host] = task
+
+        defer { faviconInFlight[host] = nil }
+        let result = try await task.value
+        storeFaviconInCache(result, for: host)
+        return result
+    }
+
     private func storeInCache(_ metadata: LinkMetadata, for url: String) {
         if cache[url] == nil {
             cacheOrder.append(url)
@@ -113,6 +132,17 @@ actor LinkMetadataService {
         while cacheOrder.count > Constants.Metadata.cacheEntryLimit {
             let evicted = cacheOrder.removeFirst()
             cache[evicted] = nil
+        }
+    }
+
+    private func storeFaviconInCache(_ favicon: Data, for host: String) {
+        if faviconCache[host] == nil {
+            faviconCacheOrder.append(host)
+        }
+        faviconCache[host] = favicon
+        while faviconCacheOrder.count > Constants.Metadata.cacheEntryLimit {
+            let evicted = faviconCacheOrder.removeFirst()
+            faviconCache[evicted] = nil
         }
     }
 
@@ -138,9 +168,27 @@ actor LinkMetadataService {
                 description: decoded.description,
                 siteName: decoded.site_name,
                 image: decoded.image,
-                faviconBytes: decoded.favicon_bytes,
                 cached: decoded.cached ?? false
             )
+        } catch {
+            throw LinkMetadataError.decodingFailed
+        }
+    }
+
+    private func fetchFavicon(url: String) async throws -> Data {
+        let client = try await getClient()
+        let body = try JSONEncoder().encode(MetadataRequest(url: url))
+        let response = try await client.post(
+            url: "\(Constants.Metadata.enclaveURL)/favicon",
+            headers: ["Content-Type": "application/json"],
+            body: body
+        )
+
+        guard (200..<300).contains(response.statusCode) else {
+            throw LinkMetadataError.badStatus(response.statusCode)
+        }
+        do {
+            return try JSONDecoder().decode(FaviconResponse.self, from: response.body).favicon_bytes
         } catch {
             throw LinkMetadataError.decodingFailed
         }

--- a/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/LinkPreviewWidget.swift
@@ -18,7 +18,7 @@ struct LinkPreviewWidget: GenUIWidget {
     }
 
     let name = "render_link_preview"
-    let description = "Display a rich preview card for a single web link. Use when linking to an article, page, or resource and you want to surface title, description, and favicon. The card fetches metadata (title, description, site name, image, favicon) from the opengraph-metadata.tinfoil.sh enclave. Provide only the URL and a fallback title — every other field is resolved server-side."
+    let description = "Display a rich preview card for a single web link. Use when linking to an article, page, or resource and you want to surface title, description, and favicon. The card fetches metadata and the favicon from the opengraph-metadata.tinfoil.sh enclave. Provide only the URL and a fallback title — every other field is resolved server-side."
     let promptHint = "rich preview card for a single web link"
 
     var schema: JSONSchema {

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -14,7 +14,7 @@ import UIKit
 /// Resolves a citation's favicon bytes from the attested metadata enclave so citation chips never
 /// reach an external icon host directly.
 private func citationFaviconData(for url: URL) async -> Data? {
-    try? await LinkMetadataService.shared.metadata(for: url.absoluteString).faviconBytes
+    try? await LinkMetadataService.shared.favicon(for: url.absoluteString)
 }
 
 /// Renders markdown through `StructuredText` with the shared Tinfoil citation treatment, used by
@@ -1363,5 +1363,4 @@ struct MathView: UIViewRepresentable {
         uiView.sizeToFit()
     }
 }
-
 

--- a/TinfoilChat/Views/WebSearchBox.swift
+++ b/TinfoilChat/Views/WebSearchBox.swift
@@ -209,13 +209,13 @@ struct FaviconImage: View {
             iconImage = nil
             loadFailed = false
             do {
-                let metadata = try await LinkMetadataService.shared.metadata(for: url)
+                let bytes = try await LinkMetadataService.shared.favicon(for: url)
                 // The shared in-flight fetch doesn't observe this
                 // task's cancellation, so a superseded task can reach
                 // this point; bail before stomping the new task's state.
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
-                    if let bytes = metadata.faviconBytes, let image = UIImage(data: bytes) {
+                    if let image = UIImage(data: bytes) {
                         iconImage = image
                     } else {
                         loadFailed = true
@@ -227,6 +227,7 @@ struct FaviconImage: View {
                 // surface a failure for an expected cancel.
                 return
             } catch {
+                guard !Task.isCancelled else { return }
                 await MainActor.run { loadFailed = true }
             }
         }


### PR DESCRIPTION
## Summary
- fetch favicons through the new favicon-only enclave endpoint
- cache and deduplicate favicon requests by hostname
- keep full metadata requests limited to rich link previews

## Testing
- Not run; repository instructions require building and testing manually in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the enclave’s favicon-only endpoint and host-level caching to avoid full metadata fetches when only an icon is needed. This reduces requests and speeds up favicon loads in citations and search.

- **Refactors**
  - Added `favicon(for:)` in `LinkMetadataService` using the `/favicon` endpoint; deduplicates in-flight by host and caches with eviction up to `Constants.Metadata.cacheEntryLimit`.
  - Removed favicon bytes from `LinkMetadata`; updated `LaTeXMarkdownView` and `WebSearchBox` to fetch icons via the new method.
  - Kept rich link previews on full metadata; updated `LinkPreviewWidget` description accordingly.

<sup>Written for commit 9f9bb6ba025f844d2fafb48e2a1eed7ca07837cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

