### PR TITLE
Keep iOS release settings consistent

### DIFF
--- a/.github/workflows/project-checks.yml
+++ b/.github/workflows/project-checks.yml
@@ -1,0 +1,31 @@
+name: Project checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/project-checks.yml"
+      - "scripts/check-release-settings.sh"
+      - "TinfoilChat.xcodeproj/project.pbxproj"
+      - "TinfoilChat.xcodeproj/xcshareddata/xcschemes/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/project-checks.yml"
+      - "scripts/check-release-settings.sh"
+      - "TinfoilChat.xcodeproj/project.pbxproj"
+      - "TinfoilChat.xcodeproj/xcshareddata/xcschemes/**"
+
+permissions:
+  contents: read
+
+jobs:
+  release-settings:
+    name: Release settings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check release settings
+        run: bash scripts/check-release-settings.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Check release settings
+        run: bash scripts/check-release-settings.sh "${GITHUB_REF_NAME}"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -447,7 +447,7 @@
 				CODE_SIGN_ENTITLEMENTS = TinfoilShareExtension/TinfoilShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 8KSH668LZT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TinfoilShareExtension/Info.plist;
@@ -457,7 +457,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -477,7 +477,7 @@
 				CODE_SIGN_ENTITLEMENTS = TinfoilShareExtension/TinfoilShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 8KSH668LZT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TinfoilShareExtension/Info.plist;
@@ -487,7 +487,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -560,6 +560,8 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TINFOIL_BUILD_NUMBER = 1;
+				TINFOIL_MARKETING_VERSION = 2.6.0;
 			};
 			name = Debug;
 		};
@@ -614,6 +616,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				TINFOIL_BUILD_NUMBER = 1;
+				TINFOIL_MARKETING_VERSION = 2.6.0;
 			};
 			name = Release;
 		};
@@ -625,7 +629,7 @@
 				CODE_SIGN_ENTITLEMENTS = TinfoilChat/TinfoilChatDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 8KSH668LZT;
 				ENABLE_PREVIEWS = YES;
@@ -646,7 +650,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -670,7 +674,7 @@
 				CODE_SIGN_ENTITLEMENTS = TinfoilChat/TinfoilChatRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 8KSH668LZT;
 				ENABLE_PREVIEWS = YES;
@@ -691,7 +695,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = sh.tinfoil.TinfoilChat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/TinfoilChat.xcodeproj/xcshareddata/xcschemes/TinfoilChat.xcscheme
+++ b/TinfoilChat.xcodeproj/xcshareddata/xcschemes/TinfoilChat.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "99F153C12F4F5F0200E9174E"
+               BuildableName = "TinfoilChat.app"
+               BlueprintName = "TinfoilChat"
+               ReferencedContainer = "container:TinfoilChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "992FC2942F532EA800699029"
+               BuildableName = "TinfoilChatTests.xctest"
+               BlueprintName = "TinfoilChatTests"
+               ReferencedContainer = "container:TinfoilChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "992FC2942F532EA800699029"
+               BuildableName = "TinfoilChatTests.xctest"
+               BlueprintName = "TinfoilChatTests"
+               ReferencedContainer = "container:TinfoilChat.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "99F153C12F4F5F0200E9174E"
+            BuildableName = "TinfoilChat.app"
+            BlueprintName = "TinfoilChat"
+            ReferencedContainer = "container:TinfoilChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "99F153C12F4F5F0200E9174E"
+            BuildableName = "TinfoilChat.app"
+            BlueprintName = "TinfoilChat"
+            ReferencedContainer = "container:TinfoilChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/check-release-settings.sh
+++ b/scripts/check-release-settings.sh
@@ -31,12 +31,39 @@ assert_setting() {
   fi
 }
 
