### PR TITLE
Bound iOS chat sync and image downloads

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -321,6 +321,7 @@ enum Constants {
 
     enum Sync {
         static let protocolVersion = 2
+        static let maxConcurrentChatUploads = 2
         static let chatSyncIntervalSeconds: TimeInterval = 20.0
         static let profileSyncIntervalSeconds: TimeInterval = 60.0  // 1 minute
         static let profileSyncProtocolVersion = 2
@@ -554,6 +555,7 @@ enum Constants {
     }
 
     enum Attachments {
+        static let maxConcurrentImageDownloads = 3
         static let maxImageDimension: CGFloat = 1536
         static let imageCompressionQuality: CGFloat = 0.85
         static let maxFileSizeBytes = SharedImportConfiguration.maximumDocumentSizeBytes

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -329,44 +329,99 @@ class CloudStorageService: ObservableObject {
 
     // MARK: - Attachments
 
+    struct ImageDownloadRequest: Sendable {
+        let attachmentId: String
+        let encryptionKey: String
+    }
+
+    static func downloadImages(
+        _ requests: [ImageDownloadRequest],
+        maxConcurrent: Int,
+        download: @escaping @Sendable (ImageDownloadRequest) async throws -> String
+    ) async throws -> [String: String] {
+        guard !requests.isEmpty else { return [:] }
+        precondition(maxConcurrent > 0)
+
+        let completed = try await withThrowingTaskGroup(
+            of: (Int, String?).self,
+            returning: [String?].self
+        ) { group in
+            let initialCount = min(maxConcurrent, requests.count)
+            var nextIndex = initialCount
+            var completed = Array<String?>(repeating: nil, count: requests.count)
+
+            for index in 0..<initialCount {
+                let request = requests[index]
+                group.addTask {
+                    try Task.checkCancellation()
+                    do {
+                        return (index, try await download(request))
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        return (index, nil)
+                    }
+                }
+            }
+
+            while let (index, base64) = try await group.next() {
+                completed[index] = base64
+                try Task.checkCancellation()
+                if nextIndex < requests.count {
+                    let replacementIndex = nextIndex
+                    let request = requests[replacementIndex]
+                    nextIndex += 1
+                    group.addTask {
+                        try Task.checkCancellation()
+                        do {
+                            return (replacementIndex, try await download(request))
+                        } catch is CancellationError {
+                            throw CancellationError()
+                        } catch {
+                            return (replacementIndex, nil)
+                        }
+                    }
+                }
+            }
+            return completed
+        }
+
+        var results: [String: String] = [:]
+        for (index, base64) in completed.enumerated() {
+            if let base64 {
+                results[requests[index].attachmentId] = base64
+            }
+        }
+        return results
+    }
+
     /// Fetch and decrypt all image attachments that have no base64 yet.
     /// Returns a dictionary mapping attachment IDs to their decoded
     /// base64 strings so callers can merge results into the current
     /// (possibly updated) messages without overwriting the entire
     /// array with a stale snapshot.
-    func loadImages(in messages: [Message]) async -> [String: String] {
-        var work: [(String, String)] = []
+    func loadImages(in messages: [Message]) async throws -> [String: String] {
+        var work: [ImageDownloadRequest] = []
         for msg in messages {
             for att in msg.attachments {
                 guard att.type == .image,
                       att.base64 == nil,
                       let attKey = att.encryptionKey else { continue }
-                work.append((att.id, attKey))
+                work.append(ImageDownloadRequest(attachmentId: att.id, encryptionKey: attKey))
             }
         }
-        guard !work.isEmpty else { return [:] }
-
-        var results: [String: String] = [:]
-        await withTaskGroup(of: (String, String?).self) { group in
-            for (attId, key) in work {
-                group.addTask {
-                    do {
-                        let bytes = try await SyncEnclaveAPI.attachmentGet(
-                            EnclaveAttachmentGetRequest(id: attId, attKey: key)
-                        )
-                        return (attId, bytes.base64EncodedString())
-                    } catch {
-                        return (attId, nil)
-                    }
-                }
-            }
-            for await (attId, base64) in group {
-                if let b64 = base64 {
-                    results[attId] = b64
-                }
-            }
+        return try await Self.downloadImages(
+            work,
+            maxConcurrent: Constants.Attachments.maxConcurrentImageDownloads
+        ) { request in
+            let bytes = try await SyncEnclaveAPI.attachmentGet(
+                EnclaveAttachmentGetRequest(
+                    id: request.attachmentId,
+                    attKey: request.encryptionKey
+                )
+            )
+            return bytes.base64EncodedString()
         }
-        return results
     }
 
     // MARK: - List

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -70,17 +70,29 @@ private enum UploadIterationOutcome {
 /// bytes under the same key and fail with 409 IDEMPOTENCY_CONFLICT
 /// instead of deduping.
 actor UploadCoalescer {
+    private struct ThrowingWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Error>
+    }
+
     private struct ChatUploadState {
         var dirty: Bool = false
         var allowWhileStreaming: Bool = false
+        var queued: Bool = false
         var workerRunning: Bool = false
         var failureCount: Int = 0
         var waiters: [CheckedContinuation<Void, Never>] = []
-        var throwingWaiters: [CheckedContinuation<Void, Error>] = []
+        var throwingWaiters: [ThrowingWaiter] = []
     }
 
     private var states: [String: ChatUploadState] = [:]
+    private var queuedChatIds: [String] = []
+    private var queuedChatIndex = 0
+    private var workerTasks: [String: Task<Void, Never>] = [:]
+    private var activeWorkerCount = 0
     private var generation = 0
+    private var pendingThrowingWaiterIds: Set<UUID> = []
+    private var cancelledThrowingWaiterIds: Set<UUID> = []
     private let prepareUpload: @Sendable (String, String, Bool) async throws -> UploadAttempt?
     private let waitBeforeRetry: @Sendable (Int) async -> Void
 
@@ -102,12 +114,12 @@ actor UploadCoalescer {
         var state = states[chatId] ?? ChatUploadState()
         state.dirty = true
         state.allowWhileStreaming = state.allowWhileStreaming || allowWhileStreaming
-        states[chatId] = state
-
-        if !state.workerRunning {
-            states[chatId]?.workerRunning = true
-            Task { await runWorker(chatId) }
+        if !state.workerRunning && !state.queued {
+            state.queued = true
+            queuedChatIds.append(chatId)
         }
+        states[chatId] = state
+        startQueuedWorkers()
     }
 
     func waitForUpload(_ chatId: String) async {
@@ -119,24 +131,82 @@ actor UploadCoalescer {
         }
     }
 
+    @discardableResult
     func enqueueAndWait(
         _ chatId: String,
         allowWhileStreaming: Bool = false
-    ) async throws {
-        enqueue(chatId, allowWhileStreaming: allowWhileStreaming)
+    ) async throws -> Bool {
+        let waiterId = UUID()
+        pendingThrowingWaiterIds.insert(waiterId)
+        return try await withTaskCancellationHandler {
+            do {
+                try Task.checkCancellation()
+                enqueue(chatId, allowWhileStreaming: allowWhileStreaming)
 
-        guard let state = states[chatId], state.workerRunning || state.dirty else {
-            return
-        }
+                guard let state = states[chatId], state.workerRunning || state.dirty else {
+                    pendingThrowingWaiterIds.remove(waiterId)
+                    cancelledThrowingWaiterIds.remove(waiterId)
+                    return false
+                }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            states[chatId]?.throwingWaiters.append(continuation)
+                let uploaded = try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Bool, Error>) in
+                    pendingThrowingWaiterIds.remove(waiterId)
+                    if Task.isCancelled || cancelledThrowingWaiterIds.remove(waiterId) != nil {
+                        continuation.resume(throwing: CancellationError())
+                    } else {
+                        states[chatId]?.throwingWaiters.append(
+                            ThrowingWaiter(id: waiterId, continuation: continuation)
+                        )
+                    }
+                }
+                try Task.checkCancellation()
+                return uploaded
+            } catch {
+                pendingThrowingWaiterIds.remove(waiterId)
+                cancelledThrowingWaiterIds.remove(waiterId)
+                throw error
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(chatId: chatId, waiterId: waiterId) }
         }
     }
 
-    private func runWorker(_ chatId: String) async {
-        let workerGeneration = generation
+    private func cancelWaiter(chatId: String, waiterId: UUID) {
+        if var state = states[chatId],
+           let index = state.throwingWaiters.firstIndex(where: { $0.id == waiterId }) {
+            let waiter = state.throwingWaiters.remove(at: index)
+            states[chatId] = state
+            waiter.continuation.resume(throwing: CancellationError())
+        } else if pendingThrowingWaiterIds.contains(waiterId) {
+            cancelledThrowingWaiterIds.insert(waiterId)
+        }
+    }
+
+    private func startQueuedWorkers() {
+        while activeWorkerCount < Constants.Sync.maxConcurrentChatUploads,
+              queuedChatIndex < queuedChatIds.count {
+            let chatId = queuedChatIds[queuedChatIndex]
+            queuedChatIndex += 1
+            guard var state = states[chatId], state.queued else { continue }
+            state.queued = false
+            state.workerRunning = true
+            states[chatId] = state
+            activeWorkerCount += 1
+            let workerGeneration = generation
+            workerTasks[chatId] = Task {
+                await self.runWorker(chatId, generation: workerGeneration)
+            }
+        }
+        if queuedChatIndex == queuedChatIds.count {
+            queuedChatIds.removeAll(keepingCapacity: true)
+            queuedChatIndex = 0
+        }
+    }
+
+    private func runWorker(_ chatId: String, generation workerGeneration: Int) async {
         var terminalError: Error?
+        var uploaded = false
 
         while states[chatId]?.dirty == true && workerGeneration == generation {
             states[chatId]?.dirty = false
@@ -160,11 +230,27 @@ actor UploadCoalescer {
                 break
             case .uploaded:
                 terminalError = nil
+                uploaded = true
             case .failed(let iterationError):
                 terminalError = iterationError
             }
         }
-        guard workerGeneration == generation else { return }
+        finishWorker(
+            chatId,
+            generation: workerGeneration,
+            uploaded: uploaded,
+            terminalError: terminalError
+        )
+    }
+
+    private func finishWorker(
+        _ chatId: String,
+        generation workerGeneration: Int,
+        uploaded: Bool,
+        terminalError: Error?
+    ) {
+        guard workerGeneration == generation,
+              states[chatId]?.workerRunning == true else { return }
 
         // Notify waiters and clean up in a single access
         let waiters = states[chatId]?.waiters ?? []
@@ -175,9 +261,9 @@ actor UploadCoalescer {
         let throwingWaiters = states[chatId]?.throwingWaiters ?? []
         for waiter in throwingWaiters {
             if let terminalError {
-                waiter.resume(throwing: terminalError)
+                waiter.continuation.resume(throwing: terminalError)
             } else {
-                waiter.resume()
+                waiter.continuation.resume(returning: uploaded)
             }
         }
 
@@ -189,6 +275,9 @@ actor UploadCoalescer {
             states[chatId]?.waiters = []
             states[chatId]?.throwingWaiters = []
         }
+        workerTasks.removeValue(forKey: chatId)
+        activeWorkerCount -= 1
+        startQueuedWorkers()
     }
 
     private func uploadWithRetry(
@@ -208,6 +297,7 @@ actor UploadCoalescer {
 
         for attempt in 0...Constants.Sync.uploadMaxRetries {
             do {
+                try Task.checkCancellation()
                 if !prepared {
                     preparedAttempt = try await prepareUpload(
                         chatId,
@@ -222,6 +312,7 @@ actor UploadCoalescer {
                 if allowWhileStreaming && preparedAttempt == nil {
                     throw UploadCoalescerError.requiredUploadNotPrepared
                 }
+                try Task.checkCancellation()
                 let attemptOutcome = try await preparedAttempt?()
                 guard workerGeneration == generation else {
                     return .failed(CancellationError())
@@ -258,9 +349,64 @@ actor UploadCoalescer {
         generation += 1
         let waiters = states.values.flatMap(\.waiters)
         let throwingWaiters = states.values.flatMap(\.throwingWaiters)
+        let tasks = Array(workerTasks.values)
         states.removeAll()
+        queuedChatIds.removeAll()
+        queuedChatIndex = 0
+        workerTasks.removeAll()
+        activeWorkerCount = 0
+        pendingThrowingWaiterIds.removeAll()
+        cancelledThrowingWaiterIds.removeAll()
+        // A canceled stale generation may briefly overlap new work, but it
+        // cannot mutate new-generation state. Fresh capacity prevents a hung
+        // old account request from starving the newly selected account.
+        tasks.forEach { $0.cancel() }
         waiters.forEach { $0.resume() }
-        throwingWaiters.forEach { $0.resume(throwing: CancellationError()) }
+        throwingWaiters.forEach { $0.continuation.resume(throwing: CancellationError()) }
+    }
+}
+
+struct PendingChatBackupBatchResult: Sendable {
+    let uploaded: Int
+    let errors: [String]
+    let failedChatIds: [String]
+}
+
+enum PendingChatBackupBatch {
+    static func run(
+        pendingChatIds: @Sendable () async throws -> [String],
+        upload: @escaping @Sendable (String) async throws -> Bool
+    ) async throws -> PendingChatBackupBatchResult {
+        let chatIds: [String]
+        do {
+            chatIds = try await pendingChatIds()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return PendingChatBackupBatchResult(uploaded: 0, errors: [], failedChatIds: [])
+        }
+
+        var uploaded = 0
+        var errors: [String] = []
+        var failedChatIds: [String] = []
+        for chatId in chatIds {
+            try Task.checkCancellation()
+            do {
+                if try await upload(chatId) {
+                    uploaded += 1
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                failedChatIds.append(chatId)
+                errors.append("Failed to backup chat \(chatId): \(error.localizedDescription)")
+            }
+        }
+        return PendingChatBackupBatchResult(
+            uploaded: uploaded,
+            errors: errors,
+            failedChatIds: failedChatIds
+        )
     }
 }
 
@@ -1051,22 +1197,6 @@ class CloudSyncService: ObservableObject {
 
     // MARK: - Bulk Sync Operations
 
-    /// Load full chat objects for every locally-modified or never-synced,
-    /// non-local-only chat. Returns nil when the account generation moved
-    /// on while loading.
-    private func loadUnsyncedChats(userId: String, generation: Int) async -> [Chat]? {
-        let unsyncedIds = (try? await EncryptedFileStorage.cloud.pendingChatIds(
-            userId: userId
-        )) ?? []
-        guard generation == accountGeneration else { return nil }
-        let unsyncedChats = (try? await EncryptedFileStorage.cloud.loadChats(
-            chatIds: unsyncedIds,
-            userId: userId
-        )) ?? []
-        guard generation == accountGeneration else { return nil }
-        return unsyncedChats
-    }
-
     /// Backup all unsynced chats
     private func backupUnsyncedChats() async -> SyncResult {
         let generation = accountGeneration
@@ -1080,54 +1210,44 @@ class CloudSyncService: ObservableObject {
             return result
         }
 
-        guard let unsyncedChats = await loadUnsyncedChats(
-            userId: userId, generation: generation
-        ) else { return result }
-        
-        
-        // Filter out blank, empty, decryption failure, and streaming chats
-        var chatsToSync: [Chat] = []
-        for chat in unsyncedChats {
-            if !chat.isBlankChat && !chat.messages.isEmpty
-                && !chat.decryptionFailed && !chat.dataCorrupted {
-                let isStreaming = streamingTracker.isStreaming(chat.id)
-                if !isStreaming {
-                    chatsToSync.append(chat)
+        let batch: PendingChatBackupBatchResult
+        do {
+            batch = try await PendingChatBackupBatch.run(
+                pendingChatIds: {
+                    try await EncryptedFileStorage.cloud.pendingChatIds(userId: userId)
+                },
+                upload: { [weak self] chatId in
+                    guard let self else { throw CancellationError() }
+                    guard await self.accountGeneration == generation else {
+                        throw CancellationError()
+                    }
+                    return try await self.uploadCoalescer.enqueueAndWait(chatId)
                 }
-            }
+            )
+        } catch is CancellationError {
+            return result
+        } catch {
+            return result
         }
-        
-        
-        // Upload chats sequentially to avoid connection exhaustion
-        for chat in chatsToSync {
-            guard generation == accountGeneration else { return result }
-            // Skip if chat started streaming
-            if streamingTracker.isStreaming(chat.id) {
-                continue
-            }
-
-            do {
-                try await uploadCoalescer.enqueueAndWait(chat.id)
-                guard generation == accountGeneration else { return result }
-                result = SyncResult(
-                    uploaded: result.uploaded + 1,
-                    downloaded: result.downloaded,
-                    errors: result.errors
-                )
-            } catch {
-                guard generation == accountGeneration else { return result }
-                SyncHealthStore.shared.reportChatSyncFailed(
-                    chat.id,
-                    message: "This chat couldn't be synced"
-                )
-                result = SyncResult(
-                    uploaded: result.uploaded,
-                    downloaded: result.downloaded,
-                    errors: result.errors + ["Failed to backup chat \(chat.id): \(error.localizedDescription)"]
-                )
-            }
+        guard generation == accountGeneration else { return result }
+        for chatId in batch.failedChatIds {
+            SyncHealthStore.shared.reportChatSyncFailed(
+                chatId,
+                message: "This chat couldn't be synced"
+            )
         }
-        
+        for error in batch.errors {
+            result = SyncResult(
+                uploaded: result.uploaded,
+                downloaded: result.downloaded,
+                errors: result.errors + [error]
+            )
+        }
+        result = SyncResult(
+            uploaded: batch.uploaded,
+            downloaded: result.downloaded,
+            errors: result.errors
+        )
         return result
     }
     

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -73,6 +73,9 @@ actor UploadCoalescer {
     private struct ThrowingWaiter {
         let id: UUID
         let continuation: CheckedContinuation<Bool, Error>
+        let targetRevision: Int
+        var uploaded = false
+        var terminalError: Error?
     }
 
     private struct ChatUploadState {
@@ -81,6 +84,7 @@ actor UploadCoalescer {
         var queued: Bool = false
         var workerRunning: Bool = false
         var failureCount: Int = 0
+        var enqueuedRevision = 0
         var waiters: [CheckedContinuation<Void, Never>] = []
         var throwingWaiters: [ThrowingWaiter] = []
     }
@@ -112,6 +116,9 @@ actor UploadCoalescer {
 
     func enqueue(_ chatId: String, allowWhileStreaming: Bool = false) {
         var state = states[chatId] ?? ChatUploadState()
+        if !state.dirty {
+            state.enqueuedRevision += 1
+        }
         state.dirty = true
         state.allowWhileStreaming = state.allowWhileStreaming || allowWhileStreaming
         if !state.workerRunning && !state.queued {
@@ -156,7 +163,11 @@ actor UploadCoalescer {
                         continuation.resume(throwing: CancellationError())
                     } else {
                         states[chatId]?.throwingWaiters.append(
-                            ThrowingWaiter(id: waiterId, continuation: continuation)
+                            ThrowingWaiter(
+                                id: waiterId,
+                                continuation: continuation,
+                                targetRevision: state.enqueuedRevision
+                            )
                         )
                     }
                 }
@@ -205,11 +216,9 @@ actor UploadCoalescer {
     }
 
     private func runWorker(_ chatId: String, generation workerGeneration: Int) async {
-        var terminalError: Error?
-        var uploaded = false
-
         while states[chatId]?.dirty == true && workerGeneration == generation {
             states[chatId]?.dirty = false
+            let revision = states[chatId]?.enqueuedRevision ?? 0
             let allowWhileStreaming = states[chatId]?.allowWhileStreaming ?? false
             states[chatId]?.allowWhileStreaming = false
 
@@ -225,29 +234,45 @@ actor UploadCoalescer {
                 allowWhileStreaming: allowWhileStreaming,
                 generation: workerGeneration
             )
-            switch iterationOutcome {
-            case .noWork:
-                break
-            case .uploaded:
-                terminalError = nil
-                uploaded = true
-            case .failed(let iterationError):
-                terminalError = iterationError
-            }
+            record(
+                iterationOutcome,
+                for: chatId,
+                through: revision,
+                generation: workerGeneration
+            )
         }
         finishWorker(
             chatId,
-            generation: workerGeneration,
-            uploaded: uploaded,
-            terminalError: terminalError
+            generation: workerGeneration
         )
+    }
+
+    private func record(
+        _ outcome: UploadIterationOutcome,
+        for chatId: String,
+        through revision: Int,
+        generation workerGeneration: Int
+    ) {
+        guard workerGeneration == generation else { return }
+        guard var state = states[chatId] else { return }
+        for index in state.throwingWaiters.indices
+        where state.throwingWaiters[index].targetRevision <= revision {
+            switch outcome {
+            case .noWork:
+                break
+            case .uploaded:
+                state.throwingWaiters[index].uploaded = true
+                state.throwingWaiters[index].terminalError = nil
+            case .failed(let error):
+                state.throwingWaiters[index].terminalError = error
+            }
+        }
+        states[chatId] = state
     }
 
     private func finishWorker(
         _ chatId: String,
-        generation workerGeneration: Int,
-        uploaded: Bool,
-        terminalError: Error?
+        generation workerGeneration: Int
     ) {
         guard workerGeneration == generation,
               states[chatId]?.workerRunning == true else { return }
@@ -260,10 +285,10 @@ actor UploadCoalescer {
 
         let throwingWaiters = states[chatId]?.throwingWaiters ?? []
         for waiter in throwingWaiters {
-            if let terminalError {
+            if let terminalError = waiter.terminalError {
                 waiter.continuation.resume(throwing: terminalError)
             } else {
-                waiter.continuation.resume(returning: uploaded)
+                waiter.continuation.resume(returning: waiter.uploaded)
             }
         }
 
@@ -383,7 +408,11 @@ enum PendingChatBackupBatch {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            return PendingChatBackupBatchResult(uploaded: 0, errors: [], failedChatIds: [])
+            return PendingChatBackupBatchResult(
+                uploaded: 0,
+                errors: ["Failed to load pending chats: \(error.localizedDescription)"],
+                failedChatIds: []
+            )
         }
 
         var uploaded = 0

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -150,6 +150,10 @@ class ChatViewModel: ObservableObject {
     @Published var localChats: [Chat] = []
     @Published var currentChat: Chat? {
         didSet {
+            if currentChat?.id != oldValue?.id {
+                selectedChatImageTask?.cancel()
+                selectedChatImageTask = nil
+            }
             let enabled = currentChat?.webSearchEnabled
                 ?? SettingsManager.shared.webSearchAvailable
             if isWebSearchEnabled != enabled {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -407,6 +407,7 @@ class ChatViewModel: ObservableObject {
     private var autoSyncTimer: Timer?
     private var recoveryScanTimer: Timer?
     private var recoveryScanTask: Task<Void, Never>?
+    private var selectedChatImageTask: Task<Void, Never>?
     private var recoveryScanGeneration = 0
     private var recoveryScanLastProgressAt: Date?
     private var recoveryScansSuspended = false
@@ -892,6 +893,7 @@ class ChatViewModel: ObservableObject {
         recoveryScanTimer?.invalidate()
         recoveryScanTimer = nil
         recoveryScanTask?.cancel()
+        selectedChatImageTask?.cancel()
 
         // Stop stream update timers
         streamUpdateTimers.values.forEach { $0.invalidate() }
@@ -1988,6 +1990,7 @@ class ChatViewModel: ObservableObject {
 
     /// Selects a chat as the current chat
     func selectChat(_ chat: Chat) {
+        selectedChatImageTask?.cancel()
         // Any explicit selection supersedes a search hit whose project
         // is still loading.
         pendingSearchResultChatId = nil
@@ -2039,16 +2042,25 @@ class ChatViewModel: ObservableObject {
         }
         if hasUnfetchedImages {
             let chatId = chatToSelect.id
-            Task {
+            selectedChatImageTask = Task { [weak self] in
                 let performanceToken = PerformanceInstrumentation.shared.begin(
                     .selectedChatImageHydration
                 )
                 defer { PerformanceInstrumentation.shared.end(performanceToken) }
-                let loadedImages = await CloudStorageService.shared.loadImages(in: chatToSelect.messages)
-                guard !loadedImages.isEmpty, self.currentChat?.id == chatId else { return }
+                let loadedImages: [String: String]
+                do {
+                    loadedImages = try await CloudStorageService.shared.loadImages(
+                        in: chatToSelect.messages
+                    )
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
+                }
+                guard !loadedImages.isEmpty, self?.currentChat?.id == chatId else { return }
                 // Merge loaded base64 data into the current messages by attachment ID,
                 // rather than replacing the whole array with a stale snapshot.
-                self.applyLoadedImages(loadedImages, toChatId: chatId)
+                self?.applyLoadedImages(loadedImages, toChatId: chatId)
             }
         }
     }

--- a/TinfoilChatTests/BoundedImageDownloadTests.swift
+++ b/TinfoilChatTests/BoundedImageDownloadTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+private enum ImageDownloadTestError: Error {
+    case failed
+}
+
+private actor ImageDownloadGate {
+    struct Snapshot: Sendable {
+        let started: [String]
+        let activeIds: [String]
+        let maximumActive: Int
+    }
+
+    private var started: [String] = []
+    private var activeIds: [String] = []
+    private var maximumActive = 0
+    private var continuations: [String: CheckedContinuation<String, Error>] = [:]
+    private var startWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func download(_ request: CloudStorageService.ImageDownloadRequest) async throws -> String {
+        let attachmentId = request.attachmentId
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                started.append(attachmentId)
+                activeIds.append(attachmentId)
+                maximumActive = max(maximumActive, activeIds.count)
+                continuations[attachmentId] = continuation
+                let readyWaiters = startWaiters.filter { started.count >= $0.0 }
+                startWaiters.removeAll { started.count >= $0.0 }
+                readyWaiters.forEach { $0.1.resume() }
+            }
+        } onCancel: {
+            Task { await self.cancel(attachmentId) }
+        }
+    }
+
+    func waitForStarts(_ count: Int) async {
+        guard started.count < count else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append((count, continuation))
+        }
+    }
+
+    func succeed(_ attachmentId: String) {
+        activeIds.removeAll { $0 == attachmentId }
+        continuations.removeValue(forKey: attachmentId)?.resume(returning: "base64-\(attachmentId)")
+    }
+
+    func fail(_ attachmentId: String) {
+        activeIds.removeAll { $0 == attachmentId }
+        continuations.removeValue(forKey: attachmentId)?.resume(throwing: ImageDownloadTestError.failed)
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(started: started, activeIds: activeIds, maximumActive: maximumActive)
+    }
+
+    private func cancel(_ attachmentId: String) {
+        activeIds.removeAll { $0 == attachmentId }
+        continuations.removeValue(forKey: attachmentId)?.resume(throwing: CancellationError())
+    }
+}
+
+struct BoundedImageDownloadTests {
+    @Test
+    func imageDownloadsAreBoundedAndKeepSuccessfulIdMapping() async throws {
+        #expect(Constants.Attachments.maxConcurrentImageDownloads == 3)
+        let gate = ImageDownloadGate()
+        let requests = makeRequests(count: 5)
+        let task = Task {
+            try await CloudStorageService.downloadImages(
+                requests,
+                maxConcurrent: Constants.Attachments.maxConcurrentImageDownloads,
+                download: { try await gate.download($0) }
+            )
+        }
+
+        await gate.waitForStarts(3)
+        var snapshot = await gate.snapshot()
+        #expect(snapshot.started.count == 3)
+        #expect(snapshot.maximumActive == 3)
+
+        let failedId = snapshot.started[0]
+        await gate.fail(failedId)
+        await gate.waitForStarts(4)
+        snapshot = await gate.snapshot()
+        await gate.succeed(snapshot.activeIds[0])
+        await gate.waitForStarts(5)
+        snapshot = await gate.snapshot()
+        for attachmentId in snapshot.activeIds {
+            await gate.succeed(attachmentId)
+        }
+
+        let result = try await task.value
+        #expect(result.count == 4)
+        #expect(result[failedId] == nil)
+        for request in requests where request.attachmentId != failedId {
+            #expect(result[request.attachmentId] == "base64-\(request.attachmentId)")
+        }
+        snapshot = await gate.snapshot()
+        #expect(snapshot.maximumActive == Constants.Attachments.maxConcurrentImageDownloads)
+    }
+
+    @Test
+    func cancellingImageDownloadsDoesNotStartReplacementWork() async {
+        let gate = ImageDownloadGate()
+        let requests = makeRequests(count: 5)
+        let task = Task {
+            try await CloudStorageService.downloadImages(
+                requests,
+                maxConcurrent: Constants.Attachments.maxConcurrentImageDownloads,
+                download: { try await gate.download($0) }
+            )
+        }
+
+        await gate.waitForStarts(3)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected image download cancellation")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let snapshot = await gate.snapshot()
+        #expect(snapshot.started.count == Constants.Attachments.maxConcurrentImageDownloads)
+        #expect(snapshot.activeIds.isEmpty)
+    }
+
+    private func makeRequests(count: Int) -> [CloudStorageService.ImageDownloadRequest] {
+        (0..<count).map {
+            CloudStorageService.ImageDownloadRequest(
+                attachmentId: "attachment-\($0)",
+                encryptionKey: "key-\($0)"
+            )
+        }
+    }
+}

--- a/TinfoilChatTests/CloudSyncUploadRetryTests.swift
+++ b/TinfoilChatTests/CloudSyncUploadRetryTests.swift
@@ -69,7 +69,335 @@ private actor UploadRetryProbe {
     }
 }
 
+private actor UploadConcurrencyGate {
+    struct Snapshot: Sendable {
+        let started: [String]
+        let active: Int
+        let maximumActive: Int
+    }
+
+    private var started: [String] = []
+    private var active = 0
+    private var maximumActive = 0
+    private var startWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var releases: [String: CheckedContinuation<Void, Never>] = [:]
+
+    func enter(_ chatId: String) async {
+        active += 1
+        maximumActive = max(maximumActive, active)
+        started.append(chatId)
+        let readyWaiters = startWaiters.filter { started.count >= $0.0 }
+        startWaiters.removeAll { started.count >= $0.0 }
+        readyWaiters.forEach { $0.1.resume() }
+        await withCheckedContinuation { continuation in
+            releases[chatId] = continuation
+        }
+        active -= 1
+    }
+
+    func waitForStarts(_ count: Int) async {
+        guard started.count < count else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append((count, continuation))
+        }
+    }
+
+    func release(_ chatId: String) {
+        releases.removeValue(forKey: chatId)?.resume()
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(started: started, active: active, maximumActive: maximumActive)
+    }
+}
+
+private actor PendingChatBackupProbe {
+    private var pendingRequests = 0
+    private var authoritativeReads: [String] = []
+
+    func pendingChatIds() -> [String] {
+        pendingRequests += 1
+        return ["dirty-one", "dirty-two", "dirty-three"]
+    }
+
+    func upload(_ chatId: String) throws -> Bool {
+        authoritativeReads.append(chatId)
+        if chatId == "dirty-two" {
+            throw UploadRetryTestError.terminal
+        }
+        return true
+    }
+
+    func snapshot() -> (Int, [String]) {
+        (pendingRequests, authoritativeReads)
+    }
+}
+
+private actor StartGate {
+    private var released = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        released = true
+        waiters.forEach { $0.resume() }
+        waiters.removeAll()
+    }
+}
+
+private actor SequentialBatchCancellationGate {
+    private var started: [String] = []
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var uploadContinuation: CheckedContinuation<Bool, Error>?
+
+    func upload(_ chatId: String) async throws -> Bool {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                started.append(chatId)
+                uploadContinuation = continuation
+                startWaiters.forEach { $0.resume() }
+                startWaiters.removeAll()
+            }
+        } onCancel: {
+            Task { await self.cancelUpload() }
+        }
+    }
+
+    func waitForUploadStart() async {
+        guard started.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func startedChatIds() -> [String] {
+        started
+    }
+
+    private func cancelUpload() {
+        uploadContinuation?.resume(throwing: CancellationError())
+        uploadContinuation = nil
+    }
+}
+
 struct CloudSyncUploadRetryTests {
+    @Test
+    func chatUploadsUseBoundedFIFOQueue() async {
+        #expect(Constants.Sync.maxConcurrentChatUploads == 2)
+        let gate = UploadConcurrencyGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { chatId, _, _ in
+                await gate.enter(chatId)
+                return { .uploaded }
+            },
+            waitBeforeRetry: { _ in }
+        )
+
+        await coalescer.enqueue("one")
+        await coalescer.enqueue("two")
+        await coalescer.enqueue("three")
+        await coalescer.enqueue("four")
+        await gate.waitForStarts(Constants.Sync.maxConcurrentChatUploads)
+        var snapshot = await gate.snapshot()
+        #expect(snapshot.started.count == Constants.Sync.maxConcurrentChatUploads)
+        #expect(snapshot.maximumActive == Constants.Sync.maxConcurrentChatUploads)
+
+        await gate.release("one")
+        await gate.waitForStarts(3)
+        snapshot = await gate.snapshot()
+        #expect(snapshot.started[2] == "three")
+
+        await gate.release("two")
+        await gate.waitForStarts(4)
+        snapshot = await gate.snapshot()
+        #expect(snapshot.started[3] == "four")
+        #expect(snapshot.maximumActive == Constants.Sync.maxConcurrentChatUploads)
+
+        await gate.release("three")
+        await gate.release("four")
+        await coalescer.waitForUpload("four")
+    }
+
+    @Test
+    func sameChatEditsStayCoalescedInOneWorker() async {
+        let gate = UploadConcurrencyGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { chatId, _, _ in
+                await gate.enter(chatId)
+                return { .uploaded }
+            },
+            waitBeforeRetry: { _ in }
+        )
+
+        await coalescer.enqueue("chat")
+        await gate.waitForStarts(1)
+        await coalescer.enqueue("chat")
+        await coalescer.enqueue("chat")
+        await gate.release("chat")
+        await gate.waitForStarts(2)
+        var snapshot = await gate.snapshot()
+        #expect(snapshot.started == ["chat", "chat"])
+        #expect(snapshot.maximumActive == 1)
+
+        await gate.release("chat")
+        await coalescer.waitForUpload("chat")
+        snapshot = await gate.snapshot()
+        #expect(snapshot.started.count == 2)
+    }
+
+    @Test
+    func cancellingWaiterDoesNotCancelSharedUpload() async {
+        let gate = UploadConcurrencyGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { chatId, _, _ in
+                await gate.enter(chatId)
+                return { .uploaded }
+            },
+            waitBeforeRetry: { _ in }
+        )
+        let waiter = Task { try await coalescer.enqueueAndWait("chat") }
+        await gate.waitForStarts(1)
+
+        waiter.cancel()
+        do {
+            _ = try await waiter.value
+            Issue.record("Expected waiter cancellation")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        var snapshot = await gate.snapshot()
+        #expect(snapshot.active == 1)
+        await gate.release("chat")
+        await coalescer.waitForUpload("chat")
+        snapshot = await gate.snapshot()
+        #expect(snapshot.active == 0)
+    }
+
+    @Test
+    func cancellationBeforeWaiterRegistrationDoesNotStartUpload() async {
+        let startGate = StartGate()
+        let uploadGate = UploadConcurrencyGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { chatId, _, _ in
+                await uploadGate.enter(chatId)
+                return { .uploaded }
+            },
+            waitBeforeRetry: { _ in }
+        )
+        let waiter = Task {
+            await startGate.wait()
+            return try await coalescer.enqueueAndWait("chat")
+        }
+
+        waiter.cancel()
+        await startGate.release()
+        do {
+            _ = try await waiter.value
+            Issue.record("Expected waiter cancellation")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let snapshot = await uploadGate.snapshot()
+        #expect(snapshot.started.isEmpty)
+        #expect(snapshot.active == 0)
+    }
+
+    @Test
+    func clearImmediatelyProvidesFreshWorkerBudget() async {
+        let gate = UploadConcurrencyGate()
+        let coalescer = UploadCoalescer(
+            prepareUpload: { chatId, _, _ in
+                await gate.enter(chatId)
+                return { .uploaded }
+            },
+            waitBeforeRetry: { _ in }
+        )
+
+        let staleWaiter = Task { try await coalescer.enqueueAndWait("old-one") }
+        await coalescer.enqueue("old-two")
+        await gate.waitForStarts(2)
+        await coalescer.clear()
+        await coalescer.enqueue("new-one")
+        await coalescer.enqueue("new-two")
+        await coalescer.enqueue("new-three")
+        await gate.waitForStarts(4)
+        var snapshot = await gate.snapshot()
+        #expect(Set(snapshot.started) == Set(["old-one", "old-two", "new-one", "new-two"]))
+
+        await gate.release("old-one")
+        await gate.release("old-two")
+        await Task.yield()
+        snapshot = await gate.snapshot()
+        #expect(!snapshot.started.contains("new-three"))
+
+        await gate.release("new-one")
+        await gate.waitForStarts(5)
+        snapshot = await gate.snapshot()
+        #expect(snapshot.started.last == "new-three")
+
+        do {
+            _ = try await staleWaiter.value
+            Issue.record("Expected stale waiter cancellation")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        await gate.release("new-two")
+        await gate.release("new-three")
+        await coalescer.waitForUpload("new-three")
+    }
+
+    @Test
+    func bulkBackupUsesPendingIdsAndAuthoritativePerChatReads() async throws {
+        let probe = PendingChatBackupProbe()
+
+        let result = try await PendingChatBackupBatch.run(
+            pendingChatIds: { await probe.pendingChatIds() },
+            upload: { try await probe.upload($0) }
+        )
+
+        let snapshot = await probe.snapshot()
+        #expect(snapshot.0 == 1)
+        #expect(snapshot.1 == ["dirty-one", "dirty-two", "dirty-three"])
+        #expect(result.uploaded == 2)
+        #expect(result.errors.count == 1)
+        #expect(result.failedChatIds == ["dirty-two"])
+    }
+
+    @Test
+    func bulkBackupCancellationStopsBeforeNextChat() async {
+        let gate = SequentialBatchCancellationGate()
+        let batch = Task {
+            try await PendingChatBackupBatch.run(
+                pendingChatIds: { ["one", "two", "three"] },
+                upload: { try await gate.upload($0) }
+            )
+        }
+        await gate.waitForUploadStart()
+
+        batch.cancel()
+        do {
+            _ = try await batch.value
+            Issue.record("Expected batch cancellation")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(await gate.startedChatIds() == ["one"])
+    }
+
     @Test
     func dirtyWriteDoesNotReplacePreparedRetry() async throws {
         let backoff = RetryBackoffGate()


### PR DESCRIPTION
## Summary
- cap distinct chat upload workers with a generation-safe FIFO queue
- load dirty chats authoritatively only after their upload worker receives capacity
- make upload waiters cancellation-aware without canceling shared work
- hydrate selected-chat images through a bounded sliding window and cancel stale selection work

## Behavior
- bulk pending uploads remain deterministic and sequential
- event-driven uploads can use at most two workers per active account generation
- account reset immediately gives the new generation a fresh budget while stale canceled work cannot mutate new state
- image failures remain isolated; cancellation stops replacement work

## Testing
- adds continuation-gated upload concurrency, FIFO, coalescing, generation reset, waiter cancellation, and pending-ID tests
- adds bounded image mapping, failure, and cancellation tests
- `git diff --check`
- static concurrency review completed
- builds and tests were not run from the CLI per `AGENTS.md`; please validate in Xcode

## Stack
- depends on #261

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds iOS chat uploads to two workers and image downloads to three, and cancels stale selected‑chat image hydration. Previously both paths spawned unbounded tasks; now uploads queue FIFO across chats with cancellation‑safe waiters, and bulk backups return accurate uploaded counts and failed IDs.

- Concurrency caps: `Constants.Sync.maxConcurrentChatUploads = 2`; `Constants.Attachments.maxConcurrentImageDownloads = 3`.
- Uploads: `UploadCoalescer` adds a bounded FIFO across chats, per‑revision waiter tracking, and cancellation that prevents starting uploads if a waiter cancels early. `enqueueAndWait` now returns `Bool` (uploaded or not). `clear()` cancels stale workers and immediately restores capacity for a new account generation.
- Bulk backups: `PendingChatBackupBatch` iterates `pendingChatIds`, uploads via the coalescer, returns accurate `uploaded` counts, collects per‑chat errors and failed IDs, and reports failures to `SyncHealthStore`. Cancellation stops before starting the next chat.
- Image hydration: `CloudStorageService.downloadImages` uses a sliding window and stops spinning up replacements on cancellation. `CloudStorageService.loadImages` throws on cancellation and returns only successful attachment IDs. `ChatViewModel` cancels previous selected‑chat hydration on chat switch and ignores cancellations/errors.

**Migration**
- Update callers of `CloudStorageService.loadImages` to handle `CancellationError`.
- Update callers of `UploadCoalescer.enqueueAndWait` to handle its `Bool` return.

<sup>Written for commit 9f99fcbbacc18cba4398fcce793c5ef68828e8cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

