### PR TITLE
Keep iOS account startup scoped to the active user

### DIFF
--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -51,9 +51,7 @@ struct ContentView: View {
 
             // Initialize encryption with existing key only (no auto-creation)
             Task {
-                if EncryptionService.shared.hasEncryptionKey() {
-                    _ = try? await EncryptionService.shared.initialize()
-                }
+                await chatViewModel.initializeExistingEncryptionKeyIfAvailable()
 
                 await MainActor.run {
                     chatViewModel.updateModelBasedOnAuthStatus(
@@ -79,10 +77,10 @@ struct ContentView: View {
         .sheet(isPresented: $passkeyManager.showPasskeyRecoveryChoice) {
             PasskeyRecoveryChoiceView(
                 onTryAgain: {
-                    await passkeyManager.retryPasskeyRecovery()
+                    await chatViewModel.retryPasskeyRecovery()
                 },
                 onStartFresh: {
-                    await passkeyManager.startFreshWithNewKey()
+                    await chatViewModel.startFreshWithNewKey()
                 },
                 onSkip: {
                     passkeyManager.dismissRecoveryChoice()

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -64,6 +64,7 @@ final class PasskeyManager: ObservableObject {
     // MARK: - Private
 
     private var syncCheckTask: Task<Void, Never>?
+    private var accountOperationsEnabled = true
     private let passkeyService = PasskeyService.shared
 
     /// Remote keyId currently surfaced in the recovery-choice sheet,
@@ -108,7 +109,13 @@ final class PasskeyManager: ObservableObject {
 
     // MARK: - Sign-Out Reset
 
-    func reset() {
+    func reset() async {
+        accountOperationsEnabled = false
+        let canceledSyncCheckTask = syncCheckTask
+        canceledSyncCheckTask?.cancel()
+        syncCheckTask = nil
+        await canceledSyncCheckTask?.value
+
         passkeyActive = false
         passkeySetupAvailable = false
         passkeyAddDeviceAvailable = false
@@ -117,11 +124,13 @@ final class PasskeyManager: ObservableObject {
         setDismissedRecoveryKeyId(nil)
         onRecoveryComplete = nil
         onKeyRefreshedFromBackup = nil
-        syncCheckTask?.cancel()
-        syncCheckTask = nil
         passkeyService.clearCachedPrfResult()
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Secret.passkeyEnclaveKeyId)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId)
+    }
+
+    func resumeAccountOperations() {
+        accountOperationsEnabled = true
     }
 
     // MARK: - Recovery Flow
@@ -132,9 +141,11 @@ final class PasskeyManager: ObservableObject {
         do {
             state = try await SyncEnclaveAPI.keyCurrent()
         } catch {
+            guard canMutateAccountKey else { return .recoveryFailed }
             surfaceRecoveryChoice(forKeyId: nil)
             return .recoveryFailed
         }
+        guard canMutateAccountKey else { return .recoveryFailed }
 
         // When the enclave already has a usable v2 bundle, unlock
         // straight from the server. Use a silent ceremony so a device
@@ -142,6 +153,7 @@ final class PasskeyManager: ObservableObject {
         // of detouring through the cross-device QR sheet.
         if state.keyId != nil, !state.bundles.isEmpty {
             let serverResult = await PasskeyKeyFlow.unlockFromServer(silent: true)
+            guard canMutateAccountKey else { return .recoveryFailed }
             if case .success = serverResult {
                 return await applyUnlockResult(serverResult)
             }
@@ -155,6 +167,7 @@ final class PasskeyManager: ObservableObject {
                     entries: legacy,
                     enclaveKeyId: state.keyId
                 )
+                guard canMutateAccountKey else { return .recoveryFailed }
                 if case .success = legacyResult {
                     return await applyUnlockResult(legacyResult)
                 }
@@ -169,6 +182,7 @@ final class PasskeyManager: ObservableObject {
         // exclude them here and let them fall through to recovery — a
         // fresh key would strand their un-migrated data.
         let remoteState = await CloudKeyPreflightValidator.shared.inspectRemoteState()
+        guard canMutateAccountKey else { return .recoveryFailed }
         if state.keyId == nil, !state.hasData, remoteState == .empty {
             let created = await attemptNewUserPasskeySetup()
             if !created {
@@ -191,6 +205,7 @@ final class PasskeyManager: ObservableObject {
                 entries: legacy,
                 enclaveKeyId: state.keyId
             )
+            guard canMutateAccountKey else { return .recoveryFailed }
             switch legacyResult {
             case .success:
                 return await applyUnlockResult(legacyResult)
@@ -224,6 +239,7 @@ final class PasskeyManager: ObservableObject {
               remoteKeyId != localKeyId else {
             return .noMismatch
         }
+        guard canMutateAccountKey else { return .noMismatch }
 
         guard !state.bundles.isEmpty else {
             return .manualRecoveryRequired
@@ -235,13 +251,16 @@ final class PasskeyManager: ObservableObject {
             ),
             silent: true
         )
+        guard canMutateAccountKey else { return .noMismatch }
         if case .success(let recoveredCek, let keyIdHex, _, _) = result {
             do {
                 try await applyRecoveredCek(cek: recoveredCek)
             } catch {
+                guard canMutateAccountKey else { return .noMismatch }
                 surfaceRecoveryChoice(forKeyId: remoteKeyId)
                 return .passkeyPromptShown
             }
+            guard canMutateAccountKey else { return .noMismatch }
             persistEnclaveKeyId(keyIdHex)
             activatePasskey()
             onKeyRefreshedFromBackup?()
@@ -257,14 +276,17 @@ final class PasskeyManager: ObservableObject {
     private func applyUnlockResult(
         _ result: PasskeyFlowResult
     ) async -> PasskeyRecoveryResult {
+        guard canMutateAccountKey else { return .recoveryFailed }
         switch result {
         case .success(let cek, let keyIdHex, _, _):
             do {
                 try await applyRecoveredCek(cek: cek)
             } catch {
+                guard canMutateAccountKey else { return .recoveryFailed }
                 surfaceRecoveryChoice(forKeyId: keyIdHex)
                 return .recoveryFailed
             }
+            guard canMutateAccountKey else { return .recoveryFailed }
             persistEnclaveKeyId(keyIdHex)
             activatePasskey()
             return .success
@@ -288,10 +310,12 @@ final class PasskeyManager: ObservableObject {
             user: user,
             createdVia: createdVia
         )
+        guard canMutateAccountKey else { return false }
         switch result {
         case .success(let cek, let keyIdHex, _, _):
             do {
                 try await applyFreshCek(cek: cek)
+                guard canMutateAccountKey else { throw CancellationError() }
                 guard CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: authorizationMode) else {
                     EncryptionService.shared.clearKey()
                     throw CloudKeyAuthorizationError.authorizationUnavailable
@@ -374,9 +398,11 @@ final class PasskeyManager: ObservableObject {
         } catch {
             return false
         }
+        guard canMutateAccountKey else { return false }
         guard state.keyId != nil, !state.bundles.isEmpty else { return false }
 
         let result = await PasskeyKeyFlow.unlockFromServer()
+        guard canMutateAccountKey else { return false }
         switch result {
         case .success(let cek, let keyIdHex, _, _):
             do {
@@ -384,6 +410,7 @@ final class PasskeyManager: ObservableObject {
             } catch {
                 return false
             }
+            guard canMutateAccountKey else { return false }
             persistEnclaveKeyId(keyIdHex)
             activatePasskey()
             showPasskeyRecoveryChoice = false
@@ -415,7 +442,7 @@ final class PasskeyManager: ObservableObject {
                 passkeySetupAvailable = true
                 return .manualRecoveryRequired
             }
-            await createPasskeyBackup()
+            _ = await createPasskeyBackup()
             return .success
         }
         return await attemptPasskeyKeyRecovery()
@@ -498,6 +525,7 @@ final class PasskeyManager: ObservableObject {
     /// may have changed (e.g. legacy-blob migration completed,
     /// another device just added a bundle).
     func refreshBundleState() async {
+        guard accountOperationsEnabled else { return }
         guard EncryptionService.shared.hasEncryptionKey() else { return }
         await checkPasskeyStateForExistingKey()
     }
@@ -525,20 +553,22 @@ final class PasskeyManager: ObservableObject {
 
     /// Create a passkey bundle for the user's existing CEK. Used by
     /// "Add this device to passkey backup" in Settings.
-    func createPasskeyBackup() async {
-        guard let user = userInfo() else { return }
-        guard await ensureCurrentPrimaryKeyAuthorized() else { return }
+    func createPasskeyBackup() async -> Bool {
+        guard canMutateAccountKey else { return false }
+        guard let user = userInfo() else { return false }
+        guard await ensureCurrentPrimaryKeyAuthorized() else { return false }
+        guard canMutateAccountKey else { return false }
         let cek: Data
         do {
             cek = try EncryptionService.shared.getKeyBytesOrThrow()
         } catch {
-            return
+            return false
         }
         let keyIdHex: String
         do {
             keyIdHex = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
         } catch {
-            return
+            return false
         }
 
         // Determine whether to register-key or add-bundle by probing
@@ -549,26 +579,20 @@ final class PasskeyManager: ObservableObject {
         // existing key.
         do {
             let state = try await SyncEnclaveAPI.keyCurrent()
+            guard canMutateAccountKey else { return false }
             if state.keyId == nil {
                 let result = await PasskeyKeyFlow.registerExistingKeyWithPasskey(
                     existingCek: cek,
                     user: user,
                     createdVia: .recovery
                 )
+                guard canMutateAccountKey else { return false }
                 if case .success = result {
                     persistEnclaveKeyId(keyIdHex)
                     activatePasskey()
-                    // Adopting the existing CEK just registered it as
-                    // the current key, so the migration gate that the
-                    // launch-time pass tripped over now clears. Re-seal
-                    // any legacy rows now instead of waiting for the
-                    // next launch.
-                    Task.detached(priority: .background) {
-                        _ = await LegacyBlobMigration.runAndFinalize()
-                        await PasskeyManager.shared.refreshBundleState()
-                    }
+                    return true
                 }
-                return
+                return false
             }
 
             // Existing key — enroll a new passkey for it.
@@ -577,13 +601,16 @@ final class PasskeyManager: ObservableObject {
                 keyIdHex: keyIdHex,
                 user: user
             )
+            guard canMutateAccountKey else { return false }
             if case .success = result {
                 persistEnclaveKeyId(keyIdHex)
                 activatePasskey()
+                return true
             }
         } catch {
             // Non-fatal — leave state unchanged.
         }
+        return false
     }
 
     /// No-op shim retained for compatibility with views that still
@@ -604,10 +631,19 @@ final class PasskeyManager: ObservableObject {
         startSyncCheck()
     }
 
+    private var canMutateAccountKey: Bool {
+        accountOperationsEnabled && !Task.isCancelled
+    }
+
     private func applyRecoveredCek(cek: Data) async throws {
+        guard canMutateAccountKey else { throw CancellationError() }
         let bytes = try await snapshotCurrentKeys()
+        guard canMutateAccountKey else { throw CancellationError() }
         do {
             try await EncryptionService.shared.setKeyBytes(cek)
+            guard canMutateAccountKey else {
+                throw CancellationError()
+            }
         } catch {
             try EncryptionService.shared.replaceKeyBundle(
                 primary: bytes.primary,
@@ -616,15 +652,28 @@ final class PasskeyManager: ObservableObject {
             throw error
         }
 
+        guard canMutateAccountKey else { throw CancellationError() }
         let mode = try await CloudKeyAuthorizationStore.shared
             .authorizeCurrentPrimaryKeyAfterValidation(rollbackTo: bytes)
+        guard canMutateAccountKey else {
+            try EncryptionService.shared.replaceKeyBundle(
+                primary: bytes.primary,
+                alternatives: bytes.alternatives
+            )
+            throw CancellationError()
+        }
         _ = mode
     }
 
     private func applyFreshCek(cek: Data) async throws {
+        guard canMutateAccountKey else { throw CancellationError() }
         let bytes = try await snapshotCurrentKeys()
+        guard canMutateAccountKey else { throw CancellationError() }
         do {
             try await EncryptionService.shared.setKeyBytes(cek)
+            guard canMutateAccountKey else {
+                throw CancellationError()
+            }
         } catch {
             try EncryptionService.shared.replaceKeyBundle(
                 primary: bytes.primary,
@@ -685,6 +734,7 @@ final class PasskeyManager: ObservableObject {
     /// changes, the local CEK is invalidated and a fresh recovery
     /// flow is required.
     func startSyncCheck() {
+        guard accountOperationsEnabled else { return }
         syncCheckTask?.cancel()
         syncCheckTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -696,8 +746,10 @@ final class PasskeyManager: ObservableObject {
     }
 
     private func refreshKeyFromEnclave() async {
+        guard canMutateAccountKey else { return }
         do {
             let state = try await SyncEnclaveAPI.keyCurrent()
+            guard canMutateAccountKey else { return }
             guard let remoteKeyId = state.keyId else { return }
             let storedKeyId = cachedKeyIdHex()
             if let storedKeyId, storedKeyId == remoteKeyId {
@@ -724,13 +776,16 @@ final class PasskeyManager: ObservableObject {
                 prefer: UserDefaults.standard.string(forKey: Constants.StorageKeys.Secret.passkeyEnclaveCredentialId),
                 silent: true
             )
+            guard canMutateAccountKey else { return }
             switch result {
             case .success(let cek, let keyIdHex, _, _):
                 do {
                     try await applyRecoveredCek(cek: cek)
+                    guard canMutateAccountKey else { return }
                     persistEnclaveKeyId(keyIdHex)
                     onKeyRefreshedFromBackup?()
                 } catch {
+                    guard canMutateAccountKey else { return }
                     surfaceRecoveryChoice(forKeyId: remoteKeyId)
                 }
             case .failure(.enclaveUnavailable, _):

--- a/TinfoilChat/Services/Passkey/PasskeyManager.swift
+++ b/TinfoilChat/Services/Passkey/PasskeyManager.swift
@@ -65,6 +65,7 @@ final class PasskeyManager: ObservableObject {
 
     private var syncCheckTask: Task<Void, Never>?
     private var accountOperationsEnabled = true
+    private let accountOperationTracker = AccountOperationTracker()
     private let passkeyService = PasskeyService.shared
 
     /// Remote keyId currently surfaced in the recovery-choice sheet,
@@ -111,6 +112,7 @@ final class PasskeyManager: ObservableObject {
 
     func reset() async {
         accountOperationsEnabled = false
+        await accountOperationTracker.closeAndWait()
         let canceledSyncCheckTask = syncCheckTask
         canceledSyncCheckTask?.cancel()
         syncCheckTask = nil
@@ -131,6 +133,7 @@ final class PasskeyManager: ObservableObject {
 
     func resumeAccountOperations() {
         accountOperationsEnabled = true
+        accountOperationTracker.reopen()
     }
 
     // MARK: - Recovery Flow
@@ -442,7 +445,7 @@ final class PasskeyManager: ObservableObject {
                 passkeySetupAvailable = true
                 return .manualRecoveryRequired
             }
-            _ = await createPasskeyBackup()
+            guard await createPasskeyBackup() else { return .recoveryFailed }
             return .success
         }
         return await attemptPasskeyKeyRecovery()
@@ -452,6 +455,7 @@ final class PasskeyManager: ObservableObject {
     func checkPasskeyStateForExistingKey() async {
         do {
             let state = try await SyncEnclaveAPI.keyCurrent()
+            guard canMutateAccountKey else { return }
             if let remoteKeyId = state.keyId, !state.bundles.isEmpty {
                 // Derive the local key id so we can tell whether this
                 // device is actually on the current key or is holding a
@@ -514,6 +518,7 @@ final class PasskeyManager: ObservableObject {
             // state is stale and must not survive the transition.
             passkeyActive = false
         } catch {
+            guard canMutateAccountKey else { return }
             // fall through to "setup available"
         }
         passkeySetupAvailable = true
@@ -541,14 +546,27 @@ final class PasskeyManager: ObservableObject {
     /// Remove a passkey bundle from the enclave's current key, then
     /// re-evaluate the local passkey state.
     func removePasskeyBundle(credentialId: String) async throws {
-        let cek = try EncryptionService.shared.getKeyBytesOrThrow()
-        let keyIdHex = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
-        try await PasskeyKeyFlow.removeBundleFromCurrentKey(
-            cek: cek,
-            keyIdHex: keyIdHex,
-            credentialId: credentialId
-        )
-        await refreshBundleState()
+        guard accountOperationsEnabled else { throw CancellationError() }
+        let operationTask = Task {
+            try Task.checkCancellation()
+            let cek = try EncryptionService.shared.getKeyBytesOrThrow()
+            let keyIdHex = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
+            try await PasskeyKeyFlow.removeBundleFromCurrentKey(
+                cek: cek,
+                keyIdHex: keyIdHex,
+                credentialId: credentialId
+            )
+            try Task.checkCancellation()
+            guard accountOperationsEnabled else { throw CancellationError() }
+            await refreshBundleState()
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            throw CancellationError()
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        try await operationTask.value
     }
 
     /// Create a passkey bundle for the user's existing CEK. Used by

--- a/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
+++ b/TinfoilChat/Services/SyncEnclave/LegacyBlobMigration.swift
@@ -60,6 +60,7 @@ enum LegacyBlobMigration {
     /// local loop — the enclave job keeps draining and the next
     /// launch resumes polling against the same coordinator entry.
     static func run() async -> MigrationReport {
+        guard !Task.isCancelled else { return .empty }
         let targetKeyB64: String
         do {
             targetKeyB64 = try CEKEncoding.requirePrimaryKeyB64()
@@ -77,7 +78,9 @@ enum LegacyBlobMigration {
         do {
             let cek = try EncryptionService.shared.getKeyBytesOrThrow()
             let localKeyId = try SyncEnclaveKeyBundle.deriveKeyIdHex(cek: cek)
+            guard !Task.isCancelled else { return .empty }
             var current = try await SyncEnclaveAPI.keyCurrent()
+            guard !Task.isCancelled else { return .empty }
             // A v1->v2 user can hold legacy data and a local CEK without
             // ever registering it as the current key — e.g. they have no
             // passkey, or only an un-promoted legacy passkey, so none of
@@ -94,10 +97,15 @@ enum LegacyBlobMigration {
             // they diverge the helper returns nil and adoption is skipped,
             // so the gate below defers this sweep until the ceremony lands.
             if current.keyId == nil, current.hasData,
-                let safeKey = committedKeyIfActiveMatches(),
-                await adoptLocalKeyForMigration(keyB64: dataToBase64(safeKey))
+                let safeKey = committedKeyIfActiveMatches()
             {
-                current = try await SyncEnclaveAPI.keyCurrent()
+                guard !Task.isCancelled else { return .empty }
+                let adopted = await adoptLocalKeyForMigration(keyB64: dataToBase64(safeKey))
+                guard !Task.isCancelled else { return .empty }
+                if adopted {
+                    current = try await SyncEnclaveAPI.keyCurrent()
+                    guard !Task.isCancelled else { return .empty }
+                }
             }
             guard current.keyId == localKeyId else {
                 #if DEBUG
@@ -117,7 +125,9 @@ enum LegacyBlobMigration {
         // newly recovered key has a different fingerprint), so a
         // genuinely actionable retry still runs. Mirrors the webapp's
         // migration key-set gate; the server 24h cooldown is the backstop.
+        guard !Task.isCancelled else { return .empty }
         let activeUserId = await Clerk.shared.user?.id
+        guard !Task.isCancelled else { return .empty }
         let keysetFingerprint = candidateKeySetFingerprint()
         if let activeUserId, let keysetFingerprint,
             loadExhaustedKeyset(activeUserId) == keysetFingerprint
@@ -135,12 +145,15 @@ enum LegacyBlobMigration {
 
         var lastResponse: EnclaveMigrateAllResponse?
         do {
-            lastResponse = try await SyncEnclaveAPI.migrateAll(
+            guard !Task.isCancelled else { return .empty }
+            let kickoffResponse = try await SyncEnclaveAPI.migrateAll(
                 EnclaveMigrateAllRequest(
                     keys: keys,
                     target: EnclaveMigrateRequestTarget(key: targetKeyB64)
                 )
             )
+            guard !Task.isCancelled else { return .empty }
+            lastResponse = kickoffResponse
         } catch {
             #if DEBUG
             print("[LegacyBlobMigration] migrate-all kickoff failed: \(error)")
@@ -149,15 +162,27 @@ enum LegacyBlobMigration {
         }
 
         while shouldKeepPolling(lastResponse) {
+            guard !Task.isCancelled else { return .empty }
             if Date().timeIntervalSince(startedAt) > pollTimeout {
                 #if DEBUG
                 print("[LegacyBlobMigration] poll timeout — bailing")
                 #endif
                 break
             }
-            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            guard !Task.isCancelled else { return .empty }
             do {
-                lastResponse = try await SyncEnclaveAPI.migrateStatus()
+                try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            } catch is CancellationError {
+                return .empty
+            } catch {
+                return .empty
+            }
+            guard !Task.isCancelled else { return .empty }
+            do {
+                guard !Task.isCancelled else { return .empty }
+                let statusResponse = try await SyncEnclaveAPI.migrateStatus()
+                guard !Task.isCancelled else { return .empty }
+                lastResponse = statusResponse
             } catch {
                 #if DEBUG
                 print("[LegacyBlobMigration] migrate-status poll failed: \(error)")
@@ -166,6 +191,7 @@ enum LegacyBlobMigration {
             }
         }
 
+        guard !Task.isCancelled else { return .empty }
         let snapshot = lastResponse.map { snapshotScopes($0.scopes) } ?? [:]
         var report = toReport(snapshot)
         // A failed coordinator job can report partial=false: the flag
@@ -191,6 +217,7 @@ enum LegacyBlobMigration {
                     totalBlocked: 0,
                     fullyMigrated: true
                 )
+                guard !Task.isCancelled else { return .empty }
                 recordKeysetOutcome(
                     userId: activeUserId,
                     fingerprint: keysetFingerprint,
@@ -201,6 +228,7 @@ enum LegacyBlobMigration {
             }
             return .empty
         }
+        guard !Task.isCancelled else { return .empty }
         recordKeysetOutcome(
             userId: activeUserId,
             fingerprint: keysetFingerprint,
@@ -214,6 +242,7 @@ enum LegacyBlobMigration {
     /// report confirms every observed row has been re-sealed.
     @discardableResult
     static func finalizeAlternativesIfMigrated(_ report: MigrationReport) async -> Bool {
+        guard !Task.isCancelled else { return false }
         guard report.fullyMigrated else { return false }
         guard let userId = await Clerk.shared.user?.id,
               let primary = try? EncryptionService.shared.getKeyBytesOrThrow(),
@@ -221,34 +250,43 @@ enum LegacyBlobMigration {
         else {
             return false
         }
+        guard !Task.isCancelled else { return false }
         guard let entries = try? await EncryptedFileStorage.cloud.loadIndex(userId: userId)
         else {
             return false
         }
+        guard !Task.isCancelled else { return false }
         for entry in entries {
+            guard !Task.isCancelled else { return false }
             guard let chat = try? await EncryptedFileStorage.cloud.loadChat(
                 chatId: entry.id,
                 userId: userId
             ) else {
                 return false
             }
+            guard !Task.isCancelled else { return false }
             if chat.pendingRecoveries?.contains(where: { $0.keyId != primaryKeyId }) == true {
                 return false
             }
         }
+        guard !Task.isCancelled else { return false }
         guard await remoteRecoveriesUseOnlyPrimary(
             userId: userId,
             primaryKeyId: primaryKeyId
         ) else {
             return false
         }
+        guard !Task.isCancelled else { return false }
         EncryptionService.shared.clearFallbackKeys()
         return true
     }
 
     static func runAndFinalize() async -> MigrationReport {
+        guard !Task.isCancelled else { return .empty }
         let report = await run()
+        guard !Task.isCancelled else { return .empty }
         _ = await finalizeAlternativesIfMigrated(report)
+        guard !Task.isCancelled else { return .empty }
         return report
     }
 
@@ -261,6 +299,7 @@ enum LegacyBlobMigration {
         var cursor: String?
         var seenCursors: Set<String> = []
         repeat {
+            guard !Task.isCancelled else { return false }
             guard await Clerk.shared.user?.id == userId,
                   let page = try? await CloudStorageService.shared.listChats(
                       limit: Constants.SyncEnclave.listStatusPageLimit,
@@ -270,7 +309,9 @@ enum LegacyBlobMigration {
             else {
                 return false
             }
+            guard !Task.isCancelled else { return false }
             for remote in page.conversations {
+                guard !Task.isCancelled else { return false }
                 guard let content = remote.content,
                       let data = content.data(using: .utf8),
                       let chat = try? JSONDecoder().decode(StoredChat.self, from: data)
@@ -396,8 +437,11 @@ enum LegacyBlobMigration {
     /// user adopts their key on their next write instead of deferring
     /// forever while they wait for the out-of-band migration kick.
     static func adoptLocalKeyForMigration(keyB64: String) async -> Bool {
+        guard !Task.isCancelled else { return false }
         let initialBundle = await initialBundleFromCachedPrf()
+        guard !Task.isCancelled else { return false }
         do {
+            guard !Task.isCancelled else { return false }
             _ = try await SyncEnclaveAPI.registerKey(
                 EnclaveKeyRegisterRequest(
                     key: keyB64,
@@ -407,6 +451,7 @@ enum LegacyBlobMigration {
                     initialBundle: initialBundle
                 )
             )
+            guard !Task.isCancelled else { return false }
         } catch {
             #if DEBUG
             print("[LegacyBlobMigration] local key adoption failed: \(error)")
@@ -430,10 +475,13 @@ enum LegacyBlobMigration {
     /// or re-created) must not attach an unopenable bundle, which would
     /// make the account look passkey-recoverable when it is not.
     private static func initialBundleFromCachedPrf() async -> EnclaveKeyRegisterBundleInput? {
+        guard !Task.isCancelled else { return nil }
         guard let cached = await PasskeyService.shared.getCachedPrfResult() else {
             return nil
         }
+        guard !Task.isCancelled else { return nil }
         let entries = await LegacyPasskeyCredentials.fetch()
+        guard !Task.isCancelled else { return nil }
         guard entries.contains(where: { $0.id == cached.credentialId }) else {
             return nil
         }

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -104,26 +104,6 @@ struct TinfoilChatApp: App {
                                         }
                                     }
 
-                                    // Opportunistically rewrap any legacy v0/v1
-                                    // rows under the current primary CEK so the
-                                    // alternative-keys list can eventually drain,
-                                    // then drop any stale ciphertext-only chats
-                                    // that the removed v0/v1 client decrypt path
-                                    // used to handle.
-                                    Task.detached(priority: .background) {
-                                        _ = await LegacyBlobMigration.runAndFinalize()
-                                        // Resolve the user at eviction time: the
-                                        // migration above can run long, and a
-                                        // launch-time snapshot would target
-                                        // whoever was signed in at startup.
-                                        await LegacyChatEviction.runIfNeeded(userId: Clerk.shared.user?.id)
-                                        // The migration may have promoted a legacy
-                                        // CEK or added a fresh bundle for this device.
-                                        // Nudge the passkey state so the settings UI
-                                        // surfaces the correct row.
-                                        await PasskeyManager.shared.refreshBundleState()
-                                    }
-
                                     // Initialize ProfileManager to start auto-sync
                                     _ = ProfileManager.shared
                                     // Kick off an initial profile sync now that auth and token getter are ready

--- a/TinfoilChat/Utilities/AccountOperationFence.swift
+++ b/TinfoilChat/Utilities/AccountOperationFence.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+struct AccountOperationFence {
+    struct Token: Equatable, Sendable {
+        let userId: String
+        let generation: UInt64
+    }
+
+    private var generation: UInt64 = 0
+
+    mutating func begin(userId: String) -> Token {
+        generation += 1
+        return Token(userId: userId, generation: generation)
+    }
+
+    mutating func invalidate() {
+        generation += 1
+    }
+
+    func isCurrent(_ token: Token, currentUserId: String?) -> Bool {
+        token.generation == generation && token.userId == currentUserId
+    }
+}
+
+@MainActor
+final class AccountOperationTracker {
+    struct Token: Hashable, Sendable {
+        fileprivate let id: UInt64
+    }
+
+    private final class Registration {
+        var cancellation: (() -> Void)?
+
+        init(cancellation: @escaping () -> Void) {
+            self.cancellation = cancellation
+        }
+    }
+
+    private var isOpen = true
+    private var nextOperationId: UInt64 = 0
+    private var registrations: [Token: Registration] = [:]
+    private var closeWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func begin<Success, Failure>(task: Task<Success, Failure>) -> Token?
+    where Failure: Error {
+        guard isOpen else { return nil }
+        nextOperationId += 1
+        let token = Token(id: nextOperationId)
+        registrations[token] = Registration(cancellation: { task.cancel() })
+        return token
+    }
+
+    func end(_ token: Token) {
+        precondition(registrations.removeValue(forKey: token) != nil)
+        guard registrations.isEmpty else { return }
+
+        let waiters = closeWaiters
+        closeWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func closeAndWait() async {
+        isOpen = false
+        let registrationsToCancel = registrations.values
+        registrationsToCancel.forEach { registration in
+            registration.cancellation?()
+            registration.cancellation = nil
+        }
+        guard !registrations.isEmpty else { return }
+
+        await withCheckedContinuation { continuation in
+            closeWaiters.append(continuation)
+        }
+    }
+
+    func reopen() {
+        isOpen = true
+    }
+}

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -277,6 +277,7 @@ class AuthManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: userDataKey)
         UserDefaults.standard.removeObject(forKey: subscriptionKey)
 
+        chatViewModel?.completeAccountTeardown()
     }
     
     func signOut() async {
@@ -284,11 +285,9 @@ class AuthManager: ObservableObject {
             // If we have a Clerk instance, use it, otherwise fall back to Clerk.shared
             let clerk = self.clerk ?? Clerk.shared
             try await clerk.auth.signOut()
-            
-            await clearAuthState()
-            
         } catch {
         }
+        await clearAuthState()
     }
     
     /// Fetches subscription status directly from the API

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -28,7 +28,7 @@ class AuthManager: ObservableObject {
     private var hasTriggeredSignIn = false
     private var accountSwitchTask: Task<Void, Never>?
     private var accountTeardownTask: Task<Void, Never>?
-    private var accountTeardownGeneration: UInt64 = 0
+    private var accountTeardownId: UUID?
     
     // UserDefaults keys
     private let authStateKey = Constants.StorageKeys.Auth.state
@@ -243,18 +243,23 @@ class AuthManager: ObservableObject {
     }
     
     private func clearAuthState() async {
-        accountTeardownGeneration += 1
-        let generation = accountTeardownGeneration
-        let previousTask = accountTeardownTask
+        if let accountTeardownTask {
+            await accountTeardownTask.value
+            return
+        }
+
+        let teardownId = UUID()
         let teardownTask = Task { @MainActor [weak self] in
-            await previousTask?.value
             guard let self else { return }
             await self.performAccountTeardown()
-            guard self.accountTeardownGeneration == generation else { return }
             self.chatViewModel?.completeAccountTeardown()
         }
+        accountTeardownId = teardownId
         accountTeardownTask = teardownTask
         await teardownTask.value
+        guard accountTeardownId == teardownId else { return }
+        accountTeardownTask = nil
+        accountTeardownId = nil
     }
 
     private func performAccountTeardown() async {

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -27,6 +27,8 @@ class AuthManager: ObservableObject {
     private var clerk: Clerk?
     private var hasTriggeredSignIn = false
     private var accountSwitchTask: Task<Void, Never>?
+    private var accountTeardownTask: Task<Void, Never>?
+    private var accountTeardownGeneration: UInt64 = 0
     
     // UserDefaults keys
     private let authStateKey = Constants.StorageKeys.Auth.state
@@ -241,6 +243,21 @@ class AuthManager: ObservableObject {
     }
     
     private func clearAuthState() async {
+        accountTeardownGeneration += 1
+        let generation = accountTeardownGeneration
+        let previousTask = accountTeardownTask
+        let teardownTask = Task { @MainActor [weak self] in
+            await previousTask?.value
+            guard let self else { return }
+            await self.performAccountTeardown()
+            guard self.accountTeardownGeneration == generation else { return }
+            self.chatViewModel?.completeAccountTeardown()
+        }
+        accountTeardownTask = teardownTask
+        await teardownTask.value
+    }
+
+    private func performAccountTeardown() async {
         // Handle chat state BEFORE clearing auth so the view model can still
         // save the current chat (hasChatAccess depends on isAuthenticated).
         await chatViewModel?.handleSignOut()
@@ -276,8 +293,6 @@ class AuthManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: authStateKey)
         UserDefaults.standard.removeObject(forKey: userDataKey)
         UserDefaults.standard.removeObject(forKey: subscriptionKey)
-
-        chatViewModel?.completeAccountTeardown()
     }
     
     func signOut() async {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -5747,14 +5747,17 @@ class ChatViewModel: ObservableObject {
                 // do we persist it. If the enclave can't be reached we throw
                 // and discard the staged key, so a new key is never stranded
                 // locally while the enclave keeps the old one.
+                var remoteRegistrationCommitted = false
                 do {
                     try await EncryptionService.shared.setKey(key, persist: false)
                     try ensureCurrentAccount(operationUserId)
                     try await CloudKeyAuthorizationStore.shared.registerStartFreshKeyIfNeeded()
-                    try ensureCurrentAccount(operationUserId)
+                    remoteRegistrationCommitted = true
                     try EncryptionService.shared.persistCurrentKeyState()
                 } catch {
-                    EncryptionService.shared.discardStagedKeyState()
+                    if !remoteRegistrationCommitted {
+                        EncryptionService.shared.discardStagedKeyState()
+                    }
                     throw error
                 }
                 // The enclave has already rebound the account to this key

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -420,6 +420,7 @@ class ChatViewModel: ObservableObject {
     private var pendingStreamUpdates: [String: Chat] = [:]
     private var pendingSaveTask: Task<Void, Never>?
     private var pendingBackupTasks: [UUID: Task<Void, Never>] = [:]
+    private var activeFullSyncId: UUID?
     private var lastKnownAuthState: Bool?
     @Published private var genUIRetryStates: [GenUIRetryKey: GenUIRetryState] = [:]
     private var activeGenUIRetryIds: [GenUIRetryKey: UUID] = [:]
@@ -4448,7 +4449,7 @@ class ChatViewModel: ObservableObject {
                 defer { self?.pendingBackupTasks[backupId] = nil }
                 await saveTask?.value
                 guard let self, self.acceptsChatSaves else { return }
-                await self.cloudSync.backupChat(chat.id)
+                await self.cloudSync.backupChat(chat.id, ensureLatestUpload: true)
             }
             pendingBackupTasks[backupId] = backupTask
         }
@@ -4483,7 +4484,8 @@ class ChatViewModel: ObservableObject {
 
     private func drainPendingSaves() async {
         await pendingSaveTask?.value
-        while let backupTask = pendingBackupTasks.values.first {
+        let backupTasks = Array(pendingBackupTasks.values)
+        for backupTask in backupTasks {
             await backupTask.value
         }
     }
@@ -4679,6 +4681,8 @@ class ChatViewModel: ObservableObject {
         clearHydratedFavorites()
         isAccountTeardownInProgress = true
         clearProjectState()
+        activeFullSyncId = nil
+        isSyncing = false
         let canceledSignInTask = cancelSignInOperation()
         let canceledLegacyMigrationTask = cancelLegacyMigration()
         hasPerformedInitialSync = false
@@ -5461,8 +5465,14 @@ class ChatViewModel: ObservableObject {
     
     /// Intelligently update chats after sync without resetting pagination
     @MainActor
-    private func updateChatsAfterSync() async {
-        guard let userId = currentUserId else { return }
+    private func updateChatsAfterSync(
+        token: AccountOperationFence.Token? = nil,
+        userId expectedUserId: String? = nil
+    ) async {
+        guard let userId = expectedUserId ?? currentUserId else { return }
+        if let token {
+            guard isCurrentSignIn(token, userId: userId) else { return }
+        }
 
         // IMPORTANT: Preserve pagination token before updating
         let savedPaginationToken = self.paginationToken
@@ -5475,6 +5485,9 @@ class ChatViewModel: ObservableObject {
         // Load first page of cloud chats from files, excluding locally modified ones
         let result = await loadFirstPageOfChats(userId: userId, excluding: initiallyProtectedIds, filter: \.isCloudDisplayable)
         guard currentUserId == userId else { return }
+        if let token {
+            guard isCurrentSignIn(token, userId: userId) else { return }
+        }
 
         // Re-read protected state after the storage await so a new edit or stream
         // that started while loading cannot be replaced by the disk snapshot.
@@ -5575,6 +5588,9 @@ class ChatViewModel: ObservableObject {
             self.isPaginationActive = savedIsPaginationActive
         }
         await refreshCurrentCloudChatFromStorage(userId: userId)
+        if let token {
+            guard isCurrentSignIn(token, userId: userId) else { return }
+        }
         scanPendingRecoveries()
     }
     
@@ -5604,40 +5620,52 @@ class ChatViewModel: ObservableObject {
             return
         }
 
-        await MainActor.run {
-            self.isSyncing = true
-            self.syncErrors = []
+        guard isCurrentSignIn(token, userId: userId) else { return }
+        let syncId = UUID()
+        activeFullSyncId = syncId
+        isSyncing = true
+        syncErrors = []
+        defer {
+            if activeFullSyncId == syncId {
+                activeFullSyncId = nil
+                if isCurrentAccountOperation(token, userId: userId) {
+                    isSyncing = false
+                }
+            }
         }
         
         let result = await cloudSync.syncAllChats()
+        guard isCurrentSignIn(token, userId: userId) else { return }
         
         // Update chats if there were changes (await this before marking sync complete)
         if result.downloaded > 0 || result.uploaded > 0 || result.deleted > 0 {
-            await self.updateChatsAfterSync()
+            await updateChatsAfterSync(token: token, userId: userId)
+            guard isCurrentSignIn(token, userId: userId) else { return }
         }
         
         // Always refresh pagination token and hasMore state from the server after a sync
         // This guards against cold-start races where the token wasn't available yet
-        await self.setupPaginationForAppRestart(userId: userId, token: token)
+        await setupPaginationForAppRestart(userId: userId, token: token)
+        guard isCurrentSignIn(token, userId: userId) else { return }
         
         // Also sync profile settings
         await ProfileManager.shared.performFullSync()
+        guard isCurrentSignIn(token, userId: userId) else { return }
 
         // Project metadata is synced separately from chat revisions.
         await loadProjects()
+        guard isCurrentSignIn(token, userId: userId) else { return }
         
         // Re-load localChats from the local-only store
-        let freshLocal = await loadAllLocalChats(userId: self.currentUserId)
+        let freshLocal = await loadAllLocalChats(userId: userId)
+        guard isCurrentSignIn(token, userId: userId) else { return }
 
-        await MainActor.run {
-            self.localChats = freshLocal
-            self.isSyncing = false
-            self.lastSyncDate = Date()
-            self.ensureBlankChatAtTop()
-            
-            if !result.errors.isEmpty {
-                self.syncErrors = result.errors
-            }
+        localChats = freshLocal
+        lastSyncDate = Date()
+        ensureBlankChatAtTop()
+
+        if !result.errors.isEmpty {
+            syncErrors = result.errors
         }
     }
     

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -264,6 +264,13 @@ class ChatViewModel: ObservableObject {
     private let streamingTracker = StreamingTracker.shared
     private let projectStorage = ProjectStorageService.shared
     private var isSignInInProgress: Bool = false  // Prevent duplicate sign-in flows
+    private var signInTask: Task<Void, Never>?
+    private var legacyMigrationTask: Task<Void, Never>?
+    private var accountOperationFence = AccountOperationFence()
+    private let accountOperationTracker = AccountOperationTracker()
+    private var activeSignInToken: AccountOperationFence.Token?
+    private var isAccountTeardownInProgress = false
+    private var acceptsChatSaves = true
     private var hasPerformedInitialSync: Bool = false  // Track if initial sync has been done
     private var hasAnonymousChatsToSync: Bool = false  // Track if we have anonymous chats to sync
     
@@ -744,6 +751,10 @@ class ChatViewModel: ObservableObject {
     
     private func loadPersistedPaginationState() {
         guard let userId = currentUserId else { return }
+        loadPersistedPaginationState(userId: userId)
+    }
+
+    private func loadPersistedPaginationState(userId: String) {
         if let token = UserDefaults.standard.string(forKey: Constants.StorageKeys.Sync.paginationToken(userId: userId)) {
             paginationToken = token
         }
@@ -870,6 +881,9 @@ class ChatViewModel: ObservableObject {
     }
     
     deinit {
+        signInTask?.cancel()
+        legacyMigrationTask?.cancel()
+
         // Stop sync timers
         autoSyncTimer?.invalidate()
         autoSyncTimer = nil
@@ -4208,51 +4222,28 @@ class ChatViewModel: ObservableObject {
 
     /// Resume the sign-in flow after the user completes manual key setup via CloudSyncOnboardingView.
     func resumeAfterManualKeySetup() {
-        Task {
-            do {
-                let key = try await EncryptionService.shared.initialize()
-                self.encryptionKey = key
-
-                await self.passkeyManager.checkPasskeyStateForExistingKey()
-
-                await retryDecryptionAndReloadChats()
-
-                if SettingsManager.shared.isCloudSyncEnabled {
-                    await initializeCloudSync()
-                    await ProfileManager.shared.performFullSync()
-                }
-
-                await MainActor.run {
-                    let activeList = SettingsManager.shared.isCloudSyncEnabled ? self.chats : self.localChats
-                    if activeList.isEmpty {
-                        self.createNewChat()
-                    } else {
-                        self.ensureBlankChatAtTop()
-                    }
-                }
-            } catch {
-                await MainActor.run {
-                    self.showEncryptionSetup = true
-                }
-            }
-        }
+        handleSignIn()
     }
     
     // MARK: - Private Methods
 
     private func retryDecryptionAndReloadChats() async {
-        let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
-        guard decryptedCount > 0 else { return }
+        guard let userId = currentUserId else { return }
+        await retryDecryptionAndReloadChats(userId: userId)
+    }
 
-        let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
-        await MainActor.run {
-            self.chats = result.chats
-            if let currentId = self.currentChat?.id,
-               let refreshed = result.chats.first(where: { $0.id == currentId }) {
-                self.currentChat = refreshed
-            }
-            normalizeChatsArray()
+    private func retryDecryptionAndReloadChats(userId: String) async {
+        let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
+        guard currentUserId == userId, decryptedCount > 0 else { return }
+
+        let result = await loadFirstPageOfChats(userId: userId, filter: \.isCloudDisplayable)
+        guard currentUserId == userId else { return }
+        chats = result.chats
+        if let currentId = currentChat?.id,
+           let refreshed = result.chats.first(where: { $0.id == currentId }) {
+            currentChat = refreshed
         }
+        normalizeChatsArray()
     }
 
     private func endStreamingAndBackup(chatId: String) {
@@ -4435,6 +4426,7 @@ class ChatViewModel: ObservableObject {
     
     /// Saves a single chat to per-chat file storage and triggers cloud backup
     private func saveChat(_ chat: Chat, shouldBackup: Bool = true) {
+        guard acceptsChatSaves else { return }
         guard !chat.isTemporary else { return }
         guard hasChatAccess else { return }
         guard !chat.messages.isEmpty || chat.decryptionFailed else { return }
@@ -4450,9 +4442,37 @@ class ChatViewModel: ObservableObject {
         // has messages, and no active stream.
         if shouldBackup && SettingsManager.shared.isCloudSyncEnabled && !chat.isLocalOnly && !chat.messages.isEmpty && !chat.hasActiveStream {
             let saveTask = pendingSaveTask
-            Task {
+            Task { [weak self] in
                 await saveTask?.value
-                await cloudSync.backupChat(chat.id)
+                guard let self, self.acceptsChatSaves else { return }
+                await self.cloudSync.backupChat(chat.id)
+            }
+        }
+    }
+
+    private func saveChatForSignIn(
+        _ chat: Chat,
+        userId: String,
+        token: AccountOperationFence.Token
+    ) async {
+        guard acceptsChatSaves else { return }
+        guard isCurrentSignIn(token, userId: userId) else { return }
+        guard !chat.isTemporary else { return }
+        guard !chat.messages.isEmpty || chat.decryptionFailed else { return }
+
+        await Chat.saveChat(chat, userId: userId)
+        guard acceptsChatSaves,
+              isCurrentSignIn(token, userId: userId)
+        else {
+            return
+        }
+
+        if SettingsManager.shared.isCloudSyncEnabled && !chat.isLocalOnly && !chat.messages.isEmpty && !chat.hasActiveStream {
+            await cloudSync.backupChat(chat.id)
+            guard acceptsChatSaves,
+                  isCurrentSignIn(token, userId: userId)
+            else {
+                return
             }
         }
     }
@@ -4506,6 +4526,95 @@ class ChatViewModel: ObservableObject {
     }
     
     // MARK: - Authentication & Model Access
+
+    private func isCurrentAccountOperation(
+        _ token: AccountOperationFence.Token,
+        userId: String
+    ) -> Bool {
+        token.userId == userId
+            && accountOperationFence.isCurrent(token, currentUserId: currentUserId)
+    }
+
+    private func isCurrentSignIn(
+        _ token: AccountOperationFence.Token,
+        userId: String
+    ) -> Bool {
+        !Task.isCancelled && isCurrentAccountOperation(token, userId: userId)
+    }
+
+    private func legacyMigrationToken(userId: String) -> AccountOperationFence.Token {
+        if let activeSignInToken,
+           accountOperationFence.isCurrent(activeSignInToken, currentUserId: userId) {
+            return activeSignInToken
+        }
+        let token = accountOperationFence.begin(userId: userId)
+        activeSignInToken = token
+        return token
+    }
+
+    private func startLegacyMigration(
+        token: AccountOperationFence.Token,
+        userId: String
+    ) {
+        let previousTask = legacyMigrationTask
+        previousTask?.cancel()
+        legacyMigrationTask = Task { [weak self] in
+            await previousTask?.value
+            guard !Task.isCancelled,
+                  self?.isCurrentAccountOperation(token, userId: userId) == true
+            else {
+                return
+            }
+            _ = await LegacyBlobMigration.runAndFinalize()
+            guard let self,
+                  !Task.isCancelled,
+                  self.isCurrentAccountOperation(token, userId: userId)
+            else {
+                return
+            }
+            await self.passkeyManager.refreshBundleState()
+            guard !Task.isCancelled,
+                  self.isCurrentAccountOperation(token, userId: userId)
+            else {
+                return
+            }
+        }
+    }
+
+    @discardableResult
+    private func cancelLegacyMigration() -> Task<Void, Never>? {
+        let canceledTask = legacyMigrationTask
+        canceledTask?.cancel()
+        legacyMigrationTask = nil
+        return canceledTask
+    }
+
+    @discardableResult
+    private func cancelSignInOperation() -> Task<Void, Never>? {
+        let canceledTask = signInTask
+        canceledTask?.cancel()
+        signInTask = nil
+        activeSignInToken = nil
+        accountOperationFence.invalidate()
+        isSignInInProgress = false
+        hasAnonymousChatsToSync = false
+        return canceledTask
+    }
+
+    func completeAccountTeardown() {
+        acceptsChatSaves = true
+        isAccountTeardownInProgress = false
+        accountOperationTracker.reopen()
+    }
+
+    private func finishSignIn(
+        _ token: AccountOperationFence.Token,
+        userId: String
+    ) {
+        guard isCurrentSignIn(token, userId: userId) else { return }
+        isSignInInProgress = false
+        signInTask = nil
+    }
     
     /// Updates the current model if needed based on auth status changes
     func updateModelBasedOnAuthStatus(isAuthenticated: Bool, hasActiveSubscription: Bool) {
@@ -4561,12 +4670,15 @@ class ChatViewModel: ObservableObject {
         let signingOutUserId = currentUserId
 
         clearHydratedFavorites()
+        isAccountTeardownInProgress = true
         clearProjectState()
-
-        // Allow a new sign-in flow after sign-out
-        isSignInInProgress = false
+        let canceledSignInTask = cancelSignInOperation()
+        let canceledLegacyMigrationTask = cancelLegacyMigration()
         hasPerformedInitialSync = false
         let canceledStreamTasks = cancelAllGenerations()
+        await accountOperationTracker.closeAndWait()
+        await canceledSignInTask?.value
+        await canceledLegacyMigrationTask?.value
         await drainStreamTasks(canceledStreamTasks)
 
         // Stop sync timers when signing out
@@ -4588,10 +4700,13 @@ class ChatViewModel: ObservableObject {
             }
         }
 
+        acceptsChatSaves = false
+        await drainPendingSaves()
+
         // Clear sync caches so stale state doesn't leak into the next session
         await cloudSync.clearSyncStatus(forUser: signingOutUserId)
         DeletedChatsTracker.shared.clear()
-        CloudKeyAuthorizationStore.shared.clearAuthorization(userId: currentUserId)
+        CloudKeyAuthorizationStore.shared.clearAuthorization(userId: signingOutUserId)
 
         // Reset to the default model when signing out
         let allModels = AppConfig.shared.filteredModelTypes()
@@ -4608,7 +4723,7 @@ class ChatViewModel: ObservableObject {
         hasAttemptedLoadMore = false
 
         // Reset passkey state
-        passkeyManager.reset()
+        await passkeyManager.reset()
 
         // Clear cloud chats and create a new empty one with the free model.
         // On-disk local chats are wiped immediately after this by clearAuthState's
@@ -4623,22 +4738,31 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Clear all local chats and reset to fresh state
-    func clearAllChatsFromDevice(resumeRecoveryScans: Bool = true) async {
+    func clearAllChatsFromDevice(
+        resumeRecoveryScans: Bool = true,
+        reopenAccountOperations: Bool = true
+    ) async {
         clearHydratedFavorites()
+        acceptsChatSaves = false
+        let canceledSignInTask = cancelSignInOperation()
+        let canceledLegacyMigrationTask = cancelLegacyMigration()
         let canceledStreamTasks = cancelAllGenerations()
+        let userId = currentUserId
+        await accountOperationTracker.closeAndWait()
+        await canceledSignInTask?.value
+        await canceledLegacyMigrationTask?.value
         await suspendRecoveryScans()
+        await drainStreamTasks(canceledStreamTasks)
+        await drainPendingSaves()
 
         // Clear all chats from memory
         ChatRecoveryDraftStore.shared.clearAll()
         chats.removeAll()
         localChats.removeAll()
         currentChat = nil
-        
+
         // Clear from file storage (both local and cloud stores),
         // fencing in-flight sync before the deletion.
-        let userId = currentUserId
-        await drainStreamTasks(canceledStreamTasks)
-        await drainPendingSaves()
         await cloudSync.handleLocalStoreWipe(forUser: userId)
         await Chat.deleteAllChatsFromStorage(userId: userId)
         
@@ -4657,8 +4781,12 @@ class ChatViewModel: ObservableObject {
         
         // Clear encryption key reference
         encryptionKey = nil
-        if resumeRecoveryScans {
+        if resumeRecoveryScans && !isAccountTeardownInProgress {
             recoveryScansSuspended = false
+        }
+        if !isAccountTeardownInProgress && reopenAccountOperations {
+            acceptsChatSaves = true
+            accountOperationTracker.reopen()
         }
     }
 
@@ -4668,10 +4796,9 @@ class ChatViewModel: ObservableObject {
     /// manager clears its authenticated state so currentUserId still resolves.
     func wipeLocalChatsForSignOut() async {
         clearHydratedFavorites()
-        // Drain the queued disk saves first; the queue is chained, so
-        // awaiting the latest task flushes every earlier one. Otherwise a
-        // detached save kicked off by handleSignOut could land after the
-        // wipe and resurrect the signed-out user's chat files.
+        acceptsChatSaves = false
+        // Save admission remains closed throughout auth cleanup. Drain the
+        // queued chain defensively before deleting the signed-out user's files.
         await drainPendingSaves()
         await Chat.deleteAllChatsFromStorage(userId: currentUserId)
     }
@@ -4681,7 +4808,21 @@ class ChatViewModel: ObservableObject {
     /// Routes the manual setup / recovery outcomes to the onboarding
     /// sheet, matching the sign-in flow.
     func reattemptPasskeyRecovery() async {
-        let result = await passkeyManager.reenableRecoveryPrompt()
+        guard let operationUserId = currentUserId else { return }
+        let operationTask = Task { [passkeyManager] in
+            guard !Task.isCancelled else { return nil as PasskeyRecoveryResult? }
+            let result = await passkeyManager.reenableRecoveryPrompt()
+            guard !Task.isCancelled else { return nil }
+            return result
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        guard let result = await operationTask.value else { return }
+        guard currentUserId == operationUserId else { return }
         switch result {
         case .manualSetupRequired:
             cloudSyncOnboardingMode = .setup
@@ -4702,10 +4843,16 @@ class ChatViewModel: ObservableObject {
 
     /// Handle sign-in by loading user's saved chats and triggering sync
     func handleSignIn() {
-        recoveryScansSuspended = false
-        #if DEBUG
-        print("handleSignIn called")
-        #endif
+        guard !isAccountTeardownInProgress, acceptsChatSaves else { return }
+
+        guard hasChatAccess, let userId = currentUserId else {
+            if let canceledTask = cancelSignInOperation() {
+                signInTask = canceledTask
+            }
+            return
+        }
+
+        passkeyManager.resumeAccountOperations()
 
         // Wire up passkey recovery callback
         passkeyManager.onRecoveryComplete = { [weak self] in
@@ -4716,266 +4863,250 @@ class ChatViewModel: ObservableObject {
         // another device updates the key bundle
         passkeyManager.onKeyRefreshedFromBackup = { [weak self] in
             Task { @MainActor in
-                await self?.retryDecryptionWithNewKey()
+                self?.handleSignIn()
             }
         }
 
-        // Prevent duplicate sign-in flows
-        guard !isSignInInProgress else {
-            #if DEBUG
-            print("handleSignIn: Already in progress, skipping")
-            #endif
+        if let activeSignInToken,
+           signInTask != nil,
+           accountOperationFence.isCurrent(activeSignInToken, currentUserId: userId) {
             return
         }
 
-        #if DEBUG
-        print("handleSignIn: hasChatAccess=\(hasChatAccess), userId=\(currentUserId ?? "nil")")
-        #endif
-        
-        if hasChatAccess, let userId = currentUserId {
-            isProjectAccountActive = true
-            isSignInInProgress = true
-            #if DEBUG
-            print("handleSignIn: Starting sign-in flow for user \(userId)")
-            #endif
-            
-            // Restore pagination state immediately for better UX on cold start
-            loadPersistedPaginationState()
-            
-            // Check if we have any anonymous chats to migrate
-            let anonymousChats = (chats + localChats).filter { chat in
-                chat.userId == nil && !chat.messages.isEmpty
+        if activeSignInToken?.userId != userId {
+            hasAnonymousChatsToSync = false
+        }
+        isProjectAccountActive = true
+        let previousSignInTask = signInTask
+        previousSignInTask?.cancel()
+        legacyMigrationTask?.cancel()
+        let token = accountOperationFence.begin(userId: userId)
+        activeSignInToken = token
+        isSignInInProgress = true
+        recoveryScansSuspended = false
+        signInTask = Task { [weak self] in
+            guard let self,
+                  self.isCurrentSignIn(token, userId: userId)
+            else {
+                return
             }
-            
-            if !anonymousChats.isEmpty {
-                #if DEBUG
-                print("Found \(anonymousChats.count) anonymous chats to migrate")
-                #endif
-                // Migrate anonymous chats to the current user
-                for var chat in anonymousChats {
-                    chat.userId = userId
+            await previousSignInTask?.value
+            guard self.isCurrentSignIn(token, userId: userId) else { return }
+            await self.performSignIn(token: token, userId: userId)
+            guard self.isCurrentAccountOperation(token, userId: userId) else { return }
+        }
+    }
+
+    private func performSignIn(
+        token: AccountOperationFence.Token,
+        userId: String
+    ) async {
+        guard isCurrentSignIn(token, userId: userId) else { return }
+
+        // Restore pagination state immediately for better UX on cold start
+        loadPersistedPaginationState(userId: userId)
+
+        // Check if we have any anonymous chats to migrate
+        let anonymousChats = (chats + localChats).filter { chat in
+            chat.userId == nil && !chat.messages.isEmpty
+        }
+
+        if !anonymousChats.isEmpty {
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            await drainPendingSaves()
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            // Migrate anonymous chats to the current user
+            for var chat in anonymousChats {
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                chat.userId = userId
+                chat.locallyModified = true
+                chat.syncVersion = 0  // Reset sync version to force upload
+                replaceChat(chat)
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                await saveChatForSignIn(chat, userId: userId, token: token)
+                guard isCurrentSignIn(token, userId: userId) else { return }
+            }
+
+            // Mark that we have anonymous chats that need to be synced after encryption setup
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            hasAnonymousChatsToSync = true
+        }
+
+        // Start auto-sync timer now that user is authenticated
+        // (This also handles the case where someone signs in after app launch)
+        guard isCurrentSignIn(token, userId: userId) else { return }
+        setupAutoSyncTimer()
+
+        // One-shot legacy cleanup for users who sign in after launch;
+        // the launch-time pass only covers an already-signed-in user.
+        // Flag-gated per user, so re-running is cheap.
+        Task.detached(priority: .background) {
+            await LegacyChatEviction.runIfNeeded(userId: userId)
+        }
+
+        // Check if we need to set up encryption first
+        // IMPORTANT: Do NOT auto-generate a key here; allow UI to prompt the user
+        do {
+            // Sign-out clears account-bound token providers, so restore them
+            // before passkey recovery or any other enclave request.
+            try await cloudSync.initialize()
+            guard isCurrentSignIn(token, userId: userId) else { return }
+
+            // Always load local chats first — they use the device key,
+            // not the cloud encryption key, so they're available regardless
+            // of cloud sync setup state.
+            let allLocal = await loadAllLocalChats(userId: userId)
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            localChats = allLocal
+            normalizeLocalChatsArray()
+            if currentChat == nil, let first = localChats.first {
+                currentChat = first
+            }
+            // Auto-enable local-only mode when local chats with messages exist,
+            // but only if the user has never explicitly set the preference
+            let hasNonEmptyLocalChats = localChats.contains { !$0.messages.isEmpty }
+            let userHasSetPreference = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.localOnlyModeEnabled) != nil
+            if hasNonEmptyLocalChats && !userHasSetPreference {
+                SettingsManager.shared.isLocalOnlyModeEnabled = true
+            }
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            scanPendingRecoveries()
+
+            // If no cloud key exists, try passkey recovery before falling back
+            if !EncryptionService.shared.hasEncryptionKey() {
+                let passkeyResult = await passkeyManager.attemptPasskeyKeyRecovery()
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                switch passkeyResult {
+                case .success, .newUserSetupDone:
+                    break
+                case .manualSetupRequired:
+                    cloudSyncOnboardingMode = .setup
+                    showCloudSyncOnboarding = true
+                    finishSignIn(token, userId: userId)
+                    return
+                case .manualRecoveryRequired:
+                    cloudSyncOnboardingMode = .recovery
+                    showCloudSyncOnboarding = true
+                    finishSignIn(token, userId: userId)
+                    return
+                case .recoveryFailed:
+                    finishSignIn(token, userId: userId)
+                    return
+                }
+            }
+
+            // Initialize encryption - this will load existing key from keychain
+            let key = try await EncryptionService.shared.initialize()
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            encryptionKey = key
+
+            // Ensure the current key is authorized for cloud writes.
+            // Existing users upgrading may have a valid key but no
+            // authorization record yet.
+            if !CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey(userId: userId) {
+                let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                if validation.canWrite {
+                    _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated, userId: userId)
+                }
+            }
+
+            // A local key that mismatches the enclave's registered
+            // key can never sync or migrate. Converge silently via
+            // passkey when possible; otherwise prompt the user to
+            // recover so this stale device enters v2.
+            if SettingsManager.shared.isCloudSyncEnabled {
+                let mismatchResult = await passkeyManager.resolveKeyMismatchAtLaunch()
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                if mismatchResult == .manualRecoveryRequired {
+                    cloudSyncOnboardingMode = .recovery
+                    showCloudSyncOnboarding = true
+                }
+            }
+
+            // Check passkey state for users who already have keys
+            await passkeyManager.checkPasskeyStateForExistingKey()
+            guard isCurrentSignIn(token, userId: userId) else { return }
+
+            // Rewrap any legacy rows under the current primary key, then
+            // refresh passkey state in case migration added a device bundle.
+            startLegacyMigration(token: token, userId: userId)
+
+            // Retry decryption for any previously failed chats now that key is loaded
+            let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            if decryptedCount > 0 {
+                let result = await loadFirstPageOfChats(userId: userId, filter: \.isCloudDisplayable)
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                chats = result.chats
+                // Refresh currentChat to show decrypted content
+                if let currentId = currentChat?.id,
+                   let refreshed = result.chats.first(where: { $0.id == currentId }) {
+                    currentChat = refreshed
+                }
+                normalizeChatsArray()
+            }
+
+            // If we have anonymous chats to sync, force re-encryption with proper key
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            if hasAnonymousChatsToSync {
+                // Force all cloud chats to be marked for sync
+                let cloudChats = (try? await EncryptedFileStorage.cloud.loadAllChats(userId: userId)) ?? []
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                for var chat in cloudChats {
+                    guard isCurrentSignIn(token, userId: userId) else { return }
                     chat.locallyModified = true
-                    chat.syncVersion = 0  // Reset sync version to force upload
-                    replaceChat(chat)
-                    saveChat(chat)
+                    chat.syncVersion = 0
+                    try? await EncryptedFileStorage.cloud.saveChat(chat, userId: userId)
+                    guard isCurrentSignIn(token, userId: userId) else { return }
                 }
-                
-                // Mark that we have anonymous chats that need to be synced after encryption setup
-                Task { @MainActor in
-                    self.hasAnonymousChatsToSync = true
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                hasAnonymousChatsToSync = false
+            }
+
+            // Local chats were already loaded above the early return.
+
+            // Only proceed with cloud sync if cloud sync is enabled
+            if SettingsManager.shared.isCloudSyncEnabled {
+                await initializeCloudSync(token: token, userId: userId)
+                guard isCurrentSignIn(token, userId: userId) else { return }
+
+                // Restore persisted tab preference now that cloud chats are loaded
+                if let savedTab = UserDefaults.standard.string(forKey: Constants.StorageKeys.Settings.cloudSyncActiveTab),
+                   let tab = ChatStorageTab(rawValue: savedTab) {
+                    activeStorageTab = tab
                 }
+
+                // Sync user profile settings
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                await ProfileManager.shared.performFullSync()
+                guard isCurrentSignIn(token, userId: userId) else { return }
+            } else {
+                guard isCurrentSignIn(token, userId: userId) else { return }
+                chats = []
+                hasMoreChats = false
+                activeStorageTab = .local
             }
-            
-            // Start auto-sync timer now that user is authenticated
-            // (This also handles the case where someone signs in after app launch)
-            setupAutoSyncTimer()
 
-            // One-shot legacy cleanup for users who sign in after launch;
-            // the launch-time pass only covers an already-signed-in user.
-            // Flag-gated per user, so re-running is cheap.
-            Task.detached(priority: .background) {
-                await LegacyChatEviction.runIfNeeded(userId: userId)
+            // Update last sync date
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            lastSyncDate = Date()
+
+            // After sync completes, ensure we have proper chat setup
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            let activeList = SettingsManager.shared.isCloudSyncEnabled ? chats : localChats
+            if activeList.isEmpty {
+                createNewChat()
+            } else {
+                ensureBlankChatAtTop()
             }
-            
-            // Check if we need to set up encryption first
-            // IMPORTANT: Do NOT auto-generate a key here; allow UI to prompt the user
-            Task {
-                do {
-                    // Sign-out clears account-bound token providers, so restore them
-                    // before passkey recovery or any other enclave request.
-                    try await self.cloudSync.initialize()
-                    guard self.currentUserId == userId,
-                          self.hasChatAccess,
-                          self.isProjectAccountActive else {
-                        if self.currentUserId == userId {
-                            self.isSignInInProgress = false
-                        }
-                        return
-                    }
-
-                    // Always load local chats first — they use the device key,
-                    // not the cloud encryption key, so they're available regardless
-                    // of cloud sync setup state.
-                    let allLocal = await loadAllLocalChats(userId: userId)
-                    guard self.currentUserId == userId,
-                          self.isSignInInProgress,
-                          self.isProjectAccountActive else { return }
-                    await MainActor.run {
-                        self.localChats = allLocal
-                        normalizeLocalChatsArray()
-                        if self.currentChat == nil, let first = self.localChats.first {
-                            self.currentChat = first
-                        }
-                        // Auto-enable local-only mode when local chats with messages exist,
-                        // but only if the user has never explicitly set the preference
-                        let hasNonEmptyLocalChats = self.localChats.contains { !$0.messages.isEmpty }
-                        let userHasSetPreference = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.localOnlyModeEnabled) != nil
-                        if hasNonEmptyLocalChats && !userHasSetPreference {
-                            SettingsManager.shared.isLocalOnlyModeEnabled = true
-                        }
-                    }
-                    self.scanPendingRecoveries()
-
-                    // If no cloud key exists, try passkey recovery before falling back
-                    if !EncryptionService.shared.hasEncryptionKey() {
-                        let passkeyResult = await self.passkeyManager.attemptPasskeyKeyRecovery()
-                        guard self.currentUserId == userId,
-                              self.isSignInInProgress,
-                              self.isProjectAccountActive else { return }
-                        switch passkeyResult {
-                        case .success, .newUserSetupDone:
-                            break
-                        case .manualSetupRequired:
-                            await MainActor.run {
-                                self.cloudSyncOnboardingMode = .setup
-                                self.showCloudSyncOnboarding = true
-                                self.isSignInInProgress = false
-                            }
-                            return
-                        case .manualRecoveryRequired:
-                            await MainActor.run {
-                                self.cloudSyncOnboardingMode = .recovery
-                                self.showCloudSyncOnboarding = true
-                                self.isSignInInProgress = false
-                            }
-                            return
-                        case .recoveryFailed:
-                            await MainActor.run {
-                                self.isSignInInProgress = false
-                            }
-                            return
-                        }
-                    }
-
-                    // Initialize encryption - this will load existing key from keychain
-                    let key = try await EncryptionService.shared.initialize()
-                    guard self.currentUserId == userId,
-                          self.isSignInInProgress,
-                          self.isProjectAccountActive else { return }
-                    self.encryptionKey = key
-
-                    // Ensure the current key is authorized for cloud writes.
-                    // Existing users upgrading may have a valid key but no
-                    // authorization record yet.
-                    if !CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey(userId: userId) {
-                        let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
-                        guard self.currentUserId == userId,
-                              self.isSignInInProgress,
-                              self.isProjectAccountActive else { return }
-                        if validation.canWrite {
-                            _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated, userId: userId)
-                        }
-                    }
-
-                    // A local key that mismatches the enclave's registered
-                    // key can never sync or migrate. Converge silently via
-                    // passkey when possible; otherwise prompt the user to
-                    // recover so this stale device enters v2.
-                    if SettingsManager.shared.isCloudSyncEnabled {
-                        let mismatchResult = await self.passkeyManager.resolveKeyMismatchAtLaunch()
-                        guard self.currentUserId == userId,
-                              self.isSignInInProgress,
-                              self.isProjectAccountActive else { return }
-                        if mismatchResult == .manualRecoveryRequired {
-                            await MainActor.run {
-                                self.cloudSyncOnboardingMode = .recovery
-                                self.showCloudSyncOnboarding = true
-                            }
-                        }
-                    }
-
-                    // Check passkey state for users who already have keys
-                    await self.passkeyManager.checkPasskeyStateForExistingKey()
-                    guard self.currentUserId == userId,
-                          self.isSignInInProgress,
-                          self.isProjectAccountActive else { return }
-
-                    // Retry decryption for any previously failed chats now that key is loaded
-                    let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
-                    guard self.currentUserId == userId,
-                          self.isSignInInProgress,
-                          self.isProjectAccountActive else { return }
-                    if decryptedCount > 0 {
-                        let result = await loadFirstPageOfChats(userId: userId, filter: \.isCloudDisplayable)
-                        guard self.currentUserId == userId,
-                              self.isSignInInProgress,
-                              self.isProjectAccountActive else { return }
-                        await MainActor.run {
-                            self.chats = result.chats
-                            // Refresh currentChat to show decrypted content
-                            if let currentId = self.currentChat?.id,
-                               let refreshed = result.chats.first(where: { $0.id == currentId }) {
-                                self.currentChat = refreshed
-                            }
-                            normalizeChatsArray()
-                        }
-                    }
-
-                    // If we have anonymous chats to sync, force re-encryption with proper key
-                    if self.hasAnonymousChatsToSync {
-                        // Force all cloud chats to be marked for sync
-                        if let userId = self.currentUserId {
-                            let cloudChats = (try? await EncryptedFileStorage.cloud.loadAllChats(userId: userId)) ?? []
-                            for var chat in cloudChats {
-                                chat.locallyModified = true
-                                chat.syncVersion = 0
-                                try? await EncryptedFileStorage.cloud.saveChat(chat, userId: userId)
-                            }
-                        }
-                        self.hasAnonymousChatsToSync = false
-                    }
-
-                    // Local chats were already loaded above the early return.
-
-                    // Only proceed with cloud sync if cloud sync is enabled
-                    if SettingsManager.shared.isCloudSyncEnabled {
-                        await initializeCloudSync()
-
-                        // Restore persisted tab preference now that cloud chats are loaded
-                        if let savedTab = UserDefaults.standard.string(forKey: Constants.StorageKeys.Settings.cloudSyncActiveTab),
-                           let tab = ChatStorageTab(rawValue: savedTab) {
-                            await MainActor.run {
-                                self.activeStorageTab = tab
-                            }
-                        }
-
-                        // Sync user profile settings
-                        await ProfileManager.shared.performFullSync()
-                    } else {
-                        await MainActor.run {
-                            self.chats = []
-                            self.hasMoreChats = false
-                            self.activeStorageTab = .local
-                        }
-                    }
-                    
-                    // Update last sync date
-                    await MainActor.run {
-                        self.lastSyncDate = Date()
-                    }
-                    
-                    // After sync completes, ensure we have proper chat setup
-                    await MainActor.run {
-                        let activeList = SettingsManager.shared.isCloudSyncEnabled ? self.chats : self.localChats
-                        if activeList.isEmpty {
-                            self.createNewChat()
-                        } else {
-                            self.ensureBlankChatAtTop()
-                        }
-                        self.isSignInInProgress = false
-                    }
-                } catch {
-                    // If key initialization fails, fall back to showing setup modal
-                    await MainActor.run {
-                        self.isFirstTimeUser = true
-                        self.showEncryptionSetup = true
-                        self.isSignInInProgress = false
-                    }
-                }
-            }
-        } else {
-            // User doesn't have chat access, reset flag
-            isSignInInProgress = false
+            finishSignIn(token, userId: userId)
+        } catch {
+            // If key initialization fails, fall back to showing setup modal
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            isFirstTimeUser = true
+            showEncryptionSetup = true
+            finishSignIn(token, userId: userId)
         }
     }
     
@@ -5037,103 +5168,61 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    /// Initialize cloud sync when user signs in
-    private func initializeCloudSync() async {
+    private func initializeCloudSync(
+        token: AccountOperationFence.Token,
+        userId: String
+    ) async {
+        guard isCurrentSignIn(token, userId: userId) else { return }
         do {
             // Mark that initial sync has been done to avoid duplicate
             hasPerformedInitialSync = true
-            
+
             // Initialize cloud sync service
             try await cloudSync.initialize()
-            
+            guard isCurrentSignIn(token, userId: userId) else { return }
+
             // Perform sync
             let _ = await cloudSync.syncAllChats()
-            
+            guard isCurrentSignIn(token, userId: userId) else { return }
+
             // Load and display synced chats from file index (cloud chats only, paginated)
             let result = await loadFirstPageOfChats(
-                userId: currentUserId,
+                userId: userId,
                 filter: \.isCloudDisplayable
             )
+            guard isCurrentSignIn(token, userId: userId) else { return }
 
-            await MainActor.run {
-                self.chats = result.chats
-                normalizeChatsArray()
+            chats = result.chats
+            normalizeChatsArray()
 
-                // Only select the first chat if we don't have a current chat selected
-                if self.currentChat == nil, let first = self.chats.first {
-                    self.currentChat = first
-                }
-
-                // Mark that we've loaded the initial page
-                self.hasLoadedInitialPage = true
-                self.isPaginationActive = result.totalEntries > 0
-
-                // Set hasMoreChats based on total count
-                self.hasMoreChats = result.totalEntries > Constants.Pagination.chatsPerPage
+            // Only select the first chat if we don't have a current chat selected
+            if currentChat == nil, let first = chats.first {
+                currentChat = first
             }
-            if let userId = currentUserId {
-                await refreshCurrentCloudChatFromStorage(userId: userId)
-            }
-            
+
+            // Mark that we've loaded the initial page
+            hasLoadedInitialPage = true
+            isPaginationActive = result.totalEntries > 0
+
+            // Set hasMoreChats based on total count
+            hasMoreChats = result.totalEntries > Constants.Pagination.chatsPerPage
+
+            await refreshCurrentCloudChatFromStorage(userId: userId)
+            guard isCurrentSignIn(token, userId: userId) else { return }
+
             // Setup pagination token
-            await setupPaginationForAppRestart()
+            await setupPaginationForAppRestart(token: token, userId: userId)
+            guard isCurrentSignIn(token, userId: userId) else { return }
+
             await loadProjects()
+            guard isCurrentSignIn(token, userId: userId) else { return }
             scanPendingRecoveries()
         } catch {
-            await MainActor.run {
-                self.syncErrors.append(error.localizedDescription)
-            }
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            syncErrors.append(error.localizedDescription)
         }
     }
 
-    /// Continues the sign-in flow (encryption, cloud sync, profile sync) after migration decision
-    private func startEncryptedSyncFlow() async {
-        // Avoid double starts
-        if isSignInInProgress { return }
-        isSignInInProgress = true
-        
-        // Ensure auto-sync timer is scheduled (will no-op if gated)
-        setupAutoSyncTimer()
-        
-        do {
-            // Ensure an encryption key exists before proceeding
-            guard EncryptionService.shared.hasEncryptionKey() else {
-                await MainActor.run {
-                    self.isFirstTimeUser = true
-                    self.isSignInInProgress = false
-                }
-                return
-            }
-
-            // Initialize encryption with the existing key
-            let key = try await EncryptionService.shared.initialize()
-            await MainActor.run { self.encryptionKey = key }
-            
-            // Initialize cloud sync service and perform initial sync
-            await initializeCloudSync()
-
-            // Sync user profile settings
-            await ProfileManager.shared.performFullSync()
-            
-            await MainActor.run {
-                self.lastSyncDate = Date()
-                // After sync completes, ensure we have proper chat setup
-                if self.chats.isEmpty {
-                    self.createNewChat()
-                } else {
-                    self.ensureBlankChatAtTop()
-                }
-                self.isSignInInProgress = false
-            }
-        } catch {
-            await MainActor.run {
-                self.isFirstTimeUser = true
-                self.showEncryptionSetup = true
-                self.isSignInInProgress = false
-            }
-        }
-    }
-    
     // MARK: - Pagination Methods
     
     /// Setup pagination state for app restart (when already authenticated)
@@ -5153,6 +5242,26 @@ class ChatViewModel: ObservableObject {
                     self.hasLoadedInitialPage = true
                 }
             }
+        }
+    }
+
+    private func setupPaginationForAppRestart(
+        token: AccountOperationFence.Token,
+        userId: String
+    ) async {
+        guard isCurrentSignIn(token, userId: userId) else { return }
+        // Try to get pagination token from cloud to enable Load More
+        let listResult = try? await CloudStorageService.shared.listChats(
+            limit: Constants.Pagination.chatsPerPage,
+            continuationToken: nil,
+            includeContent: false
+        )
+        guard isCurrentSignIn(token, userId: userId) else { return }
+        if let listResult {
+            paginationToken = listResult.nextContinuationToken
+            hasMoreChats = listResult.hasMore
+            isPaginationActive = true
+            hasLoadedInitialPage = true
         }
     }
     
@@ -5536,16 +5645,67 @@ class ChatViewModel: ObservableObject {
     func reloadEncryptionKey() {
         encryptionKey = EncryptionService.shared.getKey()
     }
+
+    func initializeExistingEncryptionKeyIfAvailable() async {
+        guard let operationUserId = currentUserId else { return }
+        guard EncryptionService.shared.hasEncryptionKey() else { return }
+        let operationTask = Task {
+            guard !Task.isCancelled else { return }
+            _ = try? await EncryptionService.shared.initialize()
+            guard !Task.isCancelled else { return }
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        await operationTask.value
+        guard currentUserId == operationUserId else { return }
+    }
     
     /// Set encryption key (for key rotation)
     func setEncryptionKey(
         _ key: String,
         mode: CloudKeyActivationMode = .recoverExisting
     ) async throws {
+        guard let operationUserId = currentUserId else {
+            throw CancellationError()
+        }
+        let operationTask = Task {
+            try await self.performSetEncryptionKey(
+                key,
+                mode: mode,
+                operationUserId: operationUserId
+            )
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            throw CancellationError()
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        try await operationTask.value
+        try ensureCurrentAccount(operationUserId)
+        // A v1 user activating their key on a fresh device has legacy
+        // cloud data but no registered key. Re-kick migration now that
+        // a key is active so adoption happens in-session.
+        let migrationToken = legacyMigrationToken(userId: operationUserId)
+        startLegacyMigration(token: migrationToken, userId: operationUserId)
+    }
+
+    private func performSetEncryptionKey(
+        _ key: String,
+        mode: CloudKeyActivationMode,
+        operationUserId: String
+    ) async throws {
+        try Task.checkCancellation()
+
         do {
             switch mode {
             case .recoverExisting:
                 _ = try await CloudKeyAuthorizationStore.shared.applyPrimaryKeyWithValidation(key)
+                try ensureCurrentAccount(operationUserId)
             case .explicitStartFresh:
                 // Stage the key in memory so the enclave handshake runs
                 // against it without writing it to the Keychain first. Only
@@ -5554,9 +5714,11 @@ class ChatViewModel: ObservableObject {
                 // do we persist it. If the enclave can't be reached we throw
                 // and discard the staged key, so a new key is never stranded
                 // locally while the enclave keeps the old one.
-                try await EncryptionService.shared.setKey(key, persist: false)
                 do {
+                    try await EncryptionService.shared.setKey(key, persist: false)
+                    try ensureCurrentAccount(operationUserId)
                     try await CloudKeyAuthorizationStore.shared.registerStartFreshKeyIfNeeded()
+                    try ensureCurrentAccount(operationUserId)
                     try EncryptionService.shared.persistCurrentKeyState()
                 } catch {
                     EncryptionService.shared.discardStagedKeyState()
@@ -5570,55 +5732,141 @@ class ChatViewModel: ObservableObject {
                 _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .explicitStartFresh)
             }
 
-            await MainActor.run {
-                self.encryptionKey = EncryptionService.shared.getKey()
-                self.showEncryptionSetup = false
-            }
-
-            // A v1 user activating their key on a fresh device has legacy
-            // cloud data but no registered key: the launch-time migration
-            // pass ran before any key existed, so without a re-kick the
-            // key is never adopted and cloud writes stay deferred for the
-            // whole session. Run the migration again now that a key is
-            // active so adoption happens in-session.
-            Task.detached(priority: .background) {
-                _ = await LegacyBlobMigration.runAndFinalize()
-                await PasskeyManager.shared.refreshBundleState()
-            }
+            try ensureCurrentAccount(operationUserId)
+            encryptionKey = EncryptionService.shared.getKey()
+            showEncryptionSetup = false
 
             await ProfileManager.shared.retryDecryptionWithNewKey()
-            await retryDecryptionAndReloadChats()
+            try ensureCurrentAccount(operationUserId)
+            await retryDecryptionAndReloadChats(userId: operationUserId)
+            try ensureCurrentAccount(operationUserId)
 
             // If this was first-time setup, initialize cloud sync and load chats
             if isFirstTimeUser {
-                await MainActor.run {
-                    self.isFirstTimeUser = false
-                }
+                try ensureCurrentAccount(operationUserId)
+                isFirstTimeUser = false
                 try await cloudSync.initialize()
+                try ensureCurrentAccount(operationUserId)
                 await performFullSync()
-                
+                try ensureCurrentAccount(operationUserId)
+
                 // After first-time sync, check if we have chats
-                await MainActor.run {
-                    if self.chats.isEmpty {
-                        self.createNewChat()
-                    } else {
-                        // Select the most recent chat
-                        if let mostRecent = self.chats.first {
-                            self.currentChat = mostRecent
-                        }
+                if chats.isEmpty {
+                    createNewChat()
+                } else {
+                    // Select the most recent chat
+                    if let mostRecent = chats.first {
+                        currentChat = mostRecent
                     }
                 }
             }
 
             // If passkey is active, re-encrypt the backup with the updated key bundle
             if passkeyManager.passkeyActive {
+                try ensureCurrentAccount(operationUserId)
                 await passkeyManager.updatePasskeyBackup()
+                try ensureCurrentAccount(operationUserId)
             }
         } catch {
-            await MainActor.run {
-                self.syncErrors.append(error.localizedDescription)
+            guard currentUserId == operationUserId else {
+                throw CancellationError()
+            }
+            if !(error is CancellationError) {
+                syncErrors.append(error.localizedDescription)
             }
             throw error  // Re-throw to let caller handle it
+        }
+    }
+
+    func retryPasskeyRecovery() async -> Bool {
+        guard let operationUserId = currentUserId else { return false }
+        let operationTask = Task { [passkeyManager] in
+            guard !Task.isCancelled else { return false }
+            let succeeded = await passkeyManager.retryPasskeyRecovery()
+            guard !Task.isCancelled else { return false }
+            return succeeded
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return false
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        let succeeded = await operationTask.value
+        guard currentUserId == operationUserId else { return false }
+        return succeeded
+    }
+
+    func startFreshWithNewKey() async -> Bool {
+        guard let operationUserId = currentUserId else { return false }
+        let operationTask = Task { [passkeyManager] in
+            guard !Task.isCancelled else { return false }
+            let succeeded = await passkeyManager.startFreshWithNewKey()
+            guard !Task.isCancelled else { return false }
+            return succeeded
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return false
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        let succeeded = await operationTask.value
+        guard currentUserId == operationUserId else { return false }
+        return succeeded
+    }
+
+    func retryPasskeySetup() async -> PasskeyRecoveryResult {
+        guard let operationUserId = currentUserId else { return .recoveryFailed }
+        let operationTask = Task { [passkeyManager] in
+            guard !Task.isCancelled else { return PasskeyRecoveryResult.recoveryFailed }
+            let result = await passkeyManager.retryPasskeySetup()
+            guard !Task.isCancelled else { return .recoveryFailed }
+            return result
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return .recoveryFailed
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        let result = await operationTask.value
+        guard currentUserId == operationUserId else { return .recoveryFailed }
+        switch result {
+        case .success, .newUserSetupDone:
+            let migrationToken = legacyMigrationToken(userId: operationUserId)
+            startLegacyMigration(token: migrationToken, userId: operationUserId)
+        default:
+            break
+        }
+        return result
+    }
+
+    func createPasskeyBackup() async {
+        guard let operationUserId = currentUserId else { return }
+        let operationTask = Task { [passkeyManager] in
+            guard !Task.isCancelled else { return false }
+            let succeeded = await passkeyManager.createPasskeyBackup()
+            guard !Task.isCancelled else { return false }
+            return succeeded
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return
+        }
+        defer { accountOperationTracker.end(operationToken) }
+
+        let succeeded = await operationTask.value
+        guard currentUserId == operationUserId else { return }
+        guard succeeded else { return }
+        let migrationToken = legacyMigrationToken(userId: operationUserId)
+        startLegacyMigration(token: migrationToken, userId: operationUserId)
+    }
+
+    private func ensureCurrentAccount(_ userId: String) throws {
+        try Task.checkCancellation()
+        guard currentUserId == userId else {
+            throw CancellationError()
         }
     }
     

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -419,6 +419,7 @@ class ChatViewModel: ObservableObject {
     private var streamUpdateTimers: [String: Timer] = [:]
     private var pendingStreamUpdates: [String: Chat] = [:]
     private var pendingSaveTask: Task<Void, Never>?
+    private var pendingBackupTasks: [UUID: Task<Void, Never>] = [:]
     private var lastKnownAuthState: Bool?
     @Published private var genUIRetryStates: [GenUIRetryKey: GenUIRetryState] = [:]
     private var activeGenUIRetryIds: [GenUIRetryKey: UUID] = [:]
@@ -4442,11 +4443,14 @@ class ChatViewModel: ObservableObject {
         // has messages, and no active stream.
         if shouldBackup && SettingsManager.shared.isCloudSyncEnabled && !chat.isLocalOnly && !chat.messages.isEmpty && !chat.hasActiveStream {
             let saveTask = pendingSaveTask
-            Task { [weak self] in
+            let backupId = UUID()
+            let backupTask = Task { [weak self] in
+                defer { self?.pendingBackupTasks[backupId] = nil }
                 await saveTask?.value
                 guard let self, self.acceptsChatSaves else { return }
                 await self.cloudSync.backupChat(chat.id)
             }
+            pendingBackupTasks[backupId] = backupTask
         }
     }
 
@@ -4479,6 +4483,9 @@ class ChatViewModel: ObservableObject {
 
     private func drainPendingSaves() async {
         await pendingSaveTask?.value
+        while let backupTask = pendingBackupTasks.values.first {
+            await backupTask.value
+        }
     }
 
     private func persistRecoveryCriticalSnapshot(
@@ -4542,7 +4549,7 @@ class ChatViewModel: ObservableObject {
         !Task.isCancelled && isCurrentAccountOperation(token, userId: userId)
     }
 
-    private func legacyMigrationToken(userId: String) -> AccountOperationFence.Token {
+    private func currentAccountOperationToken(userId: String) -> AccountOperationFence.Token {
         if let activeSignInToken,
            accountOperationFence.isCurrent(activeSignInToken, currentUserId: userId) {
             return activeSignInToken
@@ -5211,7 +5218,7 @@ class ChatViewModel: ObservableObject {
             guard isCurrentSignIn(token, userId: userId) else { return }
 
             // Setup pagination token
-            await setupPaginationForAppRestart(token: token, userId: userId)
+            await setupPaginationForAppRestart(userId: userId, token: token)
             guard isCurrentSignIn(token, userId: userId) else { return }
 
             await loadProjects()
@@ -5225,38 +5232,18 @@ class ChatViewModel: ObservableObject {
 
     // MARK: - Pagination Methods
     
-    /// Setup pagination state for app restart (when already authenticated)
-    private func setupPaginationForAppRestart() async {
-        // Try to get pagination token from cloud to enable Load More
-        do {
-            // Get the list result to check if there are more pages
-            if let listResult = try? await CloudStorageService.shared.listChats(
-                limit: Constants.Pagination.chatsPerPage,
-                continuationToken: nil,
-                includeContent: false
-            ) {
-                await MainActor.run {
-                    self.paginationToken = listResult.nextContinuationToken
-                    self.hasMoreChats = listResult.hasMore
-                    self.isPaginationActive = true
-                    self.hasLoadedInitialPage = true
-                }
-            }
-        }
-    }
-
     private func setupPaginationForAppRestart(
-        token: AccountOperationFence.Token,
-        userId: String
+        userId: String,
+        token: AccountOperationFence.Token? = nil
     ) async {
-        guard isCurrentSignIn(token, userId: userId) else { return }
+        guard isCurrentPaginationOperation(userId: userId, token: token) else { return }
         // Try to get pagination token from cloud to enable Load More
         let listResult = try? await CloudStorageService.shared.listChats(
             limit: Constants.Pagination.chatsPerPage,
             continuationToken: nil,
             includeContent: false
         )
-        guard isCurrentSignIn(token, userId: userId) else { return }
+        guard isCurrentPaginationOperation(userId: userId, token: token) else { return }
         if let listResult {
             paginationToken = listResult.nextContinuationToken
             hasMoreChats = listResult.hasMore
@@ -5264,11 +5251,27 @@ class ChatViewModel: ObservableObject {
             hasLoadedInitialPage = true
         }
     }
+
+    private func isCurrentPaginationOperation(
+        userId: String,
+        token: AccountOperationFence.Token?
+    ) -> Bool {
+        guard !Task.isCancelled,
+              !isAccountTeardownInProgress,
+              currentUserId == userId
+        else {
+            return false
+        }
+        guard let token else { return true }
+        return isCurrentSignIn(token, userId: userId)
+    }
     
     /// Perform initial sync if it hasn't been done yet
     private func performInitialSyncIfNeeded() async {
         guard !hasPerformedInitialSync else { return }
         guard hasChatAccess else { return }
+        guard let userId = currentUserId else { return }
+        let token = currentAccountOperationToken(userId: userId)
         
         hasPerformedInitialSync = true
         
@@ -5291,11 +5294,11 @@ class ChatViewModel: ObservableObject {
             }
             
             // Setup pagination after sync
-            await setupPaginationForAppRestart()
+            await setupPaginationForAppRestart(userId: userId, token: token)
             
             // Load and display cloud chats after sync from file index
             let result = await loadFirstPageOfChats(
-                userId: currentUserId,
+                userId: userId,
                 filter: \.isCloudDisplayable
             )
             await MainActor.run {
@@ -5589,6 +5592,8 @@ class ChatViewModel: ObservableObject {
     
     /// Perform a full sync with the cloud
     func performFullSync() async {
+        guard let userId = currentUserId else { return }
+        let token = currentAccountOperationToken(userId: userId)
         // Gate sync when cloud sync is disabled
         if !SettingsManager.shared.isCloudSyncEnabled {
             return
@@ -5613,7 +5618,7 @@ class ChatViewModel: ObservableObject {
         
         // Always refresh pagination token and hasMore state from the server after a sync
         // This guards against cold-start races where the token wasn't available yet
-        await self.setupPaginationForAppRestart()
+        await self.setupPaginationForAppRestart(userId: userId, token: token)
         
         // Also sync profile settings
         await ProfileManager.shared.performFullSync()
@@ -5690,7 +5695,7 @@ class ChatViewModel: ObservableObject {
         // A v1 user activating their key on a fresh device has legacy
         // cloud data but no registered key. Re-kick migration now that
         // a key is active so adoption happens in-session.
-        let migrationToken = legacyMigrationToken(userId: operationUserId)
+        let migrationToken = currentAccountOperationToken(userId: operationUserId)
         startLegacyMigration(token: migrationToken, userId: operationUserId)
     }
 
@@ -5834,7 +5839,7 @@ class ChatViewModel: ObservableObject {
         guard currentUserId == operationUserId else { return .recoveryFailed }
         switch result {
         case .success, .newUserSetupDone:
-            let migrationToken = legacyMigrationToken(userId: operationUserId)
+            let migrationToken = currentAccountOperationToken(userId: operationUserId)
             startLegacyMigration(token: migrationToken, userId: operationUserId)
         default:
             break
@@ -5859,7 +5864,7 @@ class ChatViewModel: ObservableObject {
         let succeeded = await operationTask.value
         guard currentUserId == operationUserId else { return }
         guard succeeded else { return }
-        let migrationToken = legacyMigrationToken(userId: operationUserId)
+        let migrationToken = currentAccountOperationToken(userId: operationUserId)
         startLegacyMigration(token: migrationToken, userId: operationUserId)
     }
 

--- a/TinfoilChat/Views/CloudSyncSettingsView.swift
+++ b/TinfoilChat/Views/CloudSyncSettingsView.swift
@@ -28,7 +28,7 @@ struct CloudSyncSettingsView: View {
                         Task { await viewModel.performFullSync() }
                     } else {
                         Task {
-                            let result = await passkeyManager.retryPasskeySetup()
+                            let result = await viewModel.retryPasskeySetup()
                             switch result {
                             case .manualSetupRequired:
                                 await MainActor.run {
@@ -393,21 +393,21 @@ struct CloudSyncSettingsView: View {
                         title: "Set Up Passkey on This Device",
                         subtitle: "Your other devices use a passkey already. Add one here for one-tap access."
                     ) {
-                        await passkeyManager.createPasskeyBackup()
+                        await viewModel.createPasskeyBackup()
                     }
                 } else if passkeyManager.passkeySetupAvailable && EncryptionService.shared.hasEncryptionKey() {
                     passkeyActionButton(
                         title: "Add Passkey for seamless sync",
                         subtitle: "Use Face ID or Touch ID to sync chats across devices"
                     ) {
-                        await passkeyManager.createPasskeyBackup()
+                        await viewModel.createPasskeyBackup()
                     }
                 } else if passkeyManager.passkeySetupAvailable && !EncryptionService.shared.hasEncryptionKey() {
                     passkeyActionButton(
                         title: "Add Passkey for seamless sync",
                         subtitle: "Create a passkey to sync chats across devices"
                     ) {
-                        let result = await passkeyManager.retryPasskeySetup()
+                        let result = await viewModel.retryPasskeySetup()
                         switch result {
                         case .manualSetupRequired:
                             await MainActor.run {

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -356,10 +356,13 @@ struct SettingsView: View {
     /// Shared destructive cleanup used by both "Delete Everything" and "Delete Account".
     private func performFullDataCleanup() async {
         await ProfileManager.shared.clearLocalProfileForAccountRemoval()
-        await chatViewModel.clearAllChatsFromDevice(resumeRecoveryScans: false)
+        await chatViewModel.clearAllChatsFromDevice(
+            resumeRecoveryScans: false,
+            reopenAccountOperations: false
+        )
+        await PasskeyManager.shared.reset()
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()
-        chatViewModel.resumeRecoveryScans()
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.hasLaunchedBefore)
         settings.clearAllSettings()
     }

--- a/TinfoilChatTests/AccountOperationFenceTests.swift
+++ b/TinfoilChatTests/AccountOperationFenceTests.swift
@@ -1,0 +1,148 @@
+import Testing
+@testable import TinfoilChat
+
+struct AccountOperationFenceTests {
+    @Test func newlyBegunTokenIsCurrent() {
+        var fence = AccountOperationFence()
+        let token = fence.begin(userId: "user-a")
+
+        #expect(fence.isCurrent(token, currentUserId: "user-a"))
+    }
+
+    @Test func newerBeginInvalidatesOlderToken() {
+        var fence = AccountOperationFence()
+        let olderToken = fence.begin(userId: "user-a")
+        let newerToken = fence.begin(userId: "user-a")
+
+        #expect(!fence.isCurrent(olderToken, currentUserId: "user-a"))
+        #expect(fence.isCurrent(newerToken, currentUserId: "user-a"))
+    }
+
+    @Test func invalidateInvalidatesCurrentToken() {
+        var fence = AccountOperationFence()
+        let token = fence.begin(userId: "user-a")
+
+        fence.invalidate()
+
+        #expect(!fence.isCurrent(token, currentUserId: "user-a"))
+    }
+
+    @Test func matchingGenerationForWrongUserIsRejected() {
+        var fence = AccountOperationFence()
+        let token = fence.begin(userId: "user-a")
+        let wrongUserToken = AccountOperationFence.Token(
+            userId: "user-b",
+            generation: token.generation
+        )
+
+        #expect(!fence.isCurrent(wrongUserToken, currentUserId: "user-a"))
+        #expect(!fence.isCurrent(token, currentUserId: "user-b"))
+    }
+
+    @Test func generationsIncreaseMonotonically() {
+        var fence = AccountOperationFence()
+        let first = fence.begin(userId: "user-a")
+        let second = fence.begin(userId: "user-a")
+        fence.invalidate()
+        let third = fence.begin(userId: "user-a")
+
+        #expect(first.generation < second.generation)
+        #expect(second.generation < third.generation)
+    }
+}
+
+@MainActor
+struct AccountOperationTrackerTests {
+    @Test func beginAndEndCompleteAnOperation() async {
+        let tracker = AccountOperationTracker()
+        let operationTask = Task {}
+
+        let token = tracker.begin(task: operationTask)
+        #expect(token != nil)
+        if let token {
+            tracker.end(token)
+        }
+        await tracker.closeAndWait()
+
+        #expect(tracker.begin(task: Task {}) == nil)
+    }
+
+    @Test func closeRejectsNewOperations() async {
+        let tracker = AccountOperationTracker()
+
+        await tracker.closeAndWait()
+
+        #expect(tracker.begin(task: Task {}) == nil)
+    }
+
+    @Test func closeCancelsAndWaitsForActiveOperation() async {
+        let tracker = AccountOperationTracker()
+        let operationTask = Task {}
+        let token = tracker.begin(task: operationTask)
+        #expect(token != nil)
+        var closeFinished = false
+        var closeTask: Task<Void, Never>!
+
+        await withCheckedContinuation { (closeStarted: CheckedContinuation<Void, Never>) in
+            closeTask = Task { @MainActor in
+                closeStarted.resume()
+                await tracker.closeAndWait()
+                closeFinished = true
+            }
+        }
+
+        #expect(operationTask.isCancelled)
+        #expect(!closeFinished)
+
+        if let token {
+            tracker.end(token)
+        }
+        await closeTask.value
+
+        #expect(closeFinished)
+    }
+
+    @Test func operationTokensEndOnlyTheirOwnRegistration() async {
+        let tracker = AccountOperationTracker()
+        let firstToken = tracker.begin(task: Task {})
+        let secondToken = tracker.begin(task: Task {})
+
+        #expect(firstToken != nil)
+        #expect(secondToken != nil)
+        #expect(firstToken != secondToken)
+
+        if let firstToken {
+            tracker.end(firstToken)
+        }
+
+        var closeFinished = false
+        var closeTask: Task<Void, Never>!
+        await withCheckedContinuation { (closeStarted: CheckedContinuation<Void, Never>) in
+            closeTask = Task { @MainActor in
+                closeStarted.resume()
+                await tracker.closeAndWait()
+                closeFinished = true
+            }
+        }
+        #expect(!closeFinished)
+
+        if let secondToken {
+            tracker.end(secondToken)
+        }
+        await closeTask.value
+        #expect(closeFinished)
+    }
+
+    @Test func reopenPermitsNewOperations() async {
+        let tracker = AccountOperationTracker()
+        await tracker.closeAndWait()
+
+        tracker.reopen()
+
+        let token = tracker.begin(task: Task {})
+        #expect(token != nil)
+        if let token {
+            tracker.end(token)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make sign-in startup cancelable and generation-scoped to the captured account
- close save/key operation admission during sign-out and destructive cleanup, then drain tracked work before wiping keys or files
- route manual/passkey key activation through tracked operations and own legacy migration in a cancellable background task
- make legacy migration polling cancellation-aware so teardown cannot wait through the full migration timeout

## Safety invariants
- stale account tasks cannot publish chats, pagination, onboarding, sync, profile, or key state
- queued saves are drained with admission closed before account storage is deleted
- passkey refresh and key activation are canceled/drained before key cleanup
- migration remains asynchronous during normal startup and is awaited only during teardown

## Testing
- adds deterministic generation-fence and operation-tracker tests
- `git diff --check`
- static concurrency/lifecycle review completed
- builds and tests were not run from the CLI per `AGENTS.md`; please validate in Xcode

## Stack
- depends on #259

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes iOS account startup, passkey, and teardown to the active user to prevent cross‑account mutations and sign‑out races while preserving remotely committed keys. Old: detached tasks could modify chats/keys after user switches and teardowns overlapped; new: startup is generation‑scoped and fenced, stale work cancels and drains, teardown is single and awaited, and passkey reset drains without deleting remotely committed keys.

- Await `PasskeyManager.reset()` during sign‑out/cleanup and keep account operations closed.
- Use `ChatViewModel` wrappers instead of direct `PasskeyManager`/`EncryptionService` calls: `initializeExistingEncryptionKeyIfAvailable`, `retryPasskeySetup`, `retryPasskeyRecovery`, `startFreshWithNewKey`, `createPasskeyBackup`.
- Register per‑account work with `AccountOperationTracker` and fence with `AccountOperationFence`; remove detached launch‑time migration (polling is now cancellation‑aware and scoped to the active account).

<sup>Written for commit d1676b568c19af7609334e0d3aa51d59c5f9226d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

