### PR TITLE
fix: stop chat from scrolling to the bottom after a response finishes

### DIFF
--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -200,7 +200,13 @@ struct ChatListView: View {
         .onChange(of: pendingRecoveryTurnIds) { _, _ in
             pruneRecoveryDrafts()
         }
-        .onChange(of: viewModel.currentChat?.createdAt) { _, _ in
+        // Keyed off the chat id: reassigning the same chat (e.g. the disk
+        // reload after a stream's backup completes) must not read as a chat
+        // switch, since this handler force-scrolls to the bottom. Timestamps
+        // are unsuitable as the key because createdAt loses sub-millisecond
+        // precision through the cloud sync ISO8601 round-trip, making
+        // reloaded copies of the same chat compare unequal.
+        .onChange(of: viewModel.currentChat?.id) { _, _ in
             refreshArchivedMessagesStartIndex()
             pruneRecoveryDrafts()
             userHasScrolled = false


### PR DESCRIPTION
## Summary
- Fixes a bug where the chat would scroll to the bottom a moment after a stream completed, even when the user had scrolled up to read.
- Root cause: `ChatListView` detected chat switches by watching `currentChat?.createdAt`. After a stream ends, `endStreamingAndBackup` reloads the chat from disk and reassigns `currentChat` — and `createdAt` never survives the cloud sync ISO8601 round-trip bit-exact (millisecond precision vs `Date`'s sub-millisecond), so the reloaded copy compared unequal and fired the chat-switch handler, which force-scrolls to the bottom.
- Fix: key the handler off `currentChat?.id` instead, with a comment explaining why timestamps can't be used. The temp→permanent ID conversion flow that originally motivated the `createdAt` key (c15dc9b) no longer exists, and `MessageTableView` handles ID conversion independently via message-ID matching.

## Test plan
- [ ] Stream a long response, scroll up mid-stream, confirm the position holds after completion (including a couple seconds later when the backup lands and reloads the chat)
- [ ] Switch between chats and confirm the view still resets/scrolls to bottom correctly
- [ ] Create a new blank chat and confirm no unwanted fade/scroll

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the chat from jumping to the bottom after a streamed response finishes, preserving the user’s scroll position when reading earlier messages.

- **Bug Fixes**
  - Detect chat switches via `currentChat?.id` instead of `createdAt` in `ChatListView` to prevent false triggers after backup-driven reloads (timestamp precision loss during ISO8601 round-trip made identical chats compare different).

<sup>Written for commit 29264ec5f58bb68fad5acdc75d01e797952aa0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

