### PR TITLE
fix: await cloud sync authentication state

### DIFF
--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -453,17 +453,17 @@ class CloudSyncService: ObservableObject {
         let tokenGetter: SyncEnclaveClient.TokenGetter = { forceRefresh in
             do {
                 // Check if Clerk has a publishable key
-                guard !Clerk.shared.publishableKey.isEmpty else {
+                guard await !Clerk.shared.publishableKey.isEmpty else {
                     return nil
                 }
                 
                 // Ensure Clerk is loaded
-                if !Clerk.shared.isLoaded {
+                if await !Clerk.shared.isLoaded {
                     try await Clerk.shared.refreshClient()
                 }
                 
                 // Get fresh token from session
-                if let session = Clerk.shared.session {
+                if let session = await Clerk.shared.session {
                     // Try to get a fresh token first (refresh if needed)
                     if let token = try? await session.getToken(.init(skipCache: forceRefresh)) {
                         return token


### PR DESCRIPTION
## Summary
- await main-actor-isolated Clerk state while resolving cloud sync tokens
- fix Swift concurrency errors in cloud sync initialization

## Validation
- `git diff --check`
- Build not run per repository instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await `Clerk` auth state on the main actor while resolving cloud sync tokens to fix Swift concurrency errors and prevent race conditions during initialization.
Token retrieval now waits for `publishableKey`, `isLoaded`, and `session` before calling `getToken`.

<sup>Written for commit 6baed163fcbc50eef6bec73850f65483760f3d6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

