### PR TITLE
fix: show each thinking phase inline with tool calls during streaming

### DIFF
--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -72,6 +72,15 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     // Ordered content segments (text + inline event refs) that preserve
     // the exact order in which events arrived relative to streamed text.
     private var segments: [MessageSegment] = []
+    // Index of the currently-open `.thinking` segment, if a thinking
+    // round is in flight. Each thinking round (agentic models think
+    // again between tool calls) gets its own ordered segment so the UI
+    // interleaves thought boxes with tool calls chronologically.
+    private var currentThinkingSegmentIndex: Int? = nil
+    // Total thinking time accumulated across all rounds; feeds the
+    // flat `generationTimeSeconds` while each segment keeps its own
+    // per-round duration.
+    private var totalThinkingSeconds: TimeInterval = 0
     private var webSearches: [WebSearchInstance] = []
     private var nextSearchId = 0
     // Track whether web search started before thinking (shared across the
@@ -90,12 +99,17 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     private var streamingToolCalls: [Int: GenUIToolCall] = [:]
     private var timelineBlocks: [JSONValue] = []
 
+    // Summary actions produced outside `process` (thinking rounds closed
+    // by tool boundaries during main-actor event application). Drained
+    // into the next chunk outcome so the summary session state stays in
+    // sync without an extra main-actor channel.
+    private var pendingSummaryActions: [SummaryAction] = []
+
     // Web search state tracking
     private var collectedSources: [WebSearchSource] = []
     private var collectedAnnotations: [Annotation] = []
 
     private var thinkStartTime: Date? = nil
-    private var hasThinkTag = false
     private var thoughtsBuffer = ""
     private var isInThinkingMode: Bool
     private var isUsingReasoningFormat = false
@@ -108,8 +122,6 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     private var thinkingClosedByContent = false
     private var didRecordWebSearchBeforeThinking = false
     private var webSearchBeforeThinking: Bool? = nil
-    private var initialContentBuffer = ""
-    private var isFirstChunk = true
     private var responseContent: String
     private var currentThoughts: String?
     private var generationTimeSeconds: TimeInterval?
@@ -136,12 +148,15 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         self.currentThoughts = currentThoughts
         self.generationTimeSeconds = generationTimeSeconds
         self.isInThinkingMode = isInThinkingMode
+        self.totalThinkingSeconds = generationTimeSeconds ?? 0
     }
 
     // MARK: - Event application accessors (main actor, serialized)
 
     var currentSegments: [MessageSegment] { segments }
     var currentWebSearches: [WebSearchInstance] { webSearches }
+    var currentIsThinking: Bool { isInThinkingMode }
+    var currentGenerationTimeSeconds: TimeInterval? { generationTimeSeconds }
 
     func markWebSearchStarted() {
         webSearchStarted = true
@@ -153,6 +168,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     }
 
     func appendURLFetchSegment(_ fetchId: String) {
+        closeThinkingRoundForToolBoundary()
         segments.append(.urlFetch(fetchId: fetchId))
     }
 
@@ -160,6 +176,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         if let idx = webSearches.firstIndex(where: { $0.id == instance.id }) {
             webSearches[idx] = instance
         } else {
+            closeThinkingRoundForToolBoundary()
             webSearches.append(instance)
             segments.append(.webSearch(searchId: instance.id))
         }
@@ -205,6 +222,15 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         let hasReasoningContent = chunk.choices.first?.delta.reasoning != nil
         let reasoningContent = chunk.choices.first?.delta.reasoning ?? ""
 
+        // Thinking rounds closed by tool boundaries during main-actor
+        // event application queue their summary teardown here; forward
+        // it with this chunk's outcome.
+        if !pendingSummaryActions.isEmpty {
+            outcome.summaryActions.append(contentsOf: pendingSummaryActions)
+            pendingSummaryActions.removeAll()
+            outcome.didMutateState = true
+        }
+
         // Accumulate GenUI tool-call deltas. Mirrors the
         // webapp's normalizer: deltas may carry only
         // partial fragments and we merge them by index.
