### PR TITLE
chore: require tinfoil-swift 0.7.0

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -770,7 +770,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.5;
+				minimumVersion = 0.7.0;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {
@@ -788,6 +788,8 @@
 				kind = upToNextMajorVersion;
 				minimumVersion = 9.5.1;
 			};
+			traits = (
+			);
 		};
 		99F1546D2F4F60F600E9174E /* XCRemoteSwiftPackageReference "purchases-ios-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;


### PR DESCRIPTION
## Summary
- Bumps the minimum tinfoil-swift version requirement from 0.6.5 to 0.7.0 so package resolution picks up the version pinned in Package.resolved (SwiftPM treats 0.x minor bumps as breaking, so 0.7.0 was outside the previous allowed range)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the minimum `tinfoil-swift` version to 0.7.0 so SwiftPM resolves to the pinned 0.7.0 and uses the newer verification SDK. This fixes resolution issues caused by 0.x minor versions being treated as breaking.

<sup>Written for commit 936791de221efd08f1dd4597b9e85068c5481684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

