### PR TITLE
Measure iOS chat performance stages

### DIFF
--- a/TinfoilChat/Config/AppConfig.swift
+++ b/TinfoilChat/Config/AppConfig.swift
@@ -333,6 +333,8 @@ class AppConfig: ObservableObject {
     
     
     func loadRemoteConfig() async {
+        let performanceToken = PerformanceInstrumentation.shared.begin(.remoteConfigLoad)
+        defer { PerformanceInstrumentation.shared.end(performanceToken) }
         do {
             guard networkMonitor.isConnected else {
                 initializationError = NSError(

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1348,8 +1348,10 @@ class CloudSyncService: ObservableObject {
         }
 
         isSyncing = true
+        let performanceToken = PerformanceInstrumentation.shared.begin(.cloudSyncCycle)
         syncStatus = "Syncing..."
         defer {
+            PerformanceInstrumentation.shared.end(performanceToken)
             if generation == accountGeneration {
                 isSyncing = false
                 syncStatus = ""

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -222,6 +222,8 @@ actor EncryptedFileStorage {
     // MARK: - Index Operations
 
     func loadIndex(userId: String) async throws -> [ChatIndexEntry] {
+        let performanceToken = PerformanceInstrumentation.shared.begin(.chatIndexLoad)
+        defer { PerformanceInstrumentation.shared.end(performanceToken) }
         if let cached = indexCache[userId] {
             if !contentIntegrityCheckedUserIds.contains(userId) {
                 try detectMissingChatContent(in: cached, userId: userId)
@@ -1328,6 +1330,8 @@ actor EncryptedFileStorage {
     // MARK: - Private Helpers
 
     private func loadChatFromFile(_ fileURL: URL, isRaw: Bool) async throws -> Chat? {
+        let performanceToken = PerformanceInstrumentation.shared.begin(.fullChatLoad)
+        defer { PerformanceInstrumentation.shared.end(performanceToken) }
         let data = try Data(contentsOf: fileURL)
 
         if isRaw {

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -503,7 +503,9 @@ final class StreamingResponseProcessor: @unchecked Sendable {
     }
 
     func snapshot() -> Snapshot {
-        Snapshot(
+        let performanceToken = PerformanceInstrumentation.shared.begin(.streamSnapshotBuild)
+        defer { PerformanceInstrumentation.shared.end(performanceToken) }
+        return Snapshot(
             responseContent: responseContent,
             modelDisplayName: modelDisplayName,
             thoughts: currentThoughts,

--- a/TinfoilChat/Utilities/PerformanceInstrumentation.swift
+++ b/TinfoilChat/Utilities/PerformanceInstrumentation.swift
@@ -1,0 +1,141 @@
+import Foundation
+import os
+
+enum PerformancePhase: String, CaseIterable, Sendable {
+    case remoteConfigLoad
+    case chatIndexLoad
+    case fullChatLoad
+    case cloudSyncCycle
+    case firstChatPageLoad
+    case streamSnapshotBuild
+    case selectedChatImageHydration
+}
+
+struct PerformanceIntervalToken: Hashable, Sendable {
+    fileprivate let id: UUID?
+    let phase: PerformancePhase
+}
+
+protocol PerformanceInstrumentationSink: AnyObject, Sendable {
+    var isEnabled: Bool { get }
+    func begin(_ token: PerformanceIntervalToken)
+    func end(_ token: PerformanceIntervalToken)
+}
+
+final class PerformanceInstrumentation: @unchecked Sendable {
+    static let shared = PerformanceInstrumentation(sink: PointsOfInterestSignpostSink())
+
+    private let sink: any PerformanceInstrumentationSink
+    private let lock = NSLock()
+    private var activeTokenIds: Set<UUID> = []
+
+    init(sink: any PerformanceInstrumentationSink) {
+        self.sink = sink
+    }
+
+    @discardableResult
+    func begin(_ phase: PerformancePhase) -> PerformanceIntervalToken {
+        guard sink.isEnabled else {
+            return PerformanceIntervalToken(id: nil, phase: phase)
+        }
+        let token = PerformanceIntervalToken(id: UUID(), phase: phase)
+        guard let tokenId = token.id else { return token }
+        lock.lock()
+        activeTokenIds.insert(tokenId)
+        lock.unlock()
+        sink.begin(token)
+        return token
+    }
+
+    func end(_ token: PerformanceIntervalToken) {
+        guard let tokenId = token.id else { return }
+        lock.lock()
+        let wasActive = activeTokenIds.remove(tokenId) != nil
+        lock.unlock()
+        guard wasActive else { return }
+        sink.end(token)
+    }
+
+    func measure<Result>(
+        _ phase: PerformancePhase,
+        operation: () throws -> Result
+    ) rethrows -> Result {
+        let token = begin(phase)
+        defer { end(token) }
+        return try operation()
+    }
+}
+
+private final class PointsOfInterestSignpostSink: PerformanceInstrumentationSink, @unchecked Sendable {
+    private let signposter = OSSignposter(
+        logHandle: OSLog(
+            subsystem: Bundle.main.bundleIdentifier ?? "com.tinfoil.chat",
+            category: .pointsOfInterest
+        )
+    )
+    private let lock = NSLock()
+    private var states: [UUID: OSSignpostIntervalState] = [:]
+
+    var isEnabled: Bool {
+        signposter.isEnabled
+    }
+
+    func begin(_ token: PerformanceIntervalToken) {
+        let state = beginInterval(token.phase)
+        guard let tokenId = token.id else { return }
+        lock.lock()
+        states[tokenId] = state
+        lock.unlock()
+    }
+
+    func end(_ token: PerformanceIntervalToken) {
+        guard let tokenId = token.id else { return }
+        lock.lock()
+        let state = states.removeValue(forKey: tokenId)
+        lock.unlock()
+        guard let state else { return }
+        endInterval(token.phase, state: state)
+    }
+
+    private func beginInterval(_ phase: PerformancePhase) -> OSSignpostIntervalState {
+        let signpostID = signposter.makeSignpostID()
+        switch phase {
+        case .remoteConfigLoad:
+            return signposter.beginInterval("remoteConfigLoad", id: signpostID)
+        case .chatIndexLoad:
+            return signposter.beginInterval("chatIndexLoad", id: signpostID)
+        case .fullChatLoad:
+            return signposter.beginInterval("fullChatLoad", id: signpostID)
+        case .cloudSyncCycle:
+            return signposter.beginInterval("cloudSyncCycle", id: signpostID)
+        case .firstChatPageLoad:
+            return signposter.beginInterval("firstChatPageLoad", id: signpostID)
+        case .streamSnapshotBuild:
+            return signposter.beginInterval("streamSnapshotBuild", id: signpostID)
+        case .selectedChatImageHydration:
+            return signposter.beginInterval("selectedChatImageHydration", id: signpostID)
+        }
+    }
+
+    private func endInterval(
+        _ phase: PerformancePhase,
+        state: OSSignpostIntervalState
+    ) {
+        switch phase {
+        case .remoteConfigLoad:
+            signposter.endInterval("remoteConfigLoad", state)
+        case .chatIndexLoad:
+            signposter.endInterval("chatIndexLoad", state)
+        case .fullChatLoad:
+            signposter.endInterval("fullChatLoad", state)
+        case .cloudSyncCycle:
+            signposter.endInterval("cloudSyncCycle", state)
+        case .firstChatPageLoad:
+            signposter.endInterval("firstChatPageLoad", state)
+        case .streamSnapshotBuild:
+            signposter.endInterval("streamSnapshotBuild", state)
+        case .selectedChatImageHydration:
+            signposter.endInterval("selectedChatImageHydration", state)
+        }
+    }
+}

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2024,6 +2024,10 @@ class ChatViewModel: ObservableObject {
         if hasUnfetchedImages {
             let chatId = chatToSelect.id
             Task {
+                let performanceToken = PerformanceInstrumentation.shared.begin(
+                    .selectedChatImageHydration
+                )
+                defer { PerformanceInstrumentation.shared.end(performanceToken) }
                 let loadedImages = await CloudStorageService.shared.loadImages(in: chatToSelect.messages)
                 guard !loadedImages.isEmpty, self.currentChat?.id == chatId else { return }
                 // Merge loaded base64 data into the current messages by attachment ID,
@@ -5216,6 +5220,8 @@ class ChatViewModel: ObservableObject {
         filter: ((ChatIndexEntry) -> Bool)? = nil
     ) async -> (chats: [Chat], totalEntries: Int) {
         guard let userId = userId else { return ([], 0) }
+        let performanceToken = PerformanceInstrumentation.shared.begin(.firstChatPageLoad)
+        defer { PerformanceInstrumentation.shared.end(performanceToken) }
         let index = await Chat.loadChatIndex(userId: userId)
         let filtered = index
             .filter { !excludedIds.contains($0.id) }

--- a/TinfoilChatTests/PerformanceInstrumentationTests.swift
+++ b/TinfoilChatTests/PerformanceInstrumentationTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Performance instrumentation")
+struct PerformanceInstrumentationTests {
+    @Test("pairs begin and end events")
+    func pairsBeginAndEnd() {
+        let sink = RecordingPerformanceSink()
+        let instrumentation = PerformanceInstrumentation(sink: sink)
+
+        let token = instrumentation.begin(.chatIndexLoad)
+        instrumentation.end(token)
+
+        #expect(sink.recordedEvents == [
+            .begin(token),
+            .end(token),
+        ])
+    }
+
+    @Test("creates distinct interval tokens")
+    func createsDistinctTokens() {
+        let sink = RecordingPerformanceSink()
+        let instrumentation = PerformanceInstrumentation(sink: sink)
+
+        let first = instrumentation.begin(.fullChatLoad)
+        let second = instrumentation.begin(.fullChatLoad)
+        instrumentation.end(first)
+        instrumentation.end(second)
+
+        #expect(first != second)
+        #expect(sink.recordedEvents == [
+            .begin(first),
+            .begin(second),
+            .end(first),
+            .end(second),
+        ])
+    }
+
+    @Test("ends measured intervals when the operation throws")
+    func endsThrownOperation() {
+        let sink = RecordingPerformanceSink()
+        let instrumentation = PerformanceInstrumentation(sink: sink)
+
+        do {
+            try instrumentation.measure(.remoteConfigLoad) {
+                throw TestError.expected
+            }
+            Issue.record("Expected the measured operation to throw")
+        } catch TestError.expected {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let events = sink.recordedEvents
+        #expect(events.count == 2)
+        guard events.count == 2 else { return }
+        guard case .begin(let beginToken) = events[0],
+              case .end(let endToken) = events[1] else {
+            Issue.record("Expected one begin event followed by one end event")
+            return
+        }
+        #expect(beginToken == endToken)
+    }
+
+    @Test("exposes only fixed phase names")
+    func exposesFixedPhaseNames() {
+        let expectedNames: Set<String> = [
+            "remoteConfigLoad",
+            "chatIndexLoad",
+            "fullChatLoad",
+            "cloudSyncCycle",
+            "firstChatPageLoad",
+            "streamSnapshotBuild",
+            "selectedChatImageHydration",
+        ]
+
+        #expect(Set(PerformancePhase.allCases.map(\.rawValue)) == expectedNames)
+    }
+
+    @Test("does not record disabled intervals")
+    func skipsDisabledIntervals() {
+        let sink = RecordingPerformanceSink(isEnabled: false)
+        let instrumentation = PerformanceInstrumentation(sink: sink)
+
+        let token = instrumentation.begin(.streamSnapshotBuild)
+        instrumentation.end(token)
+
+        #expect(sink.recordedEvents.isEmpty)
+    }
+
+    @Test("ends measured intervals when the operation is cancelled")
+    func endsCancelledOperation() async {
+        let sink = RecordingPerformanceSink()
+        let instrumentation = PerformanceInstrumentation(sink: sink)
+        let task = Task {
+            let token = instrumentation.begin(.fullChatLoad)
+            defer { instrumentation.end(token) }
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            throw CancellationError()
+        }
+
+        while sink.recordedEvents.isEmpty {
+            await Task.yield()
+        }
+        task.cancel()
+        _ = try? await task.value
+
+        let events = sink.recordedEvents
+        #expect(events.count == 2)
+        guard events.count == 2,
+              case .begin(let beginToken) = events[0],
+              case .end(let endToken) = events[1] else {
+            Issue.record("Expected one begin event followed by one end event")
+            return
+        }
+        #expect(beginToken == endToken)
+    }
+}
+
+private enum TestError: Error {
+    case expected
+}
+
+private final class RecordingPerformanceSink: PerformanceInstrumentationSink, @unchecked Sendable {
+    enum Event: Equatable {
+        case begin(PerformanceIntervalToken)
+        case end(PerformanceIntervalToken)
+    }
+
+    private let lock = NSLock()
+    private var events: [Event] = []
+
+    let isEnabled: Bool
+
+    init(isEnabled: Bool = true) {
+        self.isEnabled = isEnabled
+    }
+
+    var recordedEvents: [Event] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+
+    func begin(_ token: PerformanceIntervalToken) {
+        lock.lock()
+        events.append(.begin(token))
+        lock.unlock()
+    }
+
+    func end(_ token: PerformanceIntervalToken) {
+        lock.lock()
+        events.append(.end(token))
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary
- add privacy-safe Points of Interest signposts for config, storage, sync, streaming snapshots, first-page loading, and selected-chat image hydration
- avoid signpost allocation and locking when Instruments collection is disabled
- add an injectable recording sink with deterministic begin/end, error, cancellation, and disabled-path coverage

## Privacy
- fixed phase names only
- no chat IDs, user IDs, titles, prompts, filenames, URLs, keys, attachment content, encryption state, or arbitrary metadata
- device-local Instruments signposts only; no telemetry or network reporting

## Validation
- `git diff --check`
- static Swift 5.7 / iOS 15 compatibility review
- builds and tests were not run from the CLI per `AGENTS.md`; please validate in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds privacy-safe performance signposts for key iOS chat stages. Previously there was no structured POI measurement; now fixed-phase intervals emit only when Instruments collects, with near-zero overhead otherwise.

- Introduces `PerformanceInstrumentation` (begin/end/measure) with a Points of Interest signpost sink; phases: remoteConfigLoad, chatIndexLoad, fullChatLoad, cloudSyncCycle, firstChatPageLoad, streamSnapshotBuild, selectedChatImageHydration.
- Instruments: AppConfig.loadRemoteConfig; CloudSyncService sync cycle; EncryptedFileStorage.loadIndex and loadChatFromFile; StreamingResponseProcessor.snapshot; ChatViewModel first page load and selected chat image hydration.
- Disabled path does no work; prevents double end; defer ensures end on throw and cancellation.
- Tests cover begin/end pairing, distinct tokens, disabled intervals, fixed phase names, and cancellation.
- Privacy: fixed phase names only; device-local POI signposts; no IDs, content, or telemetry.
- No migration required.

<sup>Written for commit 76bf86ab0576261df83cbeef67b497e6fc0163af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

