### PR TITLE
refactor: use the shared passkey package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The app is structured around several key components:
 - **[Services/EncryptionService.swift](TinfoilChat/Services/EncryptionService.swift)**: AES-GCM encryption for local chat storage
 - **[Services/EncryptedFileStorage.swift](TinfoilChat/Services/EncryptedFileStorage.swift)**: Per-chat encrypted file storage
 - **[Services/CloudSyncService.swift](TinfoilChat/Services/CloudSyncService.swift)**: Encrypted cloud backup functionality
+- **[TinfoilPasskeyKit](https://github.com/tinfoilsh/tinfoil-passkey-kit)**: Reusable passkey PRF and CEK-protection Swift package
 - **[Extensions/Model+Tinfoil.swift](TinfoilChat/Extensions/Model+Tinfoil.swift)**: Integration with Tinfoil Swift SDK
 
 ## Reporting Vulnerabilities

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1B2C3D40100000000000001 /* TinfoilPasskeyKit in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D40100000000000003 /* TinfoilPasskeyKit */; };
 		99AB00012FABC00100ABC001 /* TinfoilShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 99AB00032FABC00300ABC003 /* TinfoilShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		99DDBFA42F6869250038A729 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 99DDBFA32F6869250038A729 /* Textual */; };
 		99EAB0012FC0000100EAB001 /* EHBP in Frameworks */ = {isa = PBXBuildFile; productRef = 99EAB0032FC0000300EAB003 /* EHBP */; };
@@ -122,6 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1B2C3D40100000000000001 /* TinfoilPasskeyKit in Frameworks */,
 				99EAB0012FC0000100EAB001 /* EHBP in Frameworks */,
 				99EEFB1B2F9EE9E8005B3D75 /* TinfoilAI in Frameworks */,
 				99F1547C2F4F614400E9174E /* Gzip in Frameworks */,
