### PR TITLE
fix: preserve model reasoning according to history policy

### DIFF
--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -34,6 +34,8 @@ struct ReasoningEndpointParams: Codable, Equatable {
 /// - `effortMap` — optional translation from the UI's effort vocabulary to
 ///   the model's actual accepted values (e.g. DeepSeek V4 only accepts
 ///   `high`/`max`).
+/// - `requiresCompleteReasoningHistory` — prior assistant reasoning must be
+///   returned as `reasoning_content` on subsequent requests.
 ///
 /// The presence of a `reasoningConfig` object is itself the capability
 /// flag — there is no separate boolean.
@@ -43,6 +45,7 @@ struct ReasoningConfig: Codable, Equatable {
     let defaultEnabled: Bool?
     let effortMap: [String: String]?
     let params: [String: ReasoningEndpointParams]?
+    let requiresCompleteReasoningHistory: Bool?
 }
 
 /// Synthetic "Auto" model selection that lets the router pick the best
@@ -166,6 +169,10 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
         appConfig.reasoningConfig?.supportsToggle == true
     }
 
+    var requiresCompleteReasoningHistory: Bool {
+        appConfig.reasoningConfig?.requiresCompleteReasoningHistory == true
+    }
+
     // MARK: - Auto routing
 
     /// Capability tags advertised by the controlplane (e.g. `smart`, `fast`).
@@ -201,7 +208,10 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
                 : "Routes to the fastest available model",
             details: "",
             parameters: "",
-            contextWindow: "",
+            contextWindow: members.min {
+                TokenEstimation.parseContextWindowTokens($0.contextWindow)
+                    < TokenEstimation.parseContextWindowTokens($1.contextWindow)
+            }?.contextWindow ?? "",
             type: "chat",
             chat: true,
             paid: true,
@@ -230,6 +240,13 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
 struct ModelSelection {
     let representative: ModelType
     let autoCandidates: [ModelType]?
+
+    var contextWindow: String {
+        autoCandidates?.min {
+            TokenEstimation.parseContextWindowTokens($0.contextWindow)
+                < TokenEstimation.parseContextWindowTokens($1.contextWindow)
+        }?.contextWindow ?? representative.contextWindow
+    }
 }
 
 /// Application-wide configuration settings
