### PR TITLE
Harden revision sync against wipes, poison intents, and streaming races

### DIFF
--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -113,8 +113,7 @@ class CloudStorageService: ObservableObject {
     @discardableResult
     func uploadChat(
         _ chat: StoredChat,
-        idempotencyKey: String,
-        restoreDeleted: Bool = false
+        idempotencyKey: String
     ) async throws -> UploadChatResult {
         var chatToUpload = chat
         let rewrites = try await encryptAndUploadAttachments(&chatToUpload)
@@ -122,8 +121,7 @@ class CloudStorageService: ObservableObject {
 
         let includesProjectIntent = ProjectMetadataUploadPolicy.shouldInclude(
             syncVersion: chatToUpload.syncVersion,
-            projectLocallyModified: chatToUpload.projectLocallyModified == true,
-            restoreDeleted: restoreDeleted
+            projectLocallyModified: chatToUpload.projectLocallyModified == true
         )
         chatToUpload.projectLocallyModified = nil
         let plaintext = try Self.encodeChatPlaintext(chatToUpload)
@@ -139,21 +137,10 @@ class CloudStorageService: ObservableObject {
                 metadata["projectId"] = AnyCodable(NSNull())
             }
         }
-        if restoreDeleted {
-            metadata["restoreDeleted"] = AnyCodable(true)
-        }
 
-        // A restore re-creates a row whose server copy is gone, so there
-        // is no etag to CAS against; `if_match=null` is the enclave's
-        // create-new sentinel.
-        let ifMatch: String?
-        if restoreDeleted {
-            ifMatch = nil
-        } else {
-            ifMatch = chatToUpload.syncVersion > 0
-                ? String(chatToUpload.syncVersion)
-                : "0"
-        }
+        let ifMatch = chatToUpload.syncVersion > 0
+            ? String(chatToUpload.syncVersion)
+            : "0"
         let response = try await SyncEnclaveAPI.push(
             EnclavePushRequest(
                 scope: .chat,

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1658,9 +1658,13 @@ class CloudSyncService: ObservableObject {
         await syncAllChats()
     }
 
-    /// Clear cached sync status (call on logout)
-    func clearSyncStatus() async {
-        let userId = await getCurrentUserId()
+    /// Clear cached sync status (call on logout / account switch).
+    /// `userId` must be the signing-out user's id, resolved by the
+    /// caller BEFORE the sign-out began: by the time this runs Clerk
+    /// reports no user (sign-out) or already the next user (account
+    /// switch), so resolving it here would clear the wrong user's
+    /// revision checkpoint — or none at all.
+    func clearSyncStatus(forUser userId: String?) async {
         accountGeneration += 1
         isSyncing = false
         syncStatus = ""
@@ -1669,14 +1673,22 @@ class CloudSyncService: ObservableObject {
         pendingUploadCounts.removeAll()
         pendingUploadChatIds.removeAll()
         await uploadCoalescer.clear()
-        if let userId {
-            revisionCheckpointStore.clear(userId: userId)
-        }
+        invalidateRevisionCheckpoint(forUser: userId)
         // Drop any in-flight key registration so the next signed-in user
         // never awaits a task started under the previous user's key.
         emptyRemoteRegistration?.cancel()
         emptyRemoteRegistration = nil
         await SyncEnclaveClient.shared.reset()
+    }
+
+    /// Drop the revision checkpoint for a user whose local cloud chat
+    /// store was wiped. Every wipe path must call this: a surviving
+    /// checkpoint makes the next sync take the incremental event-replay
+    /// path against an empty local store, so chats older than the
+    /// checkpoint would never be rehydrated (bootstrap never runs).
+    func invalidateRevisionCheckpoint(forUser userId: String?) {
+        guard let userId else { return }
+        revisionCheckpointStore.clear(userId: userId)
     }
 
     // MARK: - Delete Operations

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -813,8 +813,15 @@ class CloudSyncService: ObservableObject {
         case .triggerRecoveryWizard:
             SyncHealthStore.shared.reportKeyActionRequired(.keyRecovery)
             return false
-        case .blockAllSync:
-            SyncHealthStore.shared.reportSyncPaused(.attestation)
+        case .blockAllSync(let reason):
+            switch reason {
+            case .attestationFailed:
+                SyncHealthStore.shared.reportSyncPaused(.attestation)
+            case .upgradeRequired:
+                // 426: only an app update fixes this, so it gates as
+                // actionRequired (sticky) rather than paused (self-healing).
+                SyncHealthStore.shared.reportKeyActionRequired(.upgradeRequired)
+            }
             return false
         case .migrateLegacyAndRetry:
             // The legacy re-seal runs out of band — on the next launch and right
@@ -1259,6 +1266,12 @@ class CloudSyncService: ObservableObject {
         guard !isSyncing else {
             return SyncResult()
         }
+        // A 426 gate can only be lifted by updating the app; re-running
+        // the cycle just burns requests against a server that already
+        // refused this protocol version.
+        if case .actionRequired(.upgradeRequired, _) = SyncHealthStore.shared.gate {
+            return SyncResult()
+        }
 
         isSyncing = true
         syncStatus = "Syncing..."
@@ -1328,6 +1341,12 @@ class CloudSyncService: ObservableObject {
                 errors: result.errors + uploads.errors
             )
         } catch {
+            // Surface a force-upgrade refusal (HTTP 426) from any call in
+            // the cycle so the gate check in syncAllChats stops the
+            // periodic retries and the UI can prompt for an update.
+            if case .blockAllSync(.upgradeRequired) = EnclaveErrorRecovery.decide(error).action {
+                SyncHealthStore.shared.reportKeyActionRequired(.upgradeRequired)
+            }
             return SyncResult(errors: ["Revision sync failed: \(error.localizedDescription)"])
         }
     }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1617,9 +1617,13 @@ class CloudSyncService: ObservableObject {
     /// Retry deferred remote deletes whose stream-end removal failed.
     /// Runs once per sync cycle; entries whose chat is streaming again
     /// wait for the next stream end via their registered callback.
+    /// Iterates a snapshot of the keys and re-reads the live entry each
+    /// step: the dictionary is mutated inside the loop, and the awaits
+    /// mean stream-end callbacks can also mutate it mid-iteration.
     private func retryDeferredRemoteDeletes(generation: Int) async {
-        for (chatId, pending) in deferredRemoteDeletes {
+        for chatId in Array(deferredRemoteDeletes.keys) {
             guard generation == accountGeneration else { return }
+            guard let pending = deferredRemoteDeletes[chatId] else { continue }
             guard pending.generation == accountGeneration else {
                 deferredRemoteDeletes.removeValue(forKey: chatId)
                 continue

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1909,19 +1909,18 @@ class CloudSyncService: ObservableObject {
         await SyncEnclaveClient.shared.reset()
     }
 
-    /// Fence and invalidate sync state after the user's local cloud chat
-    /// store was wiped. Every wipe path must call this: a surviving
-    /// checkpoint makes the next sync take the incremental event-replay
-    /// path against an empty local store, so chats older than the
-    /// checkpoint would never be rehydrated (bootstrap never runs).
-    ///
-    /// The account generation advances BEFORE the checkpoint is cleared:
-    /// an in-flight sync pass re-checks the generation right before
-    /// every checkpoint save, so the bump guarantees it can never
-    /// rewrite the checkpoint after the wipe. Unlike clearSyncStatus
-    /// this keeps the attested client and token wiring intact — the
-    /// same account keeps syncing and the next pass bootstraps a
-    /// fresh snapshot.
+    /// Fence and invalidate sync state around a wipe of the user's local
+    /// cloud chat store. Every wipe path must call this BEFORE deleting
+    /// the store: the generation bump cancels the in-flight sync pass
+    /// (every write and checkpoint save re-checks the generation), so a
+    /// racing pass can neither recreate files after the wipe nor persist
+    /// a checkpoint that outlives it. A surviving checkpoint would make
+    /// the next sync take the incremental event-replay path against an
+    /// empty local store, so chats older than the checkpoint would never
+    /// be rehydrated (bootstrap never runs). Unlike clearSyncStatus this
+    /// keeps the attested client and token wiring intact — the same
+    /// account keeps syncing and the next pass bootstraps a fresh
+    /// snapshot.
     func handleLocalStoreWipe(forUser userId: String?) async {
         accountGeneration += 1
         isSyncing = false

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -862,9 +862,10 @@ class CloudSyncService: ObservableObject {
     ///   snapshot. Rebase the local row onto the server's current
     ///   version (so the next upload's CAS base matches) and re-upload,
     ///   letting local win instead of looping on STALE_BLOB forever.
-    /// - Remote row is gone entirely (deleted on another device): a
-    ///   locally modified copy wins by re-creating the row through the
-    ///   restore path, unless its tombstone is already being applied.
+    /// - Remote row is gone entirely (deleted on another device): the
+    ///   remote deletion wins even over a dirty local copy — the local
+    ///   row is removed and tombstoned so a racing upload can't
+    ///   resurrect it, matching the revision drain's delete-wins policy.
     ///
     /// If the pull itself fails the chat stays locallyModified and the
     /// next sync cycle retries.
@@ -1933,29 +1934,6 @@ class CloudSyncService: ObservableObject {
         )) ?? .refused
     }
 
-    /// Upload a chat to cloud and mark it as synced with the enclave's
-    /// authoritative version (the new etag), or `chat.syncVersion + 1`
-    /// when the enclave didn't return a parseable etag.
-    private func uploadAndMarkSynced(
-        _ chat: Chat,
-        idempotencyKey: String,
-        generation: Int,
-        userId: String,
-        restoreDeleted: Bool = false
-    ) async throws {
-        guard !streamingTracker.isStreaming(chat.id) else { return }
-
-        let storedChat = StoredChat(from: chat, syncVersion: chat.syncVersion)
-        let account = UploadAccount(generation: generation, userId: userId)
-        try await uploadAndMarkSynced(
-            storedChat,
-            expectedUpdatedAt: chat.updatedAt,
-            idempotencyKey: idempotencyKey,
-            account: account,
-            restoreDeleted: restoreDeleted
-        )
-    }
-
     private func uploadAndMarkSynced(_ upload: PreparedChatUpload) async throws {
         // Streaming is an eligibility check only while preparing. Once frozen,
         // this operation must finish while newer streaming edits stay dirty.
@@ -1967,12 +1945,14 @@ class CloudSyncService: ObservableObject {
         )
     }
 
+    /// Upload a chat to cloud and mark it as synced with the enclave's
+    /// authoritative version (the new etag), or `chat.syncVersion + 1`
+    /// when the enclave didn't return a parseable etag.
     private func uploadAndMarkSynced(
         _ chat: StoredChat,
         expectedUpdatedAt: Date,
         idempotencyKey: String,
-        account: UploadAccount,
-        restoreDeleted: Bool = false
+        account: UploadAccount
     ) async throws {
         guard await isCurrentUploadAccount(account) else {
             throw CancellationError()
@@ -1982,8 +1962,7 @@ class CloudSyncService: ObservableObject {
         }
         let result = try await cloudStorage.uploadChat(
             chat,
-            idempotencyKey: idempotencyKey,
-            restoreDeleted: restoreDeleted
+            idempotencyKey: idempotencyKey
         )
         guard await isCurrentUploadAccount(account) else {
             throw CancellationError()

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -339,6 +339,10 @@ class CloudSyncService: ObservableObject {
     /// device may have rotated or reset the key, leaving this device's
     /// hint stale.
     private func canWriteToCloud() async -> Bool {
+        // Guards the reportKeyHealthy calls below: a stale confirmation
+        // from an old account's in-flight request must not clear a gate
+        // the next account's session has since set.
+        let generation = accountGeneration
         let cek: Data
         do {
             cek = try EncryptionService.shared.getKeyBytesOrThrow()
@@ -388,7 +392,7 @@ class CloudSyncService: ObservableObject {
                 // kick.
                 let adopted = await LegacyBlobMigration.adoptLocalKeyForMigration(
                     keyB64: persistedB64)
-                if adopted {
+                if adopted, generation == accountGeneration {
                     SyncHealthStore.shared.reportKeyHealthy()
                 }
                 return adopted
@@ -406,7 +410,9 @@ class CloudSyncService: ObservableObject {
         if localKeyId == remoteKeyId {
             // The enclave just confirmed the local key is authoritative,
             // so any surfaced key problem is stale.
-            SyncHealthStore.shared.reportKeyHealthy()
+            if generation == accountGeneration {
+                SyncHealthStore.shared.reportKeyHealthy()
+            }
             return true
         }
         return false
@@ -423,6 +429,7 @@ class CloudSyncService: ObservableObject {
     /// only succeeds while no key is registered, and a loss just defers
     /// the push until the next validation pass sees the winner's key.
     private func registerKeyForEmptyRemote(keyB64: String) async -> Bool {
+        let generation = accountGeneration
         if let inFlight = emptyRemoteRegistration {
             return await inFlight.value
         }
@@ -445,7 +452,7 @@ class CloudSyncService: ObservableObject {
         emptyRemoteRegistration = task
         let result = await task.value
         emptyRemoteRegistration = nil
-        if result {
+        if result, generation == accountGeneration {
             // The local key just became the enclave's registered key, so
             // any surfaced key problem is stale.
             SyncHealthStore.shared.reportKeyHealthy()
@@ -992,10 +999,15 @@ class CloudSyncService: ObservableObject {
             }
             return false
         } catch {
-            SyncHealthStore.shared.reportChatSyncFailed(
-                chatId,
-                message: "This chat couldn't be synced"
-            )
+            // Generation-guarded: a failure from an old account's
+            // in-flight request must not repopulate the health store
+            // after sign-out reset it.
+            if generation == accountGeneration {
+                SyncHealthStore.shared.reportChatSyncFailed(
+                    chatId,
+                    message: "This chat couldn't be synced"
+                )
+            }
             throw error
         }
     }
@@ -1372,8 +1384,11 @@ class CloudSyncService: ObservableObject {
             // so the gate check in syncAllChats stops the periodic
             // retries (426) or the settings row explains the pause
             // (attestation), instead of the error dissolving into the
-            // generic error string.
-            if case .blockAllSync(let reason) = EnclaveErrorRecovery.decide(error).action {
+            // generic error string. Generation-guarded: a failure from
+            // an old account's in-flight request must not repopulate
+            // the health store after sign-out reset it.
+            if generation == accountGeneration,
+               case .blockAllSync(let reason) = EnclaveErrorRecovery.decide(error).action {
                 switch reason {
                 case .attestationFailed:
                     SyncHealthStore.shared.reportSyncPaused(.attestation)

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1894,6 +1894,10 @@ class CloudSyncService: ObservableObject {
     func clearSyncStatus(forUser userId: String?) async {
         await handleLocalStoreWipe(forUser: userId)
         lastSyncDate = nil
+        // The health gate is per-account state: key problems and even the
+        // sticky upgradeRequired gate must not block the NEXT account
+        // (reset() is the one designated way to lift the upgrade gate).
+        SyncHealthStore.shared.reset()
         // Drop any in-flight key registration so the next signed-in user
         // never awaits a task started under the previous user's key.
         emptyRemoteRegistration?.cancel()

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -305,10 +305,20 @@ class CloudSyncService: ObservableObject {
             )
         }
     }()
+    private struct DeferredRemoteDelete {
+        let userId: String
+        let generation: Int
+        let preserveNeverSynced: Bool
+        /// Whether an onStreamEnd callback is currently registered.
+        var callbackRegistered: Bool
+    }
+
     private var streamingCallbacks: Set<String> = []
     /// Chats whose remote delete arrived while they were streaming
-    /// locally; the local removal is deferred to stream end.
-    private var deferredRemoteDeleteChatIds: Set<String> = []
+    /// locally; the local removal is deferred to stream end. An entry
+    /// stays until the removal succeeds (or the account changes), so a
+    /// failed removal is retried on the next sync cycle.
+    private var deferredRemoteDeletes: [String: DeferredRemoteDelete] = [:]
     private var accountGeneration = 0
     private let cloudStorage = CloudStorageService.shared
     private let encryptionService = EncryptionService.shared
@@ -1335,6 +1345,8 @@ class CloudSyncService: ObservableObject {
             }
             guard generation == accountGeneration else { return SyncResult() }
 
+            await retryDeferredRemoteDeletes(generation: generation)
+            guard generation == accountGeneration else { return SyncResult() }
             let drained = try await drainDeleteIntents(userId: userId, generation: generation)
             guard generation == accountGeneration else { return SyncResult() }
             let uploads = await backupUnsyncedChats()
@@ -1515,25 +1527,104 @@ class CloudSyncService: ObservableObject {
         }
 
         deletedChatsTracker.markAsDeleted(chatId)
-        guard !deferredRemoteDeleteChatIds.contains(chatId) else { return false }
-        deferredRemoteDeleteChatIds.insert(chatId)
+        deferRemoteChatDelete(
+            chatId: chatId,
+            deferral: DeferredRemoteDelete(
+                userId: userId,
+                generation: generation,
+                preserveNeverSynced: preserveNeverSynced,
+                callbackRegistered: false
+            )
+        )
+        return false
+    }
+
+    /// Register (or refresh) the stream-end callback for a deferred
+    /// remote delete. The deferral entry outlives the callback: it is
+    /// removed only when the removal succeeds or the account changes,
+    /// so a removal that fails — or fires while a NEW stream for the
+    /// same chat is already running — re-registers and tries again at
+    /// the next stream end instead of being dropped (or worse, deleting
+    /// the new stream's files out from under it).
+    private func deferRemoteChatDelete(chatId: String, deferral: DeferredRemoteDelete) {
+        if let existing = deferredRemoteDeletes[chatId], existing.callbackRegistered {
+            return
+        }
+        var registered = deferral
+        registered.callbackRegistered = true
+        deferredRemoteDeletes[chatId] = registered
+
         streamingTracker.onStreamEnd(chatId) { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
-                self.deferredRemoteDeleteChatIds.remove(chatId)
-                guard self.accountGeneration == generation else { return }
+                guard var pending = self.deferredRemoteDeletes[chatId] else { return }
+                pending.callbackRegistered = false
+                self.deferredRemoteDeletes[chatId] = pending
+                guard self.accountGeneration == pending.generation else {
+                    self.deferredRemoteDeletes.removeValue(forKey: chatId)
+                    return
+                }
                 // A later upsert event (the chat was recreated remotely)
                 // clears the tombstone; the deferred delete must then
                 // stand down instead of removing the recreated chat.
-                guard self.deletedChatsTracker.isDeleted(chatId) else { return }
-                _ = try? await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
-                    chatId: chatId,
-                    userId: userId,
-                    preserveNeverSynced: preserveNeverSynced
-                )
+                guard self.deletedChatsTracker.isDeleted(chatId) else {
+                    self.deferredRemoteDeletes.removeValue(forKey: chatId)
+                    return
+                }
+                // A new stream for the same chat may have started before
+                // this callback ran; deleting its files now would race
+                // it exactly like the original stream. Wait it out.
+                guard !self.streamingTracker.isStreaming(chatId) else {
+                    self.deferRemoteChatDelete(chatId: chatId, deferral: pending)
+                    return
+                }
+                do {
+                    _ = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                        chatId: chatId,
+                        userId: pending.userId,
+                        preserveNeverSynced: pending.preserveNeverSynced
+                    )
+                    self.deferredRemoteDeletes.removeValue(forKey: chatId)
+                } catch {
+                    // Keep the entry; retryDeferredRemoteDeletes picks it
+                    // up on the next sync cycle. The delete event will not
+                    // replay again (the checkpoint already advanced past
+                    // it), so dropping the entry here would leave the
+                    // files behind for the rest of the session.
+                }
             }
         }
-        return false
+    }
+
+    /// Retry deferred remote deletes whose stream-end removal failed.
+    /// Runs once per sync cycle; entries whose chat is streaming again
+    /// wait for the next stream end via their registered callback.
+    private func retryDeferredRemoteDeletes(generation: Int) async {
+        for (chatId, pending) in deferredRemoteDeletes {
+            guard generation == accountGeneration else { return }
+            guard pending.generation == accountGeneration else {
+                deferredRemoteDeletes.removeValue(forKey: chatId)
+                continue
+            }
+            guard deletedChatsTracker.isDeleted(chatId) else {
+                deferredRemoteDeletes.removeValue(forKey: chatId)
+                continue
+            }
+            guard !pending.callbackRegistered, !streamingTracker.isStreaming(chatId) else {
+                continue
+            }
+            do {
+                _ = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                    chatId: chatId,
+                    userId: pending.userId,
+                    preserveNeverSynced: pending.preserveNeverSynced
+                )
+                guard generation == accountGeneration else { return }
+                deferredRemoteDeletes.removeValue(forKey: chatId)
+            } catch {
+                // Still failing; keep the entry for the next cycle.
+            }
+        }
     }
 
     private func reconcileRevisionSnapshot(
@@ -1810,7 +1901,7 @@ class CloudSyncService: ObservableObject {
         isSyncing = false
         syncStatus = ""
         streamingCallbacks.removeAll()
-        deferredRemoteDeleteChatIds.removeAll()
+        deferredRemoteDeletes.removeAll()
         pendingUploadCounts.removeAll()
         pendingUploadChatIds.removeAll()
         await uploadCoalescer.clear()

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1357,11 +1357,18 @@ class CloudSyncService: ObservableObject {
                 errors: result.errors + drained.errors + uploads.errors
             )
         } catch {
-            // Surface a force-upgrade refusal (HTTP 426) from any call in
-            // the cycle so the gate check in syncAllChats stops the
-            // periodic retries and the UI can prompt for an update.
-            if case .blockAllSync(.upgradeRequired) = EnclaveErrorRecovery.decide(error).action {
-                SyncHealthStore.shared.reportKeyActionRequired(.upgradeRequired)
+            // Surface sync-blocking failures from any call in the cycle
+            // so the gate check in syncAllChats stops the periodic
+            // retries (426) or the settings row explains the pause
+            // (attestation), instead of the error dissolving into the
+            // generic error string.
+            if case .blockAllSync(let reason) = EnclaveErrorRecovery.decide(error).action {
+                switch reason {
+                case .attestationFailed:
+                    SyncHealthStore.shared.reportSyncPaused(.attestation)
+                case .upgradeRequired:
+                    SyncHealthStore.shared.reportKeyActionRequired(.upgradeRequired)
+                }
             }
             return SyncResult(errors: ["Revision sync failed: \(error.localizedDescription)"])
         }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -451,7 +451,13 @@ class CloudSyncService: ObservableObject {
         }
         emptyRemoteRegistration = task
         let result = await task.value
-        emptyRemoteRegistration = nil
+        // Only clear the cache when no wipe intervened: after a
+        // generation bump the wipe already cleared it, and it may hold
+        // a newer post-wipe task that must not be clobbered (a clobber
+        // would let the next caller start a duplicate registration).
+        if generation == accountGeneration {
+            emptyRemoteRegistration = nil
+        }
         if result, generation == accountGeneration {
             // The local key just became the enclave's registered key, so
             // any surfaced key problem is stale.
@@ -1917,10 +1923,6 @@ class CloudSyncService: ObservableObject {
         // sticky upgradeRequired gate must not block the NEXT account
         // (reset() is the one designated way to lift the upgrade gate).
         SyncHealthStore.shared.reset()
-        // Drop any in-flight key registration so the next signed-in user
-        // never awaits a task started under the previous user's key.
-        emptyRemoteRegistration?.cancel()
-        emptyRemoteRegistration = nil
         await SyncEnclaveClient.shared.reset()
     }
 
@@ -1945,6 +1947,14 @@ class CloudSyncService: ObservableObject {
         pendingUploadCounts.removeAll()
         pendingUploadChatIds.removeAll()
         await uploadCoalescer.clear()
+        // Drop the memoized key registration: joining it across the
+        // generation bump would hand callers a result whose
+        // reportKeyHealthy was suppressed by the guard in
+        // registerKeyForEmptyRemote (and, on sign-out, a task started
+        // under the previous user's key). Post-wipe callers must re-run
+        // registration under the new generation and report fresh health.
+        emptyRemoteRegistration?.cancel()
+        emptyRemoteRegistration = nil
         if let userId {
             revisionCheckpointStore.clear(userId: userId)
         }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -306,6 +306,9 @@ class CloudSyncService: ObservableObject {
         }
     }()
     private var streamingCallbacks: Set<String> = []
+    /// Chats whose remote delete arrived while they were streaming
+    /// locally; the local removal is deferred to stream end.
+    private var deferredRemoteDeleteChatIds: Set<String> = []
     private var accountGeneration = 0
     private let cloudStorage = CloudStorageService.shared
     private let encryptionService = EncryptionService.shared
@@ -885,12 +888,12 @@ class CloudSyncService: ObservableObject {
             // Remove the cloud-backed local row and let the next revision
             // drain replay the same tombstone idempotently.
             guard var downloadedChat = remoteChat else {
-                _ = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                _ = try await applyRemoteChatDelete(
                     chatId: chatId,
                     userId: userId,
+                    generation: generation,
                     preserveNeverSynced: false
                 )
-                deletedChatsTracker.markAsDeleted(chatId)
                 return false
             }
             if downloadedChat.modelType == nil {
@@ -1421,13 +1424,13 @@ class CloudSyncService: ObservableObject {
             }
             switch event.kind {
             case .delete:
-                let removed = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                let removed = try await applyRemoteChatDelete(
                     chatId: event.id,
                     userId: userId,
+                    generation: generation,
                     preserveNeverSynced: false
                 )
                 if removed {
-                    deletedChatsTracker.markAsDeleted(event.id)
                     result = SyncResult(
                         downloaded: result.downloaded,
                         deleted: result.deleted + 1
@@ -1483,6 +1486,53 @@ class CloudSyncService: ObservableObject {
             }
         }
         return result
+    }
+
+    /// Apply a remote deletion locally, unless the chat is actively
+    /// streaming — deleting the files mid-stream would race the stream's
+    /// throttled saves, which recreate the chat with a stale sync
+    /// version that later uploads as a zombie against a tombstoned row.
+    /// Mirrors the upload path's deferral: tombstone immediately (so a
+    /// racing upload can't resurrect the row) and remove the local files
+    /// once the stream ends. Returns true when the chat was removed now.
+    private func applyRemoteChatDelete(
+        chatId: String,
+        userId: String,
+        generation: Int,
+        preserveNeverSynced: Bool
+    ) async throws -> Bool {
+        guard streamingTracker.isStreaming(chatId) else {
+            let removed = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                chatId: chatId,
+                userId: userId,
+                preserveNeverSynced: preserveNeverSynced
+            )
+            if removed {
+                deletedChatsTracker.markAsDeleted(chatId)
+            }
+            return removed
+        }
+
+        deletedChatsTracker.markAsDeleted(chatId)
+        guard !deferredRemoteDeleteChatIds.contains(chatId) else { return false }
+        deferredRemoteDeleteChatIds.insert(chatId)
+        streamingTracker.onStreamEnd(chatId) { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.deferredRemoteDeleteChatIds.remove(chatId)
+                guard self.accountGeneration == generation else { return }
+                // A later upsert event (the chat was recreated remotely)
+                // clears the tombstone; the deferred delete must then
+                // stand down instead of removing the recreated chat.
+                guard self.deletedChatsTracker.isDeleted(chatId) else { return }
+                _ = try? await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                    chatId: chatId,
+                    userId: userId,
+                    preserveNeverSynced: preserveNeverSynced
+                )
+            }
+        }
+        return false
     }
 
     private func reconcileRevisionSnapshot(
@@ -1543,12 +1593,12 @@ class CloudSyncService: ObservableObject {
         var deleted = 0
         for id in SnapshotReconciliation.locallyRemovedIds(local: local, remoteIds: remoteIds) {
             guard generation == accountGeneration else { throw CancellationError() }
-            if try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+            if try await applyRemoteChatDelete(
                 chatId: id,
                 userId: userId,
+                generation: generation,
                 preserveNeverSynced: true
             ) {
-                deletedChatsTracker.markAsDeleted(id)
                 deleted += 1
             }
         }
@@ -1737,6 +1787,7 @@ class CloudSyncService: ObservableObject {
         syncStatus = ""
         lastSyncDate = nil
         streamingCallbacks.removeAll()
+        deferredRemoteDeleteChatIds.removeAll()
         pendingUploadCounts.removeAll()
         pendingUploadChatIds.removeAll()
         await uploadCoalescer.clear()

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1557,6 +1557,24 @@ class CloudSyncService: ObservableObject {
             chatIds: local.map(\.id),
             userId: userId
         )
+        // A chat with no content file and no remote row can never be
+        // repaired: the snapshot has nothing to pull and the local file
+        // is gone (e.g. a crash between file removal and the index
+        // save). Prune its index entry, otherwise `needsContentRepair`
+        // stays true and every reconcile fails with incompletePull —
+        // which also starves delete intents and uploads forever.
+        let unrecoverableIds = ChatContentIntegrity.unrecoverableIds(
+            repairIds: missingContentIds,
+            remoteIds: remoteIds,
+            pendingDeleteIds: pendingDeleteIds
+        )
+        if !unrecoverableIds.isEmpty {
+            guard generation == accountGeneration else { throw CancellationError() }
+            _ = try await EncryptedFileStorage.cloud.pruneUnrecoverableIndexEntries(
+                chatIds: unrecoverableIds,
+                userId: userId
+            )
+        }
         let changed = SnapshotReconciliation.contentItems(
             local: local,
             remote: items.filter {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1783,16 +1783,8 @@ class CloudSyncService: ObservableObject {
     /// switch), so resolving it here would clear the wrong user's
     /// revision checkpoint — or none at all.
     func clearSyncStatus(forUser userId: String?) async {
-        accountGeneration += 1
-        isSyncing = false
-        syncStatus = ""
+        await handleLocalStoreWipe(forUser: userId)
         lastSyncDate = nil
-        streamingCallbacks.removeAll()
-        deferredRemoteDeleteChatIds.removeAll()
-        pendingUploadCounts.removeAll()
-        pendingUploadChatIds.removeAll()
-        await uploadCoalescer.clear()
-        invalidateRevisionCheckpoint(forUser: userId)
         // Drop any in-flight key registration so the next signed-in user
         // never awaits a task started under the previous user's key.
         emptyRemoteRegistration?.cancel()
@@ -1800,14 +1792,31 @@ class CloudSyncService: ObservableObject {
         await SyncEnclaveClient.shared.reset()
     }
 
-    /// Drop the revision checkpoint for a user whose local cloud chat
+    /// Fence and invalidate sync state after the user's local cloud chat
     /// store was wiped. Every wipe path must call this: a surviving
     /// checkpoint makes the next sync take the incremental event-replay
     /// path against an empty local store, so chats older than the
     /// checkpoint would never be rehydrated (bootstrap never runs).
-    func invalidateRevisionCheckpoint(forUser userId: String?) {
-        guard let userId else { return }
-        revisionCheckpointStore.clear(userId: userId)
+    ///
+    /// The account generation advances BEFORE the checkpoint is cleared:
+    /// an in-flight sync pass re-checks the generation right before
+    /// every checkpoint save, so the bump guarantees it can never
+    /// rewrite the checkpoint after the wipe. Unlike clearSyncStatus
+    /// this keeps the attested client and token wiring intact — the
+    /// same account keeps syncing and the next pass bootstraps a
+    /// fresh snapshot.
+    func handleLocalStoreWipe(forUser userId: String?) async {
+        accountGeneration += 1
+        isSyncing = false
+        syncStatus = ""
+        streamingCallbacks.removeAll()
+        deferredRemoteDeleteChatIds.removeAll()
+        pendingUploadCounts.removeAll()
+        pendingUploadChatIds.removeAll()
+        await uploadCoalescer.clear()
+        if let userId {
+            revisionCheckpointStore.clear(userId: userId)
+        }
     }
 
     // MARK: - Delete Operations

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1940,6 +1940,10 @@ class CloudSyncService: ObservableObject {
     /// snapshot.
     func handleLocalStoreWipe(forUser userId: String?) async {
         accountGeneration += 1
+        // Before the first await, so no new-generation caller can slip
+        // in during a suspension and join the stale registration task.
+        emptyRemoteRegistration?.cancel()
+        emptyRemoteRegistration = nil
         isSyncing = false
         syncStatus = ""
         streamingCallbacks.removeAll()
@@ -1947,14 +1951,6 @@ class CloudSyncService: ObservableObject {
         pendingUploadCounts.removeAll()
         pendingUploadChatIds.removeAll()
         await uploadCoalescer.clear()
-        // Drop the memoized key registration: joining it across the
-        // generation bump would hand callers a result whose
-        // reportKeyHealthy was suppressed by the guard in
-        // registerKeyForEmptyRemote (and, on sign-out, a task started
-        // under the previous user's key). Post-wipe callers must re-run
-        // registration under the new generation and report fresh health.
-        emptyRemoteRegistration?.cancel()
-        emptyRemoteRegistration = nil
         if let userId {
             revisionCheckpointStore.clear(userId: userId)
         }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1331,14 +1331,14 @@ class CloudSyncService: ObservableObject {
             }
             guard generation == accountGeneration else { return SyncResult() }
 
-            let deleted = try await drainDeleteIntents(userId: userId, generation: generation)
+            let drained = try await drainDeleteIntents(userId: userId, generation: generation)
             guard generation == accountGeneration else { return SyncResult() }
             let uploads = await backupUnsyncedChats()
             return SyncResult(
                 uploaded: uploads.uploaded,
                 downloaded: result.downloaded,
-                deleted: result.deleted + deleted,
-                errors: result.errors + uploads.errors
+                deleted: result.deleted + drained.deleted,
+                errors: result.errors + drained.errors + uploads.errors
             )
         } catch {
             // Surface a force-upgrade refusal (HTTP 426) from any call in
@@ -1633,19 +1633,49 @@ class CloudSyncService: ObservableObject {
         return SyncResult(downloaded: downloaded, deleted: deleted)
     }
 
-    private func drainDeleteIntents(userId: String, generation: Int) async throws -> Int {
-        let intents = try await EncryptedFileStorage.cloud.loadDeleteIntents(userId: userId)
+    private struct DrainDeleteIntentsResult {
         var deleted = 0
+        var errors: [String] = []
+    }
+
+    /// Push every staged delete intent to the enclave. A row-specific
+    /// failure (conflict, malformed row, ...) is recorded and skipped so
+    /// one poison intent never aborts the drain — the intent stays
+    /// queued and is retried next cycle, and the cycle still reaches
+    /// `backupUnsyncedChats`. Only failures that would hit every intent
+    /// identically (network, auth, key problems, forced upgrade) stop
+    /// the drain early.
+    private func drainDeleteIntents(
+        userId: String,
+        generation: Int
+    ) async throws -> DrainDeleteIntentsResult {
+        let intents = try await EncryptedFileStorage.cloud.loadDeleteIntents(userId: userId)
+        var result = DrainDeleteIntentsResult()
         for intent in intents.sorted(by: { $0.chatId < $1.chatId }) {
             guard generation == accountGeneration else { throw CancellationError() }
             if pendingUploadChatIds.contains(intent.chatId) {
                 await uploadCoalescer.waitForUpload(intent.chatId)
                 guard generation == accountGeneration else { throw CancellationError() }
             }
-            try await cloudStorage.deleteChat(
-                intent.chatId,
-                idempotencyKey: intent.idempotencyKey
-            )
+            do {
+                try await cloudStorage.deleteChat(
+                    intent.chatId,
+                    idempotencyKey: intent.idempotencyKey
+                )
+            } catch {
+                let decision = EnclaveErrorRecovery.decide(error)
+                if case .surfaceNotFound = decision.action {
+                    // The row is already gone remotely; the intent is
+                    // satisfied, so fall through to the local cleanup.
+                } else if DeleteIntentPlanner.isAccountWideFailure(decision.action) {
+                    throw error
+                } else {
+                    result.errors.append(
+                        "Failed to delete chat \(intent.chatId): \(error.localizedDescription)"
+                    )
+                    continue
+                }
+            }
             guard generation == accountGeneration,
                   await getCurrentUserId() == userId else {
                 throw CancellationError()
@@ -1660,9 +1690,9 @@ class CloudSyncService: ObservableObject {
                 userId: userId
             )
             deletedChatsTracker.markAsDeleted(intent.chatId)
-            deleted += 1
+            result.deleted += 1
         }
-        return deleted
+        return result
     }
 
     func smartSync() async -> SyncResult {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -662,6 +662,20 @@ class CloudSyncService: ObservableObject {
         allowWhileStreaming: Bool
     ) async throws -> UploadAttempt? {
         let generation = accountGeneration
+        // Direct backupChat calls reach here without going through
+        // syncAllChats, so the upgrade gate must be enforced in this
+        // path too — pushing against a server that refuses this
+        // protocol version can never succeed.
+        if case .actionRequired(.upgradeRequired, _) = SyncHealthStore.shared.gate {
+            if allowWhileStreaming {
+                throw SyncEnclaveError(
+                    message: "cloud sync requires an app update",
+                    status: 426,
+                    code: WireCodes.syncProtocolUpgradeRequired
+                )
+            }
+            return nil
+        }
         guard let userId = await getCurrentUserId() else {
             if allowWhileStreaming {
                 throw SyncEnclaveError(message: "recovery upload is not authenticated")
@@ -1280,9 +1294,6 @@ class CloudSyncService: ObservableObject {
         guard !isSyncing else {
             return SyncResult()
         }
-        // A 426 gate can only be lifted by updating the app; re-running
-        // the cycle just burns requests against a server that already
-        // refused this protocol version.
         if case .actionRequired(.upgradeRequired, _) = SyncHealthStore.shared.gate {
             return SyncResult()
         }

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -140,7 +140,6 @@ actor EncryptedFileStorage {
         return dir.appendingPathComponent("\(sanitizePathComponent(chatId)).sync.json")
     }
 
-    /// Whether a content file (.enc or .raw) exists for the chat.
     private func hasChatContentFile(chatId: String, userId: String) throws -> Bool {
         let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
         let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
@@ -711,7 +710,11 @@ actor EncryptedFileStorage {
             contentRepairIds[userId]?.remove(chatId)
             // Drop the sync sidecars too: a later restore of the same
             // chat id must not overlay this dead row's stale metadata.
-            try removeSyncSidecars(chatId: chatId, userId: userId)
+            if try !removeSyncSidecars(chatId: chatId, userId: userId) {
+                #if DEBUG
+                print("[EncryptedFileStorage] prune left a stale sync sidecar for chat \(chatId)")
+                #endif
+            }
             if entries.contains(where: { $0.id == chatId }) {
                 entries.removeAll { $0.id == chatId }
                 pruned += 1
@@ -834,15 +837,30 @@ actor EncryptedFileStorage {
         return true
     }
 
-    private func removeSyncSidecars(chatId: String, userId: String) throws {
+    /// Best-effort removal of the sync sidecar files. Returns false when
+    /// a sidecar exists but could not be removed, so callers for whom a
+    /// surviving sidecar matters (the prune path — stale metadata would
+    /// overlay a future restore of the same chat id) can log it.
+    @discardableResult
+    private func removeSyncSidecars(chatId: String, userId: String) throws -> Bool {
+        var removedAll = true
         let sidecarPath = try syncMetadataPath(chatId: chatId, userId: userId)
         if fileManager.fileExists(atPath: sidecarPath.path) {
-            try? fileManager.removeItem(at: sidecarPath)
+            do {
+                try fileManager.removeItem(at: sidecarPath)
+            } catch {
+                removedAll = false
+            }
         }
         let legacySidecarPath = try legacySyncMetadataPath(chatId: chatId, userId: userId)
         if fileManager.fileExists(atPath: legacySidecarPath.path) {
-            try? fileManager.removeItem(at: legacySidecarPath)
+            do {
+                try fileManager.removeItem(at: legacySidecarPath)
+            } catch {
+                removedAll = false
+            }
         }
+        return removedAll
     }
 
     private func performDeleteChat(chatId: String, userId: String) async throws {

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -693,6 +693,42 @@ actor EncryptedFileStorage {
         return .applied
     }
 
+    /// Remove index entries (and their repair bookkeeping) for chats
+    /// whose content file no longer exists anywhere. Called by snapshot
+    /// repair for rows that are also absent remotely: with no local file
+    /// and no remote row there is nothing left to recover, and keeping
+    /// the entry would hold `needsContentRepair` true and fail every
+    /// reconcile. The file check re-runs under the write lock so an
+    /// entry whose content just reappeared (concurrent save) survives.
+    func pruneUnrecoverableIndexEntries(
+        chatIds: Set<String>,
+        userId: String
+    ) async throws -> Int {
+        guard !chatIds.isEmpty else { return 0 }
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+
+        var entries = try await loadIndex(userId: userId)
+        var pruned = 0
+        for chatId in chatIds {
+            let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
+            let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
+            guard !fileManager.fileExists(atPath: encPath.path),
+                  !fileManager.fileExists(atPath: rawPath.path) else {
+                continue
+            }
+            contentRepairIds[userId]?.remove(chatId)
+            if entries.contains(where: { $0.id == chatId }) {
+                entries.removeAll { $0.id == chatId }
+                pruned += 1
+            }
+        }
+        if pruned > 0 {
+            try await saveIndex(entries, userId: userId)
+        }
+        return pruned
+    }
+
     func missingChatContentIds(chatIds: [String], userId: String) async throws -> Set<String> {
         await acquireWriteLock()
         defer { releaseWriteLock() }

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -762,11 +762,27 @@ actor EncryptedFileStorage {
             return []
         }
         let data = try Data(contentsOf: path)
-        let encrypted = try decoder.decode(EncryptedData.self, from: data)
-        let plaintext = try await encryptor.decryptData(encrypted)
-        let intents = try decoder.decode([PendingChatDelete].self, from: plaintext)
-        deleteIntentsCache[userId] = intents
-        return intents
+        // Mirror the index's rebuild-on-failure behavior: an unreadable
+        // intents file (corrupt bytes, or sealed under a key that no
+        // longer exists) must reset to empty instead of throwing on
+        // every sync cycle forever. Losing intents is bounded damage —
+        // the remote rows resurrect locally and can be re-deleted —
+        // whereas a bricked drain blocks deletes AND uploads unbounded.
+        // A missing key is the one exception: it is transient (the key
+        // loads later in the session), so rethrow and keep the file.
+        do {
+            let encrypted = try decoder.decode(EncryptedData.self, from: data)
+            let plaintext = try await encryptor.decryptData(encrypted)
+            let intents = try decoder.decode([PendingChatDelete].self, from: plaintext)
+            deleteIntentsCache[userId] = intents
+            return intents
+        } catch EncryptionError.keyNotInitialized {
+            throw EncryptionError.keyNotInitialized
+        } catch {
+            try? fileManager.removeItem(at: path)
+            deleteIntentsCache[userId] = []
+            return []
+        }
     }
 
     private func saveDeleteIntents(

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -707,14 +707,24 @@ actor EncryptedFileStorage {
             guard try !hasChatContentFile(chatId: chatId, userId: userId) else {
                 continue
             }
-            contentRepairIds[userId]?.remove(chatId)
-            // Drop the sync sidecars too: a later restore of the same
-            // chat id must not overlay this dead row's stale metadata.
-            if try !removeSyncSidecars(chatId: chatId, userId: userId) {
+            // Sidecars go first, and the entry is pruned only when they
+            // are gone: a leftover sidecar would overlay stale metadata
+            // (a stale higher syncVersion wins the sidecarIsNewer check)
+            // onto a future restore of the same chat id, silently
+            // poisoning its CAS base. Keeping the repair marker and index
+            // entry on failure means this cycle's reconcile still fails
+            // with incompletePull, but the prune — and the sidecar
+            // removal — reruns every cycle, so the stall lasts only as
+            // long as the removal failure (transient in practice, e.g.
+            // file protection while the device is locked). The lesser
+            // evil versus permanently stale metadata.
+            guard try removeSyncSidecars(chatId: chatId, userId: userId) else {
                 #if DEBUG
-                print("[EncryptedFileStorage] prune left a stale sync sidecar for chat \(chatId)")
+                print("[EncryptedFileStorage] deferring prune of chat \(chatId): sync sidecar removal failed")
                 #endif
+                continue
             }
+            contentRepairIds[userId]?.remove(chatId)
             if entries.contains(where: { $0.id == chatId }) {
                 entries.removeAll { $0.id == chatId }
                 pruned += 1

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -140,6 +140,14 @@ actor EncryptedFileStorage {
         return dir.appendingPathComponent("\(sanitizePathComponent(chatId)).sync.json")
     }
 
+    /// Whether a content file (.enc or .raw) exists for the chat.
+    private func hasChatContentFile(chatId: String, userId: String) throws -> Bool {
+        let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
+        let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
+        return fileManager.fileExists(atPath: encPath.path)
+            || fileManager.fileExists(atPath: rawPath.path)
+    }
+
     private struct SyncMetadataSidecar: Codable {
         let syncVersion: Int
         let syncedAt: Date?
@@ -251,18 +259,7 @@ actor EncryptedFileStorage {
     ) throws {
         var availableIds: Set<String> = []
         for entry in entries {
-            let encPath = try chatFilePath(
-                chatId: entry.id,
-                userId: userId,
-                isCorrupted: false
-            )
-            let rawPath = try chatFilePath(
-                chatId: entry.id,
-                userId: userId,
-                isCorrupted: true
-            )
-            if fileManager.fileExists(atPath: encPath.path)
-                || fileManager.fileExists(atPath: rawPath.path) {
+            if try hasChatContentFile(chatId: entry.id, userId: userId) {
                 availableIds.insert(entry.id)
             }
         }
@@ -293,10 +290,7 @@ actor EncryptedFileStorage {
             ignoredIds: ignoredIds
         )
         for chatId in repairCandidates {
-            let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
-            let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
-            if !fileManager.fileExists(atPath: encPath.path)
-                && !fileManager.fileExists(atPath: rawPath.path) {
+            if try !hasChatContentFile(chatId: chatId, userId: userId) {
                 unresolvedIds.insert(chatId)
             }
         }
@@ -711,13 +705,13 @@ actor EncryptedFileStorage {
         var entries = try await loadIndex(userId: userId)
         var pruned = 0
         for chatId in chatIds {
-            let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
-            let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
-            guard !fileManager.fileExists(atPath: encPath.path),
-                  !fileManager.fileExists(atPath: rawPath.path) else {
+            guard try !hasChatContentFile(chatId: chatId, userId: userId) else {
                 continue
             }
             contentRepairIds[userId]?.remove(chatId)
+            // Drop the sync sidecars too: a later restore of the same
+            // chat id must not overlay this dead row's stale metadata.
+            try removeSyncSidecars(chatId: chatId, userId: userId)
             if entries.contains(where: { $0.id == chatId }) {
                 entries.removeAll { $0.id == chatId }
                 pruned += 1
@@ -735,10 +729,7 @@ actor EncryptedFileStorage {
 
         var missingIds = contentRepairIds[userId] ?? []
         for chatId in chatIds {
-            let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
-            let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
-            if !fileManager.fileExists(atPath: encPath.path)
-                && !fileManager.fileExists(atPath: rawPath.path) {
+            if try !hasChatContentFile(chatId: chatId, userId: userId) {
                 missingIds.insert(chatId)
             }
         }
@@ -843,6 +834,17 @@ actor EncryptedFileStorage {
         return true
     }
 
+    private func removeSyncSidecars(chatId: String, userId: String) throws {
+        let sidecarPath = try syncMetadataPath(chatId: chatId, userId: userId)
+        if fileManager.fileExists(atPath: sidecarPath.path) {
+            try? fileManager.removeItem(at: sidecarPath)
+        }
+        let legacySidecarPath = try legacySyncMetadataPath(chatId: chatId, userId: userId)
+        if fileManager.fileExists(atPath: legacySidecarPath.path) {
+            try? fileManager.removeItem(at: legacySidecarPath)
+        }
+    }
+
     private func performDeleteChat(chatId: String, userId: String) async throws {
         let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
         if fileManager.fileExists(atPath: encPath.path) {
@@ -854,14 +856,7 @@ actor EncryptedFileStorage {
             try fileManager.removeItem(at: rawPath)
         }
 
-        let sidecarPath = try syncMetadataPath(chatId: chatId, userId: userId)
-        if fileManager.fileExists(atPath: sidecarPath.path) {
-            try? fileManager.removeItem(at: sidecarPath)
-        }
-        let legacySidecarPath = try legacySyncMetadataPath(chatId: chatId, userId: userId)
-        if fileManager.fileExists(atPath: legacySidecarPath.path) {
-            try? fileManager.removeItem(at: legacySidecarPath)
-        }
+        try removeSyncSidecars(chatId: chatId, userId: userId)
 
         var entries = (try? await loadIndex(userId: userId)) ?? []
         entries.removeAll { $0.id == chatId }

--- a/TinfoilChat/Services/RevisionSyncState.swift
+++ b/TinfoilChat/Services/RevisionSyncState.swift
@@ -44,6 +44,25 @@ enum DeleteIntentPlanner {
     ) -> Bool {
         !pendingDeleteIds.contains(chatId)
     }
+
+    /// True when a failed delete indicates a condition that would fail
+    /// every remaining intent identically (network trouble, auth, key
+    /// problems, attestation, forced upgrade), so the drain should stop
+    /// early instead of failing each row in turn. Row-specific outcomes
+    /// (conflicts, not-found, idempotency) keep the drain going so one
+    /// poison intent can never starve the rest of the cycle.
+    static func isAccountWideFailure(_ action: RecoveryAction) -> Bool {
+        switch action {
+        case .retry, .refreshCurrentKeyAndRetry, .migrateLegacyAndRetry,
+             .triggerRecoveryWizard, .surfaceExistingDataUnderOtherKey,
+             .blockAllSync:
+            return true
+        case .abort(let reason):
+            return reason == .authenticationRequired || reason == .forbidden
+        case .surfaceConflict, .surfaceNotFound:
+            return false
+        }
+    }
 }
 
 enum DecimalRevision {

--- a/TinfoilChat/Services/RevisionSyncState.swift
+++ b/TinfoilChat/Services/RevisionSyncState.swift
@@ -236,6 +236,20 @@ enum ChatContentIntegrity {
     ) -> Set<String> {
         repairIds.intersection(indexedIds).subtracting(ignoredIds)
     }
+
+    /// Ids whose missing content cannot be repaired from anywhere: the
+    /// local file is gone and the remote snapshot has no row to pull
+    /// from. Left in place they would keep `needsContentRepair` true and
+    /// fail every snapshot reconcile, so the repair prunes their index
+    /// entries instead. Pending deletes are excluded — their local
+    /// absence is intentional and their intents resolve separately.
+    static func unrecoverableIds(
+        repairIds: Set<String>,
+        remoteIds: Set<String>,
+        pendingDeleteIds: Set<String>
+    ) -> Set<String> {
+        repairIds.subtracting(remoteIds).subtracting(pendingDeleteIds)
+    }
 }
 
 enum ProjectMetadataUploadPolicy {

--- a/TinfoilChat/Services/RevisionSyncState.swift
+++ b/TinfoilChat/Services/RevisionSyncState.swift
@@ -255,10 +255,9 @@ enum ChatContentIntegrity {
 enum ProjectMetadataUploadPolicy {
     static func shouldInclude(
         syncVersion: Int,
-        projectLocallyModified: Bool,
-        restoreDeleted: Bool = false
+        projectLocallyModified: Bool
     ) -> Bool {
-        syncVersion == 0 || projectLocallyModified || restoreDeleted
+        syncVersion == 0 || projectLocallyModified
     }
 
     static func flagAfterUpload(

--- a/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
+++ b/TinfoilChat/Services/SyncEnclave/EnclaveErrorRecovery.swift
@@ -52,6 +52,7 @@ enum EnclaveErrorCode: String, CaseIterable {
     case network                   = "NETWORK"
     case notFound                  = "NOT_FOUND"
     case preconditionRequired      = "PRECONDITION_REQUIRED"
+    case syncProtocolUpgradeRequired = "SYNC_PROTOCOL_UPGRADE_REQUIRED"
 }
 
 struct EnclaveErrorClassification: Equatable {
@@ -86,6 +87,7 @@ enum RecoveryAction: Equatable {
     }
     enum BlockReason: String, Equatable {
         case attestationFailed = "ATTESTATION_FAILED"
+        case upgradeRequired   = "SYNC_PROTOCOL_UPGRADE_REQUIRED"
     }
     enum AbortReason: String, Equatable {
         case idempotencyConflict  = "IDEMPOTENCY_CONFLICT"
@@ -161,7 +163,7 @@ enum EnclaveErrorRecovery {
                 return EnclaveErrorClassification(kind: .retryableRefresh, code: code, status: status, message: message)
             case .syncConflict, .staleBlob, .existingDataUnderOtherKey, .notFound:
                 return EnclaveErrorClassification(kind: .userDecision, code: code, status: status, message: message)
-            case .idempotencyConflict, .unknownKey, .forbidden, .attestationFailed, .preconditionRequired, .authActionRequired:
+            case .idempotencyConflict, .unknownKey, .forbidden, .attestationFailed, .preconditionRequired, .authActionRequired, .syncProtocolUpgradeRequired:
                 return EnclaveErrorClassification(kind: .terminal, code: code, status: status, message: message)
             case .auth, .network:
                 return EnclaveErrorClassification(kind: .retryableTransient, code: code, status: status, message: message)
@@ -180,6 +182,12 @@ enum EnclaveErrorRecovery {
             }
             if status == 404 {
                 return EnclaveErrorClassification(kind: .userDecision, code: .notFound, status: status, message: message)
+            }
+            if status == 426 {
+                // 426 Upgrade Required: the server no longer speaks this
+                // client's X-Sync-Protocol version. Terminal until the app
+                // is updated; retrying can never heal it.
+                return EnclaveErrorClassification(kind: .terminal, code: .syncProtocolUpgradeRequired, status: status, message: message)
             }
         }
         return EnclaveErrorClassification(kind: .terminal, code: nil, status: status, message: message)
@@ -219,6 +227,8 @@ enum EnclaveErrorRecovery {
             return .migrateLegacyAndRetry
         case .attestationFailed:
             return .blockAllSync(reason: .attestationFailed)
+        case .syncProtocolUpgradeRequired:
+            return .blockAllSync(reason: .upgradeRequired)
         case .auth:
             return .retry(reason: .authRefresh)
         case .authActionRequired:

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveWireContract.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveWireContract.swift
@@ -62,4 +62,5 @@ enum WireCodes {
     static let authActionRequired = EnclaveErrorCode.authActionRequired.rawValue
     static let forbidden = EnclaveErrorCode.forbidden.rawValue
     static let network = EnclaveErrorCode.network.rawValue
+    static let syncProtocolUpgradeRequired = EnclaveErrorCode.syncProtocolUpgradeRequired.rawValue
 }

--- a/TinfoilChat/Services/SyncHealthStore.swift
+++ b/TinfoilChat/Services/SyncHealthStore.swift
@@ -35,6 +35,9 @@ final class SyncHealthStore: ObservableObject {
         case keyMismatch
         case keyConflict
         case accountBlocked
+        /// The server answered 426: it no longer speaks this client's
+        /// sync protocol version. Only an app update fixes it.
+        case upgradeRequired
     }
 
     enum Gate: Equatable {
@@ -73,8 +76,12 @@ final class SyncHealthStore: ObservableObject {
 
     /// The enclave confirmed the local key is the registered current
     /// key. Clears any gate — reaching that verdict required a healthy
-    /// enclave round trip, so a paused gate is stale too.
+    /// enclave round trip, so a paused gate is stale too. The upgrade
+    /// gate is the one exception: a healthy key round trip says nothing
+    /// about the sync protocol version, and only an app update (hence a
+    /// fresh launch) can lift a 426 refusal.
     func reportKeyHealthy() {
+        if case .actionRequired(.upgradeRequired, _) = gate { return }
         if gate != .ok {
             gate = .ok
         }

--- a/TinfoilChat/Services/SyncHealthStore.swift
+++ b/TinfoilChat/Services/SyncHealthStore.swift
@@ -55,10 +55,14 @@ final class SyncHealthStore: ObservableObject {
     /// The local key cannot write (stale after a rotation, unknown to
     /// the enclave, or colliding with data under another key) or the
     /// account is blocked. Requires a user-driven fix, so it sticks
-    /// until `reportKeyHealthy` confirms the key validates again.
+    /// until `reportKeyHealthy` confirms the key validates again. An
+    /// upgradeRequired gate outranks every other reason: no key fix can
+    /// resume sync against a server that refuses this protocol version,
+    /// so only `reset()` (sign-out / account change) clears it.
     func reportKeyActionRequired(_ reason: ActionReason) {
-        if case .actionRequired(let current, _) = gate, current == reason {
-            return
+        if case .actionRequired(let current, _) = gate {
+            if current == reason { return }
+            if current == .upgradeRequired { return }
         }
         gate = .actionRequired(reason: reason, since: Date())
     }

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -256,11 +256,13 @@ class AuthManager: ObservableObject {
         } else {
             // No chat view model is attached (e.g. sign-out resolved before
             // the UI wired one up); wipe directly so chat files never
-            // outlive the account on a shared device. The checkpoint must
-            // go with the wiped store — handleSignOut normally does this
-            // via clearSyncStatus, which didn't run on this branch.
+            // outlive the account on a shared device, and run the same
+            // sync teardown handleSignOut performs via clearSyncStatus —
+            // fencing in-flight sync, clearing the checkpoint, and
+            // resetting the attested client so no in-memory sync state
+            // (coalescer, deferred deletes, tokens) outlives the account.
             await Chat.deleteAllChatsFromStorage(userId: localUserId)
-            CloudSyncService.shared.invalidateRevisionCheckpoint(forUser: localUserId)
+            await CloudSyncService.shared.clearSyncStatus(forUser: localUserId)
         }
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -256,8 +256,11 @@ class AuthManager: ObservableObject {
         } else {
             // No chat view model is attached (e.g. sign-out resolved before
             // the UI wired one up); wipe directly so chat files never
-            // outlive the account on a shared device.
+            // outlive the account on a shared device. The checkpoint must
+            // go with the wiped store — handleSignOut normally does this
+            // via clearSyncStatus, which didn't run on this branch.
             await Chat.deleteAllChatsFromStorage(userId: localUserId)
+            CloudSyncService.shared.invalidateRevisionCheckpoint(forUser: localUserId)
         }
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -255,14 +255,13 @@ class AuthManager: ObservableObject {
             await chatViewModel.wipeLocalChatsForSignOut()
         } else {
             // No chat view model is attached (e.g. sign-out resolved before
-            // the UI wired one up); wipe directly so chat files never
-            // outlive the account on a shared device, and run the same
-            // sync teardown handleSignOut performs via clearSyncStatus —
-            // fencing in-flight sync, clearing the checkpoint, and
-            // resetting the attested client so no in-memory sync state
-            // (coalescer, deferred deletes, tokens) outlives the account.
-            await Chat.deleteAllChatsFromStorage(userId: localUserId)
+            // the UI wired one up); run the same sync teardown handleSignOut
+            // performs via clearSyncStatus — fencing in-flight sync,
+            // clearing the checkpoint, and resetting the attested client —
+            // and only then wipe the files, so a racing sync pass cannot
+            // recreate them after the wipe.
             await CloudSyncService.shared.clearSyncStatus(forUser: localUserId)
+            await Chat.deleteAllChatsFromStorage(userId: localUserId)
         }
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4208,6 +4208,11 @@ class ChatViewModel: ObservableObject {
     
     /// Handle sign-out by clearing current chats but preserving them in storage
     func handleSignOut() async {
+        // Capture the signing-out user's id up front. Later steps (and
+        // the auth manager's cleanup) clear the authenticated state, after
+        // which currentUserId no longer resolves this user.
+        let signingOutUserId = currentUserId
+
         // Allow a new sign-in flow after sign-out
         isSignInInProgress = false
         hasPerformedInitialSync = false
@@ -4234,7 +4239,7 @@ class ChatViewModel: ObservableObject {
         }
 
         // Clear sync caches so stale state doesn't leak into the next session
-        await cloudSync.clearSyncStatus()
+        await cloudSync.clearSyncStatus(forUser: signingOutUserId)
         DeletedChatsTracker.shared.clear()
         CloudKeyAuthorizationStore.shared.clearAuthorization(userId: currentUserId)
 
@@ -4283,6 +4288,10 @@ class ChatViewModel: ObservableObject {
         await drainStreamTasks(canceledStreamTasks)
         await drainPendingSaves()
         await Chat.deleteAllChatsFromStorage(userId: userId)
+        // The local cloud store is gone; a surviving checkpoint would make
+        // the next sync replay events instead of bootstrapping a snapshot,
+        // permanently skipping chats older than the checkpoint.
+        cloudSync.invalidateRevisionCheckpoint(forUser: userId)
         
         // Reset sync state
         lastSyncDate = nil
@@ -4619,6 +4628,10 @@ class ChatViewModel: ObservableObject {
         // Delete all cloud chats from storage (the cloud store only has cloud chats)
         if let userId = currentUserId {
             try? await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
+            // The local cloud store is gone; a surviving checkpoint would
+            // make the next sync replay events instead of bootstrapping a
+            // snapshot, permanently skipping older chats.
+            cloudSync.invalidateRevisionCheckpoint(forUser: userId)
         }
         chats = []
         hasMoreChats = false

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4283,9 +4283,8 @@ class ChatViewModel: ObservableObject {
         localChats.removeAll()
         currentChat = nil
         
-        // Clear from file storage (both local and cloud stores). The
-        // fence must run before the deletion so an in-flight sync pass
-        // cannot recreate files (or persist a checkpoint) after the wipe.
+        // Clear from file storage (both local and cloud stores),
+        // fencing in-flight sync before the deletion.
         let userId = currentUserId
         await drainStreamTasks(canceledStreamTasks)
         await drainPendingSaves()
@@ -4625,8 +4624,7 @@ class ChatViewModel: ObservableObject {
     @MainActor
     func deleteNonLocalChats() async {
         // Delete all cloud chats from storage (the cloud store only has
-        // cloud chats), fencing in-flight sync first so a racing pass
-        // cannot recreate files or persist a checkpoint after the wipe.
+        // cloud chats), fencing in-flight sync before the deletion.
         if let userId = currentUserId {
             await cloudSync.handleLocalStoreWipe(forUser: userId)
             try? await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4288,10 +4288,10 @@ class ChatViewModel: ObservableObject {
         await drainStreamTasks(canceledStreamTasks)
         await drainPendingSaves()
         await Chat.deleteAllChatsFromStorage(userId: userId)
-        // The local cloud store is gone; a surviving checkpoint would make
-        // the next sync replay events instead of bootstrapping a snapshot,
-        // permanently skipping chats older than the checkpoint.
-        cloudSync.invalidateRevisionCheckpoint(forUser: userId)
+        // Fence in-flight sync (generation bump) and drop the checkpoint,
+        // in that order, so a pass racing the wipe can never persist a
+        // checkpoint that outlives the wiped store.
+        await cloudSync.handleLocalStoreWipe(forUser: userId)
         
         // Reset sync state
         lastSyncDate = nil
@@ -4628,10 +4628,10 @@ class ChatViewModel: ObservableObject {
         // Delete all cloud chats from storage (the cloud store only has cloud chats)
         if let userId = currentUserId {
             try? await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
-            // The local cloud store is gone; a surviving checkpoint would
-            // make the next sync replay events instead of bootstrapping a
-            // snapshot, permanently skipping older chats.
-            cloudSync.invalidateRevisionCheckpoint(forUser: userId)
+            // Fence in-flight sync (generation bump) and drop the
+            // checkpoint, in that order, so a pass racing the wipe can
+            // never persist a checkpoint that outlives the wiped store.
+            await cloudSync.handleLocalStoreWipe(forUser: userId)
         }
         chats = []
         hasMoreChats = false

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4283,15 +4283,14 @@ class ChatViewModel: ObservableObject {
         localChats.removeAll()
         currentChat = nil
         
-        // Clear from file storage (both local and cloud stores)
+        // Clear from file storage (both local and cloud stores). The
+        // fence must run before the deletion so an in-flight sync pass
+        // cannot recreate files (or persist a checkpoint) after the wipe.
         let userId = currentUserId
         await drainStreamTasks(canceledStreamTasks)
         await drainPendingSaves()
-        await Chat.deleteAllChatsFromStorage(userId: userId)
-        // Fence in-flight sync (generation bump) and drop the checkpoint,
-        // in that order, so a pass racing the wipe can never persist a
-        // checkpoint that outlives the wiped store.
         await cloudSync.handleLocalStoreWipe(forUser: userId)
+        await Chat.deleteAllChatsFromStorage(userId: userId)
         
         // Reset sync state
         lastSyncDate = nil
@@ -4625,13 +4624,12 @@ class ChatViewModel: ObservableObject {
     /// Removes all cloud (non-local) chats from the device
     @MainActor
     func deleteNonLocalChats() async {
-        // Delete all cloud chats from storage (the cloud store only has cloud chats)
+        // Delete all cloud chats from storage (the cloud store only has
+        // cloud chats), fencing in-flight sync first so a racing pass
+        // cannot recreate files or persist a checkpoint after the wipe.
         if let userId = currentUserId {
-            try? await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
-            // Fence in-flight sync (generation bump) and drop the
-            // checkpoint, in that order, so a pass racing the wipe can
-            // never persist a checkpoint that outlives the wiped store.
             await cloudSync.handleLocalStoreWipe(forUser: userId)
+            try? await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
         }
         chats = []
         hasMoreChats = false

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -272,7 +272,7 @@ struct CloudSyncSettingsView: View {
                 Label(actionRequiredMessage(for: reason), systemImage: "exclamationmark.circle")
                     .font(.caption)
                     .foregroundColor(reason == .accountBlocked ? .red : .orange)
-                if reason != .accountBlocked && reason != .upgradeRequired {
+                if keyRecoveryApplies(to: reason) {
                     Button {
                         viewModel.cloudSyncOnboardingMode = .recovery
                         viewModel.showCloudSyncOnboarding = true
@@ -310,6 +310,18 @@ struct CloudSyncSettingsView: View {
             )
             .font(.caption)
             .foregroundColor(.orange)
+        }
+    }
+
+    /// Reasons the recovery wizard can actually fix. An explicit
+    /// allow-list so a future reason defaults to NOT offering key
+    /// recovery until someone decides it applies.
+    private func keyRecoveryApplies(to reason: SyncHealthStore.ActionReason) -> Bool {
+        switch reason {
+        case .keyRecovery, .keyMismatch, .keyConflict:
+            return true
+        case .accountBlocked, .upgradeRequired:
+            return false
         }
     }
 

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -272,7 +272,7 @@ struct CloudSyncSettingsView: View {
                 Label(actionRequiredMessage(for: reason), systemImage: "exclamationmark.circle")
                     .font(.caption)
                     .foregroundColor(reason == .accountBlocked ? .red : .orange)
-                if reason != .accountBlocked {
+                if reason != .accountBlocked && reason != .upgradeRequired {
                     Button {
                         viewModel.cloudSyncOnboardingMode = .recovery
                         viewModel.showCloudSyncOnboarding = true
@@ -323,6 +323,8 @@ struct CloudSyncSettingsView: View {
             return "Your cloud data is protected by a different key than this device's."
         case .accountBlocked:
             return "Sync is unavailable for this account. Please contact support if this persists."
+        case .upgradeRequired:
+            return "Sync is paused because this version of the app is out of date. Update the app to resume syncing."
         }
     }
 

--- a/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
+++ b/TinfoilChatTests/EnclaveErrorRecoveryTests.swift
@@ -39,6 +39,7 @@ let codedErrorExpectations: [CodedErrorExpectation] = [
     .init(code: .network, status: nil, action: .retry(reason: .network), kind: .retryableTransient),
     .init(code: .notFound, status: 404, action: .surfaceNotFound, kind: .userDecision),
     .init(code: .preconditionRequired, status: 428, action: .abort(reason: .preconditionRequired), kind: .terminal),
+    .init(code: .syncProtocolUpgradeRequired, status: 426, action: .blockAllSync(reason: .upgradeRequired), kind: .terminal),
 ]
 
 @Suite("EnclaveErrorRecovery dispatch table")
@@ -92,6 +93,17 @@ struct EnclaveErrorRecoveryTests {
             SyncEnclaveError(message: "missing", status: 404, code: nil)
         )
         #expect(decision.action == .surfaceNotFound)
+    }
+
+    @Test func status426WithoutCodeMapsToUpgradeRequired() {
+        // Older/simpler gateways may answer a bare 426 without the
+        // structured wire code; the status alone must gate sync.
+        let decision = EnclaveErrorRecovery.decide(
+            SyncEnclaveError(message: "upgrade required", status: 426, code: nil)
+        )
+        #expect(decision.action == .blockAllSync(reason: .upgradeRequired))
+        #expect(decision.classification.kind == .terminal)
+        #expect(decision.classification.code == .syncProtocolUpgradeRequired)
     }
 
     @Test func uncodedTerminalErrorMapsToAbortUnknown() {

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -194,6 +194,16 @@ struct RevisionSyncTests {
         #expect(candidates == ["missing"])
     }
 
+    @Test func contentRepairPrunesOnlyIdsAbsentEverywhere() {
+        let unrecoverable = ChatContentIntegrity.unrecoverableIds(
+            repairIds: ["orphaned", "pullable", "pending-delete"],
+            remoteIds: ["pullable"],
+            pendingDeleteIds: ["pending-delete"]
+        )
+
+        #expect(unrecoverable == ["orphaned"])
+    }
+
     @MainActor
     @Test func pendingMetadataSelectionExcludesLocalOnlyAndCleanChats() {
         var pendingChat = ChatSearchServiceTests.makeChat(id: "pending", title: "Pending")

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -194,6 +194,40 @@ struct RevisionSyncTests {
         #expect(candidates == ["missing"])
     }
 
+    @Test func deleteIntentDrainStopsOnlyForAccountWideFailures() {
+        #expect(DeleteIntentPlanner.isAccountWideFailure(.retry(reason: .network)))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(.refreshCurrentKeyAndRetry))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(.migrateLegacyAndRetry))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(
+            .triggerRecoveryWizard(reason: .unknownKey)
+        ))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(.surfaceExistingDataUnderOtherKey))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(
+            .blockAllSync(reason: .attestationFailed)
+        ))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(
+            .blockAllSync(reason: .upgradeRequired)
+        ))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(
+            .abort(reason: .authenticationRequired)
+        ))
+        #expect(DeleteIntentPlanner.isAccountWideFailure(.abort(reason: .forbidden)))
+
+        // Row-specific outcomes keep the drain going: one poison intent
+        // must never starve the rest of the cycle.
+        #expect(!DeleteIntentPlanner.isAccountWideFailure(
+            .surfaceConflict(reason: .staleBlob)
+        ))
+        #expect(!DeleteIntentPlanner.isAccountWideFailure(.surfaceNotFound))
+        #expect(!DeleteIntentPlanner.isAccountWideFailure(.abort(reason: .unknown)))
+        #expect(!DeleteIntentPlanner.isAccountWideFailure(
+            .abort(reason: .idempotencyConflict)
+        ))
+        #expect(!DeleteIntentPlanner.isAccountWideFailure(
+            .abort(reason: .preconditionRequired)
+        ))
+    }
+
     @Test func contentRepairPrunesOnlyIdsAbsentEverywhere() {
         let unrecoverable = ChatContentIntegrity.unrecoverableIds(
             repairIds: ["orphaned", "pullable", "pending-delete"],

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -490,11 +490,6 @@ struct RevisionSyncTests {
             syncVersion: 3,
             projectLocallyModified: true
         ))
-        #expect(ProjectMetadataUploadPolicy.shouldInclude(
-            syncVersion: 3,
-            projectLocallyModified: false,
-            restoreDeleted: true
-        ))
         #expect(ProjectMetadataUploadPolicy.flagAfterUpload(
             current: true,
             editedDuringUpload: false


### PR DESCRIPTION
## Summary

Follow-up hardening for the revision-based sync protocol merged in #252, addressing issues found in a correctness review.

- **Checkpoint invalidation on local wipes** — every path that wipes the local cloud chat store (sign-out, account switch fallback, "delete non-local chats", "clear all chats from device") now clears that user's revision checkpoint, with the user id resolved *before* the wipe begins. Previously a surviving checkpoint made the next sync take the incremental event-replay path against an empty local store, so chats older than the checkpoint were never rehydrated — history appeared permanently empty after signing back in.
- **HTTP 426 force-upgrade handling** — a 426 status (or the `SYNC_PROTOCOL_UPGRADE_REQUIRED` wire code) now classifies as a terminal upgrade-required state: it gates all future sync passes (sticky, not self-healing) and surfaces an "update the app" row in Cloud Sync settings. Classification is structural (status/wire code), never message matching.
- **Poison delete intents no longer starve sync** — `drainDeleteIntents` attempts every intent, records row-specific failures as errors, and continues to uploads. Only account-wide failures (network, auth, key problems, attestation, forced upgrade) abort the drain early. A remote NOT_FOUND now counts as intent-satisfied and cleans up locally.
- **Unrecoverable content repair no longer bricks sync** — an index entry whose content file is missing locally *and* has no remote row (e.g. crash between file removal and index save) is pruned during snapshot repair instead of failing every reconcile with `incompletePull` forever (which also blocked deletes and uploads).
- **Corrupt delete-intents file recovers** — an unreadable intents file now resets to empty (mirroring the index's rebuild-on-failure behavior) instead of throwing on every cycle. A transiently missing encryption key still rethrows and preserves the file.
- **Remote deletes of streaming chats are deferred** — applying a remote delete to an actively streaming chat now tombstones immediately but defers the file removal to stream end, so the stream's throttled saves can't recreate a zombie copy that later uploads against a tombstoned row.
- Also: fixed the stale doc comment on `resolveConflictByPullingRemote` (behavior is delete-wins, not restore) and removed the zero-caller `restoreDeleted` upload plumbing.

## Testing

Per repo policy, no builds or tests were run — **manual testing must be done in Xcode**. Pure-logic tests were extended (`EnclaveErrorRecoveryTests` dispatch table for 426, `RevisionSyncTests` for repair pruning) but not executed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened revision-based sync so local wipes, forced‑upgrade refusals (426), poison delete intents, unrecoverable content, and streaming races no longer cause empty history after sign‑in, endless retries, blocked uploads, or zombie re‑uploads. Enforces delete‑wins when the remote row is gone and removes the restore path.

- Local wipes now fence and invalidate checkpoints via `accountGeneration`; callers must capture the user id before deletion and pass it to `handleLocalStoreWipe(forUser:)`. Generation guards cancel in‑flight work, prevent post‑wipe callers from joining stale key‑registration tasks, scope health updates to the current account, and clear memoized key registration so it re‑runs after a wipe.
- 426 (or `SYNC_PROTOCOL_UPGRADE_REQUIRED`) now gates all sync and direct uploads until sign‑out/account change and shows an “Update the app” notice. `reportKeyHealthy()` cannot clear this gate; `SyncHealthStore.reset()` on account change does.
- Delete‑intent drain attempts every intent, treats remote 404 as satisfied, records per‑row errors, and stops early only for account‑wide failures (network/auth/key/attestation/upgrade).
- Snapshot repair prunes index entries that have no local file and no remote row, removing sync sidecars first to avoid stale metadata; unreadable delete‑intent queues reset to empty unless the key is missing.
- Remote deletes applied during streaming tombstone immediately and defer file removal to stream end; they retry each sync cycle and stand down if the row is recreated.
- Delete‑wins semantics remove the restore path: when a remote row is missing, the local copy is removed even if dirty; the `restoreDeleted` flag and create‑new CAS special‑casing are removed, and conflict docs now match behavior.
- Gates and health are per account and never leak across sign‑out/account changes.

**Migration**
- Update wipe/sign‑out flows to call `CloudSyncService.handleLocalStoreWipe(forUser: <user id resolved before the wipe>)` before deleting files, and use `CloudSyncService.clearSyncStatus(forUser:)` on sign‑out/account switch.
- Remove `restoreDeleted` from any calls to `CloudStorageService.uploadChat` and related helpers.

<sup>Written for commit f20a67cd433ac96738d6aea79fa4154ef62a5c27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