-project_debug="99F153CB2F4F5F0300E9174E"
-project_release="99F153CC2F4F5F0300E9174E"
-extension_debug="99AB000D2FABC00D00ABC00D"
-extension_release="99AB000E2FABC00E00ABC00E"
-app_debug="99F153CE2F4F5F0300E9174E"
-app_release="99F153CF2F4F5F0300E9174E"
+configuration_id() {
+  local owner="$1"
+  local configuration="$2"
+  awk -v owner="$owner" -v configuration="$configuration" '
+    index($0, "Build configuration list for " owner) && / \*\/ = \{/ {
+      in_owner = 1
+      next
+    }
+    in_owner && /buildConfigurations = \(/ {
+      in_configurations = 1
+      next
+    }
+    in_configurations && index($0, "/* " configuration " */") {
+      print $1
+      exit
+    }
+    in_configurations && /\);/ { exit }
+  ' "$project_file"
+}
+
+project_debug=$(configuration_id 'PBXProject "TinfoilChat"' Debug)
+project_release=$(configuration_id 'PBXProject "TinfoilChat"' Release)
+extension_debug=$(configuration_id 'PBXNativeTarget "TinfoilShareExtension"' Debug)
+extension_release=$(configuration_id 'PBXNativeTarget "TinfoilShareExtension"' Release)
+app_debug=$(configuration_id 'PBXNativeTarget "TinfoilChat"' Debug)
+app_release=$(configuration_id 'PBXNativeTarget "TinfoilChat"' Release)
+
+for configuration_id in "$project_debug" "$project_release" "$extension_debug" "$extension_release" "$app_debug" "$app_release"; do
+  if [[ -z "$configuration_id" ]]; then
+    echo "Could not derive all required Xcode configuration IDs." >&2
+    exit 1
+  fi
+done
 
 marketing_version=$(configuration_block "$project_debug" | sed -nE 's/^[[:space:]]*TINFOIL_MARKETING_VERSION = ([^;]+);/\1/p')
 build_number=$(configuration_block "$project_debug" | sed -nE 's/^[[:space:]]*TINFOIL_BUILD_NUMBER = ([^;]+);/\1/p')

--- a/scripts/check-release-settings.sh
+++ b/scripts/check-release-settings.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_file="TinfoilChat.xcodeproj/project.pbxproj"
+shared_scheme="TinfoilChat.xcodeproj/xcshareddata/xcschemes/TinfoilChat.xcscheme"
+
+marketing_versions=$(sed -nE 's/^[[:space:]]*TINFOIL_MARKETING_VERSION = ([^;]+);/\1/p' "$project_file")
+build_numbers=$(sed -nE 's/^[[:space:]]*TINFOIL_BUILD_NUMBER = ([^;]+);/\1/p' "$project_file")
+marketing_count=$(printf '%s\n' "$marketing_versions" | sed '/^$/d' | wc -l | tr -d ' ')
+build_count=$(printf '%s\n' "$build_numbers" | sed '/^$/d' | wc -l | tr -d ' ')
+marketing_version=$(printf '%s\n' "$marketing_versions" | sed -n '1p')
+build_number=$(printf '%s\n' "$build_numbers" | sed -n '1p')
+
+if [[ "$marketing_count" -ne 2 ]] || [[ $(printf '%s\n' "$marketing_versions" | sort -u | wc -l | tr -d ' ') -ne 1 ]]; then
+  echo "App Debug and Release must define one matching TINFOIL_MARKETING_VERSION." >&2
+  exit 1
+fi
+
+if [[ "$build_count" -ne 2 ]] || [[ $(printf '%s\n' "$build_numbers" | sort -u | wc -l | tr -d ' ') -ne 1 ]]; then
+  echo "App Debug and Release must define one matching TINFOIL_BUILD_NUMBER." >&2
+  exit 1
+fi
+
+marketing_references=$(grep -F -c 'MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";' "$project_file")
+build_references=$(grep -F -c 'CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";' "$project_file")
+
+if [[ "$marketing_references" -ne 4 || "$build_references" -ne 4 ]]; then
+  echo "The app and share extension must inherit version and build settings in Debug and Release." >&2
+  exit 1
+fi
+
+if [[ ! -f "$shared_scheme" ]] || ! grep -F -q 'BlueprintName = "TinfoilChat"' "$shared_scheme"; then
+  echo "The shared TinfoilChat app scheme is missing or invalid." >&2
+  exit 1
+fi
+
+release_ref="${1:-}"
+if [[ "$release_ref" == v* ]]; then
+  release_version="${release_ref#v}"
+  if [[ "$release_version" != "$marketing_version" ]]; then
+    echo "Release tag $release_ref does not match app version $marketing_version." >&2
+    exit 1
+  fi
+fi
+
+echo "Release settings are consistent: $marketing_version ($build_number)."

--- a/scripts/check-release-settings.sh
+++ b/scripts/check-release-settings.sh
@@ -21,7 +21,7 @@ assert_setting() {
   local count
   local normalized
 
-  lines=$(configuration_block "$configuration_id" | grep -E "^[[:space:]]*${setting}(\\[[^]]+\\])?[[:space:]]*=" || true)
+  lines=$(configuration_block "$configuration_id" | grep -E "^[[:space:]]*\"?${setting}(\\[[^]]+\\])?\"?[[:space:]]*=" || true)
   count=$(printf '%s\n' "$lines" | sed '/^$/d' | wc -l | tr -d ' ')
   normalized=$(printf '%s\n' "$lines" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
 

--- a/scripts/check-release-settings.sh
+++ b/scripts/check-release-settings.sh
@@ -1,33 +1,60 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-project_file="TinfoilChat.xcodeproj/project.pbxproj"
-shared_scheme="TinfoilChat.xcodeproj/xcshareddata/xcschemes/TinfoilChat.xcscheme"
+project_file="${PROJECT_FILE:-TinfoilChat.xcodeproj/project.pbxproj}"
+shared_scheme="${SHARED_SCHEME:-TinfoilChat.xcodeproj/xcshareddata/xcschemes/TinfoilChat.xcscheme}"
 
-marketing_versions=$(sed -nE 's/^[[:space:]]*TINFOIL_MARKETING_VERSION = ([^;]+);/\1/p' "$project_file")
-build_numbers=$(sed -nE 's/^[[:space:]]*TINFOIL_BUILD_NUMBER = ([^;]+);/\1/p' "$project_file")
-marketing_count=$(printf '%s\n' "$marketing_versions" | sed '/^$/d' | wc -l | tr -d ' ')
-build_count=$(printf '%s\n' "$build_numbers" | sed '/^$/d' | wc -l | tr -d ' ')
-marketing_version=$(printf '%s\n' "$marketing_versions" | sed -n '1p')
-build_number=$(printf '%s\n' "$build_numbers" | sed -n '1p')
+configuration_block() {
+  local configuration_id="$1"
+  awk -v configuration_id="$configuration_id" '
+    $0 ~ "^[[:space:]]*" configuration_id " /\\*" { in_configuration = 1 }
+    in_configuration { print }
+    in_configuration && /^[[:space:]]*name = (Debug|Release);/ { exit }
+  ' "$project_file"
+}
 
-if [[ "$marketing_count" -ne 2 ]] || [[ $(printf '%s\n' "$marketing_versions" | sort -u | wc -l | tr -d ' ') -ne 1 ]]; then
-  echo "App Debug and Release must define one matching TINFOIL_MARKETING_VERSION." >&2
+assert_setting() {
+  local configuration_id="$1"
+  local setting="$2"
+  local expected="$3"
+  local lines
+  local count
+  local normalized
+
+  lines=$(configuration_block "$configuration_id" | grep -E "^[[:space:]]*${setting}(\\[[^]]+\\])?[[:space:]]*=" || true)
+  count=$(printf '%s\n' "$lines" | sed '/^$/d' | wc -l | tr -d ' ')
+  normalized=$(printf '%s\n' "$lines" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+
+  if [[ "$count" -ne 1 || "$normalized" != "$expected" ]]; then
+    echo "Configuration $configuration_id must define exactly: $expected" >&2
+    exit 1
+  fi
+}
+
+project_debug="99F153CB2F4F5F0300E9174E"
+project_release="99F153CC2F4F5F0300E9174E"
+extension_debug="99AB000D2FABC00D00ABC00D"
+extension_release="99AB000E2FABC00E00ABC00E"
+app_debug="99F153CE2F4F5F0300E9174E"
+app_release="99F153CF2F4F5F0300E9174E"
+
+marketing_version=$(configuration_block "$project_debug" | sed -nE 's/^[[:space:]]*TINFOIL_MARKETING_VERSION = ([^;]+);/\1/p')
+build_number=$(configuration_block "$project_debug" | sed -nE 's/^[[:space:]]*TINFOIL_BUILD_NUMBER = ([^;]+);/\1/p')
+
+if [[ -z "$marketing_version" || -z "$build_number" ]]; then
+  echo "Project release settings are missing." >&2
   exit 1
 fi
 
-if [[ "$build_count" -ne 2 ]] || [[ $(printf '%s\n' "$build_numbers" | sort -u | wc -l | tr -d ' ') -ne 1 ]]; then
-  echo "App Debug and Release must define one matching TINFOIL_BUILD_NUMBER." >&2
-  exit 1
-fi
+for configuration_id in "$project_debug" "$project_release"; do
+  assert_setting "$configuration_id" TINFOIL_MARKETING_VERSION "TINFOIL_MARKETING_VERSION = $marketing_version;"
+  assert_setting "$configuration_id" TINFOIL_BUILD_NUMBER "TINFOIL_BUILD_NUMBER = $build_number;"
+done
 
-marketing_references=$(grep -F -c 'MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";' "$project_file")
-build_references=$(grep -F -c 'CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";' "$project_file")
-
-if [[ "$marketing_references" -ne 4 || "$build_references" -ne 4 ]]; then
-  echo "The app and share extension must inherit version and build settings in Debug and Release." >&2
-  exit 1
-fi
+for configuration_id in "$extension_debug" "$extension_release" "$app_debug" "$app_release"; do
+  assert_setting "$configuration_id" MARKETING_VERSION 'MARKETING_VERSION = "$(TINFOIL_MARKETING_VERSION)";'
+  assert_setting "$configuration_id" CURRENT_PROJECT_VERSION 'CURRENT_PROJECT_VERSION = "$(TINFOIL_BUILD_NUMBER)";'
+done
 
 if [[ ! -f "$shared_scheme" ]] || ! grep -F -q 'BlueprintName = "TinfoilChat"' "$shared_scheme"; then
   echo "The shared TinfoilChat app scheme is missing or invalid." >&2
@@ -37,7 +64,8 @@ fi
 release_ref="${1:-}"
 if [[ "$release_ref" == v* ]]; then
   release_version="${release_ref#v}"
-  if [[ "$release_version" != "$marketing_version" ]]; then
+  release_base_version="${release_version%%-*}"
+  if [[ "$release_base_version" != "$marketing_version" ]]; then
     echo "Release tag $release_ref does not match app version $marketing_version." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- centralize the app and share extension version/build settings
- add a shared TinfoilChat app scheme for consistent run/archive behavior
- reject target-version drift and release tags that do not match the app version

## Validation
- release-settings check passes for 2.6.0 (1)
- shared scheme XML validates successfully
- builds and tests were not run per repository policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep iOS versioning consistent across the app and share extension, and enforce tag-to-version alignment in CI. Previously targets hard-coded versions and CI didn’t validate them; now both targets inherit project variables and CI dynamically validates each configuration to prevent drift and conditional overrides.

- The app and share extension read MARKETING_VERSION and CURRENT_PROJECT_VERSION from project `TINFOIL_MARKETING_VERSION` and `TINFOIL_BUILD_NUMBER`.
- A shared TinfoilChat app scheme is checked in and required to standardize Run/Archive behavior.
- A release settings check runs on PRs and main, dynamically discovers Xcode project/app/extension Debug/Release configurations, and fails if project `TINFOIL_*` are missing, if app or extension don’t inherit them exactly, if conditional or per-arch version overrides exist, or if the shared scheme is missing.
- The release workflow runs the same check and fails if a pushed `v*` tag’s base version does not equal the app version.

**Rollout**
- Set `TINFOIL_MARKETING_VERSION` and `TINFOIL_BUILD_NUMBER` to identical values in Debug and Release.
- Create release tags as `v{marketing_version}`; pre-release suffixes (e.g., `-rc.1`) are allowed but the base must match.
- Use the shared TinfoilChat scheme for running and archiving.

<sup>Written for commit 19f581a182567091dc4826916c1ffa55c24dc928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