@@ -213,6 +239,11 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         // `TimelineToolCallBlock` exactly.
         if let deltas = chunk.choices.first?.delta.toolCalls {
             thinkingClosedByContent = false
+            closeThinkingRoundForToolBoundary()
+            if !pendingSummaryActions.isEmpty {
+                outcome.summaryActions.append(contentsOf: pendingSummaryActions)
+                pendingSummaryActions.removeAll()
+            }
             for delta in deltas {
                 let index = delta.index
                 let existing = streamingToolCalls[index]
@@ -284,7 +315,6 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         if hasReasoningContent && !isUsingReasoningFormat && !isInThinkingMode {
             isUsingReasoningFormat = true
             isInThinkingMode = true
-            isFirstChunk = false
             thinkingClosedByContent = false
             thinkStartTime = Date()
             if !didRecordWebSearchBeforeThinking {
@@ -294,6 +324,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
             thoughtsBuffer = reasoningContent
             thinkingChunker.appendToken(reasoningContent)
             currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+            openThinkingSegment(initialContent: reasoningContent)
             outcome.didMutateState = true
             // Reset summary service for new thinking session
             outcome.summaryActions.append(.beginThinkingSession)
@@ -301,13 +332,11 @@ final class StreamingResponseProcessor: @unchecked Sendable {
             // the first reasoning delta; close the thinking
             // session and emit it so the text isn't dropped.
             if !content.isEmpty {
-                if let startTime = thinkStartTime {
-                    generationTimeSeconds = Date().timeIntervalSince(startTime)
-                }
+                let roundSeconds = closeThinkingRound()
                 isInThinkingMode = false
                 thinkingClosedByContent = true
-                thinkStartTime = nil
                 thinkingChunker.finalize()
+                closeThinkingSegment(duration: roundSeconds)
                 if responseContent.isEmpty {
                     responseContent = content
                 } else {
@@ -322,6 +351,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
                     thoughtsBuffer += reasoningContent
                     thinkingChunker.appendToken(reasoningContent)
                     currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    updateOpenThinkingSegment(appending: reasoningContent)
                     outcome.didMutateState = true
                     // Generate thinking summary (reuse existing client)
                     outcome.summaryActions.append(.generate(thoughtsBuffer))
@@ -334,27 +364,34 @@ final class StreamingResponseProcessor: @unchecked Sendable {
                     thoughtsBuffer += reasoningContent
                     thinkingChunker.appendTail(reasoningContent)
                     currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    appendThinkingSegmentTail(reasoningContent)
                     outcome.didMutateState = true
                 } else {
                     // Reasoning resumed after a tool boundary —
-                    // a new thinking phase of the next model turn.
+                    // a new thinking phase of the next model turn
+                    // rendered as its own thought box, timed on
+                    // its own clock.
                     isInThinkingMode = true
+                    thinkStartTime = Date()
+                    if !thoughtsBuffer.isEmpty {
+                        thoughtsBuffer += "\n\n"
+                    }
                     thoughtsBuffer += reasoningContent
                     thinkingChunker.appendToken(reasoningContent)
                     currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+                    openThinkingSegment(initialContent: reasoningContent)
                     outcome.didMutateState = true
+                    outcome.summaryActions.append(.beginThinkingSession)
                     outcome.summaryActions.append(.generate(thoughtsBuffer))
                 }
             }
 
             if !content.isEmpty && isInThinkingMode {
-                if let startTime = thinkStartTime {
-                    generationTimeSeconds = Date().timeIntervalSince(startTime)
-                }
+                let roundSeconds = closeThinkingRound()
                 isInThinkingMode = false
                 thinkingClosedByContent = true
-                thinkStartTime = nil
                 thinkingChunker.finalize()
+                closeThinkingSegment(duration: roundSeconds)
                 currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
                 // Clear thinking summary and cancel any in-flight summary generation
                 outcome.summaryActions.append(.endThinkingSession)
@@ -379,87 +416,14 @@ final class StreamingResponseProcessor: @unchecked Sendable {
                 outcome.didMutateState = true
             }
         } else if !isUsingReasoningFormat && !content.isEmpty {
-            if isFirstChunk {
-                initialContentBuffer += content
-
-                if initialContentBuffer.contains("<think>") || initialContentBuffer.count > 5 {
-                    isFirstChunk = false
-                    let processContent = initialContentBuffer
-                    initialContentBuffer = ""
-
-                    if let thinkRange = processContent.range(of: "<think>") {
-                        isInThinkingMode = true
-                        hasThinkTag = true
-                        thinkStartTime = Date()
-                        if !didRecordWebSearchBeforeThinking {
-                            didRecordWebSearchBeforeThinking = true
-                            webSearchBeforeThinking = webSearchStarted
-                        }
-                        let afterThink = String(processContent[thinkRange.upperBound...])
-                        thoughtsBuffer = afterThink
-                        thinkingChunker.appendToken(afterThink)
-                        currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                        outcome.didMutateState = true
-                        // Reset summary service for new thinking session
-                        outcome.summaryActions.append(.beginThinkingSession)
-                    } else {
-                        if responseContent.isEmpty {
-                            responseContent = processContent
-                        } else {
-                            responseContent += processContent
-                        }
-                        chunker.appendToken(processContent)
-                        appendText(processContent)
-                        outcome.didMutateState = true
-                    }
-                }
-            } else if hasThinkTag {
-                if let endRange = content.range(of: "</think>") {
-                    let beforeEnd = String(content[..<endRange.lowerBound])
-                    thoughtsBuffer += beforeEnd
-                    thinkingChunker.appendToken(beforeEnd)
-                    thinkingChunker.finalize()
-                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                    isInThinkingMode = false
-                    // Clear thinking summary and cancel any in-flight summary generation
-                    outcome.summaryActions.append(.endThinkingSession)
-
-                    let afterEnd = String(content[endRange.upperBound...])
-                    if responseContent.isEmpty {
-                        responseContent = afterEnd
-                    } else {
-                        responseContent += afterEnd
-                    }
-                    chunker.appendToken(afterEnd)
-                    appendText(afterEnd)
-
-                    if let startTime = thinkStartTime {
-                        generationTimeSeconds = Date().timeIntervalSince(startTime)
-                    }
-
-                    hasThinkTag = false
-                    thinkStartTime = nil
-                    thoughtsBuffer = ""
-                    outcome.didMutateState = true
-                } else {
-                    thoughtsBuffer += content
-                    thinkingChunker.appendToken(content)
-                    currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                    isInThinkingMode = true
-                    outcome.didMutateState = true
-                    // Generate thinking summary (reuse existing client)
-                    outcome.summaryActions.append(.generate(thoughtsBuffer))
-                }
+            if responseContent.isEmpty {
+                responseContent = content
             } else {
-                if responseContent.isEmpty {
-                    responseContent = content
-                } else {
-                    responseContent += content
-                }
-                chunker.appendToken(content)
-                appendText(content)
-                outcome.didMutateState = true
+                responseContent += content
             }
+            chunker.appendToken(content)
+            appendText(content)
+            outcome.didMutateState = true
         }
 
         return outcome
@@ -494,32 +458,14 @@ final class StreamingResponseProcessor: @unchecked Sendable {
             }
         }
 
-        // Handle any remaining content when stream ends
-        if isInThinkingMode && !thoughtsBuffer.isEmpty {
-            if isUsingReasoningFormat {
-                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-            } else {
-                currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
-                if responseContent.isEmpty {
-                    responseContent = thoughtsBuffer
-                    currentThoughts = nil
-                    appendText(thoughtsBuffer)
-                }
+        // Close any thinking round still open when the stream ends.
+        if isInThinkingMode {
+            if !thoughtsBuffer.isEmpty {
+                currentThoughts = thoughtsBuffer
             }
-            if let startTime = thinkStartTime {
-                generationTimeSeconds = Date().timeIntervalSince(startTime)
-            }
+            let roundSeconds = closeThinkingRound()
+            closeThinkingSegment(duration: roundSeconds)
             isInThinkingMode = false
-        } else if isFirstChunk && !initialContentBuffer.isEmpty {
-            if responseContent.isEmpty {
-                responseContent = initialContentBuffer
-            } else {
-                responseContent += initialContentBuffer
-            }
-            _ = chunker.appendToken(initialContentBuffer)
-            appendText(initialContentBuffer)
-            isInThinkingMode = false
-            currentThoughts = nil
         }
 
         chunker.finalize()
@@ -566,6 +512,69 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     }
 
     // MARK: - Private helpers
+
+    /// Stops the current thinking round's clock and folds its elapsed time
+    /// into the cumulative `generationTimeSeconds`. Returns the round's own
+    /// duration for the segment being closed.
+    private func closeThinkingRound() -> TimeInterval? {
+        guard let startTime = thinkStartTime else { return nil }
+        let roundSeconds = Date().timeIntervalSince(startTime)
+        thinkStartTime = nil
+        totalThinkingSeconds += roundSeconds
+        generationTimeSeconds = totalThinkingSeconds
+        return roundSeconds
+    }
+
+    /// Opens a new ordered `.thinking` segment for a thinking round.
+    private func openThinkingSegment(initialContent: String) {
+        segments.append(.thinking(content: initialContent, isThinking: true, duration: nil))
+        currentThinkingSegmentIndex = segments.count - 1
+    }
+
+    private func updateOpenThinkingSegment(appending reasoning: String) {
+        guard let idx = currentThinkingSegmentIndex,
+              case .thinking(let existing, _, _) = segments[idx] else { return }
+        segments[idx] = .thinking(content: existing + reasoning, isThinking: true, duration: nil)
+    }
+
+    private func closeThinkingSegment(duration: TimeInterval?) {
+        guard let idx = currentThinkingSegmentIndex,
+              case .thinking(let existing, _, _) = segments[idx] else {
+            currentThinkingSegmentIndex = nil
+            return
+        }
+        segments[idx] = .thinking(content: existing, isThinking: false, duration: duration)
+        currentThinkingSegmentIndex = nil
+    }
+
+    /// Merges a late reasoning tail into the most recent closed thinking
+    /// segment so it doesn't open a phantom thought box.
+    private func appendThinkingSegmentTail(_ reasoning: String) {
+        for idx in segments.indices.reversed() {
+            if case .thinking(let existing, let isThinking, let duration) = segments[idx] {
+                segments[idx] = .thinking(
+                    content: existing + reasoning,
+                    isThinking: isThinking,
+                    duration: duration
+                )
+                return
+            }
+        }
+    }
+
+    /// Closes the in-flight thinking round when a tool call begins so the
+    /// thought box freezes to "Thought for Xs" instead of pulsing through
+    /// the tool activity. Reasoning arriving afterwards opens a new round.
+    private func closeThinkingRoundForToolBoundary() {
+        guard isInThinkingMode else { return }
+        let roundSeconds = closeThinkingRound()
+        isInThinkingMode = false
+        thinkingClosedByContent = false
+        thinkingChunker.finalize()
+        currentThoughts = thoughtsBuffer.isEmpty ? nil : thoughtsBuffer
+        closeThinkingSegment(duration: roundSeconds)
+        pendingSummaryActions.append(.endThinkingSession)
+    }
 
     private func appendText(_ text: String) {
         guard !text.isEmpty else { return }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2474,6 +2474,8 @@ class ChatViewModel: ObservableObject {
                             }
                         }
                         chat.messages[lastIndex].segments = processor.currentSegments
+                        chat.messages[lastIndex].isThinking = processor.currentIsThinking
+                        chat.messages[lastIndex].generationTimeSeconds = processor.currentGenerationTimeSeconds
                         self.updateChat(chat, throttleForStreaming: true)
                         return
                     }
@@ -2575,6 +2577,8 @@ class ChatViewModel: ObservableObject {
                     }
                     chat.messages[lastIndex].segments = processor.currentSegments
                     chat.messages[lastIndex].webSearches = processor.currentWebSearches
+                    chat.messages[lastIndex].isThinking = processor.currentIsThinking
+                    chat.messages[lastIndex].generationTimeSeconds = processor.currentGenerationTimeSeconds
                     self.updateChat(chat, throttleForStreaming: true)
                 }
 

--- a/TinfoilChatTests/StreamingResponseProcessorTests.swift
+++ b/TinfoilChatTests/StreamingResponseProcessorTests.swift
@@ -62,3 +62,195 @@ struct StreamingResponseProcessorTests {
         return try JSONDecoder().decode(ChatStreamResult.self, from: data)
     }
 }
+
+@Suite("Streaming thinking segments")
+struct StreamingThinkingSegmentTests {
+
+    @Test("reasoning then content closes the thinking segment in order")
+    func reasoningThenContent() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("Let me think.")))
+        _ = processor.process(processor.parse(try contentChunk("Answer.")))
+
+        let snapshot = processor.snapshot()
+        #expect(snapshot.isThinking == false)
+        #expect(snapshot.segments.count == 2)
+        guard case .thinking(let thought, let isThinking, let duration) = snapshot.segments[0] else {
+            Issue.record("Expected a thinking segment first, got \(snapshot.segments)")
+            return
+        }
+        #expect(thought == "Let me think.")
+        #expect(isThinking == false)
+        #expect(duration != nil)
+        #expect(snapshot.segments[1] == .text("Answer."))
+    }
+
+    @Test("web search closes the open thinking round")
+    func webSearchClosesThinking() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: true,
+            hapticEnabled: false
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("Need to search.")))
+
+        var snapshot = processor.snapshot()
+        #expect(snapshot.isThinking == true)
+
+        // A web search event arrives mid-thinking (applied on the main
+        // actor between chunks, as the view model does).
+        processor.markWebSearchStarted()
+        processor.upsertWebSearch(
+            WebSearchInstance(id: "ws-0", query: "q", status: .searching, sources: nil, reason: nil)
+        )
+
+        snapshot = processor.snapshot()
+        #expect(snapshot.isThinking == false)
+        #expect(snapshot.segments.count == 2)
+        guard case .thinking(_, let isThinking, let duration) = snapshot.segments[0] else {
+            Issue.record("Expected a thinking segment first, got \(snapshot.segments)")
+            return
+        }
+        #expect(isThinking == false)
+        #expect(duration != nil)
+        #expect(snapshot.segments[1] == .webSearch(searchId: "ws-0"))
+    }
+
+    @Test("reasoning after a tool boundary opens a new thinking segment")
+    func newThinkingRoundAfterToolBoundary() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: true,
+            hapticEnabled: false
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("First round.")))
+        processor.upsertWebSearch(
+            WebSearchInstance(id: "ws-0", query: "q", status: .searching, sources: nil, reason: nil)
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("Second round.")))
+        _ = processor.process(processor.parse(try contentChunk("Answer.")))
+
+        let snapshot = processor.snapshot()
+        #expect(snapshot.segments.count == 4)
+        guard case .thinking(let first, false, .some) = snapshot.segments[0],
+              case .webSearch(let searchId) = snapshot.segments[1],
+              case .thinking(let second, false, .some) = snapshot.segments[2],
+              case .text(let text) = snapshot.segments[3] else {
+            Issue.record("Unexpected segment shape: \(snapshot.segments)")
+            return
+        }
+        #expect(first == "First round.")
+        #expect(searchId == "ws-0")
+        #expect(second == "Second round.")
+        #expect(text == "Answer.")
+        #expect(snapshot.thoughts == "First round.\n\nSecond round.")
+    }
+
+    @Test("tool call deltas close the open thinking round")
+    func toolCallClosesThinking() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("Considering a widget.")))
+        _ = processor.process(processor.parse(try toolCallChunk(id: "call_1", name: "widget", arguments: "{}")))
+
+        let snapshot = processor.snapshot()
+        #expect(snapshot.isThinking == false)
+        #expect(snapshot.segments.count == 2)
+        guard case .thinking(_, false, .some) = snapshot.segments[0] else {
+            Issue.record("Expected a closed thinking segment first, got \(snapshot.segments)")
+            return
+        }
+        #expect(snapshot.segments[1] == .toolCall(toolCallId: "call_1"))
+    }
+
+    @Test("stream end closes an open thinking round")
+    func streamEndClosesThinking() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("Unfinished thought.")))
+        _ = processor.process(processor.parse(try contentChunk("", finishReason: "stop")))
+
+        try processor.finishStream()
+
+        let snapshot = processor.snapshot()
+        #expect(snapshot.isThinking == false)
+        #expect(snapshot.segments.count == 1)
+        guard case .thinking(let thought, false, .some) = snapshot.segments[0] else {
+            Issue.record("Expected a closed thinking segment, got \(snapshot.segments)")
+            return
+        }
+        #expect(thought == "Unfinished thought.")
+    }
+
+    @Test("late reasoning tail merges into the closed thinking segment")
+    func lateReasoningTailMerges() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        _ = processor.process(processor.parse(try reasoningChunk("Thought start")))
+        _ = processor.process(processor.parse(try contentChunk("Answer.")))
+        _ = processor.process(processor.parse(try reasoningChunk(" and tail.")))
+
+        let snapshot = processor.snapshot()
+        #expect(snapshot.segments.count == 2)
+        guard case .thinking(let thought, false, _) = snapshot.segments[0] else {
+            Issue.record("Expected a thinking segment first, got \(snapshot.segments)")
+            return
+        }
+        #expect(thought == "Thought start and tail.")
+        #expect(snapshot.segments[1] == .text("Answer."))
+    }
+
+    private func reasoningChunk(_ reasoning: String) throws -> ChatStreamResult {
+        try decode(delta: ["reasoning": reasoning])
+    }
+
+    private func contentChunk(
+        _ content: String,
+        finishReason: String? = nil
+    ) throws -> ChatStreamResult {
+        try decode(delta: ["content": content], finishReason: finishReason)
+    }
+
+    private func toolCallChunk(
+        id: String,
+        name: String,
+        arguments: String
+    ) throws -> ChatStreamResult {
+        try decode(delta: [
+            "tool_calls": [
+                [
+                    "index": 0,
+                    "id": id,
+                    "type": "function",
+                    "function": ["name": name, "arguments": arguments],
+                ]
+            ]
+        ])
+    }
+
+    private func decode(
+        delta: [String: Any],
+        finishReason: String? = nil
+    ) throws -> ChatStreamResult {
+        var choice: [String: Any] = [
+            "index": 0,
+            "delta": delta,
+        ]
+        choice["finish_reason"] = finishReason.map { $0 as Any } ?? NSNull()
+        let data = try JSONSerialization.data(withJSONObject: [
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-oss-120b",
+            "choices": [choice],
+        ])
+        return try JSONDecoder().decode(ChatStreamResult.self, from: data)
+    }
+}

