### PR TITLE
feat: show model and encryption details on messages

### DIFF
--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -258,6 +258,13 @@ class AppConfig: ObservableObject {
     
     // Available models from config
     @Published private(set) var availableModels: [ModelType] = []
+
+    var modelDisplayNamesByName: [String: String] {
+        Dictionary(
+            availableModels.map { ($0.modelName, $0.fullName) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
     
     // Premium API key flag
     @Published private(set) var isPremiumKeyRequired = false

--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -130,6 +130,8 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
     // Full model name
     var fullName: String { appConfig.name }
 
+    var responseDisplayName: String { isAuto ? displayName : fullName }
+
     // Model identifier used for API calls
     var modelName: String { appConfig.modelName }
 

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -98,6 +98,15 @@ enum Constants {
         static let maxThinkingChunkCharacters = 8_000
     }
 
+    enum MessageMetadata {
+        static let encryptedFontSize: CGFloat = 10
+        static let iconSize: CGFloat = 10
+        static let userTabCornerRadius: CGFloat = 10
+        static let userTabHorizontalPadding: CGFloat = 10
+        static let userTabVerticalPadding: CGFloat = 5
+        static let userTabHeight: CGFloat = 23
+    }
+
     enum StreamingBuffer {
         static let initialMultiplier: CGFloat = 50.0
         static let multiplierIncrement: CGFloat = 10.0

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -101,10 +101,6 @@ enum Constants {
     enum MessageMetadata {
         static let encryptedFontSize: CGFloat = 10
         static let iconSize: CGFloat = 10
-        static let userTabCornerRadius: CGFloat = 10
-        static let userTabHorizontalPadding: CGFloat = 10
-        static let userTabVerticalPadding: CGFloat = 5
-        static let userTabHeight: CGFloat = 23
     }
 
     enum StreamingBuffer {

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -703,6 +703,7 @@ struct Message: Identifiable, Codable, Equatable {
     let role: MessageRole
     var turnId: String? = nil
     var content: String
+    var modelDisplayName: String? = nil
     var thoughts: String? = nil
     var isThinking: Bool = false
     var timestamp: Date
@@ -784,6 +785,20 @@ struct Message: Identifiable, Codable, Equatable {
         role == .user && content.count >= Message.longMessageAttachmentThreshold
     }
 
+    var hasVisibleAssistantContent: Bool {
+        role == .assistant && (
+            !content.isEmpty
+                || thoughts?.isEmpty == false
+                || segments?.isEmpty == false
+                || webSearches?.isEmpty == false
+                || webSearchState != nil
+                || !urlFetches.isEmpty
+                || !toolCalls.isEmpty
+                || annotations?.isEmpty == false
+                || timeline?.isEmpty == false
+        )
+    }
+
     private static let iso8601Formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -796,11 +811,12 @@ struct Message: Identifiable, Codable, Equatable {
         return formatter
     }()
     
-    init(id: String = UUID().uuidString.lowercased(), role: MessageRole, turnId: String? = nil, content: String, thoughts: String? = nil, isThinking: Bool = false, timestamp: Date = Date(), isCollapsed: Bool = true, generationTimeSeconds: Double? = nil, contentChunks: [ContentChunk] = [], thinkingChunks: [ThinkingChunk] = [], webSearchState: WebSearchState? = nil, attachments: [Attachment] = []) {
+    init(id: String = UUID().uuidString.lowercased(), role: MessageRole, turnId: String? = nil, content: String, modelDisplayName: String? = nil, thoughts: String? = nil, isThinking: Bool = false, timestamp: Date = Date(), isCollapsed: Bool = true, generationTimeSeconds: Double? = nil, contentChunks: [ContentChunk] = [], thinkingChunks: [ThinkingChunk] = [], webSearchState: WebSearchState? = nil, attachments: [Attachment] = []) {
         self.id = id
         self.role = role
         self.turnId = turnId
         self.content = content
+        self.modelDisplayName = modelDisplayName
         self.thoughts = thoughts
         self.isThinking = isThinking
         self.timestamp = timestamp
@@ -815,7 +831,7 @@ struct Message: Identifiable, Codable, Equatable {
     // MARK: - Codable Implementation
     
     enum CodingKeys: String, CodingKey {
-        case id, role, turnId, content, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, isConnectionError, generationTimeSeconds, webSearchState
+        case id, role, turnId, content, modelDisplayName, thoughts, isThinking, timestamp, isCollapsed, isStreaming, streamError, isRequestError, isRateLimitError, isHourlyLimitError, isConnectionError, generationTimeSeconds, webSearchState
         case webSearch // Alternative key used by React app
         case urlFetches
         case attachments
@@ -834,6 +850,7 @@ struct Message: Identifiable, Codable, Equatable {
         role = try container.decode(MessageRole.self, forKey: .role)
         turnId = try container.decodeIfPresent(String.self, forKey: .turnId)
         content = try container.decode(String.self, forKey: .content)
+        modelDisplayName = try container.decodeIfPresent(String.self, forKey: .modelDisplayName)
         thoughts = try container.decodeIfPresent(String.self, forKey: .thoughts)
         isThinking = try container.decodeIfPresent(Bool.self, forKey: .isThinking) ?? false
         
@@ -1024,6 +1041,7 @@ struct Message: Identifiable, Codable, Equatable {
         try container.encode(role.rawValue, forKey: .role)
         try container.encodeIfPresent(turnId, forKey: .turnId)
         try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(modelDisplayName, forKey: .modelDisplayName)
         try container.encodeIfPresent(thoughts, forKey: .thoughts)
         try container.encode(isThinking, forKey: .isThinking)
         try container.encode(Self.iso8601Formatter.string(from: timestamp), forKey: .timestamp)

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -63,15 +63,7 @@ final class ChatRecoveryPhaseTracker: ObservableObject {
 }
 
 func recoveryDraftHasVisibleContent(_ message: Message) -> Bool {
-    !message.content.isEmpty
-        || message.thoughts?.isEmpty == false
-        || message.segments?.isEmpty == false
-        || message.webSearches?.isEmpty == false
-        || message.webSearchState != nil
-        || !message.urlFetches.isEmpty
-        || !message.toolCalls.isEmpty
-        || message.annotations?.isEmpty == false
-        || message.timeline?.isEmpty == false
+    message.hasVisibleAssistantContent
 }
 
 func recoveredResponseForPersistence(
@@ -126,6 +118,7 @@ func recoveryResponsePayloadMatches(_ lhs: Message, _ rhs: Message) -> Bool {
         && lhs.role == rhs.role
         && lhs.turnId == rhs.turnId
         && lhs.content == rhs.content
+        && lhs.modelDisplayName == rhs.modelDisplayName
         && lhs.thoughts == rhs.thoughts
         && lhs.isThinking == rhs.isThinking
         && lhs.webSearchState == rhs.webSearchState
@@ -1162,9 +1155,17 @@ actor ChatRecoveryCoordinator {
         storage: ChatRecoveryStorage,
         onProgress: @escaping @Sendable () async -> Void
     ) async throws -> Message {
+        let modelDisplayNamesByName = await MainActor.run {
+            Dictionary(
+                uniqueKeysWithValues: AppConfig.shared.availableModels.map {
+                    ($0.modelName, $0.fullName)
+                }
+            )
+        }
         let processor = StreamingResponseProcessor(
             isWebSearchEnabled: true,
-            hapticEnabled: false
+            hapticEnabled: false,
+            modelDisplayNamesByName: modelDisplayNamesByName
         )
         var eventState = RecoveredEventState()
         var lastProgressDraft: Message?
@@ -1312,6 +1313,7 @@ actor ChatRecoveryCoordinator {
             role: .assistant,
             turnId: turnId,
             content: snapshot.responseContent,
+            modelDisplayName: snapshot.modelDisplayName,
             thoughts: snapshot.thoughts,
             isThinking: snapshot.isThinking,
             timestamp: .distantPast,

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -118,7 +118,9 @@ func recoveryResponsePayloadMatches(_ lhs: Message, _ rhs: Message) -> Bool {
         && lhs.role == rhs.role
         && lhs.turnId == rhs.turnId
         && lhs.content == rhs.content
-        && lhs.modelDisplayName == rhs.modelDisplayName
+        && (lhs.modelDisplayName == nil
+            || rhs.modelDisplayName == nil
+            || lhs.modelDisplayName == rhs.modelDisplayName)
         && lhs.thoughts == rhs.thoughts
         && lhs.isThinking == rhs.isThinking
         && lhs.webSearchState == rhs.webSearchState
@@ -855,6 +857,7 @@ actor ChatRecoveryCoordinator {
                     }
                     let recoveredResponse = try await reconstructMessage(
                         stream: recovered.stream,
+                        modelDisplayName: persistedCheckpoint?.modelDisplayName,
                         chatId: chatId,
                         turnId: envelope.turnId,
                         sessionId: payload.sessionId,
@@ -1146,6 +1149,7 @@ actor ChatRecoveryCoordinator {
 
     private func reconstructMessage(
         stream: AsyncThrowingStream<ChatStreamResult, Error>,
+        modelDisplayName: String?,
         chatId: String,
         turnId: String,
         sessionId: String,
@@ -1156,15 +1160,12 @@ actor ChatRecoveryCoordinator {
         onProgress: @escaping @Sendable () async -> Void
     ) async throws -> Message {
         let modelDisplayNamesByName = await MainActor.run {
-            Dictionary(
-                uniqueKeysWithValues: AppConfig.shared.availableModels.map {
-                    ($0.modelName, $0.fullName)
-                }
-            )
+            AppConfig.shared.modelDisplayNamesByName
         }
         let processor = StreamingResponseProcessor(
             isWebSearchEnabled: true,
             hapticEnabled: false,
+            modelDisplayName: modelDisplayName,
             modelDisplayNamesByName: modelDisplayNamesByName
         )
         var eventState = RecoveredEventState()

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -27,6 +27,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     /// value so the main actor never reads live processor state.
     struct Snapshot {
         var responseContent: String
+        var modelDisplayName: String?
         var thoughts: String?
         var thinkingChunks: [ThinkingChunk]
         var contentChunks: [ContentChunk]
@@ -123,6 +124,8 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     private var didRecordWebSearchBeforeThinking = false
     private var webSearchBeforeThinking: Bool? = nil
     private var responseContent: String
+    private var modelDisplayName: String?
+    private let modelDisplayNamesByName: [String: String]
     private var currentThoughts: String?
     private var generationTimeSeconds: TimeInterval?
     private var receivedFinishReason = false
@@ -138,6 +141,8 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         isWebSearchEnabled: Bool,
         hapticEnabled: Bool,
         responseContent: String = "",
+        modelDisplayName: String? = nil,
+        modelDisplayNamesByName: [String: String] = [:],
         currentThoughts: String? = nil,
         generationTimeSeconds: TimeInterval? = nil,
         isInThinkingMode: Bool = false
@@ -145,6 +150,8 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         self.isWebSearchEnabled = isWebSearchEnabled
         self.hapticEnabled = hapticEnabled
         self.responseContent = responseContent
+        self.modelDisplayName = modelDisplayName
+        self.modelDisplayNamesByName = modelDisplayNamesByName
         self.currentThoughts = currentThoughts
         self.generationTimeSeconds = generationTimeSeconds
         self.isInThinkingMode = isInThinkingMode
@@ -219,6 +226,11 @@ final class StreamingResponseProcessor: @unchecked Sendable {
 
         let chunk = parsed.chunk
         let content = parsed.content
+        if let resolvedModelDisplayName = modelDisplayNamesByName[chunk.model],
+           resolvedModelDisplayName != modelDisplayName {
+            modelDisplayName = resolvedModelDisplayName
+            outcome.didMutateState = true
+        }
         let hasReasoningContent = chunk.choices.first?.delta.reasoning != nil
         let reasoningContent = chunk.choices.first?.delta.reasoning ?? ""
 
@@ -493,6 +505,7 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     func snapshot() -> Snapshot {
         Snapshot(
             responseContent: responseContent,
+            modelDisplayName: modelDisplayName,
             thoughts: currentThoughts,
             thinkingChunks: thinkingChunker.getAllChunks(),
             contentChunks: chunker.getAllChunks(),

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2150,6 +2150,12 @@ class ChatViewModel: ObservableObject {
         AccessibilityAnnouncer.announce(Constants.Accessibility.generatingResponse)
 
         let turnId = UUID().uuidString.lowercased()
+        let streamModel = currentModel
+        let modelDisplayNamesByName = Dictionary(
+            uniqueKeysWithValues: AppConfig.shared.availableModels.map {
+                ($0.modelName, $0.fullName)
+            }
+        )
         var turnChat = initialChat
         turnChat.hasActiveStream = true
         if let userIndex = turnChat.messages.lastIndex(where: { $0.role == .user }) {
@@ -2164,6 +2170,7 @@ class ChatViewModel: ObservableObject {
             role: .assistant,
             turnId: turnId,
             content: "",
+            modelDisplayName: streamModel.responseDisplayName,
             isCollapsed: true
         )
         addMessage(assistantMessage)
@@ -2189,7 +2196,6 @@ class ChatViewModel: ObservableObject {
         }
         streamingTracker.startStreaming(streamChatId)
         ChatRecoveryDraftStore.shared.prune(chatId: streamChatId, retaining: [])
-        let streamModel = currentModel
         let streamProject = activeProject
         let streamProjectDocuments = projectDocuments
         let streamReasoningEffort = reasoningEffort
@@ -2406,6 +2412,8 @@ class ChatViewModel: ObservableObject {
                     isWebSearchEnabled: webSearchEnabled,
                     hapticEnabled: hapticEnabled,
                     responseContent: initialResponseContent,
+                    modelDisplayName: streamModel.responseDisplayName,
+                    modelDisplayNamesByName: modelDisplayNamesByName,
                     currentThoughts: initialThoughts,
                     generationTimeSeconds: initialGenerationTime,
                     isInThinkingMode: initialIsThinking
@@ -2781,6 +2789,7 @@ class ChatViewModel: ObservableObject {
                     // Finalize all message content
                     if !chat.messages.isEmpty, let lastIndex = chat.messages.indices.last {
                         chat.messages[lastIndex].content = finalSnapshot.responseContent
+                        chat.messages[lastIndex].modelDisplayName = finalSnapshot.modelDisplayName
                         chat.messages[lastIndex].thoughts = finalSnapshot.thoughts
                         chat.messages[lastIndex].thinkingChunks = finalSnapshot.thinkingChunks
                         chat.messages[lastIndex].isThinking = false
@@ -3000,6 +3009,7 @@ class ChatViewModel: ObservableObject {
         }
 
         chat.messages[lastIndex].content = snapshot.responseContent
+        chat.messages[lastIndex].modelDisplayName = snapshot.modelDisplayName
         chat.messages[lastIndex].thoughts = snapshot.thoughts
         chat.messages[lastIndex].thinkingChunks = snapshot.thinkingChunks
         chat.messages[lastIndex].isThinking = snapshot.isThinking
@@ -3264,9 +3274,10 @@ class ChatViewModel: ObservableObject {
         let recoveryAttempt = recoveryAttempts.removeValue(forKey: chatId)
         let stoppedResponse = recoveryAttempt.flatMap { attempt -> Message? in
             guard let location = findChatLocation(chatId) else { return nil }
-            return chat(at: location).messages.last {
+            let response = chat(at: location).messages.last {
                 $0.role == .assistant && $0.turnId == attempt.turnId
             }
+            return response?.hasVisibleAssistantContent == true ? response : nil
         }
         let recoveryCleanup = recoveryAttempt.map { attempt in
             Task.detached(priority: .userInitiated) {
@@ -3281,6 +3292,10 @@ class ChatViewModel: ObservableObject {
         if let location = findChatLocation(chatId) {
             var chat = chat(at: location)
             chat.hasActiveStream = false
+            if chat.messages.last?.role == .assistant,
+               chat.messages.last?.hasVisibleAssistantContent == false {
+                chat.messages.removeLast()
+            }
             if let recoveryAttempt {
                 chat.pendingRecoveries?.removeAll {
                     $0.turnId == recoveryAttempt.turnId

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2151,11 +2151,7 @@ class ChatViewModel: ObservableObject {
 
         let turnId = UUID().uuidString.lowercased()
         let streamModel = currentModel
-        let modelDisplayNamesByName = Dictionary(
-            uniqueKeysWithValues: AppConfig.shared.availableModels.map {
-                ($0.modelName, $0.fullName)
-            }
-        )
+        let modelDisplayNamesByName = AppConfig.shared.modelDisplayNamesByName
         var turnChat = initialChat
         turnChat.hasActiveStream = true
         if let userIndex = turnChat.messages.lastIndex(where: { $0.role == .user }) {
@@ -3274,10 +3270,9 @@ class ChatViewModel: ObservableObject {
         let recoveryAttempt = recoveryAttempts.removeValue(forKey: chatId)
         let stoppedResponse = recoveryAttempt.flatMap { attempt -> Message? in
             guard let location = findChatLocation(chatId) else { return nil }
-            let response = chat(at: location).messages.last {
+            return chat(at: location).messages.last {
                 $0.role == .assistant && $0.turnId == attempt.turnId
             }
-            return response?.hasVisibleAssistantContent == true ? response : nil
         }
         let recoveryCleanup = recoveryAttempt.map { attempt in
             Task.detached(priority: .userInitiated) {
@@ -3292,10 +3287,6 @@ class ChatViewModel: ObservableObject {
         if let location = findChatLocation(chatId) {
             var chat = chat(at: location)
             chat.hasActiveStream = false
-            if chat.messages.last?.role == .assistant,
-               chat.messages.last?.hasVisibleAssistantContent == false {
-                chat.messages.removeLast()
-            }
             if let recoveryAttempt {
                 chat.pendingRecoveries?.removeAll {
                     $0.turnId == recoveryAttempt.turnId

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -129,31 +129,6 @@ private struct MessageSecurityMetadataView: View {
     }
 }
 
-private struct UserMessageSecurityTab: View {
-    let isDarkMode: Bool
-
-    var body: some View {
-        MessageSecurityMetadataView(modelDisplayName: nil, isDarkMode: isDarkMode)
-            .padding(.horizontal, Constants.MessageMetadata.userTabHorizontalPadding)
-            .padding(.vertical, Constants.MessageMetadata.userTabVerticalPadding)
-            .background {
-                if #available(iOS 26, *) {
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: Constants.MessageMetadata.userTabCornerRadius,
-                        topTrailingRadius: Constants.MessageMetadata.userTabCornerRadius
-                    )
-                    .fill(.thickMaterial)
-                } else {
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: Constants.MessageMetadata.userTabCornerRadius,
-                        topTrailingRadius: Constants.MessageMetadata.userTabCornerRadius
-                    )
-                    .fill(Color.userMessageBackground(isDarkMode: isDarkMode))
-                }
-            }
-    }
-}
-
 struct MessageView: View {
     let message: Message
     let isDarkMode: Bool
@@ -874,18 +849,6 @@ struct MessageView: View {
                     }
                 }
                 .cornerRadius(16)
-                .overlay(alignment: .topTrailing) {
-                    if message.role == .user && !message.content.isEmpty {
-                        UserMessageSecurityTab(isDarkMode: isDarkMode)
-                            .offset(y: -Constants.MessageMetadata.userTabHeight)
-                    }
-                }
-                .padding(
-                    .top,
-                    message.role == .user && !message.content.isEmpty
-                        ? Constants.MessageMetadata.userTabHeight
-                        : 0
-                )
                 .modifier(MessageBubbleModifier(isUserMessage: message.role == .user))
                 // While a stream is in flight the table reloads its rows
                 // every UI tick, which can deallocate the SwiftUI subgraph

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -99,6 +99,61 @@ private struct PendingResponseRecoveryView: View {
     }
 }
 
+private struct MessageSecurityMetadataView: View {
+    let modelDisplayName: String?
+    let isDarkMode: Bool
+
+    private var trimmedModelDisplayName: String? {
+        guard let name = modelDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !name.isEmpty else { return nil }
+        return name
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if let trimmedModelDisplayName {
+                Text(trimmedModelDisplayName)
+                    .font(.caption2)
+                Text("·")
+                    .font(.caption2)
+            }
+            HStack(spacing: 3) {
+                Image(systemName: "lock")
+                    .font(.system(size: Constants.MessageMetadata.iconSize))
+                Text("Encrypted")
+                    .font(.system(size: Constants.MessageMetadata.encryptedFontSize))
+            }
+        }
+        .foregroundStyle(isDarkMode ? Color.white.opacity(0.5) : Color.black.opacity(0.5))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct UserMessageSecurityTab: View {
+    let isDarkMode: Bool
+
+    var body: some View {
+        MessageSecurityMetadataView(modelDisplayName: nil, isDarkMode: isDarkMode)
+            .padding(.horizontal, Constants.MessageMetadata.userTabHorizontalPadding)
+            .padding(.vertical, Constants.MessageMetadata.userTabVerticalPadding)
+            .background {
+                if #available(iOS 26, *) {
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: Constants.MessageMetadata.userTabCornerRadius,
+                        topTrailingRadius: Constants.MessageMetadata.userTabCornerRadius
+                    )
+                    .fill(.thickMaterial)
+                } else {
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: Constants.MessageMetadata.userTabCornerRadius,
+                        topTrailingRadius: Constants.MessageMetadata.userTabCornerRadius
+                    )
+                    .fill(Color.userMessageBackground(isDarkMode: isDarkMode))
+                }
+            }
+    }
+}
+
 struct MessageView: View {
     let message: Message
     let isDarkMode: Bool
@@ -729,8 +784,7 @@ struct MessageView: View {
                 }
                 
                 // Add action buttons for assistant messages (only when not streaming)
-                if message.role == .assistant &&
-                   (!message.content.isEmpty || message.thoughts != nil) &&
+                if message.hasVisibleAssistantContent &&
                    !isRenderingStream {
                     HStack(spacing: 16) {
                         // Sources button - only show if we have web search sources
@@ -790,6 +844,11 @@ struct MessageView: View {
                         }
 
                         Spacer()
+
+                        MessageSecurityMetadataView(
+                            modelDisplayName: message.modelDisplayName,
+                            isDarkMode: isDarkMode
+                        )
                     }
                     .padding(.vertical, 8)
 
@@ -815,6 +874,18 @@ struct MessageView: View {
                     }
                 }
                 .cornerRadius(16)
+                .overlay(alignment: .topTrailing) {
+                    if message.role == .user && !message.content.isEmpty {
+                        UserMessageSecurityTab(isDarkMode: isDarkMode)
+                            .offset(y: -Constants.MessageMetadata.userTabHeight)
+                    }
+                }
+                .padding(
+                    .top,
+                    message.role == .user && !message.content.isEmpty
+                        ? Constants.MessageMetadata.userTabHeight
+                        : 0
+                )
                 .modifier(MessageBubbleModifier(isUserMessage: message.role == .user))
                 // While a stream is in flight the table reloads its rows
                 // every UI tick, which can deallocate the SwiftUI subgraph

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -133,6 +133,7 @@ struct ChatRecoverySchedulingTests {
             role: .assistant,
             turnId: "turn-1",
             content: "Recovered response",
+            modelDisplayName: "Model A",
             generationTimeSeconds: 1
         )
         persisted.thinkingDuration = 1
@@ -142,6 +143,7 @@ struct ChatRecoverySchedulingTests {
             role: .assistant,
             turnId: "turn-1",
             content: "Recovered response",
+            modelDisplayName: "Model A",
             generationTimeSeconds: 2
         )
         reconstructed.thinkingDuration = 2
@@ -156,6 +158,8 @@ struct ChatRecoverySchedulingTests {
         reconstructed.content = persisted.content
         reconstructed.modelDisplayName = "Different Model"
         #expect(!recoveryResponsePayloadMatches(persisted, reconstructed))
+        persisted.modelDisplayName = nil
+        #expect(recoveryResponsePayloadMatches(persisted, reconstructed))
     }
 
     @Test func registrationCleanupRequiresADefinitePreCommitFailure() {

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -7,6 +7,7 @@ struct ChatRecoverySchedulingTests {
         let emptyThinking = Message(
             role: .assistant,
             content: "",
+            modelDisplayName: "GPT-OSS 120B",
             isThinking: true
         )
         let recoveredThought = Message(
@@ -151,6 +152,9 @@ struct ChatRecoverySchedulingTests {
 
         #expect(recoveryResponsePayloadMatches(persisted, reconstructed))
         reconstructed.content = "Different response"
+        #expect(!recoveryResponsePayloadMatches(persisted, reconstructed))
+        reconstructed.content = persisted.content
+        reconstructed.modelDisplayName = "Different Model"
         #expect(!recoveryResponsePayloadMatches(persisted, reconstructed))
     }
 

--- a/TinfoilChatTests/MessageSegmentDecodeTests.swift
+++ b/TinfoilChatTests/MessageSegmentDecodeTests.swift
@@ -55,6 +55,20 @@ struct MessageSegmentDecodeTests {
         #expect(message.segments == nil)
     }
 
+    @Test func roundTripsModelDisplayName() throws {
+        let message = Message(
+            role: .assistant,
+            content: "hello",
+            modelDisplayName: "GPT-OSS 120B"
+        )
+
+        let data = try JSONEncoder().encode(message)
+        let decoded = try JSONDecoder().decode(Message.self, from: data)
+
+        #expect(decoded.modelDisplayName == "GPT-OSS 120B")
+        #expect(String(decoding: data, as: UTF8.self).contains("modelDisplayName"))
+    }
+
     @Test func decodesMessageWhenAllSegmentsAreUnknown() throws {
         let json = """
         {

--- a/TinfoilChatTests/StreamingResponseProcessorTests.swift
+++ b/TinfoilChatTests/StreamingResponseProcessorTests.swift
@@ -43,6 +43,33 @@ struct StreamingResponseProcessorTests {
         #expect(processor.snapshot().responseContent == "complete")
     }
 
+    @Test("stores the routed model display name")
+    func storesRoutedModelDisplayName() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false,
+            modelDisplayName: "Auto · Smart",
+            modelDisplayNamesByName: ["gpt-oss-120b": "GPT-OSS 120B"]
+        )
+
+        _ = processor.process(processor.parse(try chunk(content: "complete")))
+
+        #expect(processor.snapshot().modelDisplayName == "GPT-OSS 120B")
+    }
+
+    @Test("keeps the selected display name when the routed model is unknown")
+    func keepsSelectedModelDisplayName() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false,
+            modelDisplayName: "Auto · Smart"
+        )
+
+        _ = processor.process(processor.parse(try chunk(content: "complete")))
+
+        #expect(processor.snapshot().modelDisplayName == "Auto · Smart")
+    }
+
     private func chunk(
         content: String,
         finishReason: String? = nil


### PR DESCRIPTION
## Summary
- persist and cross-device sync each assistant response's model display name using the web-compatible message field
- resolve Auto-routed responses to the concrete model reported by the stream and preserve attribution through recovery
- show model and encryption metadata alongside assistant actions

## Testing
- added Codable, streaming model resolution, and recovery payload regression tests
- build and test commands not run per repository instructions; verify in Xcode