### PR TITLE
fix: align share extension version with the app release

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -457,7 +457,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.6;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -487,7 +487,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.6;
+				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
- Align the share extension's Debug and Release marketing versions with app version 2.6.0.
- Avoid archive and App Store validation failures caused by a container-extension short-version mismatch.

## Testing
- Not run per repository policy; validated the minimal project-file diff and target version/build settings by text inspection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the iOS Share Extension marketing version with the app at 2.6.0 to prevent archive/App Store validation failures from a short-version mismatch. Previously the extension used 2.4.6; now both Debug and Release use 2.6.0. No runtime behavior changes.

**Review**
- Change is limited to `MARKETING_VERSION` in `TinfoilChat.xcodeproj/project.pbxproj` for the Share Extension target (Debug and Release).
- No other targets or identifiers changed; no migration or configuration updates required.

<sup>Written for commit 8c3877a547160a2436ee73333ad43ea862037d43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

