### PR TITLE
fix: harden revision sync release gates

### DIFF
--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -151,7 +151,12 @@ actor ChatRecoverySync {
                     chatId: chatId,
                     userId: userId
                 )
-                guard !isRemoteDeleted else { throw CancellationError() }
+                guard !isRemoteDeleted else { throw ChatRecoverySyncError.chatMissing }
+                _ = try await CloudUploadGate.allowsWrite(required: true)
+                try Task.checkCancellation()
+                guard await Clerk.shared.user?.id == userId else {
+                    throw ChatRecoverySyncError.chatMissing
+                }
                 let result = try await CloudStorageService.shared.uploadChat(
                     StoredChat(from: candidate, syncVersion: remote.syncVersion),
                     idempotencyKey: UUID().uuidString.lowercased()

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -140,13 +140,18 @@ actor ChatRecoverySync {
                 var candidate = preferredBase(local: local, remote: remoteChat)
                 try apply(mutation, to: &candidate, authoritativeRemote: remoteChat)
                 candidate.syncVersion = remote.syncVersion
-                stampEdit(&candidate, observedRemote: remoteChat)
+                try stampEdit(&candidate, observedRemote: remoteChat)
                 candidate.locallyModified = true
 
                 guard await Clerk.shared.user?.id == userId else {
                     throw ChatRecoverySyncError.chatMissing
                 }
                 try Task.checkCancellation()
+                let isRemoteDeleted = try await EncryptedFileStorage.cloud.hasRemoteDeleteTombstone(
+                    chatId: chatId,
+                    userId: userId
+                )
+                guard !isRemoteDeleted else { throw CancellationError() }
                 let result = try await CloudStorageService.shared.uploadChat(
                     StoredChat(from: candidate, syncVersion: remote.syncVersion),
                     idempotencyKey: UUID().uuidString.lowercased()
@@ -202,7 +207,7 @@ actor ChatRecoverySync {
             var candidate = try mutateValidCloudRecoveryChat(local) {
                 try apply(mutation, to: &$0, authoritativeRemote: local)
             }
-            stampEdit(&candidate, observedRemote: local)
+            try stampEdit(&candidate, observedRemote: local)
             candidate.locallyModified = true
             guard await Clerk.shared.user?.id == userId else {
                 throw ChatRecoverySyncError.chatMissing
@@ -466,10 +471,10 @@ actor ChatRecoverySync {
         chat.pendingRecoveries = pending.isEmpty ? nil : pending
     }
 
-    private func stampEdit(_ chat: inout Chat, observedRemote: Chat) {
+    private func stampEdit(_ chat: inout Chat, observedRemote: Chat) throws {
         EditClockStore.observe(chat.clock)
         EditClockStore.observe(observedRemote.clock)
-        let clock = EditClockStore.nextClock(
+        let clock = try EditClockStore.nextClock(
             observedMax: max(chat.clock ?? 0, observedRemote.clock ?? 0)
         )
         chat.clock = clock.v
@@ -504,7 +509,11 @@ actor ChatRecoverySync {
                     return
                 }
                 local.syncVersion = uploaded.syncVersion
-                stampEdit(&local, observedRemote: uploaded)
+                do {
+                    try stampEdit(&local, observedRemote: uploaded)
+                } catch {
+                    return
+                }
                 local.locallyModified = true
                 candidate = local
             } else {

--- a/TinfoilChat/Services/ChatRecoverySync.swift
+++ b/TinfoilChat/Services/ChatRecoverySync.swift
@@ -157,12 +157,20 @@ actor ChatRecoverySync {
                 guard await Clerk.shared.user?.id == userId else {
                     throw ChatRecoverySyncError.chatMissing
                 }
+                let isDeletedBeforeUpload = try await EncryptedFileStorage.cloud
+                    .hasRemoteDeleteTombstone(chatId: chatId, userId: userId)
+                guard !isDeletedBeforeUpload else { throw ChatRecoverySyncError.chatMissing }
+                try Task.checkCancellation()
                 let result = try await CloudStorageService.shared.uploadChat(
                     StoredChat(from: candidate, syncVersion: remote.syncVersion),
                     idempotencyKey: UUID().uuidString.lowercased()
                 )
                 applyAttachmentRewrites(result.rewrites, to: &candidate)
-                candidate.syncVersion = result.syncVersion ?? remote.syncVersion + 1
+                guard let syncVersion = result.syncVersion
+                    ?? ChatEditClockPolicy.nextSyncVersion(after: remote.syncVersion) else {
+                    throw ChatRecoverySyncError.conflict
+                }
+                candidate.syncVersion = syncVersion
                 candidate.syncedAt = Date()
                 candidate.locallyModified = false
                 candidate.clockVersion = candidate.syncVersion
@@ -484,7 +492,10 @@ actor ChatRecoverySync {
         )
         chat.clock = clock.v
         chat.writer = clock.w
-        chat.clockVersion = chat.syncVersion + 1
+        guard let clockVersion = ChatEditClockPolicy.nextSyncVersion(after: chat.syncVersion) else {
+            throw ChatRecoverySyncError.conflict
+        }
+        chat.clockVersion = clockVersion
         chat.updatedAt = Date()
     }
 

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -587,6 +587,7 @@ class CloudSyncService: ObservableObject {
                 let uploadChat = stampClockVersionForUpload(
                     StoredChat(from: chat, syncVersion: chat.syncVersion)
                 )
+                try await ensureChatUploadIsAllowed(chatId: chat.id, userId: userId)
                 let result = try await cloudStorage.uploadChat(
                     uploadChat,
                     idempotencyKey: newSyncEnclaveIdempotencyKey()
@@ -1354,7 +1355,10 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated(),
               let userId = await getCurrentUserId() else { return SyncResult() }
         do {
-            try await restoreDurableRemoteDeletes(userId: userId, generation: generation)
+            let requiresTombstoneRecovery = try await restoreDurableRemoteDeletes(
+                userId: userId,
+                generation: generation
+            )
             guard generation == accountGeneration else { return SyncResult() }
             await retryDeferredRemoteDeletes(generation: generation)
             guard generation == accountGeneration else { return SyncResult() }
@@ -1371,7 +1375,7 @@ class CloudSyncService: ObservableObject {
             guard generation == accountGeneration else { return SyncResult() }
             let checkpoint = revisionCheckpointStore.load(userId: userId)
             var result: SyncResult
-            if needsContentRepair {
+            if needsContentRepair || requiresTombstoneRecovery {
                 result = try await reconcileRevisionSnapshot(
                     generation: generation,
                     userId: userId
@@ -1476,18 +1480,23 @@ class CloudSyncService: ObservableObject {
             userId: userId
         )
         let pendingDeleteIds = Set(pendingDeleteIntents.map(\.chatId))
+        let remoteDeleteIds = Set(
+            try await EncryptedFileStorage.cloud.loadRemoteDeleteTombstones(userId: userId).keys
+        )
         let pullIds = planned.compactMap { event -> String? in
             guard event.kind == .upsert else { return nil }
             guard DeleteIntentPlanner.shouldApplyRemoteUpsert(
                 chatId: event.id,
                 pendingDeleteIds: pendingDeleteIds
             ) else { return nil }
+            if remoteDeleteIds.contains(event.id) { return event.id }
             guard let entry = localById[event.id] else { return event.id }
             guard !entry.locallyModified else { return nil }
             return entry.decryptionFailed || String(entry.syncVersion) != event.etag
                 ? event.id : nil
         }
         let pulled = try await cloudStorage.downloadChats(pullIds)
+        let expectedPullIds = Set(pullIds)
         var result = SyncResult()
 
         for event in planned {
@@ -1514,12 +1523,6 @@ class CloudSyncService: ObservableObject {
                     chatId: event.id,
                     pendingDeleteIds: pendingDeleteIds
                 ) else { continue }
-                try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
-                    chatId: event.id,
-                    userId: userId
-                )
-                deferredRemoteDeletes.removeValue(forKey: event.id)
-                deletedChatsTracker.removeFromDeleted(event.id)
                 if let remote = pulled[event.id] {
                     var chat = remote
                     chat.projectId = event.projectId
@@ -1531,12 +1534,18 @@ class CloudSyncService: ObservableObject {
                         chat,
                         generation: generation,
                         userId: userId,
-                        expectedLocalUpdatedAt: localById[event.id]?.updatedAt
+                        expectedLocalUpdatedAt: localById[event.id]?.updatedAt,
+                        allowLocallyModified: remoteDeleteIds.contains(event.id),
+                        allowRemoteDeleteReplacement: remoteDeleteIds.contains(event.id)
                     )
                     if applyResult == .locallyModified { continue }
-                    guard applyResult == .applied else {
+                    guard RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(applyResult) else {
                         throw RevisionSyncError.incompletePull
                     }
+                    try await completeAuthoritativeRemoteUpsert(
+                        chatId: event.id,
+                        userId: userId
+                    )
                     result = SyncResult(
                         downloaded: result.downloaded + 1,
                         deleted: result.deleted
@@ -1554,59 +1563,53 @@ class CloudSyncService: ObservableObject {
                         chatId: event.id,
                         userId: userId,
                         projectId: event.projectId,
-                        syncVersion: syncVersion
+                        syncVersion: syncVersion,
+                        allowRemoteDeleteReplacement: remoteDeleteIds.contains(event.id)
                     )
                     if applyResult == .locallyModified { continue }
-                    guard applyResult == .applied else {
+                    guard RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(applyResult) else {
                         throw RevisionSyncError.incompletePull
                     }
+                    try await completeAuthoritativeRemoteUpsert(
+                        chatId: event.id,
+                        userId: userId
+                    )
+                } else if expectedPullIds.contains(event.id) {
+                    throw RevisionSyncError.incompletePull
                 }
             }
         }
         return result
     }
 
-    /// Apply a remote deletion locally, unless the chat is actively
-    /// streaming — deleting the files mid-stream would race the stream's
-    /// throttled saves, which recreate the chat with a stale sync
-    /// version that later uploads as a zombie against a tombstoned row.
-    /// Mirrors the upload path's deferral: tombstone immediately (so a
-    /// racing upload can't resurrect the row) and remove the local files
-    /// once the stream ends. Returns true when the chat was removed now.
+    /// Establish delete-wins before any local removal. Active streams defer
+    /// cleanup to stream end; every other delete removes and verifies all
+    /// local artifacts immediately. Returns true only after verified absence.
     private func applyRemoteChatDelete(
         chatId: String,
         userId: String,
         generation: Int,
         preserveNeverSynced: Bool
     ) async throws -> Bool {
-        guard streamingTracker.isStreaming(chatId) else {
-            let removed = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
-                chatId: chatId,
-                userId: userId,
-                preserveNeverSynced: preserveNeverSynced
-            )
-            if removed {
-                deletedChatsTracker.markAsDeleted(chatId)
-            }
-            return removed
-        }
-
         try await EncryptedFileStorage.cloud.persistRemoteDeleteTombstone(
             chatId: chatId,
             userId: userId,
             preserveNeverSynced: preserveNeverSynced
         )
+        guard generation == accountGeneration else { throw CancellationError() }
         deletedChatsTracker.markAsDeleted(chatId)
-        deferRemoteChatDelete(
-            chatId: chatId,
-            deferral: DeferredRemoteDelete(
-                userId: userId,
-                generation: generation,
-                preserveNeverSynced: preserveNeverSynced,
-                callbackRegistered: false
-            )
+        let pending = DeferredRemoteDelete(
+            userId: userId,
+            generation: generation,
+            preserveNeverSynced: preserveNeverSynced,
+            callbackRegistered: false
         )
-        return false
+        deferredRemoteDeletes[chatId] = pending
+        guard !streamingTracker.isStreaming(chatId) else {
+            deferRemoteChatDelete(chatId: chatId, deferral: pending)
+            return false
+        }
+        return try await finishRemoteChatDelete(chatId: chatId, pending: pending)
     }
 
     /// Register (or refresh) the stream-end callback for a deferred
@@ -1649,16 +1652,10 @@ class CloudSyncService: ObservableObject {
                     return
                 }
                 do {
-                    _ = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+                    _ = try await self.finishRemoteChatDelete(
                         chatId: chatId,
-                        userId: pending.userId,
-                        preserveNeverSynced: pending.preserveNeverSynced
+                        pending: pending
                     )
-                    try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
-                        chatId: chatId,
-                        userId: pending.userId
-                    )
-                    self.deferredRemoteDeletes.removeValue(forKey: chatId)
                 } catch {
                     // Keep the entry; retryDeferredRemoteDeletes picks it
                     // up on the next sync cycle. The delete event will not
@@ -1692,24 +1689,36 @@ class CloudSyncService: ObservableObject {
                 continue
             }
             do {
-                _ = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
-                    chatId: chatId,
-                    userId: pending.userId,
-                    preserveNeverSynced: pending.preserveNeverSynced
-                )
-                guard generation == accountGeneration else { return }
-                try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
-                    chatId: chatId,
-                    userId: pending.userId
-                )
-                deferredRemoteDeletes.removeValue(forKey: chatId)
+                _ = try await finishRemoteChatDelete(chatId: chatId, pending: pending)
             } catch {
                 // Still failing; keep the entry for the next cycle.
             }
         }
     }
 
-    private func restoreDurableRemoteDeletes(userId: String, generation: Int) async throws {
+    private func finishRemoteChatDelete(
+        chatId: String,
+        pending: DeferredRemoteDelete
+    ) async throws -> Bool {
+        let confirmedAbsent = try await EncryptedFileStorage.cloud.removeChatForConfirmedRemoteDelete(
+            chatId: chatId,
+            userId: pending.userId,
+            preserveNeverSynced: pending.preserveNeverSynced
+        )
+        guard confirmedAbsent else { return false }
+        guard pending.generation == accountGeneration else { throw CancellationError() }
+        try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
+            chatId: chatId,
+            userId: pending.userId
+        )
+        deferredRemoteDeletes.removeValue(forKey: chatId)
+        return true
+    }
+
+    private func restoreDurableRemoteDeletes(
+        userId: String,
+        generation: Int
+    ) async throws -> Bool {
         let tombstones = try await EncryptedFileStorage.cloud.loadRemoteDeleteTombstones(
             userId: userId
         )
@@ -1728,6 +1737,7 @@ class CloudSyncService: ObservableObject {
                 deferredRemoteDeletes[chatId] = pending
             }
         }
+        return try await EncryptedFileStorage.cloud.requiresRemoteDeleteRecovery(userId: userId)
     }
 
     private func reconcileRevisionSnapshot(
@@ -1772,9 +1782,11 @@ class CloudSyncService: ObservableObject {
             userId: userId
         )
         let pendingDeleteIds = Set(snapshotDeleteIntents.map(\.chatId))
-        for id in remoteIds where !pendingDeleteIds.contains(id) {
-            deletedChatsTracker.removeFromDeleted(id)
-        }
+        let remoteDeleteIds = Set(
+            try await EncryptedFileStorage.cloud.loadRemoteDeleteTombstones(userId: userId).keys
+        )
+        let requiresTombstoneRecovery = try await EncryptedFileStorage.cloud
+            .requiresRemoteDeleteRecovery(userId: userId)
         for intent in DeleteIntentPlanner.confirmedAbsent(
             snapshotDeleteIntents,
             remoteIds: remoteIds
@@ -1820,7 +1832,7 @@ class CloudSyncService: ObservableObject {
                 userId: userId
             )
         }
-        let changed = SnapshotReconciliation.contentItems(
+        let plannedChanged = SnapshotReconciliation.contentItems(
             local: local,
             remote: items.filter {
                 DeleteIntentPlanner.shouldApplyRemoteUpsert(
@@ -1831,12 +1843,23 @@ class CloudSyncService: ObservableObject {
             recentLimit: Constants.Pagination.chatsPerPage,
             missingContentIds: missingContentIds
         )
+        var changedById = Dictionary(
+            plannedChanged.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for item in items where !pendingDeleteIds.contains(item.id)
+            && (remoteDeleteIds.contains(item.id) || requiresTombstoneRecovery) {
+            changedById[item.id] = item
+        }
+        let changed = items.compactMap { changedById[$0.id] }
         var metadataOnly: [EnclaveRevisionSnapshotItem] = []
         let pullItems = changed.filter { item in
             guard let entry = localById[item.id] else { return true }
             if String(entry.syncVersion) == item.etag
                 && !entry.decryptionFailed
-                && !missingContentIds.contains(item.id) {
+                && !missingContentIds.contains(item.id)
+                && !remoteDeleteIds.contains(item.id)
+                && !requiresTombstoneRecovery {
                 metadataOnly.append(item)
                 return false
             }
@@ -1862,11 +1885,16 @@ class CloudSyncService: ObservableObject {
                 userId: userId,
                 expectedLocalUpdatedAt: localById[item.id]?.updatedAt,
                 allowLocallyModified: missingContentIds.contains(item.id)
+                    || remoteDeleteIds.contains(item.id)
+                    || requiresTombstoneRecovery,
+                allowRemoteDeleteReplacement: remoteDeleteIds.contains(item.id)
+                    || requiresTombstoneRecovery
             )
             if applyResult == .locallyModified { continue }
-            guard applyResult == .applied else {
+            guard RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(applyResult) else {
                 throw RevisionSyncError.incompletePull
             }
+            try await completeAuthoritativeRemoteUpsert(chatId: item.id, userId: userId)
             downloaded += 1
         }
         for item in metadataOnly {
@@ -1877,12 +1905,15 @@ class CloudSyncService: ObservableObject {
                 chatId: item.id,
                 userId: userId,
                 projectId: item.projectId,
-                syncVersion: syncVersion
+                syncVersion: syncVersion,
+                allowRemoteDeleteReplacement: remoteDeleteIds.contains(item.id)
+                    || requiresTombstoneRecovery
             )
             if applyResult == .locallyModified { continue }
-            guard applyResult == .applied else {
+            guard RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(applyResult) else {
                 throw RevisionSyncError.incompletePull
             }
+            try await completeAuthoritativeRemoteUpsert(chatId: item.id, userId: userId)
         }
         guard generation == accountGeneration else { throw CancellationError() }
         guard try await EncryptedFileStorage.cloud.completeContentRepairIfResolved(
@@ -1893,6 +1924,9 @@ class CloudSyncService: ObservableObject {
         }
         guard generation == accountGeneration else { throw CancellationError() }
         revisionCheckpointStore.save(snapshotRevision, userId: userId)
+        if requiresTombstoneRecovery {
+            try await EncryptedFileStorage.cloud.completeRemoteDeleteRecovery(userId: userId)
+        }
         return SyncResult(downloaded: downloaded, deleted: deleted)
     }
 
@@ -1943,7 +1977,7 @@ class CloudSyncService: ObservableObject {
                   await getCurrentUserId() == userId else {
                 throw CancellationError()
             }
-            _ = try await EncryptedFileStorage.cloud.deleteCloudChatForRevision(
+            _ = try await EncryptedFileStorage.cloud.removeChatForConfirmedRemoteDelete(
                 chatId: intent.chatId,
                 userId: userId,
                 preserveNeverSynced: false
@@ -2111,14 +2145,16 @@ class CloudSyncService: ObservableObject {
         generation: Int,
         userId: String,
         expectedLocalUpdatedAt: Date?,
-        allowLocallyModified: Bool = false
+        allowLocallyModified: Bool = false,
+        allowRemoteDeleteReplacement: Bool = false
     ) async -> Bool {
         await applyRemoteChatToStorageResult(
             storedChat,
             generation: generation,
             userId: userId,
             expectedLocalUpdatedAt: expectedLocalUpdatedAt,
-            allowLocallyModified: allowLocallyModified
+            allowLocallyModified: allowLocallyModified,
+            allowRemoteDeleteReplacement: allowRemoteDeleteReplacement
         ) == .applied
     }
 
@@ -2127,7 +2163,8 @@ class CloudSyncService: ObservableObject {
         generation: Int,
         userId: String,
         expectedLocalUpdatedAt: Date?,
-        allowLocallyModified: Bool = false
+        allowLocallyModified: Bool = false,
+        allowRemoteDeleteReplacement: Bool = false
     ) async -> RevisionApplyResult {
         guard generation == accountGeneration else { return .refused }
         guard let chat = await convertStoredChat(storedChat) else { return .refused }
@@ -2136,8 +2173,18 @@ class CloudSyncService: ObservableObject {
             chat,
             userId: userId,
             expectedLocalUpdatedAt: expectedLocalUpdatedAt,
-            allowLocallyModified: allowLocallyModified
+            allowLocallyModified: allowLocallyModified,
+            allowRemoteDeleteReplacement: allowRemoteDeleteReplacement
         )) ?? .refused
+    }
+
+    private func completeAuthoritativeRemoteUpsert(chatId: String, userId: String) async throws {
+        try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
+            chatId: chatId,
+            userId: userId
+        )
+        deferredRemoteDeletes.removeValue(forKey: chatId)
+        deletedChatsTracker.removeFromDeleted(chatId)
     }
 
     private func uploadAndMarkSynced(_ upload: PreparedChatUpload) async throws {
@@ -2163,9 +2210,7 @@ class CloudSyncService: ObservableObject {
         guard await isCurrentUploadAccount(account) else {
             throw CancellationError()
         }
-        guard !deletedChatsTracker.isDeleted(chat.id) else {
-            throw CancellationError()
-        }
+        try await ensureChatUploadIsAllowed(chatId: chat.id, userId: account.userId)
         let result = try await cloudStorage.uploadChat(
             chat,
             idempotencyKey: idempotencyKey
@@ -2215,6 +2260,15 @@ class CloudSyncService: ObservableObject {
             writer: chat.writer,
             clockVersion: chat.clockVersion
         )
+    }
+
+    private func ensureChatUploadIsAllowed(chatId: String, userId: String) async throws {
+        guard !deletedChatsTracker.isDeleted(chatId) else { throw CancellationError() }
+        let isRemoteDeleted = try await EncryptedFileStorage.cloud.hasRemoteDeleteTombstone(
+            chatId: chatId,
+            userId: userId
+        )
+        guard !isRemoteDeleted else { throw CancellationError() }
     }
 
     private func isCurrentUploadAccount(_ account: UploadAccount) async -> Bool {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1832,7 +1832,7 @@ class CloudSyncService: ObservableObject {
                 userId: userId
             )
         }
-        let plannedChanged = SnapshotReconciliation.contentItems(
+        let changed = SnapshotReconciliation.contentItemsForTombstoneRecovery(
             local: local,
             remote: items.filter {
                 DeleteIntentPlanner.shouldApplyRemoteUpsert(
@@ -1841,25 +1841,16 @@ class CloudSyncService: ObservableObject {
                 )
             },
             recentLimit: Constants.Pagination.chatsPerPage,
-            missingContentIds: missingContentIds
+            missingContentIds: missingContentIds,
+            knownTombstoneIds: remoteDeleteIds
         )
-        var changedById = Dictionary(
-            plannedChanged.map { ($0.id, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        for item in items where !pendingDeleteIds.contains(item.id)
-            && (remoteDeleteIds.contains(item.id) || requiresTombstoneRecovery) {
-            changedById[item.id] = item
-        }
-        let changed = items.compactMap { changedById[$0.id] }
         var metadataOnly: [EnclaveRevisionSnapshotItem] = []
         let pullItems = changed.filter { item in
             guard let entry = localById[item.id] else { return true }
             if String(entry.syncVersion) == item.etag
                 && !entry.decryptionFailed
                 && !missingContentIds.contains(item.id)
-                && !remoteDeleteIds.contains(item.id)
-                && !requiresTombstoneRecovery {
+                && !remoteDeleteIds.contains(item.id) {
                 metadataOnly.append(item)
                 return false
             }
@@ -1885,8 +1876,7 @@ class CloudSyncService: ObservableObject {
                 userId: userId,
                 expectedLocalUpdatedAt: localById[item.id]?.updatedAt,
                 allowLocallyModified: missingContentIds.contains(item.id)
-                    || remoteDeleteIds.contains(item.id)
-                    || requiresTombstoneRecovery,
+                    || remoteDeleteIds.contains(item.id),
                 allowRemoteDeleteReplacement: remoteDeleteIds.contains(item.id)
                     || requiresTombstoneRecovery
             )

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -607,7 +607,10 @@ class CloudSyncService: ObservableObject {
                 guard generation == accountGeneration else {
                     throw SyncEnclaveError(message: "account changed during cloud backup")
                 }
-                let newVersion = result.syncVersion ?? chat.syncVersion + 1
+                guard let newVersion = result.syncVersion
+                    ?? ChatEditClockPolicy.nextSyncVersion(after: chat.syncVersion) else {
+                    throw RevisionSyncError.invalidRevision
+                }
                 let fullySynced = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
                     chatId: chat.id,
                     userId: userId,
@@ -1713,6 +1716,7 @@ class CloudSyncService: ObservableObject {
                 chatId: chatId,
                 userId: pending.userId
             )
+            guard pending.generation == accountGeneration else { throw CancellationError() }
             deferredRemoteDeletes.removeValue(forKey: chatId)
             deletedChatsTracker.removeFromDeleted(chatId)
             return false
@@ -1721,6 +1725,7 @@ class CloudSyncService: ObservableObject {
             chatId: chatId,
             userId: pending.userId
         )
+        guard pending.generation == accountGeneration else { throw CancellationError() }
         deferredRemoteDeletes.removeValue(forKey: chatId)
         return true
     }
@@ -2219,7 +2224,10 @@ class CloudSyncService: ObservableObject {
         guard await isCurrentUploadAccount(account) else {
             throw CancellationError()
         }
-        let newVersion = result.syncVersion ?? chat.syncVersion + 1
+        guard let newVersion = result.syncVersion
+            ?? ChatEditClockPolicy.nextSyncVersion(after: chat.syncVersion) else {
+            throw RevisionSyncError.invalidRevision
+        }
         let fullySynced = try await EncryptedFileStorage.cloud.finalizeUploadIfFresh(
             chatId: chat.id,
             userId: account.userId,

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -577,7 +577,11 @@ class CloudSyncService: ObservableObject {
                 throw SyncEnclaveError(message: "required chat turn is not ready for backup")
             }
             do {
-                guard !deletedChatsTracker.isDeleted(chat.id) else {
+                guard !deletedChatsTracker.isDeleted(chat.id),
+                      try await !EncryptedFileStorage.cloud.hasRemoteDeleteTombstone(
+                          chatId: chat.id,
+                          userId: userId
+                      ) else {
                     throw CancellationError()
                 }
                 let result = try await cloudStorage.uploadChat(
@@ -696,6 +700,13 @@ class CloudSyncService: ObservableObject {
             return nil
         }
         let account = UploadAccount(generation: generation, userId: userId)
+        guard try await !EncryptedFileStorage.cloud.hasRemoteDeleteTombstone(
+            chatId: chatId,
+            userId: userId
+        ) else {
+            if allowWhileStreaming { throw CancellationError() }
+            return nil
+        }
         guard await cloudStorage.isAuthenticated() else {
             if allowWhileStreaming {
                 throw SyncEnclaveError(message: "recovery upload is not authenticated")
@@ -1337,6 +1348,10 @@ class CloudSyncService: ObservableObject {
         guard await cloudStorage.isAuthenticated(),
               let userId = await getCurrentUserId() else { return SyncResult() }
         do {
+            try await restoreDurableRemoteDeletes(userId: userId, generation: generation)
+            guard generation == accountGeneration else { return SyncResult() }
+            await retryDeferredRemoteDeletes(generation: generation)
+            guard generation == accountGeneration else { return SyncResult() }
             let summary = try await SyncEnclaveAPI.revisionSummary()
             guard generation == accountGeneration else { return SyncResult() }
             guard DecimalRevision.isValid(summary.currentRevision),
@@ -1493,6 +1508,11 @@ class CloudSyncService: ObservableObject {
                     chatId: event.id,
                     pendingDeleteIds: pendingDeleteIds
                 ) else { continue }
+                try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
+                    chatId: event.id,
+                    userId: userId
+                )
+                deferredRemoteDeletes.removeValue(forKey: event.id)
                 deletedChatsTracker.removeFromDeleted(event.id)
                 if let remote = pulled[event.id] {
                     var chat = remote
@@ -1565,6 +1585,11 @@ class CloudSyncService: ObservableObject {
             return removed
         }
 
+        try await EncryptedFileStorage.cloud.persistRemoteDeleteTombstone(
+            chatId: chatId,
+            userId: userId,
+            preserveNeverSynced: preserveNeverSynced
+        )
         deletedChatsTracker.markAsDeleted(chatId)
         deferRemoteChatDelete(
             chatId: chatId,
@@ -1623,6 +1648,10 @@ class CloudSyncService: ObservableObject {
                         userId: pending.userId,
                         preserveNeverSynced: pending.preserveNeverSynced
                     )
+                    try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
+                        chatId: chatId,
+                        userId: pending.userId
+                    )
                     self.deferredRemoteDeletes.removeValue(forKey: chatId)
                 } catch {
                     // Keep the entry; retryDeferredRemoteDeletes picks it
@@ -1663,9 +1692,34 @@ class CloudSyncService: ObservableObject {
                     preserveNeverSynced: pending.preserveNeverSynced
                 )
                 guard generation == accountGeneration else { return }
+                try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
+                    chatId: chatId,
+                    userId: pending.userId
+                )
                 deferredRemoteDeletes.removeValue(forKey: chatId)
             } catch {
                 // Still failing; keep the entry for the next cycle.
+            }
+        }
+    }
+
+    private func restoreDurableRemoteDeletes(userId: String, generation: Int) async throws {
+        let tombstones = try await EncryptedFileStorage.cloud.loadRemoteDeleteTombstones(
+            userId: userId
+        )
+        guard generation == accountGeneration else { throw CancellationError() }
+        for (chatId, preserveNeverSynced) in tombstones {
+            deletedChatsTracker.markAsDeleted(chatId)
+            let pending = DeferredRemoteDelete(
+                userId: userId,
+                generation: generation,
+                preserveNeverSynced: preserveNeverSynced,
+                callbackRegistered: false
+            )
+            if streamingTracker.isStreaming(chatId) {
+                deferRemoteChatDelete(chatId: chatId, deferral: pending)
+            } else {
+                deferredRemoteDeletes[chatId] = pending
             }
         }
     }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -584,8 +584,11 @@ class CloudSyncService: ObservableObject {
                       ) else {
                     throw CancellationError()
                 }
+                let uploadChat = stampClockVersionForUpload(
+                    StoredChat(from: chat, syncVersion: chat.syncVersion)
+                )
                 let result = try await cloudStorage.uploadChat(
-                    StoredChat(from: chat, syncVersion: chat.syncVersion),
+                    uploadChat,
                     idempotencyKey: newSyncEnclaveIdempotencyKey()
                 )
                 guard generation == accountGeneration else {
@@ -597,6 +600,7 @@ class CloudSyncService: ObservableObject {
                     userId: userId,
                     expectedUpdatedAt: chat.updatedAt,
                     syncVersion: newVersion,
+                    uploadedClock: clockState(uploadChat),
                     attachmentRewrites: result.rewrites.map {
                         (
                             clientId: $0.clientId,
@@ -641,7 +645,7 @@ class CloudSyncService: ObservableObject {
     private func trustedChatClock(_ chat: Chat) -> EditClock? {
         guard let clock = chat.clock,
               let writer = chat.writer,
-              chat.clockVersion == chat.syncVersion
+              chat.clockVersion == chat.syncVersion + (chat.locallyModified ? 1 : 0)
         else {
             return nil
         }
@@ -788,7 +792,9 @@ class CloudSyncService: ObservableObject {
         }
 
         let preparedUpload = PreparedChatUpload(
-            chat: StoredChat(from: chat, syncVersion: chat.syncVersion),
+            chat: stampClockVersionForUpload(
+                StoredChat(from: chat, syncVersion: chat.syncVersion)
+            ),
             expectedUpdatedAt: chat.updatedAt,
             idempotencyKey: idempotencyKey,
             account: account
@@ -963,10 +969,10 @@ class CloudSyncService: ObservableObject {
             }
 
             let localClock = localChat.flatMap {
-                trustedClock(
-                    clock: $0.clock, writer: $0.writer,
-                    clockVersion: $0.clockVersion, syncVersion: $0.syncVersion
-                )
+                let expectedClockVersion = $0.syncVersion + ($0.locallyModified ? 1 : 0)
+                guard $0.clockVersion == expectedClockVersion,
+                      let clock = $0.clock, let writer = $0.writer else { return nil }
+                return EditClock(v: clock, w: writer)
             }
             let remoteClock = trustedClock(
                 clock: downloadedChat.clock, writer: downloadedChat.writer,
@@ -2173,6 +2179,7 @@ class CloudSyncService: ObservableObject {
             userId: account.userId,
             expectedUpdatedAt: expectedUpdatedAt,
             syncVersion: newVersion,
+            uploadedClock: clockState(chat),
             attachmentRewrites: result.rewrites.map {
                 (
                     clientId: $0.clientId,
@@ -2187,6 +2194,27 @@ class CloudSyncService: ObservableObject {
         if fullySynced {
             SyncHealthStore.shared.reportChatSynced(chat.id)
         }
+    }
+
+    private func stampClockVersionForUpload(_ chat: StoredChat) -> StoredChat {
+        var stamped = chat
+        let state = ChatEditClockPolicy.uploadState(
+            clock: chat.clock,
+            writer: chat.writer,
+            currentSyncVersion: chat.syncVersion
+        )
+        stamped.clock = state.clock
+        stamped.writer = state.writer
+        stamped.clockVersion = state.clockVersion
+        return stamped
+    }
+
+    private func clockState(_ chat: StoredChat) -> ChatClockState {
+        ChatClockState(
+            clock: chat.clock,
+            writer: chat.writer,
+            clockVersion: chat.clockVersion
+        )
     }
 
     private func isCurrentUploadAccount(_ account: UploadAccount) async -> Bool {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -665,7 +665,15 @@ class CloudSyncService: ObservableObject {
     private func trustedChatClock(_ chat: Chat) -> EditClock? {
         guard let clock = chat.clock,
               let writer = chat.writer,
-              chat.clockVersion == chat.syncVersion + (chat.locallyModified ? 1 : 0)
+              ChatEditClockPolicy.isTrusted(
+                  ChatClockState(
+                      clock: clock,
+                      writer: writer,
+                      clockVersion: chat.clockVersion
+                  ),
+                  syncVersion: chat.syncVersion,
+                  locallyModified: chat.locallyModified
+              )
         else {
             return nil
         }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -264,6 +264,23 @@ actor UploadCoalescer {
     }
 }
 
+@MainActor
+enum CloudUploadGate {
+    static func allowsWrite(required: Bool) throws -> Bool {
+        guard case .actionRequired(.upgradeRequired, _) = SyncHealthStore.shared.gate else {
+            return true
+        }
+        if required {
+            throw SyncEnclaveError(
+                message: "cloud sync requires an app update",
+                status: 426,
+                code: WireCodes.syncProtocolUpgradeRequired
+            )
+        }
+        return false
+    }
+}
+
 /// Main service for managing cloud synchronization of chats
 @MainActor
 class CloudSyncService: ObservableObject {
@@ -555,6 +572,7 @@ class CloudSyncService: ObservableObject {
 
     func backupChatAndWait(_ chatId: String, requiredTurnId: String) async throws {
         let generation = accountGeneration
+        _ = try CloudUploadGate.allowsWrite(required: true)
         guard let userId = await getCurrentUserId(),
               await cloudStorage.isAuthenticated(), await canWriteToCloud(),
               generation == accountGeneration
@@ -577,16 +595,10 @@ class CloudSyncService: ObservableObject {
                 throw SyncEnclaveError(message: "required chat turn is not ready for backup")
             }
             do {
-                guard !deletedChatsTracker.isDeleted(chat.id),
-                      try await !EncryptedFileStorage.cloud.hasRemoteDeleteTombstone(
-                          chatId: chat.id,
-                          userId: userId
-                      ) else {
-                    throw CancellationError()
-                }
                 let uploadChat = stampClockVersionForUpload(
                     StoredChat(from: chat, syncVersion: chat.syncVersion)
                 )
+                _ = try CloudUploadGate.allowsWrite(required: true)
                 try await ensureChatUploadIsAllowed(chatId: chat.id, userId: userId)
                 let result = try await cloudStorage.uploadChat(
                     uploadChat,
@@ -610,6 +622,10 @@ class CloudSyncService: ObservableObject {
                         )
                     }
                 )
+                guard generation == accountGeneration,
+                      await getCurrentUserId() == userId else {
+                    throw CancellationError()
+                }
                 if fullySynced {
                     SyncHealthStore.shared.reportChatSynced(chat.id)
                 }
@@ -688,16 +704,7 @@ class CloudSyncService: ObservableObject {
         // syncAllChats, so the upgrade gate must be enforced in this
         // path too — pushing against a server that refuses this
         // protocol version can never succeed.
-        if case .actionRequired(.upgradeRequired, _) = SyncHealthStore.shared.gate {
-            if allowWhileStreaming {
-                throw SyncEnclaveError(
-                    message: "cloud sync requires an app update",
-                    status: 426,
-                    code: WireCodes.syncProtocolUpgradeRequired
-                )
-            }
-            return nil
-        }
+        guard try CloudUploadGate.allowsWrite(required: allowWhileStreaming) else { return nil }
         guard let userId = await getCurrentUserId() else {
             if allowWhileStreaming {
                 throw SyncEnclaveError(message: "recovery upload is not authenticated")
@@ -969,12 +976,7 @@ class CloudSyncService: ObservableObject {
                 return EditClock(v: clock, w: writer)
             }
 
-            let localClock = localChat.flatMap {
-                let expectedClockVersion = $0.syncVersion + ($0.locallyModified ? 1 : 0)
-                guard $0.clockVersion == expectedClockVersion,
-                      let clock = $0.clock, let writer = $0.writer else { return nil }
-                return EditClock(v: clock, w: writer)
-            }
+            let localClock = localChat.flatMap(trustedChatClock)
             let remoteClock = trustedClock(
                 clock: downloadedChat.clock, writer: downloadedChat.writer,
                 clockVersion: downloadedChat.clockVersion,
@@ -1705,8 +1707,16 @@ class CloudSyncService: ObservableObject {
             userId: pending.userId,
             preserveNeverSynced: pending.preserveNeverSynced
         )
-        guard confirmedAbsent else { return false }
         guard pending.generation == accountGeneration else { throw CancellationError() }
+        guard confirmedAbsent else {
+            try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
+                chatId: chatId,
+                userId: pending.userId
+            )
+            deferredRemoteDeletes.removeValue(forKey: chatId)
+            deletedChatsTracker.removeFromDeleted(chatId)
+            return false
+        }
         try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
             chatId: chatId,
             userId: pending.userId
@@ -2200,6 +2210,7 @@ class CloudSyncService: ObservableObject {
         guard await isCurrentUploadAccount(account) else {
             throw CancellationError()
         }
+        _ = try CloudUploadGate.allowsWrite(required: true)
         try await ensureChatUploadIsAllowed(chatId: chat.id, userId: account.userId)
         let result = try await cloudStorage.uploadChat(
             chat,
@@ -2236,6 +2247,8 @@ class CloudSyncService: ObservableObject {
         let state = ChatEditClockPolicy.uploadState(
             clock: chat.clock,
             writer: chat.writer,
+            sourceClockVersion: chat.clockVersion,
+            locallyModified: chat.locallyModified,
             currentSyncVersion: chat.syncVersion
         )
         stamped.clock = state.clock

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -83,14 +83,27 @@ struct ChatClockState: Equatable {
 }
 
 enum ChatEditClockPolicy {
+    static func nextSyncVersion(after syncVersion: Int) -> Int? {
+        guard syncVersion >= 0, syncVersion < Int.max else { return nil }
+        return syncVersion + 1
+    }
+
     static func isTrusted(
         _ state: ChatClockState,
         syncVersion: Int,
         locallyModified: Bool
     ) -> Bool {
-        state.clock != nil
+        let expectedClockVersion: Int
+        if locallyModified {
+            guard let nextVersion = nextSyncVersion(after: syncVersion) else { return false }
+            expectedClockVersion = nextVersion
+        } else {
+            guard syncVersion >= 0 else { return false }
+            expectedClockVersion = syncVersion
+        }
+        return state.clock != nil
             && state.writer?.isEmpty == false
-            && state.clockVersion == syncVersion + (locallyModified ? 1 : 0)
+            && state.clockVersion == expectedClockVersion
     }
 
     static func matchesFrozenMutation(
@@ -116,13 +129,13 @@ enum ChatEditClockPolicy {
             source,
             syncVersion: currentSyncVersion,
             locallyModified: locallyModified
-        ) else {
+        ), let nextVersion = nextSyncVersion(after: currentSyncVersion) else {
             return ChatClockState(clock: nil, writer: nil, clockVersion: nil)
         }
         return ChatClockState(
             clock: clock,
             writer: writer,
-            clockVersion: currentSyncVersion + 1
+            clockVersion: nextVersion
         )
     }
 
@@ -139,14 +152,13 @@ enum ChatEditClockPolicy {
                 current,
                 syncVersion: currentSyncVersion,
                 locallyModified: currentLocallyModified
-            ) else {
+            ), let nextVersion = nextSyncVersion(after: authoritativeSyncVersion) else {
                 return ChatClockState(clock: nil, writer: nil, clockVersion: nil)
             }
             return ChatClockState(
                 clock: current.clock,
                 writer: current.writer,
-                clockVersion: current.clock == nil || current.writer == nil
-                    ? nil : authoritativeSyncVersion + 1
+                clockVersion: nextVersion
             )
         }
         return ChatClockState(

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -18,6 +18,48 @@ struct EditClock: Codable, Equatable {
     let w: String
 }
 
+struct ChatClockState: Equatable {
+    let clock: Int?
+    let writer: String?
+    let clockVersion: Int?
+}
+
+enum ChatEditClockPolicy {
+    static func uploadState(
+        clock: Int?,
+        writer: String?,
+        currentSyncVersion: Int
+    ) -> ChatClockState {
+        ChatClockState(
+            clock: clock,
+            writer: writer,
+            clockVersion: clock == nil || writer == nil ? nil : currentSyncVersion + 1
+        )
+    }
+
+    static func finalizedState(
+        uploaded: ChatClockState,
+        current: ChatClockState,
+        authoritativeSyncVersion: Int,
+        editedDuringUpload: Bool
+    ) -> ChatClockState {
+        if editedDuringUpload {
+            return ChatClockState(
+                clock: current.clock,
+                writer: current.writer,
+                clockVersion: current.clock == nil || current.writer == nil
+                    ? nil : authoritativeSyncVersion + 1
+            )
+        }
+        return ChatClockState(
+            clock: uploaded.clock,
+            writer: uploaded.writer,
+            clockVersion: uploaded.clock == nil || uploaded.writer == nil
+                ? nil : authoritativeSyncVersion
+        )
+    }
+}
+
 /// Persisted Lamport counter and stable device id backing the edit
 /// clock. The device id is only a tiebreak label, never a secret.
 enum EditClockStore {

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -83,6 +83,16 @@ struct ChatClockState: Equatable {
 }
 
 enum ChatEditClockPolicy {
+    static func isTrusted(
+        _ state: ChatClockState,
+        syncVersion: Int,
+        locallyModified: Bool
+    ) -> Bool {
+        state.clock != nil
+            && state.writer?.isEmpty == false
+            && state.clockVersion == syncVersion + (locallyModified ? 1 : 0)
+    }
+
     static func matchesFrozenMutation(
         current: ChatClockState,
         uploaded: ChatClockState
@@ -93,22 +103,45 @@ enum ChatEditClockPolicy {
     static func uploadState(
         clock: Int?,
         writer: String?,
+        sourceClockVersion: Int?,
+        locallyModified: Bool,
         currentSyncVersion: Int
     ) -> ChatClockState {
-        ChatClockState(
+        let source = ChatClockState(
             clock: clock,
             writer: writer,
-            clockVersion: clock == nil || writer == nil ? nil : currentSyncVersion + 1
+            clockVersion: sourceClockVersion
+        )
+        guard isTrusted(
+            source,
+            syncVersion: currentSyncVersion,
+            locallyModified: locallyModified
+        ) else {
+            return ChatClockState(clock: nil, writer: nil, clockVersion: nil)
+        }
+        return ChatClockState(
+            clock: clock,
+            writer: writer,
+            clockVersion: currentSyncVersion + 1
         )
     }
 
     static func finalizedState(
         uploaded: ChatClockState,
         current: ChatClockState,
+        currentSyncVersion: Int,
+        currentLocallyModified: Bool,
         authoritativeSyncVersion: Int,
         editedDuringUpload: Bool
     ) -> ChatClockState {
         if editedDuringUpload {
+            guard isTrusted(
+                current,
+                syncVersion: currentSyncVersion,
+                locallyModified: currentLocallyModified
+            ) else {
+                return ChatClockState(clock: nil, writer: nil, clockVersion: nil)
+            }
             return ChatClockState(
                 clock: current.clock,
                 writer: current.writer,

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -13,9 +13,67 @@ import Foundation
 
 /// Per-unit logical edit clock: `v` is a Lamport counter, `w` the
 /// writing device id used as a deterministic tiebreak.
-struct EditClock: Codable, Equatable {
+struct EditClock: Codable, Equatable, Sendable {
     let v: Int
     let w: String
+}
+
+final class EditClockAllocator: @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    func deviceId() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return deviceIdUnlocked()
+    }
+
+    func observe(_ remoteV: Int?) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let remoteV, remoteV > 0, remoteV < EditClockStore.maxCounter else { return }
+        if remoteV > loadCounterUnlocked() {
+            persistCounterUnlocked(remoteV)
+        }
+    }
+
+    func nextClock(observedMax: Int? = nil) throws -> EditClock {
+        lock.lock()
+        defer { lock.unlock() }
+        let validObservedMax = observedMax.flatMap {
+            $0 > 0 && $0 < EditClockStore.maxCounter ? $0 : nil
+        } ?? 0
+        let base = min(
+            max(loadCounterUnlocked(), validObservedMax),
+            EditClockStore.maxCounter
+        )
+        let next = try EditClockStore.incrementedCounter(after: base)
+        persistCounterUnlocked(next)
+        return EditClock(v: next, w: deviceIdUnlocked())
+    }
+
+    private func deviceIdUnlocked() -> String {
+        if let existing = defaults.string(forKey: EditClockStore.deviceIdKey), !existing.isEmpty {
+            return existing
+        }
+        let next = UUID().uuidString.lowercased()
+        defaults.set(next, forKey: EditClockStore.deviceIdKey)
+        return next
+    }
+
+    private func loadCounterUnlocked() -> Int {
+        let value = defaults.integer(forKey: EditClockStore.counterKey)
+        guard value > 0 else { return 0 }
+        return min(value, EditClockStore.maxCounter)
+    }
+
+    private func persistCounterUnlocked(_ value: Int) {
+        defaults.set(value, forKey: EditClockStore.counterKey)
+    }
 }
 
 struct ChatClockState: Equatable {
@@ -74,51 +132,28 @@ enum EditClockStore {
         case counterExhausted
     }
 
-    private static let deviceIdKey = "tinfoil-sync-device-id"
-    private static let counterKey = "tinfoil-sync-edit-clock"
+    fileprivate static let deviceIdKey = "tinfoil-sync-device-id"
+    fileprivate static let counterKey = "tinfoil-sync-edit-clock"
+    private static let allocator = EditClockAllocator(defaults: .standard)
 
     /// Upper bound for the logical counter. Far above any value a
     /// legitimate edit history could reach, yet with ample headroom
-    /// below Int.max so incrementing can never overflow and trap, even
-    /// when a corrupted or hostile remote blob carries an absurd clock.
-    /// Matches the webapp's JS safe-integer ceiling so both platforms
-    /// clamp identically.
+    /// below Int.max so incrementing can never overflow and trap.
+    /// Matches the webapp's JS safe-integer ceiling.
     static let maxCounter = 9_007_199_254_740_991  // 2^53 - 1
-
-    private static var defaults: UserDefaults { .standard }
 
     /// Stable id for this installation. Generated once and persisted.
     static func deviceId() -> String {
-        if let existing = defaults.string(forKey: deviceIdKey), !existing.isEmpty {
-            return existing
-        }
-        let next = UUID().uuidString.lowercased()
-        defaults.set(next, forKey: deviceIdKey)
-        return next
-    }
-
-    private static func loadCounter() -> Int {
-        let value = defaults.integer(forKey: counterKey)
-        guard value > 0 else { return 0 }
-        // Clamp a previously-persisted value too, so a counter poisoned
-        // before this guard existed self-heals instead of trapping.
-        return min(value, maxCounter)
-    }
-
-    private static func persistCounter(_ value: Int) {
-        defaults.set(value, forKey: counterKey)
+        allocator.deviceId()
     }
 
     /// Advance the local counter past an observed remote value without
     /// producing a new tick, so a later local edit outranks it. Remote
-    /// values are untrusted input (decrypted blob), so a value above the
-    /// ceiling is treated as malformed and ignored rather than allowed
-    /// to poison the counter toward an overflow.
+    /// values are untrusted input (decrypted blob), so a value at or above
+    /// the ceiling is malformed: accepting it would prevent every future
+    /// local edit from allocating a distinct tuple.
     static func observe(_ remoteV: Int?) {
-        guard let remoteV = remoteV, remoteV > 0, remoteV <= maxCounter else { return }
-        if remoteV > loadCounter() {
-            persistCounter(remoteV)
-        }
+        allocator.observe(remoteV)
     }
 
     static func incrementedCounter(after base: Int) throws -> Int {
@@ -131,9 +166,6 @@ enum EditClockStore {
     /// already-high unit still moves forward. Exhaustion refuses the edit
     /// rather than reusing a tuple that would not be a monotonic tick.
     static func nextClock(observedMax: Int? = nil) throws -> EditClock {
-        let base = min(max(loadCounter(), observedMax ?? 0), maxCounter)
-        let next = try incrementedCounter(after: base)
-        persistCounter(next)
-        return EditClock(v: next, w: deviceId())
+        try allocator.nextClock(observedMax: observedMax)
     }
 }

--- a/TinfoilChat/Services/EditClock.swift
+++ b/TinfoilChat/Services/EditClock.swift
@@ -25,6 +25,13 @@ struct ChatClockState: Equatable {
 }
 
 enum ChatEditClockPolicy {
+    static func matchesFrozenMutation(
+        current: ChatClockState,
+        uploaded: ChatClockState
+    ) -> Bool {
+        current.clock == uploaded.clock && current.writer == uploaded.writer
+    }
+
     static func uploadState(
         clock: Int?,
         writer: String?,
@@ -63,6 +70,10 @@ enum ChatEditClockPolicy {
 /// Persisted Lamport counter and stable device id backing the edit
 /// clock. The device id is only a tiebreak label, never a secret.
 enum EditClockStore {
+    enum ClockError: Error {
+        case counterExhausted
+    }
+
     private static let deviceIdKey = "tinfoil-sync-device-id"
     private static let counterKey = "tinfoil-sync-edit-clock"
 
@@ -110,13 +121,18 @@ enum EditClockStore {
         }
     }
 
+    static func incrementedCounter(after base: Int) throws -> Int {
+        guard base < maxCounter else { throw ClockError.counterExhausted }
+        return base + 1
+    }
+
     /// Produce the next clock for a local edit, advancing past
     /// `observedMax` (e.g. the unit's current clock) so a re-edit of an
-    /// already-high unit still moves forward. The base is clamped to the
-    /// ceiling so the increment can never overflow Int and trap.
-    static func nextClock(observedMax: Int? = nil) -> EditClock {
+    /// already-high unit still moves forward. Exhaustion refuses the edit
+    /// rather than reusing a tuple that would not be a monotonic tick.
+    static func nextClock(observedMax: Int? = nil) throws -> EditClock {
         let base = min(max(loadCounter(), observedMax ?? 0), maxCounter)
-        let next = min(base + 1, maxCounter)
+        let next = try incrementedCounter(after: base)
         persistCounter(next)
         return EditClock(v: next, w: deviceId())
     }

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -15,6 +15,10 @@
 import Foundation
 
 actor EncryptedFileStorage {
+    enum SaveError: Error {
+        case remotelyDeleted
+    }
+
     static let local = EncryptedFileStorage(
         encryptor: DeviceEncryptionService.shared,
         subdirectory: "local"
@@ -34,6 +38,7 @@ actor EncryptedFileStorage {
     private var indexCache: [String: [ChatIndexEntry]] = [:]
     private var pendingChatIdsCache: [String: Set<String>] = [:]
     private var deleteIntentsCache: [String: [PendingChatDelete]] = [:]
+    private var remoteDeleteTombstonesCache: [String: [String: Bool]] = [:]
     private var contentIntegrityCheckedUserIds: Set<String> = []
     private var contentRepairIds: [String: Set<String>] = [:]
 
@@ -128,6 +133,11 @@ actor EncryptedFileStorage {
     private func deleteIntentsFilePath(userId: String) throws -> URL {
         let dir = try chatsDirectory(userId: userId)
         return dir.appendingPathComponent("delete-intents.enc")
+    }
+
+    private func remoteDeleteTombstonesFilePath(userId: String) throws -> URL {
+        let dir = try chatsDirectory(userId: userId)
+        return dir.appendingPathComponent("remote-delete-tombstones.enc")
     }
 
     private func syncMetadataPath(chatId: String, userId: String) throws -> URL {
@@ -425,6 +435,9 @@ actor EncryptedFileStorage {
     }
 
     private func performSaveChat(_ chat: Chat, userId: String) async throws {
+        guard try await !hasRemoteDeleteTombstone(chatId: chat.id, userId: userId) else {
+            throw SaveError.remotelyDeleted
+        }
         let isCorrupted = chat.decryptionFailed || chat.dataCorrupted
 
         let data = try encoder.encode(chat)
@@ -789,6 +802,65 @@ actor EncryptedFileStorage {
         }
     }
 
+    func persistRemoteDeleteTombstone(
+        chatId: String,
+        userId: String,
+        preserveNeverSynced: Bool
+    ) async throws {
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+        var tombstones = try await loadRemoteDeleteTombstones(userId: userId)
+        tombstones[chatId] = preserveNeverSynced
+        try await saveRemoteDeleteTombstones(tombstones, userId: userId)
+    }
+
+    func loadRemoteDeleteTombstones(userId: String) async throws -> [String: Bool] {
+        if let cached = remoteDeleteTombstonesCache[userId] { return cached }
+        let path = try remoteDeleteTombstonesFilePath(userId: userId)
+        guard fileManager.fileExists(atPath: path.path) else {
+            remoteDeleteTombstonesCache[userId] = [:]
+            return [:]
+        }
+        let data = try Data(contentsOf: path)
+        let encrypted = try decoder.decode(EncryptedData.self, from: data)
+        let plaintext = try await encryptor.decryptData(encrypted)
+        let tombstones = try decoder.decode([String: Bool].self, from: plaintext)
+        remoteDeleteTombstonesCache[userId] = tombstones
+        return tombstones
+    }
+
+    func clearRemoteDeleteTombstone(chatId: String, userId: String) async throws {
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+        var tombstones = try await loadRemoteDeleteTombstones(userId: userId)
+        guard tombstones.removeValue(forKey: chatId) != nil else { return }
+        try await saveRemoteDeleteTombstones(tombstones, userId: userId)
+    }
+
+    func hasRemoteDeleteTombstone(chatId: String, userId: String) async throws -> Bool {
+        try await loadRemoteDeleteTombstones(userId: userId)[chatId] != nil
+    }
+
+    private func saveRemoteDeleteTombstones(
+        _ tombstones: [String: Bool],
+        userId: String
+    ) async throws {
+        let path = try remoteDeleteTombstonesFilePath(userId: userId)
+        if tombstones.isEmpty {
+            if fileManager.fileExists(atPath: path.path) {
+                try fileManager.removeItem(at: path)
+            }
+        } else {
+            let plaintext = try encoder.encode(tombstones)
+            let encrypted = try await encryptor.encryptData(plaintext)
+            try encoder.encode(encrypted).write(
+                to: path,
+                options: [.atomic, .completeFileProtection]
+            )
+        }
+        remoteDeleteTombstonesCache[userId] = tombstones
+    }
+
     private func saveDeleteIntents(
         _ intents: [PendingChatDelete],
         userId: String
@@ -911,6 +983,7 @@ actor EncryptedFileStorage {
         indexCache[userId] = []
         pendingChatIdsCache[userId] = []
         deleteIntentsCache[userId] = []
+        remoteDeleteTombstonesCache[userId] = [:]
         contentIntegrityCheckedUserIds.insert(userId)
         contentRepairIds[userId] = []
     }

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -18,6 +18,7 @@ import OSLog
 actor EncryptedFileStorage {
     enum SaveError: Error {
         case remotelyDeleted
+        case invalidSyncVersion
     }
 
     static let local = EncryptedFileStorage(
@@ -362,7 +363,8 @@ actor EncryptedFileStorage {
            prepared.writer?.isEmpty == false {
             return prepared
         }
-        let carriesNewClock = chat.clockVersion == chat.syncVersion + 1
+        let nextSyncVersion = ChatEditClockPolicy.nextSyncVersion(after: chat.syncVersion)
+        let carriesNewClock = chat.clockVersion == nextSyncVersion
             && chat.clock.map { $0 > (existing?.clock ?? 0) } == true
             && chat.writer?.isEmpty == false
         if !carriesNewClock {
@@ -372,7 +374,12 @@ actor EncryptedFileStorage {
             prepared.clock = clock.v
             prepared.writer = clock.w
         }
-        prepared.clockVersion = prepared.syncVersion + 1
+        guard let preparedClockVersion = ChatEditClockPolicy.nextSyncVersion(
+            after: prepared.syncVersion
+        ) else {
+            throw SaveError.invalidSyncVersion
+        }
+        prepared.clockVersion = preparedClockVersion
         return prepared
     }
 

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -362,7 +362,8 @@ actor EncryptedFileStorage {
            prepared.writer?.isEmpty == false {
             return prepared
         }
-        let carriesNewClock = chat.clock.map { $0 > (existing?.clock ?? 0) } == true
+        let carriesNewClock = chat.clockVersion == chat.syncVersion + 1
+            && chat.clock.map { $0 > (existing?.clock ?? 0) } == true
             && chat.writer?.isEmpty == false
         if !carriesNewClock {
             let clock = try EditClockStore.nextClock(
@@ -519,6 +520,8 @@ actor EncryptedFileStorage {
                 writer: currentChat.writer,
                 clockVersion: currentChat.clockVersion
             ),
+            currentSyncVersion: currentChat.syncVersion,
+            currentLocallyModified: currentChat.locallyModified,
             authoritativeSyncVersion: syncVersion,
             editedDuringUpload: editedDuringUpload
         )

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -350,6 +350,11 @@ actor EncryptedFileStorage {
             prepared.syncVersion = existing.syncVersion
             prepared.syncedAt = existing.syncedAt
         }
+        guard let preparedClockVersion = ChatEditClockPolicy.nextSyncVersion(
+            after: prepared.syncVersion
+        ) else {
+            throw SaveError.invalidSyncVersion
+        }
         let isContentMutation = existing?.updatedAt != chat.updatedAt
         if !isContentMutation, let existing,
            (prepared.clock ?? 0) <= (existing.clock ?? 0),
@@ -373,11 +378,6 @@ actor EncryptedFileStorage {
             )
             prepared.clock = clock.v
             prepared.writer = clock.w
-        }
-        guard let preparedClockVersion = ChatEditClockPolicy.nextSyncVersion(
-            after: prepared.syncVersion
-        ) else {
-            throw SaveError.invalidSyncVersion
         }
         prepared.clockVersion = preparedClockVersion
         return prepared

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -13,6 +13,7 @@
 //
 
 import Foundation
+import OSLog
 
 actor EncryptedFileStorage {
     enum SaveError: Error {
@@ -35,10 +36,15 @@ actor EncryptedFileStorage {
     private let subdirectory: String?
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "TinfoilChat",
+        category: "EncryptedFileStorage"
+    )
     private var indexCache: [String: [ChatIndexEntry]] = [:]
     private var pendingChatIdsCache: [String: Set<String>] = [:]
     private var deleteIntentsCache: [String: [PendingChatDelete]] = [:]
     private var remoteDeleteTombstonesCache: [String: [String: Bool]] = [:]
+    private var remoteDeleteRecoveryRequiredUserIds: Set<String> = []
     private var contentIntegrityCheckedUserIds: Set<String> = []
     private var contentRepairIds: [String: Set<String>] = [:]
 
@@ -138,6 +144,11 @@ actor EncryptedFileStorage {
     private func remoteDeleteTombstonesFilePath(userId: String) throws -> URL {
         let dir = try chatsDirectory(userId: userId)
         return dir.appendingPathComponent("remote-delete-tombstones.enc")
+    }
+
+    private func quarantinedRemoteDeleteTombstonesFilePath(userId: String) throws -> URL {
+        let dir = try chatsDirectory(userId: userId)
+        return dir.appendingPathComponent("remote-delete-tombstones.corrupt.enc")
     }
 
     private func syncMetadataPath(chatId: String, userId: String) throws -> URL {
@@ -354,7 +365,7 @@ actor EncryptedFileStorage {
         let carriesNewClock = chat.clock.map { $0 > (existing?.clock ?? 0) } == true
             && chat.writer?.isEmpty == false
         if !carriesNewClock {
-            let clock = EditClockStore.nextClock(
+            let clock = try EditClockStore.nextClock(
                 observedMax: max(existing?.clock ?? 0, chat.clock ?? 0)
             )
             prepared.clock = clock.v
@@ -382,7 +393,8 @@ actor EncryptedFileStorage {
         _ chat: Chat,
         userId: String,
         expectedLocalUpdatedAt: Date?,
-        allowLocallyModified: Bool = false
+        allowLocallyModified: Bool = false,
+        allowRemoteDeleteReplacement: Bool = false
     ) async throws -> RevisionApplyResult {
         await acquireWriteLock()
         defer { releaseWriteLock() }
@@ -398,7 +410,11 @@ actor EncryptedFileStorage {
             return decision
         }
         EditClockStore.observe(chat.clock)
-        try await performSaveChat(chat, userId: userId)
+        try await performSaveChat(
+            chat,
+            userId: userId,
+            allowRemoteDeleteReplacement: allowRemoteDeleteReplacement
+        )
         return .applied
     }
 
@@ -419,7 +435,17 @@ actor EncryptedFileStorage {
         guard let existing = entries.first(where: { $0.id == chatId }) else {
             return false
         }
+        guard let persistedClock = try await loadPersistedClockState(
+            chatId: chatId,
+            userId: userId
+        ) else {
+            return false
+        }
         let editedDuringUpload = existing.updatedAt != expectedUpdatedAt
+            || !ChatEditClockPolicy.matchesFrozenMutation(
+                current: persistedClock,
+                uploaded: uploadedClock
+            )
         if !attachmentRewrites.isEmpty
             || (!editedDuringUpload && existing.projectLocallyModified == true) {
             let encPath = try chatFilePath(
@@ -514,9 +540,38 @@ actor EncryptedFileStorage {
         return !editedDuringUpload
     }
 
-    private func performSaveChat(_ chat: Chat, userId: String) async throws {
-        guard try await !hasRemoteDeleteTombstone(chatId: chat.id, userId: userId) else {
-            throw SaveError.remotelyDeleted
+    private func loadPersistedClockState(
+        chatId: String,
+        userId: String
+    ) async throws -> ChatClockState? {
+        let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
+        let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
+        let hasEncryptedFile = fileManager.fileExists(atPath: encPath.path)
+        guard hasEncryptedFile || fileManager.fileExists(atPath: rawPath.path),
+              let chat = try await loadChatFromFile(
+                  hasEncryptedFile ? encPath : rawPath,
+                  isRaw: !hasEncryptedFile
+              ) else {
+            return nil
+        }
+        return ChatClockState(
+            clock: chat.clock,
+            writer: chat.writer,
+            clockVersion: chat.clockVersion
+        )
+    }
+
+    private func performSaveChat(
+        _ chat: Chat,
+        userId: String,
+        allowRemoteDeleteReplacement: Bool = false
+    ) async throws {
+        if !allowRemoteDeleteReplacement {
+            let isTombstoned = try await hasRemoteDeleteTombstoneUnlocked(
+                chatId: chat.id,
+                userId: userId
+            )
+            guard !isTombstoned else { throw SaveError.remotelyDeleted }
         }
         let isCorrupted = chat.decryptionFailed || chat.dataCorrupted
 
@@ -677,26 +732,47 @@ actor EncryptedFileStorage {
         try await performDeleteChat(chatId: chatId, userId: userId)
     }
 
-    func deleteCloudChatForRevision(
+    func removeChatForConfirmedRemoteDelete(
         chatId: String,
         userId: String,
         preserveNeverSynced: Bool
     ) async throws -> Bool {
         await acquireWriteLock()
         defer { releaseWriteLock() }
+        let entries = try await loadIndex(userId: userId)
+        if let entry = entries.first(where: { $0.id == chatId }),
+           entry.isLocalOnly || (preserveNeverSynced && !entry.requiresCloudDelete) {
+            return false
+        }
         var intents = try await loadDeleteIntents(userId: userId)
         if intents.contains(where: { $0.chatId == chatId }) {
             intents.removeAll { $0.chatId == chatId }
             try await saveDeleteIntents(intents, userId: userId)
         }
-        let entries = try await loadIndex(userId: userId)
-        guard let entry = entries.first(where: { $0.id == chatId }),
-              !entry.isLocalOnly,
-              !(preserveNeverSynced && !entry.requiresCloudDelete) else {
-            return false
+
+        let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
+        let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
+        for path in [encPath, rawPath] where fileManager.fileExists(atPath: path.path) {
+            try fileManager.removeItem(at: path)
         }
-        try await performDeleteChat(chatId: chatId, userId: userId)
-        return true
+        try removeSyncSidecarsStrict(chatId: chatId, userId: userId)
+
+        var updatedEntries = entries
+        updatedEntries.removeAll { $0.id == chatId }
+        if updatedEntries != entries {
+            try await saveIndex(updatedEntries, userId: userId)
+        }
+        contentRepairIds[userId]?.remove(chatId)
+
+        let contentIsAbsent = try !hasChatContentFile(chatId: chatId, userId: userId)
+        let sidecarPath = try syncMetadataPath(chatId: chatId, userId: userId)
+        let legacySidecarPath = try legacySyncMetadataPath(chatId: chatId, userId: userId)
+        return RemoteDeleteTombstonePolicy.canClearAfterLocalCleanup(
+            contentExists: !contentIsAbsent,
+            sidecarExists: fileManager.fileExists(atPath: sidecarPath.path)
+                || fileManager.fileExists(atPath: legacySidecarPath.path),
+            removalFailed: false
+        )
     }
 
     func stageCloudDelete(
@@ -735,7 +811,8 @@ actor EncryptedFileStorage {
         chatId: String,
         userId: String,
         projectId: String?,
-        syncVersion: Int
+        syncVersion: Int,
+        allowRemoteDeleteReplacement: Bool = false
     ) async throws -> RevisionApplyResult {
         await acquireWriteLock()
         defer { releaseWriteLock() }
@@ -744,7 +821,8 @@ actor EncryptedFileStorage {
         guard let entry = entries.first(where: { $0.id == chatId }), !entry.isLocalOnly else {
             return .refused
         }
-        guard !entry.locallyModified, entry.projectLocallyModified != true else {
+        guard allowRemoteDeleteReplacement
+            || (!entry.locallyModified && entry.projectLocallyModified != true) else {
             return .locallyModified
         }
         let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
@@ -765,17 +843,25 @@ actor EncryptedFileStorage {
               !currentEntry.isLocalOnly else {
             return .refused
         }
-        guard !currentEntry.locallyModified,
-              currentEntry.projectLocallyModified != true,
-              !chat.locallyModified,
-              chat.projectLocallyModified != true else {
+        guard allowRemoteDeleteReplacement
+            || (!currentEntry.locallyModified
+                && currentEntry.projectLocallyModified != true
+                && !chat.locallyModified
+                && chat.projectLocallyModified != true) else {
             return .locallyModified
         }
         chat.projectId = projectId
         chat.projectLocallyModified = false
+        if allowRemoteDeleteReplacement {
+            chat.locallyModified = false
+        }
         chat.syncVersion = syncVersion
         chat.syncedAt = chat.syncedAt ?? Date()
-        try await performSaveChat(chat, userId: userId)
+        try await performSaveChat(
+            chat,
+            userId: userId,
+            allowRemoteDeleteReplacement: allowRemoteDeleteReplacement
+        )
         return .applied
     }
 
@@ -897,16 +983,39 @@ actor EncryptedFileStorage {
     func loadRemoteDeleteTombstones(userId: String) async throws -> [String: Bool] {
         if let cached = remoteDeleteTombstonesCache[userId] { return cached }
         let path = try remoteDeleteTombstonesFilePath(userId: userId)
+        let quarantinePath = try quarantinedRemoteDeleteTombstonesFilePath(userId: userId)
         guard fileManager.fileExists(atPath: path.path) else {
+            if fileManager.fileExists(atPath: quarantinePath.path) {
+                remoteDeleteRecoveryRequiredUserIds.insert(userId)
+            }
             remoteDeleteTombstonesCache[userId] = [:]
             return [:]
         }
-        let data = try Data(contentsOf: path)
-        let encrypted = try decoder.decode(EncryptedData.self, from: data)
-        let plaintext = try await encryptor.decryptData(encrypted)
-        let tombstones = try decoder.decode([String: Bool].self, from: plaintext)
-        remoteDeleteTombstonesCache[userId] = tombstones
-        return tombstones
+        do {
+            let data = try Data(contentsOf: path)
+            let encrypted = try decoder.decode(EncryptedData.self, from: data)
+            let plaintext = try await encryptor.decryptData(encrypted)
+            let tombstones = try decoder.decode([String: Bool].self, from: plaintext)
+            if fileManager.fileExists(atPath: quarantinePath.path) {
+                remoteDeleteRecoveryRequiredUserIds.insert(userId)
+            }
+            remoteDeleteTombstonesCache[userId] = tombstones
+            return tombstones
+        } catch EncryptionError.keyNotInitialized {
+            throw EncryptionError.keyNotInitialized
+        } catch {
+            // Keep one bounded quarantine artifact and gate every cloud chat
+            // save/upload until a successful authoritative snapshot has
+            // reconciled remote rows and confirmed remote absences.
+            if fileManager.fileExists(atPath: quarantinePath.path) {
+                try fileManager.removeItem(at: quarantinePath)
+            }
+            try fileManager.moveItem(at: path, to: quarantinePath)
+            remoteDeleteRecoveryRequiredUserIds.insert(userId)
+            remoteDeleteTombstonesCache[userId] = [:]
+            logger.error("Quarantined corrupt remote-delete tombstone metadata")
+            return [:]
+        }
     }
 
     func clearRemoteDeleteTombstone(chatId: String, userId: String) async throws {
@@ -918,7 +1027,32 @@ actor EncryptedFileStorage {
     }
 
     func hasRemoteDeleteTombstone(chatId: String, userId: String) async throws -> Bool {
-        try await loadRemoteDeleteTombstones(userId: userId)[chatId] != nil
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+        return try await hasRemoteDeleteTombstoneUnlocked(chatId: chatId, userId: userId)
+    }
+
+    private func hasRemoteDeleteTombstoneUnlocked(
+        chatId: String,
+        userId: String
+    ) async throws -> Bool {
+        let tombstones = try await loadRemoteDeleteTombstones(userId: userId)
+        return remoteDeleteRecoveryRequiredUserIds.contains(userId) || tombstones[chatId] != nil
+    }
+
+    func requiresRemoteDeleteRecovery(userId: String) async throws -> Bool {
+        _ = try await loadRemoteDeleteTombstones(userId: userId)
+        return remoteDeleteRecoveryRequiredUserIds.contains(userId)
+    }
+
+    func completeRemoteDeleteRecovery(userId: String) async throws {
+        await acquireWriteLock()
+        defer { releaseWriteLock() }
+        let quarantinePath = try quarantinedRemoteDeleteTombstonesFilePath(userId: userId)
+        if fileManager.fileExists(atPath: quarantinePath.path) {
+            try fileManager.removeItem(at: quarantinePath)
+        }
+        remoteDeleteRecoveryRequiredUserIds.remove(userId)
     }
 
     private func saveRemoteDeleteTombstones(
@@ -1025,6 +1159,15 @@ actor EncryptedFileStorage {
         return removedAll
     }
 
+    private func removeSyncSidecarsStrict(chatId: String, userId: String) throws {
+        let sidecarPath = try syncMetadataPath(chatId: chatId, userId: userId)
+        let legacySidecarPath = try legacySyncMetadataPath(chatId: chatId, userId: userId)
+        for path in [sidecarPath, legacySidecarPath]
+            where fileManager.fileExists(atPath: path.path) {
+            try fileManager.removeItem(at: path)
+        }
+    }
+
     private func performDeleteChat(chatId: String, userId: String) async throws {
         let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
         if fileManager.fileExists(atPath: encPath.path) {
@@ -1064,6 +1207,7 @@ actor EncryptedFileStorage {
         pendingChatIdsCache[userId] = []
         deleteIntentsCache[userId] = []
         remoteDeleteTombstonesCache[userId] = [:]
+        remoteDeleteRecoveryRequiredUserIds.remove(userId)
         contentIntegrityCheckedUserIds.insert(userId)
         contentRepairIds[userId] = []
     }

--- a/TinfoilChat/Services/EncryptedFileStorage.swift
+++ b/TinfoilChat/Services/EncryptedFileStorage.swift
@@ -312,7 +312,56 @@ actor EncryptedFileStorage {
     func saveChat(_ chat: Chat, userId: String) async throws {
         await acquireWriteLock()
         defer { releaseWriteLock() }
-        try await performSaveChat(chat, userId: userId)
+        let prepared = try await prepareLocalChatForSave(chat, userId: userId)
+        try await performSaveChat(prepared, userId: userId)
+    }
+
+    private func prepareLocalChatForSave(_ chat: Chat, userId: String) async throws -> Chat {
+        guard subdirectory == nil, chat.locallyModified else { return chat }
+        let encPath = try chatFilePath(chatId: chat.id, userId: userId, isCorrupted: false)
+        let rawPath = try chatFilePath(chatId: chat.id, userId: userId, isCorrupted: true)
+        let hasEncryptedFile = fileManager.fileExists(atPath: encPath.path)
+        var existing: Chat?
+        if hasEncryptedFile || fileManager.fileExists(atPath: rawPath.path) {
+            if var loaded = try await loadChatFromFile(
+                hasEncryptedFile ? encPath : rawPath,
+                isRaw: !hasEncryptedFile
+            ) {
+                await overlaySyncSidecar(&loaded, userId: userId)
+                existing = loaded
+            }
+        }
+        EditClockStore.observe(existing?.clock)
+        EditClockStore.observe(chat.clock)
+        var prepared = chat
+        if let existing, existing.syncVersion > prepared.syncVersion {
+            prepared.syncVersion = existing.syncVersion
+            prepared.syncedAt = existing.syncedAt
+        }
+        let isContentMutation = existing?.updatedAt != chat.updatedAt
+        if !isContentMutation, let existing,
+           (prepared.clock ?? 0) <= (existing.clock ?? 0),
+           existing.writer?.isEmpty == false {
+            prepared.clock = existing.clock
+            prepared.writer = existing.writer
+            prepared.clockVersion = existing.clockVersion
+        }
+        if !isContentMutation,
+           prepared.clock != nil,
+           prepared.writer?.isEmpty == false {
+            return prepared
+        }
+        let carriesNewClock = chat.clock.map { $0 > (existing?.clock ?? 0) } == true
+            && chat.writer?.isEmpty == false
+        if !carriesNewClock {
+            let clock = EditClockStore.nextClock(
+                observedMax: max(existing?.clock ?? 0, chat.clock ?? 0)
+            )
+            prepared.clock = clock.v
+            prepared.writer = clock.w
+        }
+        prepared.clockVersion = prepared.syncVersion + 1
+        return prepared
     }
 
     func applyRemoteChatIfFresh(
@@ -348,6 +397,7 @@ actor EncryptedFileStorage {
         guard decision == .applied else {
             return decision
         }
+        EditClockStore.observe(chat.clock)
         try await performSaveChat(chat, userId: userId)
         return .applied
     }
@@ -357,6 +407,7 @@ actor EncryptedFileStorage {
         userId: String,
         expectedUpdatedAt: Date,
         syncVersion: Int,
+        uploadedClock: ChatClockState,
         attachmentRewrites: [
             (clientId: String, serverId: String, encryptionKey: String)
         ]
@@ -423,6 +474,35 @@ actor EncryptedFileStorage {
             if didChangeChat {
                 try await performSaveChat(chat, userId: userId)
             }
+        }
+        let encPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: false)
+        let rawPath = try chatFilePath(chatId: chatId, userId: userId, isCorrupted: true)
+        let hasEncryptedFile = fileManager.fileExists(atPath: encPath.path)
+        guard hasEncryptedFile || fileManager.fileExists(atPath: rawPath.path),
+              var currentChat = try await loadChatFromFile(
+                  hasEncryptedFile ? encPath : rawPath,
+                  isRaw: !hasEncryptedFile
+              ) else {
+            return false
+        }
+        await overlaySyncSidecar(&currentChat, userId: userId)
+        let finalizedClock = ChatEditClockPolicy.finalizedState(
+            uploaded: uploadedClock,
+            current: ChatClockState(
+                clock: currentChat.clock,
+                writer: currentChat.writer,
+                clockVersion: currentChat.clockVersion
+            ),
+            authoritativeSyncVersion: syncVersion,
+            editedDuringUpload: editedDuringUpload
+        )
+        if currentChat.clock != finalizedClock.clock
+            || currentChat.writer != finalizedClock.writer
+            || currentChat.clockVersion != finalizedClock.clockVersion {
+            currentChat.clock = finalizedClock.clock
+            currentChat.writer = finalizedClock.writer
+            currentChat.clockVersion = finalizedClock.clockVersion
+            try await performSaveChat(currentChat, userId: userId)
         }
         try await performUpdateSyncMetadata(
             chatId: chatId,

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -555,7 +555,7 @@ class ProfileManager: ObservableObject {
         isSyncing = isPulling || isPushing
     }
 
-    private func prepareLocalProfileForSync() -> ProfileData {
+    private func prepareLocalProfileForSync() throws -> ProfileData {
         var profile = createProfileData()
         let changedFields = ProfileMerge.changedProfileFields(
             local: profile,
@@ -566,7 +566,7 @@ class ProfileManager: ObservableObject {
             clocks[$0] == lastSyncedProfile?.fieldClocks?[$0]
         }
         if !unstampedFields.isEmpty {
-            let tick = EditClockStore.nextClock()
+            let tick = try EditClockStore.nextClock()
             for field in unstampedFields {
                 clocks[field] = tick
             }
@@ -609,9 +609,12 @@ class ProfileManager: ObservableObject {
             if let cloudProfile = try await profileSync.fetchProfile() {
                 guard generation == accountGeneration else { return false }
                 let cloudVersion = cloudProfile.version ?? 0
-                let localProfile = hasPendingLocalProfileChanges
-                    ? prepareLocalProfileForSync()
-                    : createProfileData()
+                let localProfile: ProfileData
+                if hasPendingLocalProfileChanges {
+                    localProfile = try prepareLocalProfileForSync()
+                } else {
+                    localProfile = createProfileData()
+                }
 
                 if let baseline = lastSyncedProfile {
                     let merge = ProfileMerge.mergeProfiles(
@@ -678,7 +681,13 @@ class ProfileManager: ObservableObject {
         }
 
         guard generation == accountGeneration else { return }
-        var profile = prepareLocalProfileForSync()
+        var profile: ProfileData
+        do {
+            profile = try prepareLocalProfileForSync()
+        } catch {
+            syncError = error.localizedDescription
+            return
+        }
 
         // Only push if there is a real change vs last synced baseline.
         // When nothing diverges, clear the pending flag so a phantom

--- a/TinfoilChat/Services/RevisionSyncState.swift
+++ b/TinfoilChat/Services/RevisionSyncState.swift
@@ -274,6 +274,20 @@ enum RevisionApplyResult: Equatable {
     case refused
 }
 
+enum RemoteDeleteTombstonePolicy {
+    static func canClearAfterLocalCleanup(
+        contentExists: Bool,
+        sidecarExists: Bool,
+        removalFailed: Bool
+    ) -> Bool {
+        !contentExists && !sidecarExists && !removalFailed
+    }
+
+    static func canClearAfterRemoteApply(_ result: RevisionApplyResult) -> Bool {
+        result == .applied
+    }
+}
+
 enum RevisionApplyPolicy {
     static func contentResult(
         existing: ChatIndexEntry?,

--- a/TinfoilChat/Services/RevisionSyncState.swift
+++ b/TinfoilChat/Services/RevisionSyncState.swift
@@ -219,6 +219,29 @@ enum SnapshotReconciliation {
                 || missingContentIds.contains(item.id)
         }
     }
+
+    static func contentItemsForTombstoneRecovery(
+        local: [ChatIndexEntry],
+        remote: [EnclaveRevisionSnapshotItem],
+        recentLimit: Int,
+        missingContentIds: Set<String> = [],
+        knownTombstoneIds: Set<String>
+    ) -> [EnclaveRevisionSnapshotItem] {
+        let planned = contentItems(
+            local: local,
+            remote: remote,
+            recentLimit: recentLimit,
+            missingContentIds: missingContentIds
+        )
+        var plannedById = Dictionary(
+            planned.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for item in remote where knownTombstoneIds.contains(item.id) {
+            plannedById[item.id] = item
+        }
+        return remote.compactMap { plannedById[$0.id] }
+    }
 }
 
 enum ChatContentIntegrity {

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -3,9 +3,34 @@
 //  TinfoilChatTests
 //
 
+import Dispatch
 import Foundation
 import Testing
 @testable import TinfoilChat
+
+private final class EditClockResults: @unchecked Sendable {
+    private let lock = NSLock()
+    private var clocks: [EditClock] = []
+    private var failureCount = 0
+
+    func append(_ clock: EditClock) {
+        lock.lock()
+        clocks.append(clock)
+        lock.unlock()
+    }
+
+    func recordFailure() {
+        lock.lock()
+        failureCount += 1
+        lock.unlock()
+    }
+
+    func snapshot() -> (clocks: [EditClock], failureCount: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (clocks, failureCount)
+    }
+}
 
 struct RevisionSyncTests {
     @Test func revisionDTOsUseDecimalStringsAndSnakeCase() throws {
@@ -398,6 +423,43 @@ struct RevisionSyncTests {
     }
 
     @MainActor
+    @Test func tombstoneRecoveryPreservesDirtyRemoteRowsAndDeletesMissingSyncedRows() {
+        var dirty = ChatSearchServiceTests.makeChat(id: "dirty", title: "Dirty")
+        dirty.syncedAt = Date()
+        dirty.syncVersion = 2
+        dirty.locallyModified = true
+        var missing = ChatSearchServiceTests.makeChat(id: "missing", title: "Missing")
+        missing.syncedAt = Date()
+        missing.syncVersion = 2
+        missing.locallyModified = true
+        let remoteDirty = EnclaveRevisionSnapshotItem(
+            id: dirty.id,
+            etag: "3",
+            keyId: "key",
+            projectId: nil,
+            updatedAt: "2026-08-13T00:00:00.000Z"
+        )
+        let local = [dirty, missing].map { ChatIndexEntry(from: $0) }
+
+        #expect(SnapshotReconciliation.contentItemsForTombstoneRecovery(
+            local: local,
+            remote: [remoteDirty],
+            recentLimit: 1,
+            knownTombstoneIds: []
+        ).isEmpty)
+        #expect(SnapshotReconciliation.contentItemsForTombstoneRecovery(
+            local: local,
+            remote: [remoteDirty],
+            recentLimit: 1,
+            knownTombstoneIds: [dirty.id]
+        ) == [remoteDirty])
+        #expect(SnapshotReconciliation.locallyRemovedIds(
+            local: local,
+            remoteIds: [dirty.id]
+        ) == [missing.id])
+    }
+
+    @MainActor
     @Test func snapshotRepairsMissingContentEvenWhenIndexMetadataIsClean() {
         var clean = ChatSearchServiceTests.makeChat(id: "missing-file", title: "Missing")
         clean.syncedAt = Date()
@@ -593,6 +655,54 @@ struct RevisionSyncTests {
     @Test func editClockRefusesCounterExhaustion() {
         #expect(throws: EditClockStore.ClockError.self) {
             _ = try EditClockStore.incrementedCounter(after: EditClockStore.maxCounter)
+        }
+    }
+
+    @Test func editClockAllocatorSerializesConcurrentTicks() {
+        let suite = "edit-clock-concurrency-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let allocator = EditClockAllocator(defaults: defaults)
+        let allocationCount = 64
+        let results = EditClockResults()
+
+        DispatchQueue.concurrentPerform(iterations: allocationCount) { _ in
+            do {
+                results.append(try allocator.nextClock())
+            } catch {
+                results.recordFailure()
+            }
+        }
+
+        let snapshot = results.snapshot()
+        #expect(snapshot.failureCount == 0)
+        #expect(snapshot.clocks.count == allocationCount)
+        #expect(Set(snapshot.clocks.map(\.v)).count == allocationCount)
+        #expect(Set(snapshot.clocks.map(\.w)).count == 1)
+    }
+
+    @Test func editClockIgnoresExhaustingRemoteBoundaries() throws {
+        let suite = "edit-clock-boundary-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let allocator = EditClockAllocator(defaults: defaults)
+
+        allocator.observe(EditClockStore.maxCounter)
+        #expect(try allocator.nextClock().v == 1)
+
+        let observedSuite = "edit-clock-observed-boundary-\(UUID().uuidString)"
+        let observedDefaults = UserDefaults(suiteName: observedSuite)!
+        observedDefaults.removePersistentDomain(forName: observedSuite)
+        defer { observedDefaults.removePersistentDomain(forName: observedSuite) }
+        let observedAllocator = EditClockAllocator(defaults: observedDefaults)
+        #expect(try observedAllocator.nextClock(observedMax: EditClockStore.maxCounter).v == 1)
+
+        observedAllocator.observe(EditClockStore.maxCounter - 1)
+        #expect(try observedAllocator.nextClock().v == EditClockStore.maxCounter)
+        #expect(throws: EditClockStore.ClockError.self) {
+            _ = try observedAllocator.nextClock()
         }
     }
 

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -558,6 +558,42 @@ struct RevisionSyncTests {
             authoritativeSyncVersion: 4,
             editedDuringUpload: true
         ) == ChatClockState(clock: 8, writer: "device-a", clockVersion: 5))
+        #expect(!ChatEditClockPolicy.matchesFrozenMutation(
+            current: newer,
+            uploaded: uploaded
+        ))
+    }
+
+    @Test func remoteDeleteTombstoneClearsOnlyAfterAuthoritativeCompletion() {
+        #expect(!RemoteDeleteTombstonePolicy.canClearAfterLocalCleanup(
+            contentExists: true,
+            sidecarExists: false,
+            removalFailed: false
+        ))
+        #expect(!RemoteDeleteTombstonePolicy.canClearAfterLocalCleanup(
+            contentExists: false,
+            sidecarExists: true,
+            removalFailed: false
+        ))
+        #expect(!RemoteDeleteTombstonePolicy.canClearAfterLocalCleanup(
+            contentExists: false,
+            sidecarExists: false,
+            removalFailed: true
+        ))
+        #expect(RemoteDeleteTombstonePolicy.canClearAfterLocalCleanup(
+            contentExists: false,
+            sidecarExists: false,
+            removalFailed: false
+        ))
+        #expect(!RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(.refused))
+        #expect(!RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(.locallyModified))
+        #expect(RemoteDeleteTombstonePolicy.canClearAfterRemoteApply(.applied))
+    }
+
+    @Test func editClockRefusesCounterExhaustion() {
+        #expect(throws: EditClockStore.ClockError.self) {
+            _ = try EditClockStore.incrementedCounter(after: EditClockStore.maxCounter)
+        }
     }
 
     @MainActor

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -611,6 +611,19 @@ struct RevisionSyncTests {
             locallyModified: true,
             currentSyncVersion: 3
         ) == ChatClockState(clock: nil, writer: nil, clockVersion: nil))
+        #expect(ChatEditClockPolicy.nextSyncVersion(after: Int.max) == nil)
+        #expect(!ChatEditClockPolicy.isTrusted(
+            ChatClockState(clock: 7, writer: "device-a", clockVersion: Int.max),
+            syncVersion: Int.max,
+            locallyModified: true
+        ))
+        #expect(ChatEditClockPolicy.uploadState(
+            clock: 7,
+            writer: "device-a",
+            sourceClockVersion: Int.max,
+            locallyModified: false,
+            currentSyncVersion: Int.max
+        ) == ChatClockState(clock: nil, writer: nil, clockVersion: nil))
     }
 
     @Test func chatUploadFinalizePreservesEditsThatRaceUpload() {

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -534,6 +534,32 @@ struct RevisionSyncTests {
         ) == true)
     }
 
+    @Test func chatUploadClockTargetsExpectedCASVersion() {
+        #expect(ChatEditClockPolicy.uploadState(
+            clock: 7,
+            writer: "device-a",
+            currentSyncVersion: 3
+        ) == ChatClockState(clock: 7, writer: "device-a", clockVersion: 4))
+    }
+
+    @Test func chatUploadFinalizePreservesEditsThatRaceUpload() {
+        let uploaded = ChatClockState(clock: 7, writer: "device-a", clockVersion: 4)
+        let newer = ChatClockState(clock: 8, writer: "device-a", clockVersion: 4)
+
+        #expect(ChatEditClockPolicy.finalizedState(
+            uploaded: uploaded,
+            current: newer,
+            authoritativeSyncVersion: 4,
+            editedDuringUpload: false
+        ) == ChatClockState(clock: 7, writer: "device-a", clockVersion: 4))
+        #expect(ChatEditClockPolicy.finalizedState(
+            uploaded: uploaded,
+            current: newer,
+            authoritativeSyncVersion: 4,
+            editedDuringUpload: true
+        ) == ChatClockState(clock: 8, writer: "device-a", clockVersion: 5))
+    }
+
     @MainActor
     @Test func projectMoveIntentPersistsAndOlderChatsDecodeWithoutIt() throws {
         var chat = ChatSearchServiceTests.makeChat(id: "project-move", title: "Move")

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -600,8 +600,17 @@ struct RevisionSyncTests {
         #expect(ChatEditClockPolicy.uploadState(
             clock: 7,
             writer: "device-a",
+            sourceClockVersion: 4,
+            locallyModified: true,
             currentSyncVersion: 3
         ) == ChatClockState(clock: 7, writer: "device-a", clockVersion: 4))
+        #expect(ChatEditClockPolicy.uploadState(
+            clock: 7,
+            writer: "device-a",
+            sourceClockVersion: nil,
+            locallyModified: true,
+            currentSyncVersion: 3
+        ) == ChatClockState(clock: nil, writer: nil, clockVersion: nil))
     }
 
     @Test func chatUploadFinalizePreservesEditsThatRaceUpload() {
@@ -611,15 +620,27 @@ struct RevisionSyncTests {
         #expect(ChatEditClockPolicy.finalizedState(
             uploaded: uploaded,
             current: newer,
+            currentSyncVersion: 3,
+            currentLocallyModified: true,
             authoritativeSyncVersion: 4,
             editedDuringUpload: false
         ) == ChatClockState(clock: 7, writer: "device-a", clockVersion: 4))
         #expect(ChatEditClockPolicy.finalizedState(
             uploaded: uploaded,
             current: newer,
+            currentSyncVersion: 3,
+            currentLocallyModified: true,
             authoritativeSyncVersion: 4,
             editedDuringUpload: true
         ) == ChatClockState(clock: 8, writer: "device-a", clockVersion: 5))
+        #expect(ChatEditClockPolicy.finalizedState(
+            uploaded: uploaded,
+            current: ChatClockState(clock: 8, writer: "device-a", clockVersion: nil),
+            currentSyncVersion: 3,
+            currentLocallyModified: true,
+            authoritativeSyncVersion: 4,
+            editedDuringUpload: true
+        ) == ChatClockState(clock: nil, writer: nil, clockVersion: nil))
         #expect(!ChatEditClockPolicy.matchesFrozenMutation(
             current: newer,
             uploaded: uploaded


### PR DESCRIPTION
## Summary
- persist account-scoped remote-delete tombstones before revision checkpoints can advance, reject stale saves/uploads after relaunch, and retry local cleanup safely
- centralize logical edit clock stamping for cloud chat saves and stamp frozen upload payloads for the expected CAS version
- finalize successful uploads with authoritative clock metadata while preserving newer edits that race an upload
- add pure policy coverage for upload clock stamping and finalization

## Validation
- inspected the complete diff against `origin/main`
- ran `git diff --check origin/main...HEAD`
- did not run builds, compilation, or tests per `AGENTS.md`
- manual Xcode testing is required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens revision sync gates and finalization so remote deletes persist across restarts, clocks remain trusted and monotonic, and version bumps are bounded. Previously, deletes could be lost and uploads could finalize with stale clocks or overflowed versions; now we persist encrypted tombstones, gate writes/uploads, serialize clock allocation, reconcile final clocks, and validate versions (including on metadata-only saves).

- Persist encrypted remote-delete tombstones per account; block saves/uploads when tombstoned or upgrade‑gated via `CloudUploadGate`/`ensureChatUploadIsAllowed`; defer local cleanup while streaming; clear tombstones only after verified absence or authoritative remote apply; restore and retry across relaunches with `requiresRemoteDeleteRecovery`/`completeRemoteDeleteRecovery`.
- Enforce clock/version policy: `EditClockAllocator` serializes ticks and throws on exhaustion; `ChatEditClockPolicy` stamps upload payloads, validates finalization via `uploadedClock`, and preserves edits that race uploads; local saves validate sync versions and keep trusted clocks for metadata‑only changes; sync‑version increments use bounded `nextSyncVersion`.
- Strengthen reconciliation: treat known tombstones as must‑pull, allow authoritative upserts to replace local deletes when tombstoned, and only then clear tombstones.

**Review/migration**
- Handle `EditClockStore.nextClock` throwing (updated in `ProfileManager` and `ChatRecoverySync`).
- Update upload paths: stamp via `stampClockVersionForUpload`, pass `uploadedClock` to `finalizeUploadIfFresh`, and gate via `CloudUploadGate` and `ensureChatUploadIsAllowed`.
- Treat `EncryptedFileStorage.saveChat` throwing `SaveError.remotelyDeleted` as a cancel/no‑op; handle `SaveError.invalidSyncVersion` as conflict/invalid revision.
- Guard version increments with `ChatEditClockPolicy.nextSyncVersion` and handle `nil` as conflict/invalid revision.

<sup>Written for commit f3048e9502119bc9db0eb0365f2314e4392c51b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