@@ -237,6 +239,7 @@
 			);
 			name = TinfoilChat;
 			packageProductDependencies = (
+				A1B2C3D40100000000000003 /* TinfoilPasskeyKit */,
 				99F154682F4F60C500E9174E /* ClerkKit */,
 				99F1546A2F4F60C500E9174E /* ClerkKitUI */,
 				99F1546F2F4F610000E9174E /* SwiftMath */,
@@ -284,6 +287,7 @@
 			mainGroup = 99F153B92F4F5F0200E9174E;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				A1B2C3D40100000000000002 /* XCRemoteSwiftPackageReference "tinfoil-passkey-kit" */,
 				99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */,
 				99F1546C2F4F60E900E9174E /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				99F1546D2F4F60F600E9174E /* XCRemoteSwiftPackageReference "purchases-ios-spm" */,
@@ -745,6 +749,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		A1B2C3D40100000000000002 /* XCRemoteSwiftPackageReference "tinfoil-passkey-kit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tinfoilsh/tinfoil-passkey-kit";
+			requirement = {
+				kind = exactVersion;
+				version = 0.1.0;
+			};
+		};
 		99DDBFA22F68667C0038A729 /* XCRemoteSwiftPackageReference "textual" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/textual";
@@ -812,6 +824,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		A1B2C3D40100000000000003 /* TinfoilPasskeyKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A1B2C3D40100000000000002 /* XCRemoteSwiftPackageReference "tinfoil-passkey-kit" */;
+			productName = TinfoilPasskeyKit;
+		};
 		99DDBFA32F6869250038A729 /* Textual */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 99DDBFA22F68667C0038A729 /* XCRemoteSwiftPackageReference "textual" */;

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cb79a1b5608e14f62abcbbfcbb528fa9abcbe30aeef206432df644413b822246",
+  "originHash" : "4ac80f0a580e046777bf0dbe0208566c80c6e4952fdaf05ee5f9258f4b2fba63",
   "pins" : [
     {
       "identity" : "clerk-ios",
@@ -143,6 +143,15 @@
       "state" : {
         "revision" : "e6731067a510f6d45bdec8e090698c380a90144d",
         "version" : "0.0.10"
+      }
+    },
+    {
+      "identity" : "tinfoil-passkey-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tinfoilsh/tinfoil-passkey-kit",
+      "state" : {
+        "revision" : "803440267cf83d754ab8b1cf66b4dddd9f30e105",
+        "version" : "0.1.0"
       }
     },
     {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 Tinfoil. All rights reserved.
 
 import Foundation
+import TinfoilPasskeyKit
 
 /// Application-wide constants
 enum Constants {
@@ -367,10 +368,9 @@ enum Constants {
     enum Passkey {
         static let rpId = "tinfoil.sh"
         static let rpName = "Tinfoil Chat"
-        static let prfSalt = Data("tinfoil-chat-key-encryption".utf8)
-        static let hkdfInfo = Data("tinfoil-chat-kek-v1".utf8)
-        static let challengeByteCount = 32
-        static let kekByteCount = 32
+        static let prfSalt = PasskeyProtocol.tinfoilPRFSaltV1
+        static let hkdfInfo = PasskeyProtocol.tinfoilHKDFInfoV1
+        static let challengeByteCount = PasskeyProtocol.challengeByteCount
         static let prfCacheKeychainAccount = "sh.tinfoil.passkey-prf-cache"
         static let syncCheckIntervalSeconds: TimeInterval = 30
     }

--- a/TinfoilChat/Services/Passkey/PasskeyService.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyService.swift
@@ -2,32 +2,15 @@
 //  PasskeyService.swift
 //  TinfoilChat
 //
-//  WebAuthn PRF Create/Authenticate + HKDF Key Derivation
-//
-//  Uses ASAuthorizationController with the PRF extension to derive deterministic
-//  32-byte secrets from a passkey's built-in pseudo-random function. These secrets
-//  are processed through HKDF-SHA256 to produce an AES-256-GCM Key Encryption Key (KEK).
+//  App compatibility facade for TinfoilPasskeyKit.
 //
 
-import AuthenticationServices
 import CryptoKit
 import Foundation
+import TinfoilPasskeyKit
 
-/// Result of a PRF-capable passkey operation (create or authenticate).
-struct PrfPasskeyResult {
-    /// Base64url-encoded credential ID
-    let credentialId: String
-    /// Raw PRF output as a SymmetricKey (32 bytes)
-    let prfOutput: SymmetricKey
-    /// Whether the underlying ceremony was completed by an
-    /// authenticator attached to this device (`.platform`) or by a
-    /// cross-device hybrid transport like a paired phone or USB key
-    /// (`.crossPlatform`). Lets the caller decide whether to remember
-    /// this credential id as "this device's".
-    let isPlatformAuthenticator: Bool
-}
+typealias PrfPasskeyResult = PRFPasskeyResult
 
-/// Errors specific to passkey operations.
 enum PasskeyError: LocalizedError {
     case prfNotSupported
     case prfOutputMissing
@@ -54,355 +37,109 @@ enum PasskeyError: LocalizedError {
     }
 }
 
-/// Serializable PRF cache entry for Keychain storage.
-private struct PrfCacheEntry: Codable {
-    let credentialId: String
-    let prfOutput: Data
-    /// Optional for backward compatibility with entries cached before
-    /// the flag was persisted; readers must treat a missing value as
-    /// cross-platform so a cached hybrid credential is never wrongly
-    /// remembered as this device's.
-    var isPlatformAuthenticator: Bool?
-}
-
-/// Handles passkey creation, authentication, and KEK derivation via PRF + HKDF.
 @MainActor
-final class PasskeyService: NSObject {
+final class PasskeyService {
     static let shared = PasskeyService()
 
-    private var authContinuation: CheckedContinuation<ASAuthorization, Error>?
+    private let kit: PasskeyKit
 
-    private override init() {
-        super.init()
+    private init() {
+        let stateStore = KeychainPasskeyStateStore(
+            service: Constants.Passkey.rpId,
+            account: Constants.Passkey.prfCacheKeychainAccount,
+            localCredentialIdKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId
+        )
+        kit = PasskeyKit(
+            configuration: PasskeyKitConfiguration(
+                rpId: Constants.Passkey.rpId,
+                rpName: Constants.Passkey.rpName,
+                prfSalt: Constants.Passkey.prfSalt,
+                hkdfInfo: Constants.Passkey.hkdfInfo,
+                challengeByteCount: Constants.Passkey.challengeByteCount,
+                stateStore: stateStore
+            )
+        )
     }
 
-    // MARK: - Create Passkey
-
-    /// Create a new PRF-capable passkey for the given user.
-    ///
-    /// Returns the credential ID and PRF output. If the authenticator doesn't
-    /// return PRF results during creation (per spec, this is optional), an
-    /// immediate authentication is performed to obtain them.
-    ///
-    /// - Throws: `PasskeyError.userCancelled` if the user dismisses Face ID,
-    ///           `PasskeyError.prfNotSupported` if PRF is not available.
     func createPasskey(
         userId: String,
         userEmail: String,
         displayName: String
     ) async throws -> PrfPasskeyResult {
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: Constants.Passkey.rpId
-        )
-
-        let challenge = try Self.randomChallenge()
-        let request = provider.createCredentialRegistrationRequest(
-            challenge: challenge,
-            name: userEmail,
-            userID: Data(userId.utf8)
-        )
-        request.userVerificationPreference = .required
-
-        // PRF input for registration — request evaluation with our salt
-        request.prf = .inputValues(.saltInput1(Constants.Passkey.prfSalt))
-
-        let authorization: ASAuthorization
         do {
-            authorization = try await performAuthorization(requests: [request])
-        } catch {
-            throw Self.mapAuthError(error)
-        }
-
-        guard let credential = authorization.credential
-                as? ASAuthorizationPlatformPublicKeyCredentialRegistration else {
-            throw PasskeyError.prfNotSupported
-        }
-
-        let credentialId = Self.base64urlEncode(credential.credentialID)
-
-        // Check PRF support and results from registration.
-        // "Not all authenticators support evaluating the PRFs during credential
-        //  creation so outputs may, or may not, be provided."
-        // — W3C WebAuthn Level 3, §10.1.4
-        guard let prfOutput = credential.prf else {
-            throw PasskeyError.prfNotSupported
-        }
-
-        guard prfOutput.isSupported else {
-            throw PasskeyError.prfNotSupported
-        }
-
-        // If PRF results were returned during creation, use them directly
-        if let firstKey = prfOutput.first {
-            let result = PrfPasskeyResult(
-                credentialId: credentialId,
-                prfOutput: firstKey,
-                isPlatformAuthenticator: Self.isPlatformAttachment(credential.attachment)
+            return try await kit.createPasskey(
+                for: PasskeyUser(
+                    id: userId,
+                    name: userEmail,
+                    displayName: displayName
+                )
             )
-            cachePrfResult(result)
-            rememberLocalCredentialIfPlatform(result)
-            return result
+        } catch {
+            throw Self.mapError(error)
         }
-
-        // PRF supported but no results during create — do an immediate get()
-        return try await authenticatePasskey(credentialIds: [credentialId])
     }
 
-    // MARK: - Authenticate Passkey
-
-    /// Authenticate with an existing PRF passkey to derive the PRF output.
-    ///
-    /// - Parameter credentialIds: Base64url-encoded credential IDs to allow.
-    ///   Pass all known PRF credential IDs so the system can select the right one.
-    /// - Parameter silent: When true, sets `preferImmediatelyAvailableCredentials`
-    ///   so the system only checks locally-available credentials (iCloud Keychain,
-    ///   installed password managers, etc.) without showing any UI on failure.
-    ///   When false (default), the system shows its full passkey UI including
-    ///   "Use a Device Nearby" for cross-device transport.
-    /// - Returns: The matched credential ID and PRF output.
-    /// - Throws: `PasskeyError.userCancelled` on dismissal,
-    ///           `PasskeyError.prfOutputMissing` if the assertion lacks PRF data.
     func authenticatePasskey(
         credentialIds: [String],
         silent: Bool = false
     ) async throws -> PrfPasskeyResult {
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: Constants.Passkey.rpId
-        )
-
-        let challenge = try Self.randomChallenge()
-        let allowedCredentials = try credentialIds.map {
-            ASAuthorizationPlatformPublicKeyCredentialDescriptor(
-                credentialID: try Self.base64urlDecode($0)
-            )
-        }
-
-        let request = provider.createCredentialAssertionRequest(challenge: challenge)
-        request.allowedCredentials = allowedCredentials
-        request.userVerificationPreference = .required
-
-        // PRF input for assertion — evaluate with our salt
-        request.prf = .inputValues(.saltInput1(Constants.Passkey.prfSalt))
-
-        let authorization: ASAuthorization
         do {
-            authorization = try await performAuthorization(requests: [request], silent: silent)
+            return try await kit.authenticate(
+                credentialIds: credentialIds,
+                mode: silent ? .immediatelyAvailable : .interactive
+            )
         } catch {
-            throw Self.mapAuthError(error)
+            throw Self.mapError(error)
         }
-
-        guard let assertion = authorization.credential
-                as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
-            throw PasskeyError.prfOutputMissing
-        }
-
-        guard let prfOutput = assertion.prf else {
-            throw PasskeyError.prfOutputMissing
-        }
-
-        let credentialId = Self.base64urlEncode(assertion.credentialID)
-        let result = PrfPasskeyResult(
-            credentialId: credentialId,
-            prfOutput: prfOutput.first,
-            isPlatformAuthenticator: Self.isPlatformAttachment(assertion.attachment)
-        )
-        cachePrfResult(result)
-        rememberLocalCredentialIfPlatform(result)
-        return result
     }
 
-    /// Map an `ASAuthorizationPublicKeyCredentialAttachment` to a
-    /// plain boolean. `.platform` means the user verified on this
-    /// device; any other value (cross-platform, or a future case)
-    /// means the credential came from elsewhere and we must not
-    /// remember it as belonging to this device.
-    private static func isPlatformAttachment(
-        _ attachment: ASAuthorizationPublicKeyCredentialAttachment
-    ) -> Bool {
-        attachment == .platform
-    }
-
-    /// Remember `credentialId` as the local platform passkey for
-    /// this device. The lookup key is shared with PasskeyManager's
-    /// "is there a bundle for this device?" check. Skipped silently
-    /// when the credential was authenticated via cross-device
-    /// hybrid (a paired phone, Mac, etc.) — those credentials live
-    /// elsewhere and should not be confused with a local one.
-    func rememberLocalCredentialIfPlatform(_ result: PrfPasskeyResult) {
-        guard result.isPlatformAuthenticator else { return }
-        UserDefaults.standard.set(
-            result.credentialId,
-            forKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId
-        )
-    }
-
-    // MARK: - PRF Cache (Keychain)
-
-    /// Cache the PRF result in the Keychain to avoid re-prompting biometrics
-    /// when the passkey backup needs re-encryption (e.g. sync_version change).
-    func cachePrfResult(_ result: PrfPasskeyResult) {
-        let entry = PrfCacheEntry(
-            credentialId: result.credentialId,
-            prfOutput: result.prfOutput.withUnsafeBytes { Data($0) },
-            isPlatformAuthenticator: result.isPlatformAuthenticator
-        )
-        guard let data = try? JSONEncoder().encode(entry) else { return }
-
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Constants.Passkey.rpId,
-            kSecAttrAccount as String: Constants.Passkey.prfCacheKeychainAccount
-        ]
-
-        // Delete any existing item then add fresh
-        SecItemDelete(query as CFDictionary)
-
-        var addQuery = query
-        addQuery[kSecValueData as String] = data
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-        SecItemAdd(addQuery as CFDictionary, nil)
-    }
-
-    /// Retrieve the cached PRF result from the Keychain, if available.
     func getCachedPrfResult() -> PrfPasskeyResult? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Constants.Passkey.rpId,
-            kSecAttrAccount as String: Constants.Passkey.prfCacheKeychainAccount,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let entry = try? JSONDecoder().decode(PrfCacheEntry.self, from: data) else {
-            return nil
-        }
-
-        return PrfPasskeyResult(
-            credentialId: entry.credentialId,
-            prfOutput: SymmetricKey(data: entry.prfOutput),
-            isPlatformAuthenticator: entry.isPlatformAuthenticator ?? false
-        )
+        kit.cachedPRFResult()
     }
 
-    /// Clear the cached PRF result (e.g. on sign-out).
     func clearCachedPrfResult() {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Constants.Passkey.rpId,
-            kSecAttrAccount as String: Constants.Passkey.prfCacheKeychainAccount
-        ]
-        SecItemDelete(query as CFDictionary)
+        kit.clearCachedPRFResult()
     }
 
-    // MARK: - Key Derivation
-
-    /// Derive an AES-256-GCM Key Encryption Key (KEK) from PRF output using HKDF-SHA256.
-    ///
-    /// Raw PRF output is treated as Input Keying Material (IKM), not used directly.
-    /// HKDF with a purpose-binding info string produces the final SymmetricKey.
     nonisolated static func deriveKeyEncryptionKey(from prfOutput: SymmetricKey) -> SymmetricKey {
-        return HKDF<SHA256>.deriveKey(
-            inputKeyMaterial: prfOutput,
-            salt: Data(),
-            info: Constants.Passkey.hkdfInfo,
-            outputByteCount: Constants.Passkey.kekByteCount
+        PasskeyCrypto.deriveKeyEncryptionKey(
+            from: prfOutput,
+            info: Constants.Passkey.hkdfInfo
         )
     }
 
-    // MARK: - Base64url Helpers
-
-    /// Base64url-encode data (no padding, URL-safe alphabet).
     nonisolated static func base64urlEncode(_ data: Data) -> String {
-        return data.base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
+        PasskeyCodec.base64URLEncode(data)
     }
 
-    /// Decode a base64url string back to Data.
     nonisolated static func base64urlDecode(_ string: String) throws -> Data {
-        var base64 = string
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        let remainder = base64.count % 4
-        if remainder > 0 {
-            base64 += String(repeating: "=", count: 4 - remainder)
-        }
-        guard let data = Data(base64Encoded: base64) else {
+        do {
+            return try PasskeyCodec.base64URLDecode(string)
+        } catch {
             throw PasskeyError.invalidBase64url
         }
-        return data
     }
 
-    // MARK: - Private Helpers
-
-    /// Generate a random 32-byte challenge for WebAuthn ceremonies.
-    nonisolated private static func randomChallenge() throws -> Data {
-        var bytes = [UInt8](repeating: 0, count: Constants.Passkey.challengeByteCount)
-        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
-            throw PasskeyError.randomGenerationFailed
+    private nonisolated static func mapError(_ error: Error) -> PasskeyError {
+        guard let passkeyError = error as? PasskeyKitError else {
+            return .authorizationFailed(error)
         }
-        return Data(bytes)
-    }
-
-    /// Perform an ASAuthorizationController request and await the result.
-    ///
-    /// - Parameter silent: When true, sets `preferImmediatelyAvailableCredentials`
-    ///   so the controller only checks locally-available credentials without
-    ///   showing any UI if nothing matches.
-    private func performAuthorization(
-        requests: [ASAuthorizationRequest],
-        silent: Bool = false
-    ) async throws -> ASAuthorization {
-        guard authContinuation == nil else {
-            throw PasskeyError.authorizationFailed(
-                NSError(domain: "PasskeyService", code: -1,
-                        userInfo: [NSLocalizedDescriptionKey: "Another passkey operation is already in progress"])
-            )
-        }
-
-        return try await withCheckedThrowingContinuation { continuation in
-            self.authContinuation = continuation
-            let controller = ASAuthorizationController(authorizationRequests: requests)
-            controller.delegate = self
-            if silent {
-                controller.performRequests(options: .preferImmediatelyAvailableCredentials)
-            } else {
-                controller.performRequests()
-            }
-        }
-    }
-
-    /// Map ASAuthorizationError to PasskeyError.
-    nonisolated private static func mapAuthError(_ error: Error) -> PasskeyError {
-        if let authError = error as? ASAuthorizationError,
-           authError.code == .canceled {
+        switch passkeyError {
+        case .prfNotSupported:
+            return .prfNotSupported
+        case .prfOutputMissing:
+            return .prfOutputMissing
+        case .userCancelled:
             return .userCancelled
+        case .authorizationFailed(let underlyingError):
+            return .authorizationFailed(underlyingError)
+        case .randomGenerationFailed:
+            return .randomGenerationFailed
+        case .invalidBase64URL:
+            return .invalidBase64url
+        case .operationInProgress, .noCredentialIDs, .noMatchingBundle,
+             .invalidChallengeLength, .userHandleTooLong:
+            return .authorizationFailed(passkeyError)
         }
-        return .authorizationFailed(error)
-    }
-}
-
-// MARK: - ASAuthorizationControllerDelegate
-
-extension PasskeyService: ASAuthorizationControllerDelegate {
-    func authorizationController(
-        controller: ASAuthorizationController,
-        didCompleteWithAuthorization authorization: ASAuthorization
-    ) {
-        authContinuation?.resume(returning: authorization)
-        authContinuation = nil
-    }
-
-    func authorizationController(
-        controller: ASAuthorizationController,
-        didCompleteWithError error: Error
-    ) {
-        authContinuation?.resume(throwing: error)
-        authContinuation = nil
     }
 }

--- a/TinfoilChat/Services/SyncEnclave/PasskeyKeyFlow.swift
+++ b/TinfoilChat/Services/SyncEnclave/PasskeyKeyFlow.swift
@@ -27,8 +27,8 @@
 //
 
 import ClerkKit
-import CryptoKit
 import Foundation
+import TinfoilPasskeyKit
 
 enum PasskeyFlowFailure: String, Sendable {
     case userCancelled
@@ -70,14 +70,15 @@ enum PasskeyKeyFlow {
         user: PasskeyUserInfo,
         createdVia: SyncEnclaveCreatedVia = .passkey
     ) async -> PasskeyFlowResult {
-        var cekBytes = [UInt8](repeating: 0, count: SyncEnclaveKeyBundle.cekByteCount)
-        let cekRandomStatus = SecRandomCopyBytes(kSecRandomDefault, cekBytes.count, &cekBytes)
-        guard cekRandomStatus == errSecSuccess else {
-            return .failure(.registerFailed, message: "Secure random generation failed (status \(cekRandomStatus))")
+        let cek: Data
+        do {
+            cek = try PasskeyCrypto.generateCEK()
+        } catch {
+            return .failure(.registerFailed, message: error.localizedDescription)
         }
         let result = await registerKeyWithPasskey(
             user: user,
-            cek: Data(cekBytes),
+            cek: cek,
             createdVia: createdVia
         )
         // A 409 means another device won the register race, so the

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveKeyBundle.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveKeyBundle.swift
@@ -13,6 +13,7 @@
 
 import CryptoKit
 import Foundation
+import TinfoilPasskeyKit
 
 struct SyncEnclaveBundleBody {
     /// Base64url-encoded credential id (matches WebAuthn convention).
@@ -52,14 +53,14 @@ struct SyncEnclaveUnwrappedCek {
 
 enum SyncEnclaveKeyBundle {
 
-    static let cekByteCount = 32
-    static let aesGcmIvByteCount = 12
-    static let keyIdByteCount = 16
+    static let cekByteCount = PasskeyProtocol.cekByteCount
+    static let aesGcmIvByteCount = PasskeyProtocol.aesGCMIVByteCount
+    static let keyIdByteCount = PasskeyProtocol.keyIDByteCount
 
     /// HKDF `info` string used to derive the deterministic 16-byte
     /// key_id from a raw CEK. Mirrors the Go enclave's `crypto.DeriveKeyID`
     /// byte-for-byte.
-    static let keyIdInfo = Data("tinfoil-key-id-v1".utf8)
+    static let keyIdInfo = PasskeyProtocol.tinfoilKeyIDInfoV1
 
     /// Wrap a raw 32-byte CEK under a passkey-PRF-derived KEK via
     /// AES-256-GCM. Returns hex-encoded IV + wrapped key in the shape
@@ -72,27 +73,27 @@ enum SyncEnclaveKeyBundle {
         kek: SymmetricKey,
         cek: Data
     ) throws -> SyncEnclaveBundleBody {
-        guard cek.count == cekByteCount else {
-            throw SyncEnclaveKeyBundleError.wrongCekLength(cek.count)
+        do {
+            let wrapped = try PasskeyCrypto.wrapCEK(
+                credentialId: credentialId,
+                kek: kek,
+                cek: cek
+            )
+            return SyncEnclaveBundleBody(
+                credentialId: wrapped.credentialId,
+                kekIvHex: wrapped.kekIvHex,
+                wrappedKeyHex: wrapped.wrappedKeyHex
+            )
+        } catch let error as PasskeyCryptoError {
+            switch error {
+            case .wrongCEKLength(let count):
+                throw SyncEnclaveKeyBundleError.wrongCekLength(count)
+            case .randomGenerationFailed(let status):
+                throw SyncEnclaveKeyBundleError.randomGenerationFailed(status)
+            default:
+                throw error
+            }
         }
-        var ivBytes = [UInt8](repeating: 0, count: aesGcmIvByteCount)
-        let status = SecRandomCopyBytes(kSecRandomDefault, ivBytes.count, &ivBytes)
-        guard status == errSecSuccess else {
-            throw SyncEnclaveKeyBundleError.randomGenerationFailed(status)
-        }
-        let iv = Data(ivBytes)
-        let nonce = try AES.GCM.Nonce(data: iv)
-        let sealed = try AES.GCM.seal(cek, using: kek, nonce: nonce)
-        // The enclave persists kek_iv (12 B) + ciphertext + tag (16 B)
-        // as separate hex strings. SealedBox.ciphertext does not include
-        // the tag — we append it explicitly to match the on-wire layout.
-        var ciphertextAndTag = Data(sealed.ciphertext)
-        ciphertextAndTag.append(sealed.tag)
-        return SyncEnclaveBundleBody(
-            credentialId: credentialId,
-            kekIvHex: dataToHex(iv),
-            wrappedKeyHex: dataToHex(ciphertextAndTag)
-        )
     }
 
     /// Inverse of `wrapCek`. Returns the raw 32-byte CEK from a hex
@@ -120,21 +121,19 @@ enum SyncEnclaveKeyBundle {
         kekIvHex: String,
         wrappedKeyHex: String
     ) throws -> SyncEnclaveUnwrappedCek {
-        let iv = try hexToData(kekIvHex)
-        guard iv.count == aesGcmIvByteCount else {
-            throw SyncEnclaveKeyBundleError.wrongIvLength(iv.count)
+        let plaintext: Data
+        do {
+            plaintext = try PasskeyCrypto.decryptWrappedPayload(
+                WrappedCEK(
+                    credentialId: "",
+                    kekIvHex: kekIvHex,
+                    wrappedKeyHex: wrappedKeyHex
+                ),
+                using: kek
+            )
+        } catch PasskeyCryptoError.wrongIVLength(let count) {
+            throw SyncEnclaveKeyBundleError.wrongIvLength(count)
         }
-        let combinedCipher = try hexToData(wrappedKeyHex)
-        // AES-GCM tag is 128 bits / 16 bytes.
-        let tagSize = 16
-        guard combinedCipher.count > tagSize else {
-            throw SyncEnclaveError(message: "Wrapped CEK too short to contain tag")
-        }
-        let ciphertext = combinedCipher.prefix(combinedCipher.count - tagSize)
-        let tag = combinedCipher.suffix(tagSize)
-        let nonce = try AES.GCM.Nonce(data: iv)
-        let sealed = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
-        let plaintext = try AES.GCM.open(sealed, using: kek)
         if plaintext.count == cekByteCount {
             return SyncEnclaveUnwrappedCek(cek: plaintext, legacyAlternativeKeys: [])
         }
@@ -217,17 +216,16 @@ enum SyncEnclaveKeyBundle {
     /// with `info = "tinfoil-key-id-v1"` and an empty salt — matches the
     /// enclave's `crypto.DeriveKeyID` byte-for-byte.
     static func deriveKeyIdHex(cek: Data) throws -> String {
-        guard cek.count == cekByteCount else {
-            throw SyncEnclaveKeyBundleError.wrongCekLength(cek.count)
+        do {
+            return PasskeyCodec.hexEncode(
+                try PasskeyCrypto.deriveKeyID(
+                    from: cek,
+                    info: keyIdInfo,
+                    outputByteCount: keyIdByteCount
+                )
+            )
+        } catch PasskeyCryptoError.wrongCEKLength(let count) {
+            throw SyncEnclaveKeyBundleError.wrongCekLength(count)
         }
-        let ikm = SymmetricKey(data: cek)
-        let derived = HKDF<SHA256>.deriveKey(
-            inputKeyMaterial: ikm,
-            salt: Data(),
-            info: keyIdInfo,
-            outputByteCount: keyIdByteCount
-        )
-        let bytes = derived.withUnsafeBytes { Data($0) }
-        return dataToHex(bytes)
     }
 }


### PR DESCRIPTION
## Summary
- consume `TinfoilPasskeyKit` from the public SwiftPM `0.1.0` release
- keep the app-facing passkey service as a compatibility facade
- share passkey protocol constants, CEK generation, wrapping, and key-ID derivation with the package
- preserve app-owned enclave networking and legacy key migration

## Validation
- Xcode project file passes `plutil -lint`
- `xcodebuild -resolvePackageDependencies` resolves `TinfoilPasskeyKit` at `0.1.0`
- package Swift suite passes 15 tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the app to the shared `TinfoilPasskeyKit` (v0.1.0) for passkey PRF, KEK derivation, CEK wrap/unwrap, and key ID derivation. Keeps the app-facing `PasskeyService` as a thin compatibility facade and preserves enclave networking and legacy key migration.

- **Refactors**
  - Replaced custom passkey flows with `PasskeyKit`; `PasskeyService` now delegates create/auth flows and error mapping.
  - Centralized constants via `PasskeyProtocol` (PRF salt, HKDF info, challenge and size constants).
  - Moved CEK generation, wrap/unwrap, KEK derivation, and codec helpers to `PasskeyCrypto`/`PasskeyCodec`.
  - Adopted `KeychainPasskeyStateStore` for PRF caching and local credential tracking.

- **Dependencies**
  - Added `tinfoil-passkey-kit` (SPM) pinned to `0.1.0`.
  - Updated `Package.resolved` and linked the package in the README.

<sup>Written for commit ab2e8155bcc0818743a24fdf1eea156943c0b2c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