@@ -456,6 +473,13 @@ class AppConfig: ObservableObject {
     /// Real chat models advertising the given capability tier.
     func tierModels(_ tier: String) -> [ModelType] {
         availableModels.filter { $0.isChat && $0.attributes.contains(tier) }
+    }
+
+    func requiresCompleteReasoningHistory(for model: ModelType) -> Bool {
+        guard model.isAuto, let tier = model.autoTier else {
+            return model.requiresCompleteReasoningHistory
+        }
+        return tierModels(tier).contains { $0.requiresCompleteReasoningHistory }
     }
 
     /// Synthetic Auto entries for tiers that currently have at least one member.

--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -34,18 +34,46 @@ struct ReasoningEndpointParams: Codable, Equatable {
 /// - `effortMap` — optional translation from the UI's effort vocabulary to
 ///   the model's actual accepted values (e.g. DeepSeek V4 only accepts
 ///   `high`/`max`).
-/// - `requiresCompleteReasoningHistory` — prior assistant reasoning must be
-///   returned as `reasoning_content` on subsequent requests.
+/// - `reasoningHistoryPolicy` — controls whether prior assistant reasoning is
+///   returned for every assistant message, tool-call messages only, or never.
 ///
 /// The presence of a `reasoningConfig` object is itself the capability
 /// flag — there is no separate boolean.
+enum ReasoningHistoryPolicy: String, Codable, Equatable {
+    case none
+    case toolCallOnly = "tool-call-only"
+    case all
+
+    private var rank: Int {
+        switch self {
+        case .none: return 0
+        case .toolCallOnly: return 1
+        case .all: return 2
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .none
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    static func strongest(_ first: Self, _ second: Self) -> Self {
+        second.rank > first.rank ? second : first
+    }
+}
+
 struct ReasoningConfig: Codable, Equatable {
     let supportsEffort: Bool?
     let supportsToggle: Bool?
     let defaultEnabled: Bool?
     let effortMap: [String: String]?
     let params: [String: ReasoningEndpointParams]?
-    let requiresCompleteReasoningHistory: Bool?
+    let reasoningHistoryPolicy: ReasoningHistoryPolicy?
 }
 
 /// Synthetic "Auto" model selection that lets the router pick the best
@@ -169,8 +197,8 @@ struct ModelType: Identifiable, Codable, Hashable, Equatable {
         appConfig.reasoningConfig?.supportsToggle == true
     }
 
-    var requiresCompleteReasoningHistory: Bool {
-        appConfig.reasoningConfig?.requiresCompleteReasoningHistory == true
+    var reasoningHistoryPolicy: ReasoningHistoryPolicy {
+        appConfig.reasoningConfig?.reasoningHistoryPolicy ?? .none
     }
 
     // MARK: - Auto routing
@@ -475,11 +503,13 @@ class AppConfig: ObservableObject {
         availableModels.filter { $0.isChat && $0.attributes.contains(tier) }
     }
 
-    func requiresCompleteReasoningHistory(for model: ModelType) -> Bool {
+    func reasoningHistoryPolicy(for model: ModelType) -> ReasoningHistoryPolicy {
         guard model.isAuto, let tier = model.autoTier else {
-            return model.requiresCompleteReasoningHistory
+            return model.reasoningHistoryPolicy
         }
-        return tierModels(tier).contains { $0.requiresCompleteReasoningHistory }
+        return tierModels(tier).reduce(ReasoningHistoryPolicy.none) { policy, candidate in
+            ReasoningHistoryPolicy.strongest(policy, candidate.reasoningHistoryPolicy)
+        }
     }
 
     /// Synthetic Auto entries for tiers that currently have at least one member.

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -362,6 +362,12 @@ enum MessageRole: String, Codable {
     case assistant
 }
 
+extension ReasoningHistoryPolicy {
+    func includesReasoning(for message: Message) -> Bool {
+        self == .all || (self == .toolCallOnly && !message.toolCalls.isEmpty)
+    }
+}
+
 // MARK: - Web Search Types
 
 /// Represents a source from web search results

--- a/TinfoilChat/Models/ChatModels.swift
+++ b/TinfoilChat/Models/ChatModels.swift
@@ -748,6 +748,23 @@ struct Message: Identifiable, Codable, Equatable {
     /// `segments` representation.
     var timeline: [JSONValue]? = nil
 
+    var reasoningContentForHistory: String? {
+        if let segments {
+            let reasoning = segments.reduce(into: "") { result, segment in
+                if case .thinking(let content, _, _) = segment {
+                    result += content
+                }
+            }
+            if !reasoning.isEmpty {
+                return reasoning
+            }
+        }
+        if let thoughts, !thoughts.isEmpty {
+            return thoughts
+        }
+        return nil
+    }
+
     /// True when this assistant message has at least one tool call whose
     /// widget is not registered on this client. Used to surface the
     /// "interactive component unavailable" notice for forward

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -99,17 +99,24 @@ struct ChatQueryBuilder {
             }
         }
 
-        let includesReasoningHistory = reasoningConfig?.requiresCompleteReasoningHistory == true
-            || autoCandidates?.contains { $0.requiresCompleteReasoningHistory } == true
+        let candidateReasoningHistoryPolicy = autoCandidates?.reduce(ReasoningHistoryPolicy.none) { policy, candidate in
+            ReasoningHistoryPolicy.strongest(policy, candidate.reasoningHistoryPolicy)
+        } ?? .none
+        let reasoningHistoryPolicy = ReasoningHistoryPolicy.strongest(
+            reasoningConfig?.reasoningHistoryPolicy ?? .none,
+            candidateReasoningHistoryPolicy
+        )
         let recentMessages = TokenEstimation.selectMessagesWithinBudget(
             conversationMessages,
             contextWindow: contextWindow,
-            includesReasoning: includesReasoningHistory
+            reasoningHistoryPolicy: reasoningHistoryPolicy
         )
         var hasAddedSystemInstructions = useSystemRole
 
         for msg in recentMessages {
-            let reasoningContent = includesReasoningHistory ? msg.reasoningContentForHistory : nil
+            let reasoningContent = reasoningHistoryPolicy.includesReasoning(for: msg)
+                ? msg.reasoningContentForHistory
+                : nil
             if msg.role == .user {
                 var userContent = msg.content
 

--- a/TinfoilChat/Utilities/ChatQueryBuilder.swift
+++ b/TinfoilChat/Utilities/ChatQueryBuilder.swift
@@ -99,10 +99,17 @@ struct ChatQueryBuilder {
             }
         }
 
-        let recentMessages = TokenEstimation.selectMessagesWithinBudget(conversationMessages, contextWindow: contextWindow)
+        let includesReasoningHistory = reasoningConfig?.requiresCompleteReasoningHistory == true
+            || autoCandidates?.contains { $0.requiresCompleteReasoningHistory } == true
+        let recentMessages = TokenEstimation.selectMessagesWithinBudget(
+            conversationMessages,
+            contextWindow: contextWindow,
+            includesReasoning: includesReasoningHistory
+        )
         var hasAddedSystemInstructions = useSystemRole
 
         for msg in recentMessages {
+            let reasoningContent = includesReasoningHistory ? msg.reasoningContentForHistory : nil
             if msg.role == .user {
                 var userContent = msg.content
 
@@ -162,7 +169,7 @@ struct ChatQueryBuilder {
                 } else {
                     messages.append(.user(.init(content: .string(userContent))))
                 }
-            } else if !msg.content.isEmpty || !msg.toolCalls.isEmpty {
+            } else if !msg.content.isEmpty || !msg.toolCalls.isEmpty || reasoningContent != nil {
                 // Emit `tool_calls` on the assistant message so the model
                 // sees its previously-rendered widgets, then synthesize
                 // `role: 'tool'` results so the API's tool-call/tool-result
@@ -186,6 +193,7 @@ struct ChatQueryBuilder {
                         : .textContent(msg.content)
                 messages.append(.assistant(.init(
                     content: assistantContent,
+                    reasoningContent: reasoningContent,
                     toolCalls: toolCallParams
                 )))
                 if let toolCallParams {

--- a/TinfoilChat/Utilities/TokenEstimation.swift
+++ b/TinfoilChat/Utilities/TokenEstimation.swift
@@ -43,14 +43,17 @@ enum TokenEstimation {
     }
 
     /// Estimate the prompt tokens contributed by a single message, including
-    /// tool calls and attachment text. Thoughts are excluded because they are
-    /// never sent back in prompts. Search reasoning is counted even though
-    /// this app's query builder doesn't resend it yet: the webapp sends it
-    /// for multi-turn context and counts it, and matching its estimate keeps
-    /// the archive boundary identical across platforms (erring toward a
-    /// smaller prompt, never an overflow).
-    static func estimateMessageTokens(_ message: Message) -> Int {
+    /// tool calls and attachment text. Reasoning is counted when the selected
+    /// model requires it to be returned in subsequent requests. Search
+    /// reasoning is counted even though this app's query builder doesn't resend
+    /// it yet: the webapp sends it for multi-turn context and counts it, and
+    /// matching its estimate keeps the archive boundary identical across
+    /// platforms (erring toward a smaller prompt, never an overflow).
+    static func estimateMessageTokens(_ message: Message, includesReasoning: Bool = false) -> Int {
         var tokens = estimateTokenCount(message.content)
+        if includesReasoning {
+            tokens += estimateTokenCount(message.reasoningContentForHistory)
+        }
         if let searchReasoning = message.searchReasoning {
             tokens += estimateTokenCount(searchReasoning)
         }
@@ -72,11 +75,15 @@ enum TokenEstimation {
     /// (like the empty assistant placeholder appended before streaming) must
     /// not satisfy that guarantee on their own, or the latest user message
     /// could be dropped from the prompt.
-    static func findContextStartIndex(messages: [Message], budgetTokens: Int) -> Int {
+    static func findContextStartIndex(
+        messages: [Message],
+        budgetTokens: Int,
+        includesReasoning: Bool = false
+    ) -> Int {
         var usedTokens = 0
         var hasIncludedSubstantiveMessage = false
         for i in stride(from: messages.count - 1, through: 0, by: -1) {
-            let messageTokens = estimateMessageTokens(messages[i])
+            let messageTokens = estimateMessageTokens(messages[i], includesReasoning: includesReasoning)
             usedTokens += messageTokens
             if usedTokens > budgetTokens && hasIncludedSubstantiveMessage {
                 return i + 1
@@ -90,8 +97,16 @@ enum TokenEstimation {
 
     /// The trailing slice of messages that fits within the model's context
     /// token budget.
-    static func selectMessagesWithinBudget(_ messages: [Message], contextWindow: String?) -> [Message] {
+    static func selectMessagesWithinBudget(
+        _ messages: [Message],
+        contextWindow: String?,
+        includesReasoning: Bool = false
+    ) -> [Message] {
         let budget = contextTokenBudget(contextWindow)
-        return Array(messages[findContextStartIndex(messages: messages, budgetTokens: budget)...])
+        return Array(messages[findContextStartIndex(
+            messages: messages,
+            budgetTokens: budget,
+            includesReasoning: includesReasoning
+        )...])
     }
 }

--- a/TinfoilChat/Utilities/TokenEstimation.swift
+++ b/TinfoilChat/Utilities/TokenEstimation.swift
@@ -49,9 +49,12 @@ enum TokenEstimation {
     /// it yet: the webapp sends it for multi-turn context and counts it, and
     /// matching its estimate keeps the archive boundary identical across
     /// platforms (erring toward a smaller prompt, never an overflow).
-    static func estimateMessageTokens(_ message: Message, includesReasoning: Bool = false) -> Int {
+    static func estimateMessageTokens(
+        _ message: Message,
+        reasoningHistoryPolicy: ReasoningHistoryPolicy = .none
+    ) -> Int {
         var tokens = estimateTokenCount(message.content)
-        if includesReasoning {
+        if reasoningHistoryPolicy.includesReasoning(for: message) {
             tokens += estimateTokenCount(message.reasoningContentForHistory)
         }
         if let searchReasoning = message.searchReasoning {
@@ -78,12 +81,15 @@ enum TokenEstimation {
     static func findContextStartIndex(
         messages: [Message],
         budgetTokens: Int,
-        includesReasoning: Bool = false
+        reasoningHistoryPolicy: ReasoningHistoryPolicy = .none
     ) -> Int {
         var usedTokens = 0
         var hasIncludedSubstantiveMessage = false
         for i in stride(from: messages.count - 1, through: 0, by: -1) {
-            let messageTokens = estimateMessageTokens(messages[i], includesReasoning: includesReasoning)
+            let messageTokens = estimateMessageTokens(
+                messages[i],
+                reasoningHistoryPolicy: reasoningHistoryPolicy
+            )
             usedTokens += messageTokens
             if usedTokens > budgetTokens && hasIncludedSubstantiveMessage {
                 return i + 1
@@ -100,13 +106,13 @@ enum TokenEstimation {
     static func selectMessagesWithinBudget(
         _ messages: [Message],
         contextWindow: String?,
-        includesReasoning: Bool = false
+        reasoningHistoryPolicy: ReasoningHistoryPolicy = .none
     ) -> [Message] {
         let budget = contextTokenBudget(contextWindow)
         return Array(messages[findContextStartIndex(
             messages: messages,
             budgetTokens: budget,
-            includesReasoning: includesReasoning
+            reasoningHistoryPolicy: reasoningHistoryPolicy
         )...])
     }
 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2369,7 +2369,7 @@ class ChatViewModel: ObservableObject {
                     systemPrompt: systemPrompt,
                     rules: processedRules,
                     conversationMessages: conversationMessages,
-                    contextWindow: representativeModel.contextWindow,
+                    contextWindow: modelSelection.contextWindow,
                     webSearchEnabled: webSearchEnabled,
                     isMultimodal: representativeModel.isMultimodal,
                     reasoningConfig: representativeModel.reasoningConfig,

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -56,9 +56,11 @@ struct ChatListView: View {
     /// instead of on every body evaluation during streaming.
     private func refreshArchivedMessagesStartIndex() {
         let persistedMessages = viewModel.messages
+        let includesReasoning = AppConfig.shared.requiresCompleteReasoningHistory(for: viewModel.currentModel)
         let persistedStartIndex = TokenEstimation.findContextStartIndex(
             messages: persistedMessages,
-            budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
+            budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow),
+            includesReasoning: includesReasoning
         )
         guard persistedMessages.indices.contains(persistedStartIndex) else {
             archivedMessagesStartIndex = 0

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -56,11 +56,11 @@ struct ChatListView: View {
     /// instead of on every body evaluation during streaming.
     private func refreshArchivedMessagesStartIndex() {
         let persistedMessages = viewModel.messages
-        let includesReasoning = AppConfig.shared.requiresCompleteReasoningHistory(for: viewModel.currentModel)
+        let reasoningHistoryPolicy = AppConfig.shared.reasoningHistoryPolicy(for: viewModel.currentModel)
         let persistedStartIndex = TokenEstimation.findContextStartIndex(
             messages: persistedMessages,
             budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow),
-            includesReasoning: includesReasoning
+            reasoningHistoryPolicy: reasoningHistoryPolicy
         )
         guard persistedMessages.indices.contains(persistedStartIndex) else {
             archivedMessagesStartIndex = 0

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -404,19 +404,19 @@ struct MessageInputView: View {
     /// model's token budget. Mirrors the webapp's calculation.
     private var contextUsage: ContextUsage {
         let limitTokens = TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
-        let includesReasoning = AppConfig.shared.requiresCompleteReasoningHistory(for: viewModel.currentModel)
+        let reasoningHistoryPolicy = AppConfig.shared.reasoningHistoryPolicy(for: viewModel.currentModel)
         var usedTokens = TokenEstimation.estimateTokenCount(messageText)
 
         let messages = viewModel.messages
         let startIndex = TokenEstimation.findContextStartIndex(
             messages: messages,
             budgetTokens: limitTokens,
-            includesReasoning: includesReasoning
+            reasoningHistoryPolicy: reasoningHistoryPolicy
         )
         for i in startIndex..<messages.count {
             usedTokens += TokenEstimation.estimateMessageTokens(
                 messages[i],
-                includesReasoning: includesReasoning
+                reasoningHistoryPolicy: reasoningHistoryPolicy
             )
         }
 

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -404,12 +404,20 @@ struct MessageInputView: View {
     /// model's token budget. Mirrors the webapp's calculation.
     private var contextUsage: ContextUsage {
         let limitTokens = TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
+        let includesReasoning = AppConfig.shared.requiresCompleteReasoningHistory(for: viewModel.currentModel)
         var usedTokens = TokenEstimation.estimateTokenCount(messageText)
 
         let messages = viewModel.messages
-        let startIndex = TokenEstimation.findContextStartIndex(messages: messages, budgetTokens: limitTokens)
+        let startIndex = TokenEstimation.findContextStartIndex(
+            messages: messages,
+            budgetTokens: limitTokens,
+            includesReasoning: includesReasoning
+        )
         for i in startIndex..<messages.count {
-            usedTokens += TokenEstimation.estimateMessageTokens(messages[i])
+            usedTokens += TokenEstimation.estimateMessageTokens(
+                messages[i],
+                includesReasoning: includesReasoning
+            )
         }
 
         for attachment in viewModel.pendingAttachments {

--- a/TinfoilChat/Views/OptimizedChatListView.swift
+++ b/TinfoilChat/Views/OptimizedChatListView.swift
@@ -28,11 +28,11 @@ struct OptimizedChatListView: View {
     /// refreshed only when the conversation, model, or message count changes
     /// instead of on every body evaluation during streaming.
     private func refreshArchivedMessagesStartIndex() {
-        let includesReasoning = AppConfig.shared.requiresCompleteReasoningHistory(for: viewModel.currentModel)
+        let reasoningHistoryPolicy = AppConfig.shared.reasoningHistoryPolicy(for: viewModel.currentModel)
         archivedMessagesStartIndex = TokenEstimation.findContextStartIndex(
             messages: messages,
             budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow),
-            includesReasoning: includesReasoning
+            reasoningHistoryPolicy: reasoningHistoryPolicy
         )
     }
 

--- a/TinfoilChat/Views/OptimizedChatListView.swift
+++ b/TinfoilChat/Views/OptimizedChatListView.swift
@@ -28,9 +28,11 @@ struct OptimizedChatListView: View {
     /// refreshed only when the conversation, model, or message count changes
     /// instead of on every body evaluation during streaming.
     private func refreshArchivedMessagesStartIndex() {
+        let includesReasoning = AppConfig.shared.requiresCompleteReasoningHistory(for: viewModel.currentModel)
         archivedMessagesStartIndex = TokenEstimation.findContextStartIndex(
             messages: messages,
-            budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow)
+            budgetTokens: TokenEstimation.contextTokenBudget(viewModel.currentModel.contextWindow),
+            includesReasoning: includesReasoning
         )
     }
 

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -321,7 +321,7 @@ struct ChatQueryBuilderReasoningTests {
     }
 
     @Test @MainActor
-    func reasoningIsOmittedWithoutPreservedHistoryCapability() throws {
+    func reasoningIsOmittedForNonToolCallAssistantUnderToolCallOnlyPolicy() throws {
         let query = ChatQueryBuilder.buildQuery(
             modelId: "gpt-oss-120b",
             systemPrompt: "",

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -41,7 +41,7 @@ struct ChatQueryBuilderReasoningTests {
                     ])
                 )
             ],
-            requiresCompleteReasoningHistory: nil
+            reasoningHistoryPolicy: .none
         )
     }
 
@@ -59,7 +59,7 @@ struct ChatQueryBuilderReasoningTests {
                     disable: nil
                 )
             ],
-            requiresCompleteReasoningHistory: nil
+            reasoningHistoryPolicy: .toolCallOnly
         )
     }
 
@@ -83,7 +83,7 @@ struct ChatQueryBuilderReasoningTests {
                     ])
                 )
             ],
-            requiresCompleteReasoningHistory: nil
+            reasoningHistoryPolicy: .toolCallOnly
         )
     }
 
@@ -94,7 +94,7 @@ struct ChatQueryBuilderReasoningTests {
             defaultEnabled: nil,
             effortMap: nil,
             params: nil,
-            requiresCompleteReasoningHistory: true
+            reasoningHistoryPolicy: .all
         )
     }
 
@@ -122,11 +122,18 @@ struct ChatQueryBuilderReasoningTests {
         ))
     }
 
-    @Test func preservedHistoryCapabilityDecodesFromModelConfig() throws {
-        let data = Data(#"{"requiresCompleteReasoningHistory":true}"#.utf8)
+    @Test func reasoningHistoryPolicyDecodesFromModelConfig() throws {
+        let data = Data(#"{"reasoningHistoryPolicy":"tool-call-only"}"#.utf8)
         let config = try JSONDecoder().decode(ReasoningConfig.self, from: data)
 
-        #expect(config.requiresCompleteReasoningHistory == true)
+        #expect(config.reasoningHistoryPolicy == .toolCallOnly)
+    }
+
+    @Test func unknownReasoningHistoryPolicyFallsBackSafely() throws {
+        let data = Data(#"{"reasoningHistoryPolicy":"future-policy"}"#.utf8)
+        let config = try JSONDecoder().decode(ReasoningConfig.self, from: data)
+
+        #expect(config.reasoningHistoryPolicy == .none)
     }
 
     @Test func deepseekLowEffortMapsToHighInsideChatTemplateKwargs() {
@@ -323,11 +330,36 @@ struct ChatQueryBuilderReasoningTests {
                 Message(role: .assistant, content: "answer", thoughts: "reasoning")
             ],
             stream: false,
+            reasoningConfig: gptOssConfig(),
             genUIEnabled: false
         )
 
         let messages = try encodedMessages(from: query)
         #expect(messages.first?["reasoning_content"] == nil)
+    }
+
+    @Test @MainActor
+    func toolCallPolicyPreservesOnlyToolCallReasoning() throws {
+        var toolCallAssistant = Message(role: .assistant, content: "", thoughts: "keep this")
+        toolCallAssistant.toolCalls = [
+            GenUIToolCall(id: "call_1", name: "render_chart", arguments: "{}")
+        ]
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "gpt-oss-120b",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [
+                Message(role: .assistant, content: "ordinary", thoughts: "omit this"),
+                toolCallAssistant,
+            ],
+            stream: false,
+            reasoningConfig: gptOssConfig(),
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        #expect(messages.first?["reasoning_content"] == nil)
+        #expect(messages[1]["reasoning_content"] as? String == "keep this")
     }
 
     @Test @MainActor

--- a/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
+++ b/TinfoilChatTests/ChatQueryBuilderReasoningTests.swift
@@ -40,7 +40,8 @@ struct ChatQueryBuilderReasoningTests {
                         ])
                     ])
                 )
-            ]
+            ],
+            requiresCompleteReasoningHistory: nil
         )
     }
 
@@ -57,7 +58,8 @@ struct ChatQueryBuilderReasoningTests {
                     ]),
                     disable: nil
                 )
-            ]
+            ],
+            requiresCompleteReasoningHistory: nil
         )
     }
 
@@ -80,8 +82,51 @@ struct ChatQueryBuilderReasoningTests {
                         ])
                     ])
                 )
-            ]
+            ],
+            requiresCompleteReasoningHistory: nil
         )
+    }
+
+    private func preservedHistoryConfig() -> ReasoningConfig {
+        ReasoningConfig(
+            supportsEffort: nil,
+            supportsToggle: nil,
+            defaultEnabled: nil,
+            effortMap: nil,
+            params: nil,
+            requiresCompleteReasoningHistory: true
+        )
+    }
+
+    private func model(
+        id: String,
+        contextWindow: String = "256k tokens",
+        reasoningConfig: ReasoningConfig?
+    ) -> ModelType {
+        ModelType(from: AppModelConfig(
+            modelName: id,
+            image: "",
+            name: id,
+            nameShort: id,
+            description: "",
+            details: "",
+            parameters: "",
+            contextWindow: contextWindow,
+            type: "chat",
+            chat: true,
+            paid: true,
+            multimodal: false,
+            toolCalling: true,
+            attributes: ["smart"],
+            reasoningConfig: reasoningConfig
+        ))
+    }
+
+    @Test func preservedHistoryCapabilityDecodesFromModelConfig() throws {
+        let data = Data(#"{"requiresCompleteReasoningHistory":true}"#.utf8)
+        let config = try JSONDecoder().decode(ReasoningConfig.self, from: data)
+
+        #expect(config.requiresCompleteReasoningHistory == true)
     }
 
     @Test func deepseekLowEffortMapsToHighInsideChatTemplateKwargs() {
@@ -221,6 +266,101 @@ struct ChatQueryBuilderReasoningTests {
         #expect(messages.count == 1)
         #expect(messages.first?["role"] as? String == "user")
         #expect(messages.first?["content"] as? String == "hello")
+    }
+
+    @Test @MainActor
+    func preservedReasoningIsReturnedWithAssistantContentAndToolCalls() throws {
+        var assistant = Message(role: .assistant, content: "answer", thoughts: "reasoning")
+        assistant.toolCalls = [
+            GenUIToolCall(id: "call_1", name: "render_chart", arguments: "{\"value\":1}")
+        ]
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "kimi-k3",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [assistant],
+            stream: false,
+            reasoningConfig: preservedHistoryConfig(),
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        let encodedAssistant = try #require(messages.first)
+        #expect(encodedAssistant["role"] as? String == "assistant")
+        #expect(encodedAssistant["content"] as? String == "answer")
+        #expect(encodedAssistant["reasoning_content"] as? String == "reasoning")
+        #expect((encodedAssistant["tool_calls"] as? [[String: Any]])?.count == 1)
+        #expect(messages.last?["role"] as? String == "tool")
+    }
+
+    @Test @MainActor
+    func reasoningOnlyAssistantIsKeptWhenHistoryIsRequired() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "kimi-k3",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [
+                Message(role: .assistant, content: "", thoughts: "reasoning only")
+            ],
+            stream: false,
+            reasoningConfig: preservedHistoryConfig(),
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        #expect(messages.count == 1)
+        #expect(messages.first?["role"] as? String == "assistant")
+        #expect(messages.first?["reasoning_content"] as? String == "reasoning only")
+    }
+
+    @Test @MainActor
+    func reasoningIsOmittedWithoutPreservedHistoryCapability() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "gpt-oss-120b",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [
+                Message(role: .assistant, content: "answer", thoughts: "reasoning")
+            ],
+            stream: false,
+            genUIEnabled: false
+        )
+
+        let messages = try encodedMessages(from: query)
+        #expect(messages.first?["reasoning_content"] == nil)
+    }
+
+    @Test @MainActor
+    func autoPreservesReasoningWhenAnyCandidateRequiresIt() throws {
+        let query = ChatQueryBuilder.buildQuery(
+            modelId: "glm-5-2",
+            systemPrompt: "",
+            rules: "",
+            conversationMessages: [
+                Message(role: .assistant, content: "answer", thoughts: "reasoning")
+            ],
+            stream: false,
+            genUIEnabled: false,
+            autoCandidates: [
+                model(id: "glm-5-2", reasoningConfig: nil),
+                model(id: "kimi-k3", reasoningConfig: preservedHistoryConfig()),
+            ]
+        )
+
+        let messages = try encodedMessages(from: query)
+        #expect(messages.first?["reasoning_content"] as? String == "reasoning")
+    }
+
+    @Test func autoSelectionUsesTheSmallestCandidateContextWindow() {
+        let selection = ModelSelection(
+            representative: model(id: "large", contextWindow: "256k tokens", reasoningConfig: nil),
+            autoCandidates: [
+                model(id: "large", contextWindow: "256k tokens", reasoningConfig: nil),
+                model(id: "small", contextWindow: "128k tokens", reasoningConfig: nil),
+            ]
+        )
+
+        #expect(selection.contextWindow == "128k tokens")
     }
 
     private func encodedMessages(from query: ChatQuery) throws -> [[String: Any]] {

--- a/TinfoilChatTests/StreamingResponseProcessorTests.swift
+++ b/TinfoilChatTests/StreamingResponseProcessorTests.swift
@@ -103,6 +103,18 @@ struct StreamingThinkingSegmentTests {
         #expect(snapshot.segments[1] == .text("Answer."))
     }
 
+    @Test("reasoning_content is decoded into thinking state")
+    func reasoningContentIsDecoded() throws {
+        let processor = StreamingResponseProcessor(
+            isWebSearchEnabled: false,
+            hapticEnabled: false
+        )
+        let chunk = try decodeStreamChunk(delta: ["reasoning_content": "K3 thought."])
+        _ = processor.process(processor.parse(chunk))
+
+        #expect(processor.snapshot().thoughts == "K3 thought.")
+    }
+
     @Test("web search closes the open thinking round")
     func webSearchClosesThinking() throws {
         let processor = StreamingResponseProcessor(
@@ -160,6 +172,9 @@ struct StreamingThinkingSegmentTests {
         #expect(second == "Second round.")
         #expect(text == "Answer.")
         #expect(snapshot.thoughts == "First round.\n\nSecond round.")
+        var message = Message(role: .assistant, content: snapshot.responseContent, thoughts: snapshot.thoughts)
+        message.segments = snapshot.segments
+        #expect(message.reasoningContentForHistory == "First round.Second round.")
     }
 
     @Test("tool call deltas close the open thinking round")

--- a/TinfoilChatTests/TokenEstimationTests.swift
+++ b/TinfoilChatTests/TokenEstimationTests.swift
@@ -53,7 +53,7 @@ struct TokenEstimationTests {
         msg.thoughts = "abcdefgh"
 
         #expect(TokenEstimation.estimateMessageTokens(msg) == 1)
-        #expect(TokenEstimation.estimateMessageTokens(msg, includesReasoning: true) == 3)
+        #expect(TokenEstimation.estimateMessageTokens(msg, reasoningHistoryPolicy: .all) == 3)
     }
 
     @Test func derivesReasoningFromThinkingSegments() {
@@ -66,7 +66,17 @@ struct TokenEstimationTests {
         ]
 
         #expect(msg.reasoningContentForHistory == "first second")
-        #expect(TokenEstimation.estimateMessageTokens(msg, includesReasoning: true) == 3)
+        #expect(TokenEstimation.estimateMessageTokens(msg, reasoningHistoryPolicy: .all) == 3)
+    }
+
+    @Test func toolCallPolicyCountsOnlyToolCallReasoning() {
+        var ordinary = message(role: .assistant, content: "abcd")
+        ordinary.thoughts = "abcdefgh"
+        var toolCall = ordinary
+        toolCall.toolCalls = [GenUIToolCall(id: "call_1", name: "tool", arguments: "{}")]
+
+        #expect(TokenEstimation.estimateMessageTokens(ordinary, reasoningHistoryPolicy: .toolCallOnly) == 1)
+        #expect(TokenEstimation.estimateMessageTokens(toolCall, reasoningHistoryPolicy: .toolCallOnly) == 5)
     }
 
     @Test func archivesOldestMessagesBeyondBudget() {

--- a/TinfoilChatTests/TokenEstimationTests.swift
+++ b/TinfoilChatTests/TokenEstimationTests.swift
@@ -48,6 +48,27 @@ struct TokenEstimationTests {
         #expect(TokenEstimation.estimateMessageTokens(msg) == 5)
     }
 
+    @Test func includesReasoningOnlyWhenItWillBeSent() {
+        var msg = message(role: .assistant, content: "abcd")
+        msg.thoughts = "abcdefgh"
+
+        #expect(TokenEstimation.estimateMessageTokens(msg) == 1)
+        #expect(TokenEstimation.estimateMessageTokens(msg, includesReasoning: true) == 3)
+    }
+
+    @Test func derivesReasoningFromThinkingSegments() {
+        var msg = message(role: .assistant, content: "")
+        msg.thoughts = "first \n\nsecond"
+        msg.segments = [
+            .thinking(content: "first ", isThinking: false, duration: 1),
+            .webSearch(searchId: "search_1"),
+            .thinking(content: "second", isThinking: false, duration: 1),
+        ]
+
+        #expect(msg.reasoningContentForHistory == "first second")
+        #expect(TokenEstimation.estimateMessageTokens(msg, includesReasoning: true) == 3)
+    }
+
     @Test func archivesOldestMessagesBeyondBudget() {
         // Each message is 40 chars = 10 tokens
         let messages = (0..<5).map { _ in message(content: String(repeating: "a", count: 40)) }


### PR DESCRIPTION
## Summary
- decode `all`, `tool-call-only`, and `none` reasoning-history policies with a safe unknown-policy fallback
- use the strongest policy across possible Auto candidates
- preserve exact assistant reasoning according to each message's policy
- align request construction, token budgeting, and archive indicators

## Testing
- added query-builder, streaming-decoder, policy-decoding, and token-estimation regression tests
- not run locally; repository instructions require Xcode execution

## Related PRs
- tinfoilsh/controlplane#554
- tinfoilsh/confidential-model-router#454
- tinfoilsh/tinfoil-webapp#467