--- a/TinfoilChatTests/StreamingResponseProcessorTests.swift
+++ b/TinfoilChatTests/StreamingResponseProcessorTests.swift
@@ -47,19 +47,7 @@ struct StreamingResponseProcessorTests {
         content: String,
         finishReason: String? = nil
     ) throws -> ChatStreamResult {
-        var choice: [String: Any] = [
-            "index": 0,
-            "delta": ["content": content],
-        ]
-        choice["finish_reason"] = finishReason.map { $0 as Any } ?? NSNull()
-        let data = try JSONSerialization.data(withJSONObject: [
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1,
-            "model": "gpt-oss-120b",
-            "choices": [choice],
-        ])
-        return try JSONDecoder().decode(ChatStreamResult.self, from: data)
+        try decodeStreamChunk(delta: ["content": content], finishReason: finishReason)
     }
 }
 
@@ -208,14 +196,14 @@ struct StreamingThinkingSegmentTests {
     }
 
     private func reasoningChunk(_ reasoning: String) throws -> ChatStreamResult {
-        try decode(delta: ["reasoning": reasoning])
+        try decodeStreamChunk(delta: ["reasoning": reasoning])
     }
 
     private func contentChunk(
         _ content: String,
         finishReason: String? = nil
     ) throws -> ChatStreamResult {
-        try decode(delta: ["content": content], finishReason: finishReason)
+        try decodeStreamChunk(delta: ["content": content], finishReason: finishReason)
     }
 
     private func toolCallChunk(
@@ -223,7 +211,7 @@ struct StreamingThinkingSegmentTests {
         name: String,
         arguments: String
     ) throws -> ChatStreamResult {
-        try decode(delta: [
+        try decodeStreamChunk(delta: [
             "tool_calls": [
                 [
                     "index": 0,
@@ -234,23 +222,24 @@ struct StreamingThinkingSegmentTests {
             ]
         ])
     }
+}
 
-    private func decode(
-        delta: [String: Any],
-        finishReason: String? = nil
-    ) throws -> ChatStreamResult {
-        var choice: [String: Any] = [
-            "index": 0,
-            "delta": delta,
-        ]
-        choice["finish_reason"] = finishReason.map { $0 as Any } ?? NSNull()
-        let data = try JSONSerialization.data(withJSONObject: [
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "created": 1,
-            "model": "gpt-oss-120b",
-            "choices": [choice],
-        ])
-        return try JSONDecoder().decode(ChatStreamResult.self, from: data)
-    }
+/// Builds and decodes a `ChatStreamResult` fixture from a raw delta payload.
+private func decodeStreamChunk(
+    delta: [String: Any],
+    finishReason: String? = nil
+) throws -> ChatStreamResult {
+    var choice: [String: Any] = [
+        "index": 0,
+        "delta": delta,
+    ]
+    choice["finish_reason"] = finishReason.map { $0 as Any } ?? NSNull()
+    let data = try JSONSerialization.data(withJSONObject: [
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "gpt-oss-120b",
+        "choices": [choice],
+    ])
+    return try JSONDecoder().decode(ChatStreamResult.self, from: data)
 }


### PR DESCRIPTION
## Summary
- During agentic streaming (web search / tool calls), the UI kept showing a pulsing "Thinking..." box at the top of the message even after the model had moved on to searching and streaming intermediate content.
- Thinking now streams into ordered `.thinking` segments (the same segments pipeline used to render webapp-origin messages), one per thinking round. Tool boundaries (web search, URL fetch, GenUI tool calls) close the open round so it freezes to "Thought for Xs", and reasoning that resumes after a tool boundary opens a new thought box with its own timer — matching the webapp's chronological timeline ordering.
- Removes stream-time `<think>` tag parsing: vLLM now returns reasoning via `reasoning`/`reasoning_content` deltas, so the first-chunk tag sniffing is dead code. Render-time `<think>` fallbacks for old persisted messages are untouched.

## Test plan
- Added processor tests covering reasoning→content ordering, tool boundaries closing the open thinking round (web search + tool call deltas), a new thinking round after a tool boundary, stream-end close, and late reasoning tails merging into the previous thought.
- Manual: run a web-search / agentic query and verify the sequence renders as `[Thought for Xs] [Searched the web] [intermediate response] [Searching the web...]` instead of a stuck `[Thinking...]` at the top.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show each thinking phase inline with web searches and tool calls during streaming to fix the stuck “Thinking…” state and keep events in time order. Switch to reasoning deltas, time each round, and update the UI with accurate thinking state and total duration.

- **Bug Fixes**
  - Stream reasoning as ordered `.thinking` segments; each round is timed and `generationTimeSeconds` accumulates across rounds.
  - Close the open thought at tool boundaries (web search, URL fetch, GenUI tool calls); reasoning after a boundary opens a new thought.
  - Merge late reasoning tails into the previous thought; close any open thought at stream end.
  - Remove stream-time `<think>` parsing in favor of `reasoning` deltas; keep render-time fallbacks for old messages.
  - `ChatViewModel` now mirrors `isThinking` and `generationTimeSeconds`; tests added for ordering and tool boundary behavior.

- **Refactors**
  - Share the stream chunk fixture across test suites for reuse.

<sup>Written for commit 351a1d9f334e784f7fe28a5f53df23583aad61cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

