### PR TITLE
Hide empty chats from the sidebar

### DIFF
--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -13,11 +13,11 @@ import SafariServices
 /// index covers every synced chat and the webapp shows them too); only
 /// temporary and undecryptable chats are excluded.
 func isSearchResultSidebarChat(_ chat: Chat) -> Bool {
-    !chat.isTemporary && !chat.decryptionFailed
+    !chat.isTemporary && !chat.decryptionFailed && !chat.isBlankChat
 }
 
 func isRootSidebarChat(_ chat: Chat) -> Bool {
-    isSearchResultSidebarChat(chat) && chat.projectId == nil
+    isSearchResultSidebarChat(chat) && chat.projectId == nil && !chat.isBlankChat
 }
 
 func isSidebarChatSearchEnabled(

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -169,21 +169,24 @@ struct ChatSearchControllerTests {
 
     @Test
     func searchResultFilterKeepsProjectChatsButDropsTemporaryAndEncrypted() {
-        let root = ChatSearchServiceTests.makeChat(id: "root", title: "Root")
+        var root = ChatSearchServiceTests.makeChat(id: "root", title: "Root")
+        root.messages = [Message(role: .user, content: "Hello")]
         var project = ChatSearchServiceTests.makeChat(id: "project", title: "Project")
         project.projectId = "project-1"
+        project.messages = [Message(role: .user, content: "Project question")]
+        let blank = ChatSearchServiceTests.makeChat(id: "blank", title: "New Chat")
         var temporary = ChatSearchServiceTests.makeChat(id: "temp", title: "Temp")
         temporary.isTemporary = true
         var encrypted = ChatSearchServiceTests.makeChat(id: "encrypted", title: "Encrypted")
         encrypted.decryptionFailed = true
 
-        let visible = [root, project, temporary, encrypted]
+        let visible = [root, project, blank, temporary, encrypted]
             .filter(isSearchResultSidebarChat)
             .map(\.id)
         #expect(visible == ["root", "project"])
 
-        // The root chat list itself still excludes project chats.
-        #expect([root, project].filter(isRootSidebarChat).map(\.id) == ["root"])
+        // The root chat list itself still excludes project and blank chats.
+        #expect([root, project, blank].filter(isRootSidebarChat).map(\.id) == ["root"])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- exclude unsaved blank chats from root sidebar history
- keep blank chats out of sidebar search results while preserving internal current-chat state
- update sidebar filtering coverage

## Tests
- not run; repository instructions require validation in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide empty chats from the sidebar and sidebar search. Only chats with messages now appear, reducing clutter.

- **Bug Fixes**
  - Filter out `isBlankChat` in `isSearchResultSidebarChat` and `isRootSidebarChat`.
  - Updated tests to confirm blank chats are excluded while project chats still show in search.

<sup>Written for commit 1f142d13ed374f1866012aceaf9a6f53e2acb5c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

