### PR TITLE
Preserve more context headroom for chat responses

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -267,7 +267,7 @@ enum Constants {
         /// Fraction of the model's context window usable by conversation
         /// history. The remainder is headroom for the system prompt and the
         /// model's response. Mirrors the webapp's CONTEXT_WINDOW_USAGE_RATIO.
-        static let contextWindowUsageRatio: Double = 0.9
+        static let contextWindowUsageRatio: Double = 0.8
         /// Fallback context window size when a model doesn't report one.
         static let defaultContextWindowTokens = 64_000
         /// Smallest plausible model context window accepted from remote config.

--- a/TinfoilChatTests/TokenEstimationTests.swift
+++ b/TinfoilChatTests/TokenEstimationTests.swift
@@ -36,7 +36,7 @@ struct TokenEstimationTests {
     }
 
     @Test func budgetIsUsageRatioOfWindow() {
-        #expect(TokenEstimation.contextTokenBudget(100_000) == 90_000)
+        #expect(TokenEstimation.contextTokenBudget(100_000) == 80_000)
         #expect(TokenEstimation.contextTokenBudget(nil) ==
                 Int(Double(Constants.Context.defaultContextWindowTokens) * Constants.Context.contextWindowUsageRatio))
     }


### PR DESCRIPTION
## Summary
- archive older conversation messages after 80% of the model context is used
- reserve 20% of the context window for system instructions and new responses
- keep context budgeting aligned with the web app

## Testing
- Not run per repository instructions; verify in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves more headroom for chat responses by reducing the conversation context budget from 90% to 80%. This aligns with the web app and reduces response truncation.

- Old: 90% of the model window used for history. New: 80%. Side effects: older messages archive sooner; more room for the system prompt and the model’s reply.
- Updates TokenEstimationTests to expect an 80k budget for a 100k window; fallback calculation remains unchanged. No migration required.

<sup>Written for commit 098ac1a23490b4eaea026e0cf52fadbafd35089f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

