### PR TITLE
Fix cramped assistant message controls

### DIFF
--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -753,69 +753,71 @@ struct MessageView: View {
                 // Add action buttons for assistant messages (only when not streaming)
                 if message.hasVisibleAssistantContent &&
                    !isRenderingStream {
-                    HStack(spacing: 16) {
-                        // Sources button - only show if we have web search sources
-                        if let webSearchState = message.webSearchState,
-                           !webSearchState.sources.isEmpty {
-                            SourcesButton(
-                                sources: webSearchState.sources,
-                                isDarkMode: isDarkMode
-                            ) {
-                                showSourcesSheet = true
-                            }
-                        }
-
-                        Button {
-                            showRawContentModal = true
-                        } label: {
-                            Image(systemName: "doc.on.doc")
-                                .font(.system(size: 16))
-                                .foregroundColor(isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5))
-                                .frame(width: 32, height: 32)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .accessibilityLabel("Copy")
-                        .accessibleHitTarget()
-
-                        // Regenerate button - only on the last assistant message
-                        if isLastMessage && !viewModel.isLoading && messageIndex > 0 {
-                            Button {
-                                viewModel.regenerateMessage(at: messageIndex - 1)
-                            } label: {
-                                Image(systemName: "arrow.clockwise")
-                                    .font(.system(size: 16))
-                                    .foregroundColor(isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5))
-                                    .frame(width: 32, height: 32)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .accessibilityLabel("Regenerate response")
-                            .accessibleHitTarget()
-                        }
-
-                        // Share button - only on the last assistant message
-                        if isLastMessage && !viewModel.isLoading {
-                            Button {
-                                showShareSheet = true
-                            } label: {
-                                Image(systemName: "square.and.arrow.up")
-                                    .font(.system(size: 16))
-                                    .foregroundColor(isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5))
-                                    .frame(width: 32, height: 32)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .accessibilityLabel("Share")
-                            .accessibleHitTarget()
-                        }
-
-                        Spacer()
-
+                    VStack(alignment: .leading) {
                         MessageSecurityMetadataView(
                             modelDisplayName: message.modelDisplayName,
                             isDarkMode: isDarkMode
                         )
+
+                        HStack(spacing: 16) {
+                            // Sources button - only show if we have web search sources
+                            if let webSearchState = message.webSearchState,
+                               !webSearchState.sources.isEmpty {
+                                SourcesButton(
+                                    sources: webSearchState.sources,
+                                    isDarkMode: isDarkMode
+                                ) {
+                                    showSourcesSheet = true
+                                }
+                            }
+
+                            Button {
+                                showRawContentModal = true
+                            } label: {
+                                Image(systemName: "doc.on.doc")
+                                    .font(.system(size: 16))
+                                    .foregroundColor(isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5))
+                                    .frame(width: 32, height: 32)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                            .accessibilityLabel("Copy")
+                            .accessibleHitTarget()
+
+                            // Regenerate button - only on the last assistant message
+                            if isLastMessage && !viewModel.isLoading && messageIndex > 0 {
+                                Button {
+                                    viewModel.regenerateMessage(at: messageIndex - 1)
+                                } label: {
+                                    Image(systemName: "arrow.clockwise")
+                                        .font(.system(size: 16))
+                                        .foregroundColor(isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5))
+                                        .frame(width: 32, height: 32)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                                .accessibilityLabel("Regenerate response")
+                                .accessibleHitTarget()
+                            }
+
+                            // Share button - only on the last assistant message
+                            if isLastMessage && !viewModel.isLoading {
+                                Button {
+                                    showShareSheet = true
+                                } label: {
+                                    Image(systemName: "square.and.arrow.up")
+                                        .font(.system(size: 16))
+                                        .foregroundColor(isDarkMode ? .white.opacity(0.5) : .black.opacity(0.5))
+                                        .frame(width: 32, height: 32)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                                .accessibilityLabel("Share")
+                                .accessibleHitTarget()
+                            }
+
+                            Spacer()
+                        }
                     }
                     .padding(.vertical, 8)
 


### PR DESCRIPTION
## Summary
- place model and encryption metadata below assistant text
- move assistant actions to a separate row to preserve control spacing

## Testing
- not run (repository instructions require building and testing in Xcode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops assistant message controls from getting cramped by placing model/encryption metadata on its own row below the assistant text and moving action buttons to a dedicated row. Previously, metadata and actions shared one row, squeezing controls; now spacing is consistent with no change to button logic.

- Only `TinfoilChat/Views/MessageView.swift` layout is refactored: metadata rendered via `MessageSecurityMetadataView` above an actions `HStack` within a `VStack`.
- Button visibility/behavior unchanged: Sources show only when sources exist; Regenerate and Share only on the last assistant message and when not loading; Copy is available when assistant content is visible.
- Applies only when assistant content is visible and not streaming; no state, model, or accessibility changes.

<sup>Written for commit 04c4dd2ece228a1897edce0fa292ba2a1bf1a81d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

