### PR TITLE
perf: stream responses before cloud synchronization

### DIFF
--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -726,6 +726,7 @@ actor ChatRecoveryCoordinator {
             return
         }
         var locallyRecoveredResponse: Message?
+        var generatedTitle: String?
         do {
             let initialStatus = try await ChatRecoveryClient.shared.status(
                 sessionId: payload.sessionId
@@ -993,7 +994,6 @@ actor ChatRecoveryCoordinator {
                     turnId: envelope.turnId
                 )
             }
-            var generatedTitle: String?
             if let titleMessages {
                 generatedTitle = await SummarizerService.shared.generateChatTitle(
                     from: titleMessages
@@ -1104,11 +1104,11 @@ actor ChatRecoveryCoordinator {
                         mutation: .complete(
                             envelope: envelope,
                             response: response,
-                            title: nil,
-                            titleState: nil
+                            title: generatedTitle,
+                            titleState: generatedTitle == nil ? nil : .generated
                         )
                     )
-                    guard await recoveryScanCanMutate(
+                    guard recoveryScanCompletionIsCurrent(
                         chatId: chatId,
                         turnId: envelope.turnId,
                         storage: storage,
@@ -1116,7 +1116,27 @@ actor ChatRecoveryCoordinator {
                         scanGeneration: scanGeneration,
                         userId: userId
                     ) else { return }
-                    await CloudSyncService.shared.backupChat(chatId)
+                    try await CloudSyncService.shared.backupRecoveryChatAndWait(
+                        chatId,
+                        allowWhileStreaming: true
+                    )
+                    guard recoveryScanCompletionIsCurrent(
+                        chatId: chatId,
+                        turnId: envelope.turnId,
+                        storage: storage,
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else { return }
+                    await deleteSessionAfterMutation(payload.sessionId)
+                    guard recoveryScanCompletionIsCurrent(
+                        chatId: chatId,
+                        turnId: envelope.turnId,
+                        storage: storage,
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else { return }
                     postRecoveryUpdate(
                         chatId: chatId,
                         userId: userId,
@@ -1454,6 +1474,22 @@ actor ChatRecoveryCoordinator {
               !(await isChatStreaming(chatId)) else {
             return false
         }
+        return scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ) && !cancelledTurns.contains(key)
+    }
+
+    private func recoveryScanCompletionIsCurrent(
+        chatId: String,
+        turnId: String,
+        storage: ChatRecoveryStorage,
+        accountGeneration: Int,
+        scanGeneration: Int,
+        userId: String
+    ) -> Bool {
+        let key = turnKey(chatId: chatId, turnId: turnId, storage: storage)
         return scanIsCurrent(
             accountGeneration: accountGeneration,
             scanGeneration: scanGeneration,

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -1120,14 +1120,6 @@ actor ChatRecoveryCoordinator {
                         chatId,
                         allowWhileStreaming: true
                     )
-                    guard recoveryScanCompletionIsCurrent(
-                        chatId: chatId,
-                        turnId: envelope.turnId,
-                        storage: storage,
-                        accountGeneration: accountGeneration,
-                        scanGeneration: scanGeneration,
-                        userId: userId
-                    ) else { return }
                     await deleteSessionAfterMutation(payload.sessionId)
                     guard recoveryScanCompletionIsCurrent(
                         chatId: chatId,

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -223,18 +223,14 @@ actor ChatRecoveryCoordinator {
         )
     }
 
-    func register(
+    func registerLocally(
         attempt: ChatRecoveryAttempt,
         token: ChatRecoveryTokenPayload
-    ) async throws -> PendingRecoveryEnvelope {
-        let key = turnKey(
-            chatId: attempt.chatId,
-            turnId: attempt.turnId,
-            storage: attempt.storage
-        )
-        if cancelledTurns.contains(key)
-            || attempt.generation != accountGeneration
-            || activeAccountId != attempt.userId {
+    ) async throws -> (
+        envelope: PendingRecoveryEnvelope,
+        metadata: ChatRecoveryLocalMutationResult
+    ) {
+        guard liveAttemptIsCurrent(attempt) else {
             try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             throw CancellationError()
         }
@@ -256,101 +252,86 @@ actor ChatRecoveryCoordinator {
                 recoveryToken: token
             )
         } catch {
-            Task {
-                try? await ChatRecoveryClient.shared.delete(
-                    sessionId: attempt.sessionId
-                )
-            }
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             throw error
         }
+        let metadata: ChatRecoveryLocalMutationResult
         do {
-            try await ChatRecoverySync.shared.mutate(
+            metadata = try await ChatRecoverySync.shared.mutateLocally(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
                 storage: attempt.storage,
                 mutation: .add(envelope)
             )
         } catch {
-            if registrationFailureDefinitelyDidNotPersist(error) {
-                Task {
-                    try? await ChatRecoveryClient.shared.delete(
-                        sessionId: attempt.sessionId
-                    )
-                }
+            let containsEnvelope = try? await attempt.storage.fileStorage.containsPendingRecovery(
+                chatId: attempt.chatId,
+                userId: attempt.userId,
+                envelope: envelope
+            )
+            if containsEnvelope == false {
+                try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             }
             throw error
         }
-        if cancelledTurns.contains(key)
-            || attempt.generation != accountGeneration
-            || activeAccountId != attempt.userId {
-            await cancel(attempt: attempt)
+        guard liveAttemptIsCurrent(attempt) else {
+            let cancelled = await cancelLocally(attempt: attempt, response: nil)
+            if cancelled != nil, attempt.storage == .cloud {
+                await CloudSyncService.shared.backupChat(
+                    attempt.chatId,
+                    allowWhileStreaming: true
+                )
+            }
             throw CancellationError()
         }
-        return envelope
+        return (envelope, metadata)
     }
 
-    func complete(
+    func completeLocally(
         attempt: ChatRecoveryAttempt,
         envelope: PendingRecoveryEnvelope,
         response: Message,
-        title: String? = nil,
-        titleState: Chat.TitleState? = nil
-    ) async throws {
-        let key = turnKey(
-            chatId: attempt.chatId,
-            turnId: attempt.turnId,
-            storage: attempt.storage
-        )
-        guard !cancelledTurns.contains(key),
-              attempt.generation == accountGeneration,
-              activeAccountId == attempt.userId
-        else {
-            await cancel(attempt: attempt)
+        title: String?,
+        titleState: Chat.TitleState?
+    ) async throws -> ChatRecoveryLocalMutationResult {
+        guard liveAttemptIsCurrent(attempt) else {
+            let cancelled = await cancelLocally(attempt: attempt, response: response)
+            if cancelled != nil, attempt.storage == .cloud {
+                await CloudSyncService.shared.backupChat(
+                    attempt.chatId,
+                    allowWhileStreaming: true
+                )
+            }
             throw CancellationError()
         }
-        do {
-            try await ChatRecoverySync.shared.mutate(
-                chatId: attempt.chatId,
-                userId: attempt.userId,
-                storage: attempt.storage,
-                mutation: .complete(
-                    envelope: envelope,
-                    response: response,
-                    title: title,
-                    titleState: titleState
-                )
+        let metadata = try await ChatRecoverySync.shared.mutateLocally(
+            chatId: attempt.chatId,
+            userId: attempt.userId,
+            storage: attempt.storage,
+            mutation: .complete(
+                envelope: envelope,
+                response: response,
+                title: title,
+                titleState: titleState
             )
-            await MainActor.run {
-                ChatRecoveryDraftStore.shared.clear(
-                    chatId: attempt.chatId,
-                    turnId: attempt.turnId
-                )
-            }
-            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-        } catch ChatRecoverySyncError.envelopeMissing {
-            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-            if attempt.storage == .cloud {
-                try await ChatRecoverySync.shared.refreshFromRemote(
-                    chatId: attempt.chatId,
-                    userId: attempt.userId
-                )
-            }
-            postRecoveryUpdate(
+        )
+        await MainActor.run {
+            ChatRecoveryDraftStore.shared.clear(
                 chatId: attempt.chatId,
-                userId: attempt.userId,
-                storage: attempt.storage
+                turnId: attempt.turnId
             )
-        } catch {
-            throw error
         }
+        if attempt.storage == .local {
+            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
+        }
+        return metadata
     }
 
-    func cancel(attempt: ChatRecoveryAttempt, response: Message? = nil) async {
-        cancelledTurns.insert(turnKey(
-            chatId: attempt.chatId,
-            turnId: attempt.turnId,
-            storage: attempt.storage
-        ))
+    func cancelLocally(
+        attempt: ChatRecoveryAttempt,
+        response: Message?
+    ) async -> ChatRecoveryLocalMutationResult? {
+        markCancelled(attempt: attempt)
         let shouldClearPhase = !hasActiveRecovery(turnId: attempt.turnId)
         await MainActor.run {
             if shouldClearPhase {
@@ -362,30 +343,42 @@ actor ChatRecoveryCoordinator {
             )
         }
         do {
-            try await ChatRecoverySync.shared.mutate(
+            let metadata = try await ChatRecoverySync.shared.mutateLocally(
                 chatId: attempt.chatId,
                 userId: attempt.userId,
                 storage: attempt.storage,
                 mutation: .cancel(turnId: attempt.turnId, response: response)
             )
-            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-        } catch ChatRecoverySyncError.envelopeMissing {
-            if attempt.storage == .cloud {
-                try? await ChatRecoverySync.shared.refreshFromRemote(
-                    chatId: attempt.chatId,
-                    userId: attempt.userId
-                )
+            if attempt.storage == .local {
+                try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
             }
-            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-            postRecoveryUpdate(
-                chatId: attempt.chatId,
-                userId: attempt.userId,
-                storage: attempt.storage
-            )
+            return metadata
         } catch {
-            try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
-            return
+            return nil
         }
+    }
+
+    func markCancelled(attempt: ChatRecoveryAttempt) {
+        cancelledTurns.insert(turnKey(
+            chatId: attempt.chatId,
+            turnId: attempt.turnId,
+            storage: attempt.storage
+        ))
+    }
+
+    func liveAttemptIsCurrent(_ attempt: ChatRecoveryAttempt) -> Bool {
+        let key = turnKey(
+            chatId: attempt.chatId,
+            turnId: attempt.turnId,
+            storage: attempt.storage
+        )
+        return !cancelledTurns.contains(key)
+            && attempt.generation == accountGeneration
+            && activeAccountId == attempt.userId
+    }
+
+    func deleteSession(attempt: ChatRecoveryAttempt) async {
+        try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
     }
 
     func cancelRecoveredTurn(
@@ -434,15 +427,16 @@ actor ChatRecoveryCoordinator {
             )
         } catch ChatRecoverySyncError.envelopeMissing {
             if storage == .cloud {
-                try? await ChatRecoverySync.shared.refreshFromRemote(
-                    chatId: chatId,
-                    userId: userId
-                )
+                do {
+                    try await ChatRecoverySync.shared.refreshFromRemote(
+                        chatId: chatId,
+                        userId: userId
+                    )
+                } catch {
+                    return
+                }
             }
         } catch {
-            if let sessionId {
-                try? await ChatRecoveryClient.shared.delete(sessionId: sessionId)
-            }
             return
         }
         if let sessionId {
@@ -453,10 +447,6 @@ actor ChatRecoveryCoordinator {
             userId: userId,
             storage: storage
         )
-    }
-
-    func deleteSession(attempt: ChatRecoveryAttempt) async {
-        try? await ChatRecoveryClient.shared.delete(sessionId: attempt.sessionId)
     }
 
     func scan(
@@ -735,6 +725,7 @@ actor ChatRecoveryCoordinator {
         ) else {
             return
         }
+        var locallyRecoveredResponse: Message?
         do {
             let initialStatus = try await ChatRecoveryClient.shared.status(
                 sessionId: payload.sessionId
@@ -979,6 +970,7 @@ actor ChatRecoveryCoordinator {
             }
             guard let response else { return }
             let persistedResponse = recoveredResponseForPersistence(response)
+            locallyRecoveredResponse = persistedResponse
             guard scanIsCurrent(
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
@@ -1046,7 +1038,10 @@ actor ChatRecoveryCoordinator {
             }
             await deleteSessionAfterMutation(payload.sessionId)
         } catch ChatRecoverySyncError.envelopeMissing {
-            guard scanIsCurrent(
+            guard await recoveryScanCanMutate(
+                chatId: chatId,
+                turnId: envelope.turnId,
+                storage: storage,
                 accountGeneration: accountGeneration,
                 scanGeneration: scanGeneration,
                 userId: userId
@@ -1054,10 +1049,83 @@ actor ChatRecoveryCoordinator {
                 return
             }
             if storage == .cloud {
-                try? await ChatRecoverySync.shared.refreshFromRemote(
+                let reconciled = try? await ChatRecoverySync.shared.reconcileResolvedTurnFromRemote(
                     chatId: chatId,
-                    userId: userId
+                    turnId: envelope.turnId,
+                    userId: userId,
+                    isCurrent: {
+                        await self.recoveryScanCanMutate(
+                            chatId: chatId,
+                            turnId: envelope.turnId,
+                            storage: storage,
+                            accountGeneration: accountGeneration,
+                            scanGeneration: scanGeneration,
+                            userId: userId
+                        )
+                    }
                 )
+                guard await recoveryScanCanMutate(
+                    chatId: chatId,
+                    turnId: envelope.turnId,
+                    storage: storage,
+                    accountGeneration: accountGeneration,
+                    scanGeneration: scanGeneration,
+                    userId: userId
+                ) else { return }
+                if reconciled == true {
+                    try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
+                    postRecoveryUpdate(
+                        chatId: chatId,
+                        userId: userId,
+                        storage: storage
+                    )
+                    return
+                }
+                guard let response = locallyRecoveredResponse else { return }
+                let containsEnvelope = try? await storage.fileStorage.containsPendingRecovery(
+                    chatId: chatId,
+                    userId: userId,
+                    envelope: envelope
+                )
+                guard containsEnvelope == true,
+                      await recoveryScanCanMutate(
+                          chatId: chatId,
+                          turnId: envelope.turnId,
+                          storage: storage,
+                          accountGeneration: accountGeneration,
+                          scanGeneration: scanGeneration,
+                          userId: userId
+                      ) else { return }
+                do {
+                    _ = try await ChatRecoverySync.shared.mutateLocally(
+                        chatId: chatId,
+                        userId: userId,
+                        storage: storage,
+                        mutation: .complete(
+                            envelope: envelope,
+                            response: response,
+                            title: nil,
+                            titleState: nil
+                        )
+                    )
+                    guard await recoveryScanCanMutate(
+                        chatId: chatId,
+                        turnId: envelope.turnId,
+                        storage: storage,
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId
+                    ) else { return }
+                    await CloudSyncService.shared.backupChat(chatId)
+                    postRecoveryUpdate(
+                        chatId: chatId,
+                        userId: userId,
+                        storage: storage
+                    )
+                } catch {
+                    return
+                }
+                return
             }
             try? await ChatRecoveryClient.shared.delete(sessionId: payload.sessionId)
             postRecoveryUpdate(
@@ -1366,6 +1434,31 @@ actor ChatRecoveryCoordinator {
                 userId: userId
             )
             && scanGeneration == self.scanGeneration
+    }
+
+    private func recoveryScanCanMutate(
+        chatId: String,
+        turnId: String,
+        storage: ChatRecoveryStorage,
+        accountGeneration: Int,
+        scanGeneration: Int,
+        userId: String
+    ) async -> Bool {
+        let key = turnKey(chatId: chatId, turnId: turnId, storage: storage)
+        guard scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ),
+              !cancelledTurns.contains(key),
+              !(await isChatStreaming(chatId)) else {
+            return false
+        }
+        return scanIsCurrent(
+            accountGeneration: accountGeneration,
+            scanGeneration: scanGeneration,
+            userId: userId
+        ) && !cancelledTurns.contains(key)
     }
 
     private func accountIsCurrent(

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -8,6 +8,46 @@ enum ChatRecoverySyncError: Error {
     case conflict
 }
 
+struct ChatRecoveryLocalMutationResult: Sendable {
+    let clock: Int?
+    let writer: String?
+    let clockVersion: Int?
+    let updatedAt: Date
+    let locallyModified: Bool
+}
+
+func remoteRecoveryTurnIsResolved(
+    messages: [Message],
+    pendingRecoveries: [PendingRecoveryEnvelope]?,
+    turnId: String
+) -> Bool {
+    guard pendingRecoveries?.contains(where: { $0.turnId == turnId }) != true else {
+        return false
+    }
+    return messages.contains {
+        $0.role == .assistant
+            && $0.turnId == turnId
+            && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+func resolvedRemoteMayReplaceLocal(
+    localModified: Bool,
+    localClock: EditClock?,
+    remoteClock: EditClock?,
+    localUpdatedAt: Date,
+    remoteUpdatedAt: Date
+) -> Bool {
+    guard localModified else { return true }
+    guard let localClock, let remoteClock else { return false }
+    return SyncConflictResolver.remoteWins(
+        localClock: localClock,
+        remoteClock: remoteClock,
+        localUpdatedAt: localUpdatedAt,
+        remoteUpdatedAt: remoteUpdatedAt
+    )
+}
+
 enum ChatRecoveryStorage: String, Sendable {
     case cloud
     case local
@@ -51,7 +91,7 @@ actor ChatRecoverySync {
     ) async throws {
         try Task.checkCancellation()
         if storage == .local {
-            try await mutateLocal(
+            _ = try await mutateLocal(
                 chatId: chatId,
                 userId: userId,
                 mutation: mutation
@@ -124,11 +164,63 @@ actor ChatRecoverySync {
         throw lastError
     }
 
+    func mutateLocally(
+        chatId: String,
+        userId: String,
+        storage: ChatRecoveryStorage,
+        mutation: Mutation
+    ) async throws -> ChatRecoveryLocalMutationResult {
+        if storage == .local {
+            return try await mutateLocal(
+                chatId: chatId,
+                userId: userId,
+                mutation: mutation
+            )
+        }
+
+        for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
+            try Task.checkCancellation()
+            guard await Clerk.shared.user?.id == userId,
+                  let local = try await EncryptedFileStorage.cloud.loadChat(
+                      chatId: chatId,
+                      userId: userId
+                  ) else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            var candidate = local
+            try apply(mutation, to: &candidate, authoritativeRemote: local)
+            stampEdit(&candidate, observedRemote: local)
+            candidate.locallyModified = true
+            guard await Clerk.shared.user?.id == userId else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            if try await EncryptedFileStorage.cloud.applyRemoteChatIfFresh(
+                candidate,
+                userId: userId,
+                expectedLocalUpdatedAt: local.updatedAt,
+                allowLocallyModified: true
+            ) {
+                return localResult(candidate)
+            }
+        }
+        throw ChatRecoverySyncError.conflict
+    }
+
+    private func localResult(_ chat: Chat) -> ChatRecoveryLocalMutationResult {
+        ChatRecoveryLocalMutationResult(
+            clock: chat.clock,
+            writer: chat.writer,
+            clockVersion: chat.clockVersion,
+            updatedAt: chat.updatedAt,
+            locallyModified: chat.locallyModified
+        )
+    }
+
     private func mutateLocal(
         chatId: String,
         userId: String,
         mutation: Mutation
-    ) async throws {
+    ) async throws -> ChatRecoveryLocalMutationResult {
         for _ in 0..<Constants.ChatRecovery.maxMutationAttempts {
             try Task.checkCancellation()
             guard await Clerk.shared.user?.id == userId,
@@ -154,7 +246,7 @@ actor ChatRecoverySync {
                 expectedLocalUpdatedAt: local.updatedAt,
                 allowLocallyModified: true
             ) {
-                return
+                return localResult(candidate)
             }
         }
         throw ChatRecoverySyncError.conflict
@@ -191,6 +283,51 @@ actor ChatRecoverySync {
             }
         }
         throw ChatRecoverySyncError.conflict
+    }
+
+    func reconcileResolvedTurnFromRemote(
+        chatId: String,
+        turnId: String,
+        userId: String,
+        isCurrent: @escaping @Sendable () async -> Bool
+    ) async throws -> Bool {
+        guard await Clerk.shared.user?.id == userId else { return false }
+        guard let remote = try await CloudStorageService.shared.downloadChat(chatId),
+              await isCurrent() else { return false }
+        guard var remoteChat = await MainActor.run(body: { remote.toChat() }),
+              await isCurrent(),
+              remoteRecoveryTurnIsResolved(
+                  messages: remoteChat.messages,
+                  pendingRecoveries: remoteChat.pendingRecoveries,
+                  turnId: turnId
+              ) else {
+            return false
+        }
+        let local = try await EncryptedFileStorage.cloud.loadChat(
+            chatId: chatId,
+            userId: userId
+        )
+        guard await isCurrent() else { return false }
+        if let local,
+           !resolvedRemoteMayReplaceLocal(
+               localModified: local.locallyModified,
+               localClock: trustedClock(local),
+               remoteClock: trustedClock(remoteChat),
+               localUpdatedAt: local.updatedAt,
+               remoteUpdatedAt: remoteChat.updatedAt
+           ) {
+            return false
+        }
+        guard await Clerk.shared.user?.id == userId,
+              await isCurrent() else { return false }
+        remoteChat.syncedAt = Date()
+        remoteChat.locallyModified = false
+        return try await EncryptedFileStorage.cloud.applyRemoteChatIfFresh(
+            remoteChat,
+            userId: userId,
+            expectedLocalUpdatedAt: local?.updatedAt,
+            allowLocallyModified: true
+        )
     }
 
     private func preferredBase(local: Chat?, remote: Chat) -> Chat {

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -48,6 +48,18 @@ func resolvedRemoteMayReplaceLocal(
     )
 }
 
+func mutateValidCloudRecoveryChat(
+    _ chat: Chat,
+    mutation: (inout Chat) throws -> Void
+) throws -> Chat {
+    guard !chat.decryptionFailed, !chat.dataCorrupted else {
+        throw ChatRecoverySyncError.chatMissing
+    }
+    var candidate = chat
+    try mutation(&candidate)
+    return candidate
+}
+
 enum ChatRecoveryStorage: String, Sendable {
     case cloud
     case local
@@ -187,8 +199,9 @@ actor ChatRecoverySync {
                   ) else {
                 throw ChatRecoverySyncError.chatMissing
             }
-            var candidate = local
-            try apply(mutation, to: &candidate, authoritativeRemote: local)
+            var candidate = try mutateValidCloudRecoveryChat(local) {
+                try apply(mutation, to: &$0, authoritativeRemote: local)
+            }
             stampEdit(&candidate, observedRemote: local)
             candidate.locallyModified = true
             guard await Clerk.shared.user?.id == userId else {
@@ -295,6 +308,8 @@ actor ChatRecoverySync {
         guard let remote = try await CloudStorageService.shared.downloadChat(chatId),
               await isCurrent() else { return false }
         guard var remoteChat = await MainActor.run(body: { remote.toChat() }),
+              !remoteChat.decryptionFailed,
+              !remoteChat.dataCorrupted,
               await isCurrent(),
               remoteRecoveryTurnIsResolved(
                   messages: remoteChat.messages,
@@ -474,6 +489,10 @@ actor ChatRecoverySync {
                 chatId: uploaded.id,
                 userId: userId
             )
+            guard loaded?.decryptionFailed != true,
+                  loaded?.dataCorrupted != true else {
+                return
+            }
             let expectedUpdatedAt = loaded?.updatedAt
             var candidate: Chat
             if loaded?.updatedAt == expectedBaselineUpdatedAt {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1040,7 +1040,8 @@ class CloudSyncService: ObservableObject {
         // Filter out blank, empty, decryption failure, and streaming chats
         var chatsToSync: [Chat] = []
         for chat in unsyncedChats {
-            if !chat.isBlankChat && !chat.messages.isEmpty && !chat.decryptionFailed {
+            if !chat.isBlankChat && !chat.messages.isEmpty
+                && !chat.decryptionFailed && !chat.dataCorrupted {
                 let isStreaming = streamingTracker.isStreaming(chat.id)
                 if !isStreaming {
                     chatsToSync.append(chat)
@@ -2214,6 +2215,7 @@ class CloudSyncService: ObservableObject {
             guard !chat.isBlankChat,
                   !chat.messages.isEmpty,
                   !chat.decryptionFailed,
+                  !chat.dataCorrupted,
                   !streamingTracker.isStreaming(chat.id) else {
                 continue
             }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -41,10 +41,21 @@ private func parseISODate(_ dateString: String) -> Date? {
 /// snapshot and returns this closure; every retry replays it, so the
 /// bytes pushed to the enclave are identical across attempts and the
 /// enclave can de-duplicate them into a single committed effect.
-typealias UploadAttempt = @MainActor @Sendable () async throws -> Void
+enum UploadAttemptOutcome: Equatable {
+    case noUpload
+    case uploaded
+}
+
+typealias UploadAttempt = @MainActor @Sendable () async throws -> UploadAttemptOutcome
 
 enum UploadCoalescerError: Error {
     case requiredUploadNotPrepared
+}
+
+private enum UploadIterationOutcome {
+    case noWork
+    case uploaded
+    case failed(Error)
 }
 
 /// Coalesces rapid upload requests per chat into single uploads with exponential backoff retry.
@@ -138,13 +149,18 @@ actor UploadCoalescer {
             // committed effect, even when a previous attempt
             // already committed and we lost the response.
             let idempotencyKey = newSyncEnclaveIdempotencyKey()
-            let iterationError = await uploadWithRetry(
+            let iterationOutcome = await uploadWithRetry(
                 chatId,
                 idempotencyKey: idempotencyKey,
                 allowWhileStreaming: allowWhileStreaming,
                 generation: workerGeneration
             )
-            if let iterationError {
+            switch iterationOutcome {
+            case .noWork:
+                break
+            case .uploaded:
+                terminalError = nil
+            case .failed(let iterationError):
                 terminalError = iterationError
             }
         }
@@ -180,7 +196,7 @@ actor UploadCoalescer {
         idempotencyKey: String,
         allowWhileStreaming: Bool,
         generation workerGeneration: Int
-    ) async -> Error? {
+    ) async -> UploadIterationOutcome {
         var lastError: Error?
         // Frozen on the first successful prepare so every retry replays
         // the exact payload the enclave may have already committed. Only
@@ -200,23 +216,21 @@ actor UploadCoalescer {
                     )
                     prepared = true
                     guard workerGeneration == generation else {
-                        return CancellationError()
+                        return .failed(CancellationError())
                     }
                 }
                 if allowWhileStreaming && preparedAttempt == nil {
                     throw UploadCoalescerError.requiredUploadNotPrepared
                 }
-                if let uploadAttempt = preparedAttempt {
-                    try await uploadAttempt()
-                }
+                let attemptOutcome = try await preparedAttempt?()
                 guard workerGeneration == generation else {
-                    return CancellationError()
+                    return .failed(CancellationError())
                 }
                 states[chatId]?.failureCount = 0
-                return nil
+                return attemptOutcome == .uploaded ? .uploaded : .noWork
             } catch {
                 guard workerGeneration == generation else {
-                    return CancellationError()
+                    return .failed(CancellationError())
                 }
                 lastError = error
                 let currentCount = states[chatId]?.failureCount ?? 0
@@ -232,12 +246,12 @@ actor UploadCoalescer {
                     break
                 }
                 guard workerGeneration == generation else {
-                    return CancellationError()
+                    return .failed(CancellationError())
                 }
             }
         }
 
-        return lastError
+        return .failed(lastError ?? UploadCoalescerError.requiredUploadNotPrepared)
     }
 
     func clear() {
@@ -708,7 +722,8 @@ class CloudSyncService: ObservableObject {
         // Don't sync blank, empty, decryption-failure, or local-only chats.
         // Local-only chats are the user's explicit choice to keep a chat off
         // the cloud, so they must never be uploaded.
-        if chat.isBlankChat || chat.messages.isEmpty || chat.decryptionFailed || chat.isLocalOnly {
+        if chat.isBlankChat || chat.messages.isEmpty || chat.decryptionFailed
+            || chat.dataCorrupted || chat.isLocalOnly {
             if allowWhileStreaming {
                 throw UploadCoalescerError.requiredUploadNotPrepared
             }
@@ -734,19 +749,22 @@ class CloudSyncService: ObservableObject {
             }
             do {
                 try await self.uploadAndMarkSynced(preparedUpload)
+                return .uploaded
             } catch {
                 guard await self.isCurrentUploadAccount(preparedUpload.account) else {
                     throw CancellationError()
                 }
-                if allowWhileStreaming {
-                    throw error
-                }
-                try await self.handleUploadFailure(
+                let reconciledUpload = try await self.handleUploadFailure(
                     chatId: chatId,
                     error: error,
                     generation: preparedUpload.account.generation,
-                    userId: preparedUpload.account.userId
+                    userId: preparedUpload.account.userId,
+                    allowWhileStreaming: allowWhileStreaming
                 )
+                if allowWhileStreaming && !reconciledUpload {
+                    throw error
+                }
+                return reconciledUpload ? .uploaded : .noUpload
             }
         }
     }
@@ -763,8 +781,9 @@ class CloudSyncService: ObservableObject {
         chatId: String,
         error: Error,
         generation: Int,
-        userId: String
-    ) async throws {
+        userId: String,
+        allowWhileStreaming: Bool
+    ) async throws -> Bool {
         let decision = EnclaveErrorRecovery.decide(error)
         switch decision.action {
         case .retry:
@@ -775,26 +794,27 @@ class CloudSyncService: ObservableObject {
             SyncHealthStore.shared.reportKeyActionRequired(.keyMismatch)
             throw error
         case .surfaceConflict:
-            try await resolveConflictByPullingRemote(
+            return try await resolveConflictByPullingRemote(
                 chatId,
                 generation: generation,
-                userId: userId
+                userId: userId,
+                allowWhileStreaming: allowWhileStreaming
             )
         case .surfaceExistingDataUnderOtherKey:
             SyncHealthStore.shared.reportKeyActionRequired(.keyConflict)
-            return
+            return false
         case .surfaceNotFound:
             SyncHealthStore.shared.reportChatSyncFailed(
                 chatId,
                 message: "This chat no longer exists in the cloud"
             )
-            return
+            return false
         case .triggerRecoveryWizard:
             SyncHealthStore.shared.reportKeyActionRequired(.keyRecovery)
-            return
+            return false
         case .blockAllSync:
             SyncHealthStore.shared.reportSyncPaused(.attestation)
-            return
+            return false
         case .migrateLegacyAndRetry:
             // The legacy re-seal runs out of band — on the next launch and right
             // after the key is adopted (see PasskeyManager) — both
@@ -813,7 +833,7 @@ class CloudSyncService: ObservableObject {
                     message: "This chat couldn't be synced"
                 )
             }
-            return
+            return false
         }
     }
 
@@ -840,17 +860,18 @@ class CloudSyncService: ObservableObject {
     private func resolveConflictByPullingRemote(
         _ chatId: String,
         generation: Int,
-        userId: String
-    ) async throws {
+        userId: String,
+        allowWhileStreaming: Bool
+    ) async throws -> Bool {
         do {
             let remoteChat = try await cloudStorage.downloadChat(chatId)
-            guard generation == accountGeneration else { return }
+            guard generation == accountGeneration else { return false }
 
             let localChat = try await EncryptedFileStorage.cloud.loadChat(
                 chatId: chatId,
                 userId: userId
             )
-            guard generation == accountGeneration else { return }
+            guard generation == accountGeneration else { return false }
 
             // The remote row vanished (concurrent delete). A clean local
             // copy is removed by the deletion reconciliation pass. A
@@ -865,8 +886,10 @@ class CloudSyncService: ObservableObject {
                 guard let localChat,
                       localChat.locallyModified,
                       !localChat.isLocalOnly,
+                      !localChat.decryptionFailed,
+                      !localChat.dataCorrupted,
                       !deletedChatsTracker.isDeleted(chatId) else {
-                    return
+                    return false
                 }
                 // The row may have been tombstoned after the last pass
                 // fetched its deletion window, in which case the tracker
@@ -879,19 +902,23 @@ class CloudSyncService: ObservableObject {
                     generation: generation,
                     userId: userId
                 )
-                guard generation == accountGeneration else { return }
+                guard generation == accountGeneration else { return false }
                 guard !deletions.failed,
                       !deletedChatsTracker.isDeleted(chatId) else {
-                    return
+                    return false
                 }
+                let storedChat = StoredChat(
+                    from: localChat,
+                    syncVersion: localChat.syncVersion
+                )
                 try await uploadAndMarkSynced(
-                    localChat,
+                    storedChat,
+                    expectedUpdatedAt: localChat.updatedAt,
                     idempotencyKey: newSyncEnclaveIdempotencyKey(),
-                    generation: generation,
-                    userId: userId,
+                    account: UploadAccount(generation: generation, userId: userId),
                     restoreDeleted: true
                 )
-                return
+                return true
             }
             if downloadedChat.modelType == nil {
                 downloadedChat.modelType = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first
@@ -930,22 +957,25 @@ class CloudSyncService: ObservableObject {
             )
 
             if !remoteWins {
-                guard generation == accountGeneration else { return }
+                guard generation == accountGeneration else { return false }
                 try await rebaseSyncVersion(
                     chatId,
                     version: downloadedChat.syncVersion,
                     generation: generation,
                     userId: userId
                 )
-                guard generation == accountGeneration else { return }
+                guard generation == accountGeneration else { return false }
                 // Re-enqueue rather than wait: the coalescer worker will
                 // pick up the dirty flag and re-run the upload with the
                 // rebased version.
-                await backupChat(chatId)
-                return
+                await backupChat(
+                    chatId,
+                    allowWhileStreaming: allowWhileStreaming
+                )
+                return false
             }
 
-            guard generation == accountGeneration else { return }
+            guard generation == accountGeneration else { return false }
             downloadedChat.syncedAt = Date()
             downloadedChat.locallyModified = false
             let applied = await applyRemoteChatToStorage(
@@ -958,6 +988,7 @@ class CloudSyncService: ObservableObject {
             if applied {
                 SyncHealthStore.shared.reportChatSynced(downloadedChat.id)
             }
+            return false
         } catch {
             SyncHealthStore.shared.reportChatSyncFailed(
                 chatId,

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -43,6 +43,10 @@ private func parseISODate(_ dateString: String) -> Date? {
 /// enclave can de-duplicate them into a single committed effect.
 typealias UploadAttempt = @MainActor @Sendable () async throws -> Void
 
+enum UploadCoalescerError: Error {
+    case requiredUploadNotPrepared
+}
+
 /// Coalesces rapid upload requests per chat into single uploads with exponential backoff retry.
 /// Uses a dirty-flag + worker-loop pattern to batch rapid successive writes.
 ///
@@ -57,6 +61,7 @@ typealias UploadAttempt = @MainActor @Sendable () async throws -> Void
 actor UploadCoalescer {
     private struct ChatUploadState {
         var dirty: Bool = false
+        var allowWhileStreaming: Bool = false
         var workerRunning: Bool = false
         var failureCount: Int = 0
         var waiters: [CheckedContinuation<Void, Never>] = []
@@ -65,11 +70,11 @@ actor UploadCoalescer {
 
     private var states: [String: ChatUploadState] = [:]
     private var generation = 0
-    private let prepareUpload: @Sendable (String, String) async throws -> UploadAttempt?
+    private let prepareUpload: @Sendable (String, String, Bool) async throws -> UploadAttempt?
     private let waitBeforeRetry: @Sendable (Int) async -> Void
 
     init(
-        prepareUpload: @escaping @Sendable (String, String) async throws -> UploadAttempt?,
+        prepareUpload: @escaping @Sendable (String, String, Bool) async throws -> UploadAttempt?,
         waitBeforeRetry: @escaping @Sendable (Int) async -> Void = { attempt in
             let delay = min(
                 Constants.Sync.uploadBaseDelaySeconds * pow(2.0, Double(attempt)),
@@ -82,9 +87,10 @@ actor UploadCoalescer {
         self.waitBeforeRetry = waitBeforeRetry
     }
 
-    func enqueue(_ chatId: String) {
+    func enqueue(_ chatId: String, allowWhileStreaming: Bool = false) {
         var state = states[chatId] ?? ChatUploadState()
         state.dirty = true
+        state.allowWhileStreaming = state.allowWhileStreaming || allowWhileStreaming
         states[chatId] = state
 
         if !state.workerRunning {
@@ -102,8 +108,11 @@ actor UploadCoalescer {
         }
     }
 
-    func enqueueAndWait(_ chatId: String) async throws {
-        enqueue(chatId)
+    func enqueueAndWait(
+        _ chatId: String,
+        allowWhileStreaming: Bool = false
+    ) async throws {
+        enqueue(chatId, allowWhileStreaming: allowWhileStreaming)
 
         guard let state = states[chatId], state.workerRunning || state.dirty else {
             return
@@ -120,6 +129,8 @@ actor UploadCoalescer {
 
         while states[chatId]?.dirty == true && workerGeneration == generation {
             states[chatId]?.dirty = false
+            let allowWhileStreaming = states[chatId]?.allowWhileStreaming ?? false
+            states[chatId]?.allowWhileStreaming = false
 
             // Mint one idempotency key per logical write. All HTTP
             // retries inside uploadWithRetry replay under the same
@@ -127,11 +138,15 @@ actor UploadCoalescer {
             // committed effect, even when a previous attempt
             // already committed and we lost the response.
             let idempotencyKey = newSyncEnclaveIdempotencyKey()
-            terminalError = await uploadWithRetry(
+            let iterationError = await uploadWithRetry(
                 chatId,
                 idempotencyKey: idempotencyKey,
+                allowWhileStreaming: allowWhileStreaming,
                 generation: workerGeneration
             )
+            if let iterationError {
+                terminalError = iterationError
+            }
         }
         guard workerGeneration == generation else { return }
 
@@ -163,6 +178,7 @@ actor UploadCoalescer {
     private func uploadWithRetry(
         _ chatId: String,
         idempotencyKey: String,
+        allowWhileStreaming: Bool,
         generation workerGeneration: Int
     ) async -> Error? {
         var lastError: Error?
@@ -177,11 +193,18 @@ actor UploadCoalescer {
         for attempt in 0...Constants.Sync.uploadMaxRetries {
             do {
                 if !prepared {
-                    preparedAttempt = try await prepareUpload(chatId, idempotencyKey)
+                    preparedAttempt = try await prepareUpload(
+                        chatId,
+                        idempotencyKey,
+                        allowWhileStreaming
+                    )
                     prepared = true
                     guard workerGeneration == generation else {
                         return CancellationError()
                     }
+                }
+                if allowWhileStreaming && preparedAttempt == nil {
+                    throw UploadCoalescerError.requiredUploadNotPrepared
                 }
                 if let uploadAttempt = preparedAttempt {
                     try await uploadAttempt()
@@ -260,8 +283,12 @@ class CloudSyncService: ObservableObject {
     
     // MARK: - Private Properties
     private lazy var uploadCoalescer: UploadCoalescer = {
-        UploadCoalescer { [weak self] chatId, idempotencyKey in
-            try await self?.doBackupChat(chatId, idempotencyKey: idempotencyKey)
+        UploadCoalescer { [weak self] chatId, idempotencyKey, allowWhileStreaming in
+            try await self?.doBackupChat(
+                chatId,
+                idempotencyKey: idempotencyKey,
+                allowWhileStreaming: allowWhileStreaming
+            )
         }
     }()
     private var streamingCallbacks: Set<String> = []
@@ -450,20 +477,18 @@ class CloudSyncService: ObservableObject {
     // MARK: - Single Chat Backup
     
     /// Backup a single chat to the cloud, coalescing rapid successive calls
-    func backupChat(_ chatId: String, ensureLatestUpload: Bool = false) async {
+    func backupChat(
+        _ chatId: String,
+        ensureLatestUpload: Bool = false,
+        allowWhileStreaming: Bool = false
+    ) async {
         let generation = accountGeneration
-        // Don't attempt backup if not authenticated
-        guard await cloudStorage.isAuthenticated() else {
-            return
-        }
-
-        guard await canWriteToCloud() else {
-            return
-        }
-        guard generation == accountGeneration else { return }
 
         beginPendingUpload(chatId)
-        await uploadCoalescer.enqueue(chatId)
+        await uploadCoalescer.enqueue(
+            chatId,
+            allowWhileStreaming: allowWhileStreaming
+        )
         Task { [weak self] in
             await self?.uploadCoalescer.waitForUpload(chatId)
             self?.endPendingUpload(chatId, generation: generation)
@@ -471,6 +496,22 @@ class CloudSyncService: ObservableObject {
 
         if ensureLatestUpload {
             await uploadCoalescer.waitForUpload(chatId)
+        }
+    }
+
+    func backupRecoveryChatAndWait(
+        _ chatId: String,
+        allowWhileStreaming: Bool
+    ) async throws {
+        let generation = accountGeneration
+        beginPendingUpload(chatId)
+        defer { endPendingUpload(chatId, generation: generation) }
+        try await uploadCoalescer.enqueueAndWait(
+            chatId,
+            allowWhileStreaming: allowWhileStreaming
+        )
+        guard generation == accountGeneration else {
+            throw CancellationError()
         }
     }
 
@@ -587,15 +628,38 @@ class CloudSyncService: ObservableObject {
     /// between attempts, turning a committed-but-lost write into a
     /// 409 IDEMPOTENCY_CONFLICT. Returns nil when there is nothing
     /// to upload.
-    private func doBackupChat(_ chatId: String, idempotencyKey: String) async throws -> UploadAttempt? {
+    private func doBackupChat(
+        _ chatId: String,
+        idempotencyKey: String,
+        allowWhileStreaming: Bool
+    ) async throws -> UploadAttempt? {
         let generation = accountGeneration
-        guard let userId = await getCurrentUserId() else { return nil }
+        guard let userId = await getCurrentUserId() else {
+            if allowWhileStreaming {
+                throw SyncEnclaveError(message: "recovery upload is not authenticated")
+            }
+            return nil
+        }
         let account = UploadAccount(generation: generation, userId: userId)
-        guard await canWriteToCloud() else { return nil }
-        guard await isCurrentUploadAccount(account) else { return nil }
+        guard await cloudStorage.isAuthenticated() else {
+            if allowWhileStreaming {
+                throw SyncEnclaveError(message: "recovery upload is not authenticated")
+            }
+            return nil
+        }
+        guard await canWriteToCloud() else {
+            if allowWhileStreaming {
+                throw SyncEnclaveError(message: "recovery upload is not writable")
+            }
+            return nil
+        }
+        guard await isCurrentUploadAccount(account) else {
+            if allowWhileStreaming { throw CancellationError() }
+            return nil
+        }
 
         // Check if chat is currently streaming
-        if streamingTracker.isStreaming(chatId) {
+        if streamingTracker.isStreaming(chatId) && !allowWhileStreaming {
             // Check if we already have a callback registered for this chat
             if streamingCallbacks.contains(chatId) {
                 return nil
@@ -622,24 +686,37 @@ class CloudSyncService: ObservableObject {
         }
         
         // Load chat from storage
-        guard let chat = try? await EncryptedFileStorage.cloud.loadChat(
-            chatId: chatId,
-            userId: userId
-        ) else {
+        let chat: Chat
+        do {
+            guard let loadedChat = try await EncryptedFileStorage.cloud.loadChat(
+                chatId: chatId,
+                userId: userId
+            ) else {
+                throw ChatRecoverySyncError.chatMissing
+            }
+            chat = loadedChat
+        } catch {
+            if allowWhileStreaming { throw error }
             return nil // Chat might have been deleted
         }
-        guard await isCurrentUploadAccount(account) else { return nil }
+        guard await isCurrentUploadAccount(account) else {
+            if allowWhileStreaming { throw CancellationError() }
+            return nil
+        }
         
         
         // Don't sync blank, empty, decryption-failure, or local-only chats.
         // Local-only chats are the user's explicit choice to keep a chat off
         // the cloud, so they must never be uploaded.
         if chat.isBlankChat || chat.messages.isEmpty || chat.decryptionFailed || chat.isLocalOnly {
+            if allowWhileStreaming {
+                throw UploadCoalescerError.requiredUploadNotPrepared
+            }
             return nil
         }
 
         // Double-check streaming status right before upload
-        if streamingTracker.isStreaming(chatId) {
+        if streamingTracker.isStreaming(chatId) && !allowWhileStreaming {
             return nil
         }
 
@@ -660,6 +737,9 @@ class CloudSyncService: ObservableObject {
             } catch {
                 guard await self.isCurrentUploadAccount(preparedUpload.account) else {
                     throw CancellationError()
+                }
+                if allowWhileStreaming {
+                    throw error
                 }
                 try await self.handleUploadFailure(
                     chatId: chatId,

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -434,6 +434,33 @@ actor EncryptedFileStorage {
         return nil
     }
 
+    func containsPendingRecovery(
+        chatId: String,
+        userId: String,
+        envelope: PendingRecoveryEnvelope
+    ) async throws -> Bool {
+        try await loadChat(chatId: chatId, userId: userId)?
+            .pendingRecoveries?
+            .contains(envelope) == true
+    }
+
+    func containsRecoverySnapshot(
+        chatId: String,
+        userId: String,
+        turnId: String
+    ) async throws -> Bool {
+        guard let chat = try await loadChat(chatId: chatId, userId: userId) else {
+            return false
+        }
+        let hasUserTurn = chat.messages.contains {
+            $0.role == .user && $0.turnId == turnId
+        }
+        let hasAssistantPlaceholder = chat.messages.contains {
+            $0.role == .assistant && $0.turnId == turnId && $0.content.isEmpty
+        }
+        return hasUserTurn && hasAssistantPlaceholder
+    }
+
     func deleteChat(chatId: String, userId: String) async throws {
         await acquireWriteLock()
         defer { releaseWriteLock() }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -300,6 +300,7 @@ class ChatViewModel: ObservableObject {
     private var client: TinfoilAI?
     private var streamTasks: [String: Task<Void, Never>] = [:]
     private var recoveryAttempts: [String: ChatRecoveryAttempt] = [:]
+    private var recoverySessionCleanupTasks: [String: Task<Void, Never>] = [:]
     private var thinkingSummaryServices: [String: ThinkingSummaryService] = [:]
     private var autoSyncTimer: Timer?
     private var recoveryScanTimer: Timer?
@@ -584,6 +585,8 @@ class ChatViewModel: ObservableObject {
         streamUpdateTimers.removeAll()
         streamTasks.values.forEach { $0.cancel() }
         streamTasks.removeAll()
+        recoverySessionCleanupTasks.values.forEach { $0.cancel() }
+        recoverySessionCleanupTasks.removeAll()
 
         // Cancel network status observer
         networkStatusCancellable?.cancel()
@@ -2220,18 +2223,20 @@ class ChatViewModel: ObservableObject {
             
             var hasRetriedWithFreshKey = false
             var recoveryAttempt: ChatRecoveryAttempt?
+            var recoveryRegistered = false
+            var recoveryRegistrationAttempted = false
+            var recoverySessionMayHaveStarted = false
 
             retryLoop: do {
-                if !hasRetriedWithFreshKey {
-                    if let recoveryStorage {
-                        await self.drainPendingSaves()
-                        if recoveryStorage == .cloud {
-                            try await self.cloudSync.backupChatAndWait(
-                                streamChatId,
-                                requiredTurnId: turnId
-                            )
-                        }
-                    }
+                if !hasRetriedWithFreshKey,
+                   let recoveryStorage,
+                   let userId = recoveryUserId {
+                    try await self.persistRecoveryCriticalSnapshot(
+                        streamChat,
+                        userId: userId,
+                        storage: recoveryStorage,
+                        turnId: turnId
+                    )
                 }
 
                 // Wait for client initialization if needed
@@ -2441,24 +2446,40 @@ class ChatViewModel: ObservableObject {
                     )
                     recoveryAttempt = attempt
                     recoveryAttempts[streamChatId] = attempt
+                    recoverySessionMayHaveStarted = true
                     let recoverable = try await ChatRecoveryClient.shared.start(
                         query: chatQuery,
                         sessionId: attempt.sessionId,
                         bearerToken: bearerToken,
                         userId: userId
                     )
-                    let envelope = try await ChatRecoveryCoordinator.shared.register(
+                    recoveryRegistrationAttempted = true
+                    let registration = try await ChatRecoveryCoordinator.shared.registerLocally(
                         attempt: attempt,
                         token: recoverable.token
                     )
+                    let envelope = registration.envelope
+                    recoveryRegistered = true
                     recoveryEnvelope = envelope
+                    if recoveryStorage == .cloud {
+                        // Local registration is durable; cross-device publication is eventual.
+                        await cloudSync.backupChat(
+                            streamChatId,
+                            allowWhileStreaming: true
+                        )
+                    }
                     if let location = findChatLocation(streamChatId) {
                         var chat = self.chat(at: location)
                         var pending = chat.pendingRecoveries ?? []
                         pending.removeAll { $0.turnId == turnId }
                         pending.append(envelope)
                         chat.pendingRecoveries = pending
-                        updateChat(chat)
+                        chat.clock = registration.metadata.clock
+                        chat.writer = registration.metadata.writer
+                        chat.clockVersion = registration.metadata.clockVersion
+                        chat.updatedAt = registration.metadata.updatedAt
+                        chat.locallyModified = registration.metadata.locallyModified
+                        updateChat(chat, persist: false)
                     }
                     stream = recoverable.stream
                 } else {
@@ -2821,7 +2842,7 @@ class ChatViewModel: ObservableObject {
                     // content. Title generation (async) then delays the real updateChat,
                     // and no subsequent updateUIView branch refreshes the wrapper — causing
                     // the first assistant response to appear truncated.
-                    self.updateChat(chat)
+                    self.updateChat(chat, persist: false)
                     if self.currentChat?.id == sid {
                         AccessibilityAnnouncer.announce(Constants.Accessibility.responseComplete)
                         HapticFeedback.trigger(.success)
@@ -2851,27 +2872,33 @@ class ChatViewModel: ObservableObject {
                    let response = finalizedChat?.messages.last(where: {
                        $0.role == .assistant && $0.turnId == turnId
                    }) {
-                    do {
-                        try await ChatRecoveryCoordinator.shared.complete(
-                            attempt: attempt,
-                            envelope: envelope,
-                            response: response,
-                            title: finalizedChat?.title,
-                            titleState: finalizedChat?.titleState
-                        )
-                    } catch {
-                        recoveryAttempts.removeValue(forKey: streamChatId)
-                        recoveryAttempt = nil
-                        throw error
-                    }
+                    let metadata = try await ChatRecoveryCoordinator.shared.completeLocally(
+                        attempt: attempt,
+                        envelope: envelope,
+                        response: response,
+                        title: finalizedChat?.title,
+                        titleState: finalizedChat?.titleState
+                    )
                     if var chat = finalizedChat {
                         chat.pendingRecoveries?.removeAll { $0.turnId == turnId }
                         if chat.pendingRecoveries?.isEmpty == true {
                             chat.pendingRecoveries = nil
                         }
+                        chat.clock = metadata.clock
+                        chat.writer = metadata.writer
+                        chat.clockVersion = metadata.clockVersion
+                        chat.updatedAt = metadata.updatedAt
+                        chat.locallyModified = metadata.locallyModified
                         finalizedChat = chat
                     }
                     recoveryAttempts.removeValue(forKey: streamChatId)
+                    recoveryRegistered = false
+                    if attempt.storage == .cloud {
+                        scheduleRecoverySessionCleanup(
+                            attempt: attempt,
+                            allowWhileStreaming: true
+                        )
+                    }
                 }
 
                 guard !Task.isCancelled else { return }
@@ -2886,6 +2913,11 @@ class ChatViewModel: ObservableObject {
                 }
             } catch {
                 if error is CancellationError || Task.isCancelled {
+                    if recoverySessionMayHaveStarted,
+                       !recoveryRegistrationAttempted,
+                       let attempt = recoveryAttempt {
+                        await ChatRecoveryCoordinator.shared.deleteSession(attempt: attempt)
+                    }
                     return
                 }
 
@@ -2907,24 +2939,57 @@ class ChatViewModel: ObservableObject {
 
                 if shouldRetry {
                     hasRetriedWithFreshKey = true
+                    var recoveryAllowsRetry = true
+                    var cancellationMetadata: ChatRecoveryLocalMutationResult?
                     if let attempt = recoveryAttempt {
-                        await ChatRecoveryCoordinator.shared.cancel(attempt: attempt)
+                        if recoveryRegistered {
+                            cancellationMetadata = await ChatRecoveryCoordinator.shared.cancelLocally(
+                                attempt: attempt,
+                                response: nil
+                            )
+                            recoveryAllowsRetry = cancellationMetadata != nil
+                            if recoveryAllowsRetry, attempt.storage == .cloud {
+                                scheduleRecoverySessionCleanup(
+                                    attempt: attempt,
+                                    allowWhileStreaming: true
+                                )
+                            }
+                        } else if recoverySessionMayHaveStarted {
+                            await ChatRecoveryCoordinator.shared.deleteSession(attempt: attempt)
+                        }
+                        recoveryRegistered = false
+                        recoveryRegistrationAttempted = false
+                        recoverySessionMayHaveStarted = false
                         recoveryAttempt = nil
                         recoveryAttempts.removeValue(forKey: streamChatId)
-                        if let location = findChatLocation(streamChatId) {
+                        if recoveryAllowsRetry,
+                           let location = findChatLocation(streamChatId) {
                             var chat = self.chat(at: location)
                             chat.pendingRecoveries?.removeAll { $0.turnId == turnId }
                             if chat.pendingRecoveries?.isEmpty == true {
                                 chat.pendingRecoveries = nil
                             }
-                            updateChat(chat)
+                            if let cancellationMetadata {
+                                chat.clock = cancellationMetadata.clock
+                                chat.writer = cancellationMetadata.writer
+                                chat.clockVersion = cancellationMetadata.clockVersion
+                                chat.updatedAt = cancellationMetadata.updatedAt
+                                chat.locallyModified = cancellationMetadata.locallyModified
+                            }
+                            updateChat(chat, persist: false)
                         }
                     }
                     // The token is reminted by acquireTokenForSend at the top of
                     // the retry pass (forceRefresh), so no separate refresh here.
-                    if await MainActor.run(body: { self.client != nil }) {
+                    if recoveryAllowsRetry,
+                       await MainActor.run(body: { self.client != nil }) {
                         continue retryLoop
                     }
+                }
+                if recoverySessionMayHaveStarted,
+                   !recoveryRegistrationAttempted,
+                   let attempt = recoveryAttempt {
+                    await ChatRecoveryCoordinator.shared.deleteSession(attempt: attempt)
                 }
                 recoveryAttempts.removeValue(forKey: streamChatId)
 
@@ -3259,6 +3324,27 @@ class ChatViewModel: ObservableObject {
         }
     }
 
+    private func scheduleRecoverySessionCleanup(
+        attempt: ChatRecoveryAttempt,
+        allowWhileStreaming: Bool
+    ) {
+        let sessionId = attempt.sessionId
+        let cloudSync = self.cloudSync
+        recoverySessionCleanupTasks[sessionId] = Task { [weak self] in
+            do {
+                try await cloudSync.backupRecoveryChatAndWait(
+                    attempt.chatId,
+                    allowWhileStreaming: allowWhileStreaming
+                )
+                try Task.checkCancellation()
+                await ChatRecoveryCoordinator.shared.deleteSession(attempt: attempt)
+            } catch {
+                // Session retention handles cleanup when publication is unavailable.
+            }
+            self?.recoverySessionCleanupTasks.removeValue(forKey: sessionId)
+        }
+    }
+
     @discardableResult
     private func cancelGeneration(
         chatId: String,
@@ -3268,50 +3354,65 @@ class ChatViewModel: ObservableObject {
 
         let streamTask = streamTasks[chatId]
         let recoveryAttempt = recoveryAttempts.removeValue(forKey: chatId)
-        let stoppedResponse = recoveryAttempt.flatMap { attempt -> Message? in
-            guard let location = findChatLocation(chatId) else { return nil }
-            return chat(at: location).messages.last {
-                $0.role == .assistant && $0.turnId == attempt.turnId
-            }
-        }
-        let recoveryCleanup = recoveryAttempt.map { attempt in
-            Task.detached(priority: .userInitiated) {
-                await ChatRecoveryCoordinator.shared.cancel(
-                    attempt: attempt,
-                    response: stoppedResponse
-                )
-            }
-        }
         streamTask?.cancel()
         flushPendingStreamUpdate(chatId: chatId)
         if let location = findChatLocation(chatId) {
             var chat = chat(at: location)
             chat.hasActiveStream = false
+            updateChat(chat, persist: false)
+            streamingTracker.endStreaming(chat.id)
+        } else {
+            streamingTracker.endStreaming(chatId)
+        }
+
+        if announce {
+            AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
+        }
+        return Task {
             if let recoveryAttempt {
+                await ChatRecoveryCoordinator.shared.markCancelled(
+                    attempt: recoveryAttempt
+                )
+            }
+            await streamTask?.value
+            self.flushPendingStreamUpdate(chatId: chatId)
+            self.finishStreamState(chatId: chatId)
+            let metadata: ChatRecoveryLocalMutationResult?
+            if let recoveryAttempt {
+                let stoppedResponse = self.findChatLocation(chatId).flatMap { location in
+                    self.chat(at: location).messages.last {
+                        $0.role == .assistant && $0.turnId == recoveryAttempt.turnId
+                    }
+                }
+                metadata = await ChatRecoveryCoordinator.shared.cancelLocally(
+                    attempt: recoveryAttempt,
+                    response: stoppedResponse
+                )
+                if metadata != nil, recoveryAttempt.storage == .cloud {
+                    self.scheduleRecoverySessionCleanup(
+                        attempt: recoveryAttempt,
+                        allowWhileStreaming: true
+                    )
+                }
+            } else {
+                metadata = nil
+            }
+            if let metadata,
+               let recoveryAttempt,
+               let location = self.findChatLocation(chatId) {
+                var chat = self.chat(at: location)
                 chat.pendingRecoveries?.removeAll {
                     $0.turnId == recoveryAttempt.turnId
                 }
                 if chat.pendingRecoveries?.isEmpty == true {
                     chat.pendingRecoveries = nil
                 }
-            }
-            updateChat(chat)
-            streamingTracker.endStreaming(chat.id)
-        } else {
-            streamingTracker.endStreaming(chatId)
-        }
-
-        finishStreamState(chatId: chatId)
-        if announce {
-            AccessibilityAnnouncer.announce(Constants.Accessibility.generationStopped)
-        }
-        return Task {
-            await recoveryCleanup?.value
-            await streamTask?.value
-            if let recoveryAttempt {
-                await ChatRecoveryCoordinator.shared.deleteSession(
-                    attempt: recoveryAttempt
-                )
+                chat.clock = metadata.clock
+                chat.writer = metadata.writer
+                chat.clockVersion = metadata.clockVersion
+                chat.updatedAt = metadata.updatedAt
+                chat.locallyModified = metadata.locallyModified
+                self.updateChat(chat)
             }
         }
     }
@@ -3635,7 +3736,11 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Updates a chat in the chats array AND saves
-    private func updateChat(_ chat: Chat, throttleForStreaming: Bool = false) {
+    private func updateChat(
+        _ chat: Chat,
+        throttleForStreaming: Bool = false,
+        persist: Bool = true
+    ) {
         var updatedChat = chat
         
         // If the chat has an active stream or is being actively modified, ensure it's marked as locally modified
@@ -3653,7 +3758,9 @@ class ChatViewModel: ObservableObject {
         }
 
         // During streaming, batch saves to reduce disk I/O
-        if throttleForStreaming {
+        if !persist {
+            return
+        } else if throttleForStreaming {
             let chatId = updatedChat.id
 
             // Store pending update
@@ -3700,6 +3807,30 @@ class ChatViewModel: ObservableObject {
 
     private func drainPendingSaves() async {
         await pendingSaveTask?.value
+    }
+
+    private func persistRecoveryCriticalSnapshot(
+        _ chat: Chat,
+        userId: String,
+        storage: ChatRecoveryStorage,
+        turnId: String
+    ) async throws {
+        await drainPendingSaves()
+        if try await storage.fileStorage.containsRecoverySnapshot(
+            chatId: chat.id,
+            userId: userId,
+            turnId: turnId
+        ) {
+            return
+        }
+        try await storage.fileStorage.saveChat(chat, userId: userId)
+        guard try await storage.fileStorage.containsRecoverySnapshot(
+            chatId: chat.id,
+            userId: userId,
+            turnId: turnId
+        ) else {
+            throw ChatRecoverySyncError.chatMissing
+        }
     }
     
     

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -279,7 +279,6 @@ struct ChatRecoverySchedulingTests {
             }
         }
         #expect(!mutationApplied)
-        #expect(chat.title != "Mutated")
 
         chat.decryptionFailed = false
         chat.dataCorrupted = true
@@ -290,7 +289,6 @@ struct ChatRecoverySchedulingTests {
             }
         }
         #expect(!mutationApplied)
-        #expect(chat.title != "Mutated")
     }
 }
 

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -185,4 +185,84 @@ struct ChatRecoverySchedulingTests {
             )
         ))
     }
+
+    @Test @MainActor
+    func cancellationImmediatelyInvalidatesLiveAttempt() async throws {
+        let coordinator = ChatRecoveryCoordinator()
+        let attempt = try await coordinator.begin(
+            chatId: "chat-1",
+            turnId: "turn-1",
+            userId: "user-1",
+            storage: .cloud
+        )
+
+        await coordinator.markCancelled(attempt: attempt)
+
+        let isCurrent = await coordinator.liveAttemptIsCurrent(attempt)
+        #expect(isCurrent == false)
+    }
+
+    @Test func remoteResolutionRequiresFinalAssistantContent() {
+        let placeholder = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: ""
+        )
+        let completed = Message(
+            role: .assistant,
+            turnId: "turn-1",
+            content: "Recovered"
+        )
+        let envelope = PendingRecoveryEnvelope(
+            v: 1,
+            turnId: "turn-1",
+            keyId: "key",
+            createdAt: "2026-08-11T00:00:00Z",
+            expiresAt: "2026-08-12T00:00:00Z",
+            nonce: "nonce",
+            ciphertext: "ciphertext"
+        )
+
+        #expect(!remoteRecoveryTurnIsResolved(
+            messages: [placeholder],
+            pendingRecoveries: nil,
+            turnId: "turn-1"
+        ))
+        #expect(remoteRecoveryTurnIsResolved(
+            messages: [completed],
+            pendingRecoveries: nil,
+            turnId: "turn-1"
+        ))
+        #expect(!remoteRecoveryTurnIsResolved(
+            messages: [completed],
+            pendingRecoveries: [envelope],
+            turnId: "turn-1"
+        ))
+    }
+
+    @Test func locallyModifiedResolutionRequiresRemoteClockWin() {
+        let now = Date()
+
+        #expect(!resolvedRemoteMayReplaceLocal(
+            localModified: true,
+            localClock: nil,
+            remoteClock: EditClock(v: 2, w: "remote"),
+            localUpdatedAt: now,
+            remoteUpdatedAt: now
+        ))
+        #expect(resolvedRemoteMayReplaceLocal(
+            localModified: true,
+            localClock: EditClock(v: 1, w: "local"),
+            remoteClock: EditClock(v: 2, w: "remote"),
+            localUpdatedAt: now,
+            remoteUpdatedAt: now
+        ))
+        #expect(!resolvedRemoteMayReplaceLocal(
+            localModified: true,
+            localClock: EditClock(v: 2, w: "local"),
+            remoteClock: EditClock(v: 1, w: "remote"),
+            localUpdatedAt: now,
+            remoteUpdatedAt: now
+        ))
+    }
 }

--- a/TinfoilChatTests/ChatRecoverySchedulingTests.swift
+++ b/TinfoilChatTests/ChatRecoverySchedulingTests.swift
@@ -265,4 +265,51 @@ struct ChatRecoverySchedulingTests {
             remoteUpdatedAt: now
         ))
     }
+
+    @Test @MainActor
+    func corruptedCloudChatIsRejectedBeforeRecoveryMutation() {
+        var chat = Chat(modelType: recoverySchedulingTestModel)
+        chat.decryptionFailed = true
+        var mutationApplied = false
+
+        #expect(throws: ChatRecoverySyncError.self) {
+            _ = try mutateValidCloudRecoveryChat(chat) { candidate in
+                mutationApplied = true
+                candidate.title = "Mutated"
+            }
+        }
+        #expect(!mutationApplied)
+        #expect(chat.title != "Mutated")
+
+        chat.decryptionFailed = false
+        chat.dataCorrupted = true
+        #expect(throws: ChatRecoverySyncError.self) {
+            _ = try mutateValidCloudRecoveryChat(chat) { candidate in
+                mutationApplied = true
+                candidate.title = "Mutated"
+            }
+        }
+        #expect(!mutationApplied)
+        #expect(chat.title != "Mutated")
+    }
 }
+
+private let recoverySchedulingTestModel = ModelType(
+    from: AppModelConfig(
+        modelName: "gpt-oss-120b",
+        image: "openai.png",
+        name: "GPT OSS 120B",
+        nameShort: "GPT OSS",
+        description: "",
+        details: "",
+        parameters: "",
+        contextWindow: "64k tokens",
+        type: "chat",
+        chat: true,
+        paid: false,
+        multimodal: false,
+        toolCalling: nil,
+        attributes: nil,
+        reasoningConfig: nil
+    )
+)

--- a/TinfoilChatTests/CloudSyncUploadRetryTests.swift
+++ b/TinfoilChatTests/CloudSyncUploadRetryTests.swift
@@ -40,13 +40,16 @@ private actor UploadRetryProbe {
     struct Snapshot: Sendable {
         let preparedKeys: [String]
         let executedKeys: [String]
+        let allowWhileStreaming: [Bool]
     }
 
     private var preparedKeys: [String] = []
     private var executedKeys: [String] = []
+    private var allowWhileStreaming: [Bool] = []
 
-    func prepare(key: String) -> Int {
+    func prepare(key: String, allowWhileStreaming: Bool) -> Int {
         preparedKeys.append(key)
+        self.allowWhileStreaming.append(allowWhileStreaming)
         return preparedKeys.count
     }
 
@@ -58,7 +61,11 @@ private actor UploadRetryProbe {
     }
 
     func snapshot() -> Snapshot {
-        Snapshot(preparedKeys: preparedKeys, executedKeys: executedKeys)
+        Snapshot(
+            preparedKeys: preparedKeys,
+            executedKeys: executedKeys,
+            allowWhileStreaming: allowWhileStreaming
+        )
     }
 }
 
@@ -68,8 +75,11 @@ struct CloudSyncUploadRetryTests {
         let backoff = RetryBackoffGate()
         let probe = UploadRetryProbe()
         let coalescer = UploadCoalescer(
-            prepareUpload: { _, key in
-                let preparation = await probe.prepare(key: key)
+            prepareUpload: { _, key, allowWhileStreaming in
+                let preparation = await probe.prepare(
+                    key: key,
+                    allowWhileStreaming: allowWhileStreaming
+                )
                 return {
                     try await probe.execute(key: key, preparation: preparation)
                 }
@@ -77,7 +87,7 @@ struct CloudSyncUploadRetryTests {
             waitBeforeRetry: { _ in await backoff.pause() }
         )
 
-        await coalescer.enqueue("chat")
+        await coalescer.enqueue("chat", allowWhileStreaming: true)
         await backoff.waitUntilEntered()
         await coalescer.enqueue("chat")
         await backoff.release()
@@ -90,6 +100,7 @@ struct CloudSyncUploadRetryTests {
         #expect(snapshot.executedKeys[1] == snapshot.preparedKeys[0])
         #expect(snapshot.executedKeys[2] == snapshot.preparedKeys[1])
         #expect(snapshot.preparedKeys[0] != snapshot.preparedKeys[1])
+        #expect(snapshot.allowWhileStreaming == [true, false])
     }
 
     @Test
@@ -97,8 +108,11 @@ struct CloudSyncUploadRetryTests {
         let backoff = RetryBackoffGate()
         let probe = UploadRetryProbe()
         let coalescer = UploadCoalescer(
-            prepareUpload: { _, key in
-                let preparation = await probe.prepare(key: key)
+            prepareUpload: { _, key, allowWhileStreaming in
+                let preparation = await probe.prepare(
+                    key: key,
+                    allowWhileStreaming: allowWhileStreaming
+                )
                 return {
                     try await probe.execute(key: key, preparation: preparation)
                 }
@@ -127,6 +141,53 @@ struct CloudSyncUploadRetryTests {
         #expect(waiterCancelled)
         #expect(snapshot.preparedKeys.count == 1)
         #expect(snapshot.executedKeys.count == 1)
+        #expect(snapshot.allowWhileStreaming == [false])
+    }
+
+    @Test func requiredUploadCannotSucceedWithoutPreparedWork() async {
+        let coalescer = UploadCoalescer(
+            prepareUpload: { _, _, _ in nil },
+            waitBeforeRetry: { _ in }
+        )
+
+        do {
+            try await coalescer.enqueueAndWait(
+                "chat",
+                allowWhileStreaming: true
+            )
+            Issue.record("Expected required upload preparation to fail")
+        } catch UploadCoalescerError.requiredUploadNotPrepared {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func laterNoOpDoesNotClearRequiredUploadFailure() async {
+        let backoff = RetryBackoffGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { _, _, allowWhileStreaming in
+                guard allowWhileStreaming else { return nil }
+                return { throw UploadRetryTestError.transient }
+            },
+            waitBeforeRetry: { _ in await backoff.pause() }
+        )
+        let waiter = Task {
+            try await coalescer.enqueueAndWait(
+                "chat",
+                allowWhileStreaming: true
+            )
+        }
+        await backoff.waitUntilEntered()
+        await coalescer.enqueue("chat")
+        await backoff.release()
+
+        do {
+            try await waiter.value
+            Issue.record("Expected the earlier required upload failure")
+        } catch UploadRetryTestError.transient {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     @Test @MainActor

--- a/TinfoilChatTests/CloudSyncUploadRetryTests.swift
+++ b/TinfoilChatTests/CloudSyncUploadRetryTests.swift
@@ -82,6 +82,7 @@ struct CloudSyncUploadRetryTests {
                 )
                 return {
                     try await probe.execute(key: key, preparation: preparation)
+                    return .uploaded
                 }
             },
             waitBeforeRetry: { _ in await backoff.pause() }
@@ -115,6 +116,7 @@ struct CloudSyncUploadRetryTests {
                 )
                 return {
                     try await probe.execute(key: key, preparation: preparation)
+                    return .uploaded
                 }
             },
             waitBeforeRetry: { _ in await backoff.pause() }
@@ -167,7 +169,7 @@ struct CloudSyncUploadRetryTests {
         let coalescer = UploadCoalescer(
             prepareUpload: { _, _, allowWhileStreaming in
                 guard allowWhileStreaming else { return nil }
-                return { throw UploadRetryTestError.transient }
+                return { throw SyncEnclaveError(message: "Unavailable", status: 503) }
             },
             waitBeforeRetry: { _ in await backoff.pause() }
         )
@@ -184,9 +186,38 @@ struct CloudSyncUploadRetryTests {
         do {
             try await waiter.value
             Issue.record("Expected the earlier required upload failure")
-        } catch UploadRetryTestError.transient {
+        } catch let error as SyncEnclaveError {
+            #expect(error.status == 503)
         } catch {
             Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func laterActualUploadClearsRequiredUploadFailure() async {
+        let backoff = RetryBackoffGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { _, _, allowWhileStreaming in
+                if allowWhileStreaming {
+                    return { throw SyncEnclaveError(message: "Unavailable", status: 503) }
+                }
+                return { .uploaded }
+            },
+            waitBeforeRetry: { _ in await backoff.pause() }
+        )
+        let waiter = Task {
+            try await coalescer.enqueueAndWait(
+                "chat",
+                allowWhileStreaming: true
+            )
+        }
+        await backoff.waitUntilEntered()
+        await coalescer.enqueue("chat")
+        await backoff.release()
+
+        do {
+            try await waiter.value
+        } catch {
+            Issue.record("Expected the later upload to clear the failure: \(error)")
         }
     }
 
@@ -231,8 +262,11 @@ struct CloudSyncUploadRetryTests {
     func coalescerDoesNotRetryUnstructuredFailures() async {
         let probe = UploadRetryProbe()
         let coalescer = UploadCoalescer(
-            prepareUpload: { _, key in
-                _ = await probe.prepare(key: key)
+            prepareUpload: { _, key, allowWhileStreaming in
+                _ = await probe.prepare(
+                    key: key,
+                    allowWhileStreaming: allowWhileStreaming
+                )
                 return {
                     throw UploadRetryTestError.terminal
                 }


### PR DESCRIPTION
## Summary
- persist recovery state locally before displaying streamed content
- publish cloud recovery state asynchronously through the ordered per-chat upload coalescer
- preserve cancellation, conflict reconciliation, and session cleanup semantics across delayed uploads

## Testing
- `git diff --check`
- Xcode build and tests not run per repository instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams assistant responses immediately by mutating recovery state locally, then publishes to the cloud in the background with streaming‑safe uploads and strict required‑upload semantics. Latency drops while preserving async consistency, cancellation, conflict handling, and aligned session cleanup/reporting.

- **New Features**
  - Local‑first recovery APIs: `registerLocally`, `completeLocally`, `cancelLocally` return `ChatRecoveryLocalMutationResult` for instant UI updates without disk I/O (`persist: false`).
  - Critical snapshot safety: persist a recovery snapshot before streaming; added `containsPendingRecovery` and `containsRecoverySnapshot`.
  - Background publication while streaming: upload coalescer supports `allowWhileStreaming` with required‑preparation and outcome reporting; added `backupRecoveryChatAndWait`; session cleanup is scheduled after local completion.
  - Remote reconciliation: `reconcileResolvedTurnFromRemote` replaces local only when the turn has final assistant content and the remote clock wins.

- **Bug Fixes**
  - Asynchronous consistency: immediate invalidation via `markCancelled`/`liveAttemptIsCurrent`, safe session deletion, and enforced “required upload prepared” semantics; later real uploads clear failures, no‑ops don’t.
  - Conflict safety: reject corrupted/decryption‑failed chats before mutation; streaming‑aware cloud sync pulls/rebases without overwriting newer local edits.
  - UI correctness: apply returned `clock`/`writer`/`version`/`updatedAt` to in‑memory chat during streaming, throttle saves, and reliably clean up timers/tasks, including delayed session cleanup after publication.

<sup>Written for commit 6941ca6f4f42dbcc20d63dd59374c1eecd2bd424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

