### PR TITLE
UI/UX improvements and streaming render fix

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -53,6 +53,7 @@ enum Constants {
         static let tableFontSize: CGFloat = 16
         static let tableCellHorizontalPadding: CGFloat = 12
         static let streamingIndicatorDotSize: CGFloat = 10
+        static let streamingIndicatorCornerRadius: CGFloat = 3
         static let streamingIndicatorIconColumnWidth: CGFloat = 16
         static let initFailedContentSpacing: CGFloat = 24
         static let initFailedIconSize: CGFloat = 72

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -52,7 +52,7 @@ enum Constants {
         static let tableMaxColumnWidth: CGFloat = 300
         static let tableFontSize: CGFloat = 16
         static let tableCellHorizontalPadding: CGFloat = 12
-        static let streamingIndicatorDotSize: CGFloat = 10
+        static let streamingIndicatorSize: CGFloat = 10
         static let streamingIndicatorCornerRadius: CGFloat = 3
         static let streamingIndicatorIconColumnWidth: CGFloat = 16
         static let initFailedContentSpacing: CGFloat = 24

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2587,8 +2587,12 @@ class ChatViewModel: ObservableObject {
                 // actor is only hopped to for rare event application, haptics,
                 // and the throttled snapshot updates.
                 let consumeTask = Task.detached(priority: .userInitiated) { [weak self] in
-                    var lastUIUpdateTime = Date.distantPast
                     let uiUpdateInterval: TimeInterval = Constants.Streaming.uiUpdateInterval
+                    // Earliest moment the next publish may occur. Advanced on
+                    // every leading-edge publish and whenever a trailing flush
+                    // is scheduled, so flushes count against the throttle and
+                    // the publish rate stays bounded at one per interval.
+                    var nextPublishTime = Date.distantPast
                     // Latest thoughts awaiting a summary request; forwarded with
                     // the next throttled snapshot so summary generation does not
                     // force a main-actor hop per reasoning chunk.
@@ -2601,6 +2605,11 @@ class ChatViewModel: ObservableObject {
                     // reads as a stall followed by a burst. The flush publishes
                     // the held snapshot at the end of the current window instead.
                     var trailingFlushTask: Task<Void, Never>? = nil
+                    // Fire time of the pending trailing flush; nil once it has
+                    // fired or was superseded by a leading-edge publish. Tracked
+                    // here (not in the flush task) so all throttle bookkeeping
+                    // stays on this task without shared mutable state.
+                    var scheduledFlushTime: Date? = nil
                     defer { trailingFlushTask?.cancel() }
 
                     for try await chunk in stream {
@@ -2647,10 +2656,11 @@ class ChatViewModel: ObservableObject {
                         // Update UI at a throttled rate to avoid overwhelming SwiftUI with diffs
                         let now = Date()
                         if outcome.didMutateState {
-                            if now.timeIntervalSince(lastUIUpdateTime) >= uiUpdateInterval {
+                            if now >= nextPublishTime {
                                 trailingFlushTask?.cancel()
                                 trailingFlushTask = nil
-                                lastUIUpdateTime = now
+                                scheduledFlushTime = nil
+                                nextPublishTime = now.addingTimeInterval(uiUpdateInterval)
                                 let snapshot = processor.snapshot()
                                 let thoughtsForSummary = pendingSummaryThoughts
                                 pendingSummaryThoughts = nil
@@ -2671,9 +2681,28 @@ class ChatViewModel: ObservableObject {
                                 // is captured here, serialized with `process`,
                                 // because the processor must never be read from
                                 // the flush task while a later chunk mutates it.
+                                // A newer chunk replaces the pending snapshot but
+                                // keeps the original fire time, and the flush
+                                // consumes a publish slot so the rate stays at
+                                // one per interval. Pending summary thoughts are
+                                // forwarded without being cleared: a reschedule
+                                // must not drop them, and a duplicate request is
+                                // deduplicated by the summary service.
                                 trailingFlushTask?.cancel()
+                                let flushTime: Date
+                                if let pending = scheduledFlushTime, pending > now {
+                                    flushTime = pending
+                                } else {
+                                    // No pending flush (or the previous one
+                                    // already fired): schedule at the next free
+                                    // publish slot and reserve the one after it.
+                                    flushTime = nextPublishTime
+                                    scheduledFlushTime = flushTime
+                                    nextPublishTime = flushTime.addingTimeInterval(uiUpdateInterval)
+                                }
                                 let snapshot = processor.snapshot()
-                                let delay = uiUpdateInterval - now.timeIntervalSince(lastUIUpdateTime)
+                                let thoughtsForSummary = pendingSummaryThoughts
+                                let delay = max(0, flushTime.timeIntervalSince(now))
                                 let viewModel = self
                                 trailingFlushTask = Task {
                                     try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
@@ -2681,6 +2710,12 @@ class ChatViewModel: ObservableObject {
                                     await MainActor.run {
                                         guard !Task.isCancelled, let self = viewModel else { return }
                                         self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
+                                        if let thoughtsForSummary {
+                                            summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
+                                                guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
+                                                self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2593,6 +2593,15 @@ class ChatViewModel: ObservableObject {
                     // the next throttled snapshot so summary generation does not
                     // force a main-actor hop per reasoning chunk.
                     var pendingSummaryThoughts: String? = nil
+                    // Trailing-edge flush for the UI throttle below. The throttle
+                    // only publishes when a new chunk arrives after the interval
+                    // has elapsed, so content landing inside the window would
+                    // otherwise stay invisible until the next chunk — if the
+                    // stream pauses (typical right after the first tokens), that
+                    // reads as a stall followed by a burst. The flush publishes
+                    // the held snapshot at the end of the current window instead.
+                    var trailingFlushTask: Task<Void, Never>? = nil
+                    defer { trailingFlushTask?.cancel() }
 
                     for try await chunk in stream {
                         if Task.isCancelled { break }
@@ -2637,19 +2646,41 @@ class ChatViewModel: ObservableObject {
 
                         // Update UI at a throttled rate to avoid overwhelming SwiftUI with diffs
                         let now = Date()
-                        if outcome.didMutateState && now.timeIntervalSince(lastUIUpdateTime) >= uiUpdateInterval {
-                            lastUIUpdateTime = now
-                            let snapshot = processor.snapshot()
-                            let thoughtsForSummary = pendingSummaryThoughts
-                            pendingSummaryThoughts = nil
-                            let viewModel = self
-                            await MainActor.run {
-                                guard let self = viewModel else { return }
-                                self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
-                                if let thoughtsForSummary {
-                                    summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
-                                        guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
-                                        self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
+                        if outcome.didMutateState {
+                            if now.timeIntervalSince(lastUIUpdateTime) >= uiUpdateInterval {
+                                trailingFlushTask?.cancel()
+                                trailingFlushTask = nil
+                                lastUIUpdateTime = now
+                                let snapshot = processor.snapshot()
+                                let thoughtsForSummary = pendingSummaryThoughts
+                                pendingSummaryThoughts = nil
+                                let viewModel = self
+                                await MainActor.run {
+                                    guard let self = viewModel else { return }
+                                    self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
+                                    if let thoughtsForSummary {
+                                        summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
+                                            guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
+                                            self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Inside the throttle window: hold a snapshot and
+                                // publish it when the window closes. The snapshot
+                                // is captured here, serialized with `process`,
+                                // because the processor must never be read from
+                                // the flush task while a later chunk mutates it.
+                                trailingFlushTask?.cancel()
+                                let snapshot = processor.snapshot()
+                                let delay = uiUpdateInterval - now.timeIntervalSince(lastUIUpdateTime)
+                                let viewModel = self
+                                trailingFlushTask = Task {
+                                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                                    guard !Task.isCancelled else { return }
+                                    await MainActor.run {
+                                        guard !Task.isCancelled, let self = viewModel else { return }
+                                        self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
                                     }
                                 }
                             }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2605,10 +2605,11 @@ class ChatViewModel: ObservableObject {
                     // reads as a stall followed by a burst. The flush publishes
                     // the held snapshot at the end of the current window instead.
                     var trailingFlushTask: Task<Void, Never>? = nil
-                    // Fire time of the pending trailing flush; nil once it has
-                    // fired or was superseded by a leading-edge publish. Tracked
-                    // here (not in the flush task) so all throttle bookkeeping
-                    // stays on this task without shared mutable state.
+                    // Fire time of the most recently scheduled trailing flush.
+                    // Cleared when a leading-edge publish supersedes it, but not
+                    // when the flush fires: the flush task never mutates consumer
+                    // state, so a fired flush simply leaves a past date behind
+                    // and the `pending > now` check below treats it as consumed.
                     var scheduledFlushTime: Date? = nil
                     defer { trailingFlushTask?.cancel() }
 

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -1299,7 +1299,7 @@ private struct UnsupportedLaTeXView: View {
 
 /// A pulsating rounded square shown at the bottom of streaming text to
 /// indicate that more content is on the way.
-struct StreamingIndicatorDot: View {
+struct StreamingIndicator: View {
     let isDarkMode: Bool
     @State private var isPulsing = false
 
@@ -1307,8 +1307,8 @@ struct StreamingIndicatorDot: View {
         RoundedRectangle(cornerRadius: Constants.UI.streamingIndicatorCornerRadius, style: .continuous)
             .fill(isDarkMode ? Color.white : Color.black)
             .frame(
-                width: Constants.UI.streamingIndicatorDotSize,
-                height: Constants.UI.streamingIndicatorDotSize
+                width: Constants.UI.streamingIndicatorSize,
+                height: Constants.UI.streamingIndicatorSize
             )
             .scaleEffect(isPulsing ? 1.0 : 0.6)
             .opacity(isPulsing ? 1.0 : 0.4)

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -1297,14 +1297,14 @@ private struct UnsupportedLaTeXView: View {
     }
 }
 
-/// A pulsating dot shown at the bottom of streaming text to indicate
-/// that more content is on the way.
+/// A pulsating rounded square shown at the bottom of streaming text to
+/// indicate that more content is on the way.
 struct StreamingIndicatorDot: View {
     let isDarkMode: Bool
     @State private var isPulsing = false
 
     var body: some View {
-        Circle()
+        RoundedRectangle(cornerRadius: Constants.UI.streamingIndicatorCornerRadius, style: .continuous)
             .fill(isDarkMode ? Color.white : Color.black)
             .frame(
                 width: Constants.UI.streamingIndicatorDotSize,

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1487,7 +1487,7 @@ struct CollapsibleThinkingBox: View {
                             .foregroundColor(isDarkMode ? .white : Color.black.opacity(0.8))
                             .lineLimit(1)
                             .truncationMode(.tail)
-                            .modifier(TextPulseAnimation())
+                            .modifier(TextShimmerAnimation())
                     } else {
                         HStack(spacing: 4) {
                             Text("Thinking")
@@ -1495,7 +1495,7 @@ struct CollapsibleThinkingBox: View {
                                 .foregroundColor(isDarkMode ? .white : Color.black.opacity(0.8))
                             InlineLoadingDotsView(isDarkMode: isDarkMode)
                         }
-                        .modifier(TextPulseAnimation())
+                        .modifier(TextShimmerAnimation())
                     }
                 } else {
                     Text("Thinking")
@@ -1663,7 +1663,10 @@ struct PulsingAnimation: ViewModifier {
     }
 }
 
-struct TextPulseAnimation: ViewModifier {
+/// Shimmer effect for in-progress text: the content renders dimmed while a
+/// bright band of the content itself sweeps across, so the effect stays
+/// visible for any text color in both light and dark mode.
+struct TextShimmerAnimation: ViewModifier {
     @State private var offset: CGFloat = -1.0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -1672,23 +1675,25 @@ struct TextPulseAnimation: ViewModifier {
             content
         } else {
             content
+                .opacity(0.5)
                 .overlay(
-                    GeometryReader { geometry in
-                        let shimmerWidth = geometry.size.width * 0.4
-                        LinearGradient(
-                            colors: [
-                                .clear,
-                                .white.opacity(0.35),
-                                .clear
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                        .frame(width: shimmerWidth)
-                        .offset(x: offset * (geometry.size.width + shimmerWidth))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .mask(content)
+                    content.mask(
+                        GeometryReader { geometry in
+                            let shimmerWidth = geometry.size.width * 0.5
+                            LinearGradient(
+                                colors: [
+                                    .clear,
+                                    .white,
+                                    .clear
+                                ],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: shimmerWidth)
+                            .offset(x: offset * (geometry.size.width + shimmerWidth))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    )
                 )
                 .onAppear {
                     withAnimation(

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1339,13 +1339,16 @@ private struct RawContentModalView: View {
                 Image(systemName: icon)
                 Text(label)
             }
-            .font(.system(size: 15, weight: .semibold))
-            .foregroundColor(.white)
+            .font(.system(size: 15, weight: .medium))
+            .foregroundColor(isDarkMode ? .white : .black)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .background(Color.tinfoilAccentDark)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isDarkMode ? Color.white.opacity(0.06) : Color.black.opacity(0.04))
+            )
         }
+        .buttonStyle(.plain)
     }
 
     private func copyAll() {

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -708,7 +708,7 @@ struct MessageView: View {
                    isRenderingStream &&
                    (!message.content.isEmpty || message.thoughts != nil || message.isThinking ||
                     !(message.segments?.isEmpty ?? true)) {
-                    StreamingIndicatorDot(isDarkMode: isDarkMode)
+                    StreamingIndicator(isDarkMode: isDarkMode)
                         .padding(.top, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/TinfoilChat/Views/VerifierViewController.swift
+++ b/TinfoilChat/Views/VerifierViewController.swift
@@ -73,8 +73,8 @@ struct VerifierView: View {
                     Spacer()
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 16)
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(sheetBackground.ignoresSafeArea())
             .navigationTitle("Verification Center")
@@ -105,7 +105,7 @@ struct VerifierView: View {
                     .foregroundColor(.primary)
                 Spacer()
             }
-            .padding(16)
+            .padding(18)
             .background(
                 RoundedRectangle(cornerRadius: 12)
                     .fill(isDarkMode ? Color(.systemGray6).opacity(0.5) : Color(.systemGray6))
@@ -182,7 +182,7 @@ struct VerifierView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(16)
+        .padding(18)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .fill(doc.securityVerified
@@ -378,7 +378,7 @@ private struct EncryptionTabCards: View {
     let isDarkMode: Bool
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 16) {
             FingerprintCard(
                 icon: "key.fill",
                 label: "Your unique encryption key",
@@ -422,7 +422,7 @@ private struct CodeTabCards: View {
     let isDarkMode: Bool
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 16) {
             FingerprintCard(
                 icon: "touchid",
                 label: "Source code fingerprint",
@@ -513,7 +513,7 @@ private struct RuntimeTabCards: View {
     }
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 16) {
             FingerprintCard(
                 icon: "touchid",
                 label: "Enclave code fingerprint",
@@ -619,7 +619,7 @@ private struct FingerprintCard: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
         }
-        .padding(14)
+        .padding(18)
         .background(
             RoundedRectangle(cornerRadius: 10)
                 .fill(isDarkMode ? Color(.systemGray5).opacity(0.5) : Color(.systemGray6))
@@ -634,7 +634,7 @@ private struct InfoCard<Content: View>: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(14)
+            .padding(18)
             .background(
                 RoundedRectangle(cornerRadius: 10)
                     .fill(isDarkMode ? Color(.systemGray5).opacity(0.4) : Color(.systemGray6).opacity(0.7))


### PR DESCRIPTION
## Summary

### UI polish
- **Streaming indicator**: the pulsating circle at the end of streaming text is now a rounded-corner square (corner radius added to `Constants.UI`)
- **Thinking summary shimmer**: reworked `TextPulseAnimation` into `TextShimmerAnimation` — text renders dimmed with a bright band of the text itself sweeping across, visible in both light and dark mode (still respects Reduce Motion)
- **Copy buttons**: the teal `Copy All` / `Copy Response` / `Copy Thoughts` buttons in the Raw Content sheet looked out of place; restyled to the subtle neutral surface used elsewhere (e.g. Sources sheet rows)
- **Verification Center**: increased outer padding (16→20), card padding (14/16→18), and card spacing (12→16) for more breathing room

### Streaming fix
The first token of a response could take a while to appear and then arrive all at once. Root cause: the 100 ms UI update throttle in the stream consumer was leading-edge only — chunks landing inside the throttle window were held in the processor and only published when the *next* chunk arrived, so a network pause after an initial burst read as a stall followed by a burst.

Fix: added a trailing-edge flush. Chunks arriving inside the window capture a snapshot and schedule a cancellable publish at the end of the window; newer chunks replace the pending snapshot. SwiftUI invalidations stay bounded at ~10/s, but buffered text now always appears within 100 ms of arriving.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the chat UI and fixed the stream consumer so first tokens appear promptly, updates stay evenly paced, and the thinking summary stays current.

- **New Features**
  - Streaming indicator updated to a rounded-corner square and renamed `StreamingIndicator` (new size and corner-radius constants).
  - Thinking summary uses a shimmer effect (works in light/dark, respects Reduce Motion).
  - Raw Content copy buttons restyled to a subtle neutral surface; medium-weight text; plain button style.
  - Verification Center spacing increased for better breathing room.

- **Bug Fixes**
  - Added a trailing-edge flush to the 100 ms UI update throttle; flushes reserve a publish slot to keep updates at ~10/s and avoid “stall then burst” (with clearer inline docs on how the pending flush time is tracked).
  - Pending summary thoughts are carried with snapshots so summaries update during pauses; duplicate requests are deduped by the service.

<sup>Written for commit fcd1d1f5dba2c93436d2184b5c976d7ad00ac5c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



