### PR TITLE
chore: update tinfoil-swift to 0.7.0

### DIFF
--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "f3194e56338ef72a3afd206ba0dbfbb1b6db9059",
-        "version" : "0.6.6"
+        "revision" : "08f8ccd153e98a6d413f9dae0bcb53d540cdd122",
+        "version" : "0.7.0"
       }
     }
   ],

--- a/TinfoilChat/Models/VerificationModels.swift
+++ b/TinfoilChat/Models/VerificationModels.swift
@@ -27,6 +27,8 @@ extension VerificationStepState.Status {
             return .success
         case .failed:
             return .error
+        case .skipped:
+            return .pending
         }
     }
 } 


### PR DESCRIPTION
## Summary
- Updates the tinfoil-swift package from 0.6.6 to 0.7.0
- Handles the new `.skipped` verification step status in the UI status mapping (fixes non-exhaustive switch build error)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `tinfoil-swift` to 0.7.0 and adds UI handling for the new `.skipped` verification step. Fixes a non-exhaustive switch compile error and keeps the app aligned with the latest SDK.

- **Dependencies**
  - Bump `tinfoil-swift` from 0.6.6 to 0.7.0.

- **Bug Fixes**
  - Map `.skipped` in `VerificationStepState.Status` to a `.pending` UI state.

<sup>Written for commit 31d7fe1a3da7b81ac5d5de72ef39385515686f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

