### PR TITLE
Materialize only current iOS stream snapshots

### DIFF
--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -1270,55 +1270,75 @@ actor ChatRecoveryCoordinator {
         let modelDisplayNamesByName = await MainActor.run {
             AppConfig.shared.modelDisplayNamesByName
         }
-        let processor = StreamingResponseProcessor(
-            isWebSearchEnabled: true,
-            hapticEnabled: false,
-            modelDisplayName: modelDisplayName,
-            modelDisplayNamesByName: modelDisplayNamesByName
+        let processor = SynchronizedStreamingResponseProcessor(
+            StreamingResponseProcessor(
+                isWebSearchEnabled: true,
+                hapticEnabled: false,
+                modelDisplayName: modelDisplayName,
+                modelDisplayNamesByName: modelDisplayNamesByName
+            )
         )
+        let snapshotPublisher = LazySnapshotPublisher(
+            interval: Constants.Streaming.uiUpdateInterval,
+            buildSnapshot: processor.snapshot
+        )
+        let snapshotPublicationFence = SnapshotPublicationFence()
         var eventState = RecoveredEventState()
         var lastProgressDraft: Message?
         for try await chunk in stream {
             let parsed = processor.parse(chunk)
-            for event in parsed.events {
-                eventState.apply(event, processor: processor)
+            let outcome = processor.withProcessor { underlyingProcessor in
+                for event in parsed.events {
+                    eventState.apply(event, processor: underlyingProcessor)
+                }
+                return underlyingProcessor.process(parsed)
             }
-            let outcome = processor.process(parsed)
             if outcome.didMutateState || !parsed.events.isEmpty {
-                try ensureRecoveryIsCurrent(
-                    chatId: chatId,
-                    turnId: turnId,
-                    userId: userId,
-                    accountGeneration: accountGeneration,
-                    scanGeneration: scanGeneration,
-                    storage: storage
+                snapshotPublisher.markDirty()
+                let publication = snapshotPublisher.acceptUpdate(
+                    at: Date(),
+                    scheduleTrailing: false
                 )
-                let draft = recoveredMessage(
-                    snapshot: processor.snapshot(),
-                    eventState: eventState,
-                    chatId: chatId,
-                    turnId: turnId,
-                    isStreaming: true
-                )
-                if recoveryDraftHasVisibleContent(draft) {
-                    let published = try await publishRecoveryDraft(
-                        draft,
+                if let materializedSnapshot = publication.materializedSnapshot,
+                   snapshotPublicationFence.accept(materializedSnapshot.id) {
+                    try ensureRecoveryIsCurrent(
                         chatId: chatId,
                         turnId: turnId,
-                        sessionId: sessionId,
+                        userId: userId,
                         accountGeneration: accountGeneration,
                         scanGeneration: scanGeneration,
-                        userId: userId,
                         storage: storage
                     )
-                    if published && draft != lastProgressDraft {
-                        lastProgressDraft = draft
-                        await onProgress()
+                    let draft = recoveredMessage(
+                        snapshot: materializedSnapshot.snapshot,
+                        eventState: eventState,
+                        chatId: chatId,
+                        turnId: turnId,
+                        isStreaming: true
+                    )
+                    if recoveryDraftHasVisibleContent(draft) {
+                        let published = try await publishRecoveryDraft(
+                            draft,
+                            chatId: chatId,
+                            turnId: turnId,
+                            sessionId: sessionId,
+                            accountGeneration: accountGeneration,
+                            scanGeneration: scanGeneration,
+                            userId: userId,
+                            storage: storage
+                        )
+                        if published && draft != lastProgressDraft {
+                            lastProgressDraft = draft
+                            await onProgress()
+                        }
+                    } else {
+                        snapshotPublisher.discardPublication()
                     }
                 }
             }
         }
-        try processor.finishStream()
+        snapshotPublisher.cancelTrailing()
+        let finalSnapshot = try processor.finishAndSnapshot()
         try ensureRecoveryIsCurrent(
             chatId: chatId,
             turnId: turnId,
@@ -1328,7 +1348,7 @@ actor ChatRecoveryCoordinator {
             storage: storage
         )
         let message = recoveredMessage(
-            snapshot: processor.snapshot(),
+            snapshot: finalSnapshot,
             eventState: eventState,
             chatId: chatId,
             turnId: turnId,
@@ -1439,7 +1459,9 @@ actor ChatRecoveryCoordinator {
         message.timeline = snapshot.timelineBlocks
         message.urlFetches = eventState.urlFetches
         message.annotations = snapshot.collectedAnnotations
-        message.webSearchBeforeThinking = snapshot.webSearchBeforeThinking
+        if let webSearchBeforeThinking = snapshot.webSearchBeforeThinking {
+            message.webSearchBeforeThinking = webSearchBeforeThinking
+        }
         return message
     }
 

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -1285,57 +1285,84 @@ actor ChatRecoveryCoordinator {
         let snapshotPublicationFence = SnapshotPublicationFence()
         var eventState = RecoveredEventState()
         var lastProgressDraft: Message?
-        for try await chunk in stream {
-            let parsed = processor.parse(chunk)
-            let outcome = processor.withProcessor { underlyingProcessor in
-                for event in parsed.events {
-                    eventState.apply(event, processor: underlyingProcessor)
+        do {
+            for try await chunk in stream {
+                let parsed = processor.parse(chunk)
+                let outcome = processor.withProcessor { underlyingProcessor in
+                    for event in parsed.events {
+                        eventState.apply(event, processor: underlyingProcessor)
+                    }
+                    return underlyingProcessor.process(parsed)
                 }
-                return underlyingProcessor.process(parsed)
-            }
-            if outcome.didMutateState || !parsed.events.isEmpty {
-                snapshotPublisher.markDirty()
-                let publication = snapshotPublisher.acceptUpdate(
-                    at: Date(),
-                    scheduleTrailing: false
-                )
-                if let materializedSnapshot = publication.materializedSnapshot,
-                   snapshotPublicationFence.accept(materializedSnapshot.id) {
-                    try ensureRecoveryIsCurrent(
-                        chatId: chatId,
-                        turnId: turnId,
-                        userId: userId,
-                        accountGeneration: accountGeneration,
-                        scanGeneration: scanGeneration,
-                        storage: storage
+                if outcome.didMutateState || !parsed.events.isEmpty {
+                    snapshotPublisher.markDirty()
+                    let publication = snapshotPublisher.acceptUpdate(
+                        at: Date(),
+                        scheduleTrailing: false
                     )
-                    let draft = recoveredMessage(
-                        snapshot: materializedSnapshot.snapshot,
-                        eventState: eventState,
-                        chatId: chatId,
-                        turnId: turnId,
-                        isStreaming: true
-                    )
-                    if recoveryDraftHasVisibleContent(draft) {
-                        let published = try await publishRecoveryDraft(
-                            draft,
+                    if let materializedSnapshot = publication.materializedSnapshot,
+                       snapshotPublicationFence.accept(materializedSnapshot.id) {
+                        try ensureRecoveryIsCurrent(
                             chatId: chatId,
                             turnId: turnId,
-                            sessionId: sessionId,
+                            userId: userId,
                             accountGeneration: accountGeneration,
                             scanGeneration: scanGeneration,
-                            userId: userId,
                             storage: storage
                         )
-                        if published && draft != lastProgressDraft {
-                            lastProgressDraft = draft
-                            await onProgress()
+                        let draft = recoveredMessage(
+                            snapshot: materializedSnapshot.snapshot,
+                            eventState: eventState,
+                            chatId: chatId,
+                            turnId: turnId,
+                            isStreaming: true
+                        )
+                        if recoveryDraftHasVisibleContent(draft) {
+                            let published = try await publishRecoveryDraft(
+                                draft,
+                                chatId: chatId,
+                                turnId: turnId,
+                                sessionId: sessionId,
+                                accountGeneration: accountGeneration,
+                                scanGeneration: scanGeneration,
+                                userId: userId,
+                                storage: storage
+                            )
+                            if published && draft != lastProgressDraft {
+                                lastProgressDraft = draft
+                                await onProgress()
+                            }
                         }
-                    } else {
-                        snapshotPublisher.discardPublication()
                     }
                 }
             }
+        } catch {
+            snapshotPublisher.cancelTrailing()
+            if let materializedSnapshot = snapshotPublisher.flushIfDirty() {
+                let draft = recoveredMessage(
+                    snapshot: materializedSnapshot.snapshot,
+                    eventState: eventState,
+                    chatId: chatId,
+                    turnId: turnId,
+                    isStreaming: true
+                )
+                if recoveryDraftHasVisibleContent(draft) {
+                    let published = try? await publishRecoveryDraft(
+                        draft,
+                        chatId: chatId,
+                        turnId: turnId,
+                        sessionId: sessionId,
+                        accountGeneration: accountGeneration,
+                        scanGeneration: scanGeneration,
+                        userId: userId,
+                        storage: storage
+                    )
+                    if published == true && draft != lastProgressDraft {
+                        await onProgress()
+                    }
+                }
+            }
+            throw error
         }
         snapshotPublisher.cancelTrailing()
         let finalSnapshot = try processor.finishAndSnapshot()

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -16,11 +16,6 @@ enum StreamingResponseProcessorError: Error {
 /// bookkeeping) so the stream can be consumed off the main actor. The main
 /// actor only receives immutable snapshots and per-chunk outcomes.
 ///
-/// Thread-safety contract (`@unchecked Sendable`): the stream task is the
-/// single consumer. The main actor touches the processor only through the
-/// event-application accessors, and only while the stream task is suspended
-/// awaiting that main-actor hop, so all access is serialized even though the
-/// class is not internally synchronized.
 final class StreamingResponseProcessor: @unchecked Sendable {
 
     /// Everything the UI writes onto the streaming message. Captured as a
@@ -621,5 +616,213 @@ final class StreamingResponseProcessor: @unchecked Sendable {
         lastHapticTime = now
         hapticChunkCount += 1
         return true
+    }
+}
+
+final class SynchronizedStreamingResponseProcessor: @unchecked Sendable {
+    private let lock = NSLock()
+    private let processor: StreamingResponseProcessor
+
+    init(_ processor: StreamingResponseProcessor) {
+        self.processor = processor
+    }
+
+    func withProcessor<Result>(
+        _ transaction: (StreamingResponseProcessor) throws -> Result
+    ) rethrows -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return try transaction(processor)
+    }
+
+    func parse(_ chunk: ChatStreamResult) -> StreamingResponseProcessor.ParsedChunk {
+        withProcessor { $0.parse(chunk) }
+    }
+
+    func process(
+        _ parsed: StreamingResponseProcessor.ParsedChunk
+    ) -> StreamingResponseProcessor.ChunkOutcome {
+        withProcessor { $0.process(parsed) }
+    }
+
+    func snapshot() -> StreamingResponseProcessor.Snapshot {
+        withProcessor { $0.snapshot() }
+    }
+
+    func finishStream() throws {
+        try withProcessor { try $0.finishStream() }
+    }
+
+    func finishAndSnapshot() throws -> StreamingResponseProcessor.Snapshot {
+        try withProcessor {
+            try $0.finishStream()
+            return $0.snapshot()
+        }
+    }
+}
+
+struct MaterializedSnapshot<Snapshot> {
+    let id: UInt64
+    let snapshot: Snapshot
+}
+
+struct LazySnapshotPublication<Snapshot> {
+    let materializedSnapshot: MaterializedSnapshot<Snapshot>?
+    let trailingFireTime: Date?
+    let shouldCancelTrailing: Bool
+}
+
+final class SnapshotPublicationIDs: @unchecked Sendable {
+    private let lock = NSLock()
+    private var latestID: UInt64 = 0
+
+    func next() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        latestID += 1
+        return latestID
+    }
+}
+
+final class SnapshotPublicationFence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var latestAppliedID: UInt64 = 0
+
+    func accept(_ id: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard id > latestAppliedID else { return false }
+        latestAppliedID = id
+        return true
+    }
+}
+
+final class LazySnapshotPublisher<Snapshot>: @unchecked Sendable {
+    private let lock = NSLock()
+    private let interval: TimeInterval
+    private let buildSnapshot: () -> Snapshot
+    private let publicationIDs: SnapshotPublicationIDs
+    private var nextPublishTime = Date.distantPast
+    private var trailingFireTime: Date?
+    private var isDirty = false
+
+    init(
+        interval: TimeInterval,
+        publicationIDs: SnapshotPublicationIDs = SnapshotPublicationIDs(),
+        buildSnapshot: @escaping () -> Snapshot
+    ) {
+        self.interval = interval
+        self.publicationIDs = publicationIDs
+        self.buildSnapshot = buildSnapshot
+    }
+
+    func acceptUpdate(
+        at now: Date,
+        scheduleTrailing: Bool
+    ) -> LazySnapshotPublication<Snapshot> {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if now >= nextPublishTime {
+            let shouldCancelTrailing = trailingFireTime != nil
+            trailingFireTime = nil
+            isDirty = false
+            nextPublishTime = now.addingTimeInterval(interval)
+            return LazySnapshotPublication(
+                materializedSnapshot: materializeSnapshot(),
+                trailingFireTime: nil,
+                shouldCancelTrailing: shouldCancelTrailing
+            )
+        }
+
+        isDirty = true
+        guard scheduleTrailing, trailingFireTime == nil else {
+            return LazySnapshotPublication(
+                materializedSnapshot: nil,
+                trailingFireTime: nil,
+                shouldCancelTrailing: false
+            )
+        }
+
+        let fireTime = nextPublishTime
+        trailingFireTime = fireTime
+        nextPublishTime = fireTime.addingTimeInterval(interval)
+        return LazySnapshotPublication(
+            materializedSnapshot: nil,
+            trailingFireTime: fireTime,
+            shouldCancelTrailing: false
+        )
+    }
+
+    func publishTrailing(scheduledFor fireTime: Date) -> MaterializedSnapshot<Snapshot>? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard trailingFireTime == fireTime, isDirty else { return nil }
+        trailingFireTime = nil
+        isDirty = false
+        return materializeSnapshot()
+    }
+
+    func flushIfDirty() -> MaterializedSnapshot<Snapshot>? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard isDirty else { return nil }
+        trailingFireTime = nil
+        isDirty = false
+        return materializeSnapshot()
+    }
+
+    func markDirty() {
+        lock.lock()
+        isDirty = true
+        lock.unlock()
+    }
+
+    func cancelTrailing() {
+        lock.lock()
+        trailingFireTime = nil
+        lock.unlock()
+    }
+
+    func discardPublication() {
+        lock.lock()
+        nextPublishTime = .distantPast
+        trailingFireTime = nil
+        isDirty = false
+        lock.unlock()
+    }
+
+    func finish() -> MaterializedSnapshot<Snapshot> {
+        lock.lock()
+        defer { lock.unlock() }
+        trailingFireTime = nil
+        isDirty = false
+        return materializeSnapshot()
+    }
+
+    private func materializeSnapshot() -> MaterializedSnapshot<Snapshot> {
+        MaterializedSnapshot(
+            id: publicationIDs.next(),
+            snapshot: buildSnapshot()
+        )
+    }
+}
+
+final class PendingStreamingSummary: @unchecked Sendable {
+    private let lock = NSLock()
+    private var thoughts: String?
+
+    func replace(with thoughts: String?) {
+        lock.lock()
+        self.thoughts = thoughts
+        lock.unlock()
+    }
+
+    func take() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        let value = thoughts
+        thoughts = nil
+        return value
     }
 }

--- a/TinfoilChat/Services/StreamingResponseProcessor.swift
+++ b/TinfoilChat/Services/StreamingResponseProcessor.swift
@@ -784,14 +784,6 @@ final class LazySnapshotPublisher<Snapshot>: @unchecked Sendable {
         lock.unlock()
     }
 
-    func discardPublication() {
-        lock.lock()
-        nextPublishTime = .distantPast
-        trailingFireTime = nil
-        isDirty = false
-        lock.unlock()
-    }
-
     func finish() -> MaterializedSnapshot<Snapshot> {
         lock.lock()
         defer { lock.unlock() }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2684,6 +2684,9 @@ class ChatViewModel: ObservableObject {
             var recoveryRegistered = false
             var recoveryRegistrationAttempted = false
             var recoverySessionMayHaveStarted = false
+            var activeSnapshotPublisher: LazySnapshotPublisher<StreamingResponseProcessor.Snapshot>?
+            let snapshotPublicationIDs = SnapshotPublicationIDs()
+            let snapshotPublicationFence = SnapshotPublicationFence()
 
             retryLoop: do {
                 if !hasRetriedWithFreshKey,
@@ -2867,16 +2870,24 @@ class ChatViewModel: ObservableObject {
                 // thinking state machine, tool calls, web search bookkeeping)
                 // lives in the processor so the stream can be consumed off
                 // the main actor.
-                let processor = StreamingResponseProcessor(
-                    isWebSearchEnabled: webSearchEnabled,
-                    hapticEnabled: hapticEnabled,
-                    responseContent: initialResponseContent,
-                    modelDisplayName: streamModel.responseDisplayName,
-                    modelDisplayNamesByName: modelDisplayNamesByName,
-                    currentThoughts: initialThoughts,
-                    generationTimeSeconds: initialGenerationTime,
-                    isInThinkingMode: initialIsThinking
+                let processor = SynchronizedStreamingResponseProcessor(
+                    StreamingResponseProcessor(
+                        isWebSearchEnabled: webSearchEnabled,
+                        hapticEnabled: hapticEnabled,
+                        responseContent: initialResponseContent,
+                        modelDisplayName: streamModel.responseDisplayName,
+                        modelDisplayNamesByName: modelDisplayNamesByName,
+                        currentThoughts: initialThoughts,
+                        generationTimeSeconds: initialGenerationTime,
+                        isInThinkingMode: initialIsThinking
+                    )
                 )
+                let snapshotPublisher = LazySnapshotPublisher(
+                    interval: Constants.Streaming.uiUpdateInterval,
+                    publicationIDs: snapshotPublicationIDs,
+                    buildSnapshot: processor.snapshot
+                )
+                activeSnapshotPublisher = snapshotPublisher
 
                 // Web search progress now rides inline with the model's
                 // content as `<tinfoil-event>` markers (opted into via
@@ -2949,7 +2960,10 @@ class ChatViewModel: ObservableObject {
                 // callback used to provide, but driven off the inline
                 // marker stream so the app stays in sync with router
                 // progress without a second SSE channel.
-                let applyWebSearchCallEvent: @MainActor (TinfoilWebSearchCallEvent) -> Void = { [weak self] event in
+                let applyWebSearchCallEvent: @MainActor (
+                    TinfoilWebSearchCallEvent,
+                    StreamingResponseProcessor
+                ) -> Void = { [weak self] event, processor in
                     guard let self = self else { return }
                     // Look up the streaming chat by ID, not self.currentChat,
                     // so an event landing after the user switched chats never
@@ -3096,155 +3110,169 @@ class ChatViewModel: ObservableObject {
                 // actor is only hopped to for rare event application, haptics,
                 // and the throttled snapshot updates.
                 let consumeTask = Task.detached(priority: .userInitiated) { [weak self] in
-                    let uiUpdateInterval: TimeInterval = Constants.Streaming.uiUpdateInterval
-                    // Earliest moment the next publish may occur. Advanced on
-                    // every leading-edge publish and whenever a trailing flush
-                    // is scheduled, so flushes count against the throttle and
-                    // the publish rate stays bounded at one per interval.
-                    var nextPublishTime = Date.distantPast
                     // Latest thoughts awaiting a summary request; forwarded with
                     // the next throttled snapshot so summary generation does not
                     // force a main-actor hop per reasoning chunk.
-                    var pendingSummaryThoughts: String? = nil
+                    let pendingSummaryThoughts = PendingStreamingSummary()
                     // Trailing-edge flush for the UI throttle below. The throttle
                     // only publishes when a new chunk arrives after the interval
                     // has elapsed, so content landing inside the window would
                     // otherwise stay invisible until the next chunk — if the
                     // stream pauses (typical right after the first tokens), that
                     // reads as a stall followed by a burst. The flush publishes
-                    // the held snapshot at the end of the current window instead.
+                    // the latest processor state at the end of the current window instead.
                     var trailingFlushTask: Task<Void, Never>? = nil
-                    // Fire time of the most recently scheduled trailing flush.
-                    // Cleared when a leading-edge publish supersedes it, but not
-                    // when the flush fires: the flush task never mutates consumer
-                    // state, so a fired flush simply leaves a past date behind
-                    // and the `pending > now` check below treats it as consumed.
-                    var scheduledFlushTime: Date? = nil
-                    defer { trailingFlushTask?.cancel() }
+                    do {
+                        for try await chunk in stream {
+                            try Task.checkCancellation()
 
-                    for try await chunk in stream {
-                        if Task.isCancelled { break }
-
-                        let parsed = processor.parse(chunk)
-
-                        // Apply decoded marker events on the main actor before
-                        // processing the chunk's text. The loop suspends until
-                        // each event lands, so event handling stays ordered
-                        // relative to the streamed text around it and the
-                        // processor is never touched concurrently.
-                        for event in parsed.events {
-                            await applyWebSearchCallEvent(event)
-                        }
-
-                        let outcome = processor.process(parsed)
-
-                        if outcome.shouldTickHaptic {
-                            await MainActor.run {
-                                hapticGenerator?.impactOccurred(intensity: 0.5)
-                            }
-                        }
-
-                        for action in outcome.summaryActions {
-                            switch action {
-                            case .beginThinkingSession:
-                                pendingSummaryThoughts = nil
-                                await MainActor.run {
-                                    summaryService.reset()
-                                }
-                            case .endThinkingSession:
-                                pendingSummaryThoughts = nil
-                                let viewModel = self
-                                await MainActor.run {
-                                    summaryService.reset()
-                                    viewModel?.streamState.setThinkingSummary(nil, chatId: streamChatId)
-                                }
-                            case .generate(let thoughts):
-                                pendingSummaryThoughts = thoughts
-                            }
-                        }
-
-                        // Update UI at a throttled rate to avoid overwhelming SwiftUI with diffs
-                        let now = Date()
-                        if outcome.didMutateState {
-                            if now >= nextPublishTime {
-                                trailingFlushTask?.cancel()
-                                trailingFlushTask = nil
-                                scheduledFlushTime = nil
-                                nextPublishTime = now.addingTimeInterval(uiUpdateInterval)
-                                let snapshot = processor.snapshot()
-                                let thoughtsForSummary = pendingSummaryThoughts
-                                pendingSummaryThoughts = nil
-                                let viewModel = self
-                                await MainActor.run {
-                                    guard let self = viewModel else { return }
-                                    self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
-                                    if let thoughtsForSummary {
-                                        summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
-                                            guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
-                                            self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
+                            let parsed = processor.parse(chunk)
+                            let outcome: StreamingResponseProcessor.ChunkOutcome
+                            if parsed.events.isEmpty {
+                                outcome = processor.process(parsed)
+                            } else {
+                                // Keep every processor mutation for an event-bearing
+                                // chunk in one transaction so a trailing snapshot
+                                // cannot observe partially-applied search state.
+                                outcome = await MainActor.run {
+                                    processor.withProcessor { underlyingProcessor in
+                                        for event in parsed.events {
+                                            applyWebSearchCallEvent(event, underlyingProcessor)
                                         }
+                                        return underlyingProcessor.process(parsed)
                                     }
                                 }
+                            }
+
+                            let publication: LazySnapshotPublication<StreamingResponseProcessor.Snapshot>?
+                            if outcome.didMutateState || !parsed.events.isEmpty {
+                                snapshotPublisher.markDirty()
+                                publication = snapshotPublisher.acceptUpdate(
+                                    at: Date(),
+                                    scheduleTrailing: true
+                                )
                             } else {
-                                // Inside the throttle window: hold a snapshot and
-                                // publish it when the window closes. The snapshot
-                                // is captured here, serialized with `process`,
-                                // because the processor must never be read from
-                                // the flush task while a later chunk mutates it.
-                                // A newer chunk replaces the pending snapshot but
-                                // keeps the original fire time, and the flush
-                                // consumes a publish slot so the rate stays at
-                                // one per interval. Pending summary thoughts are
-                                // forwarded without being cleared: a reschedule
-                                // must not drop them, and a duplicate request is
-                                // deduplicated by the summary service.
-                                trailingFlushTask?.cancel()
-                                let flushTime: Date
-                                if let pending = scheduledFlushTime, pending > now {
-                                    flushTime = pending
-                                } else {
-                                    // No pending flush (or the previous one
-                                    // already fired): schedule at the next free
-                                    // publish slot and reserve the one after it.
-                                    flushTime = nextPublishTime
-                                    scheduledFlushTime = flushTime
-                                    nextPublishTime = flushTime.addingTimeInterval(uiUpdateInterval)
+                                publication = nil
+                            }
+
+                            if outcome.shouldTickHaptic {
+                                await MainActor.run {
+                                    hapticGenerator?.impactOccurred(intensity: 0.5)
                                 }
-                                let snapshot = processor.snapshot()
-                                let thoughtsForSummary = pendingSummaryThoughts
-                                let delay = max(0, flushTime.timeIntervalSince(now))
-                                let viewModel = self
-                                trailingFlushTask = Task {
-                                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-                                    guard !Task.isCancelled else { return }
+                            }
+
+                            for action in outcome.summaryActions {
+                                switch action {
+                                case .beginThinkingSession:
+                                    pendingSummaryThoughts.replace(with: nil)
                                     await MainActor.run {
-                                        guard !Task.isCancelled, let self = viewModel else { return }
-                                        self.applyStreamSnapshot(snapshot, streamChatId: streamChatId)
-                                        if let thoughtsForSummary {
+                                        summaryService.reset()
+                                    }
+                                case .endThinkingSession:
+                                    pendingSummaryThoughts.replace(with: nil)
+                                    let viewModel = self
+                                    await MainActor.run {
+                                        summaryService.reset()
+                                        viewModel?.streamState.setThinkingSummary(nil, chatId: streamChatId)
+                                    }
+                                case .generate(let thoughts):
+                                    pendingSummaryThoughts.replace(with: thoughts)
+                                }
+                            }
+
+                            // Update UI at a throttled rate to avoid overwhelming SwiftUI with diffs
+                            if let publication {
+                                if publication.shouldCancelTrailing {
+                                    trailingFlushTask?.cancel()
+                                    trailingFlushTask = nil
+                                }
+                                if let materializedSnapshot = publication.materializedSnapshot {
+                                    let thoughtsForSummary = pendingSummaryThoughts.take()
+                                    let viewModel = self
+                                    let applied = await MainActor.run {
+                                        guard let self = viewModel else { return false }
+                                        guard snapshotPublicationFence.accept(materializedSnapshot.id) else {
+                                            return true
+                                        }
+                                        let applied = self.applyStreamSnapshot(
+                                            materializedSnapshot.snapshot,
+                                            streamChatId: streamChatId
+                                        )
+                                        if applied, let thoughtsForSummary {
                                             summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
                                                 guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
                                                 self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
                                             }
                                         }
+                                        return applied
+                                    }
+                                    if !applied {
+                                        snapshotPublisher.markDirty()
+                                    }
+                                }
+                                if let flushTime = publication.trailingFireTime {
+                                    let delay = max(0, flushTime.timeIntervalSinceNow)
+                                    let viewModel = self
+                                    trailingFlushTask = Task {
+                                        do {
+                                            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                                        } catch {
+                                            return
+                                        }
+                                        guard !Task.isCancelled,
+                                              let materializedSnapshot = snapshotPublisher.publishTrailing(scheduledFor: flushTime) else {
+                                            return
+                                        }
+                                        let thoughtsForSummary = pendingSummaryThoughts.take()
+                                        let applied = await MainActor.run {
+                                            guard let self = viewModel else { return false }
+                                            guard snapshotPublicationFence.accept(materializedSnapshot.id) else {
+                                                return true
+                                            }
+                                            let applied = self.applyStreamSnapshot(
+                                                materializedSnapshot.snapshot,
+                                                streamChatId: streamChatId
+                                            )
+                                            if applied, let thoughtsForSummary {
+                                                summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
+                                                    guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
+                                                    self?.streamState.setThinkingSummary(summary, chatId: streamChatId)
+                                                }
+                                            }
+                                            return applied
+                                        }
+                                        if !applied {
+                                            snapshotPublisher.markDirty()
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    try processor.finishStream()
+                        trailingFlushTask?.cancel()
+                        if let trailingFlushTask {
+                            await trailingFlushTask.value
+                        }
+                        snapshotPublisher.cancelTrailing()
+                        return try processor.finishAndSnapshot()
+                    } catch {
+                        trailingFlushTask?.cancel()
+                        if let trailingFlushTask {
+                            await trailingFlushTask.value
+                        }
+                        snapshotPublisher.cancelTrailing()
+                        throw error
+                    }
                 }
 
                 // Propagate cancellation from cancelGeneration (which cancels
                 // the outer task) into the detached stream consumer.
-                try await withTaskCancellationHandler {
+                let finalSnapshot = try await withTaskCancellationHandler {
                     try await consumeTask.value
                 } onCancel: {
                     consumeTask.cancel()
                 }
                 try Task.checkCancellation()
-
-                let finalSnapshot = processor.snapshot()
 
                 // Finalize message content and prepare chat for save
                 // Look up the streaming chat by ID, not self.currentChat, because
@@ -3270,7 +3298,9 @@ class ChatViewModel: ObservableObject {
                         chat.messages[lastIndex].isThinking = false
                         chat.messages[lastIndex].generationTimeSeconds = finalSnapshot.generationTimeSeconds
                         chat.messages[lastIndex].thinkingDuration = finalSnapshot.generationTimeSeconds
-                        chat.messages[lastIndex].webSearchBeforeThinking = finalSnapshot.webSearchBeforeThinking
+                        if let webSearchBeforeThinking = finalSnapshot.webSearchBeforeThinking {
+                            chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
+                        }
                         chat.messages[lastIndex].contentChunks = finalSnapshot.contentChunks
                         chat.messages[lastIndex].segments = finalSnapshot.segments.isEmpty ? nil : finalSnapshot.segments
                         chat.messages[lastIndex].toolCalls = finalSnapshot.toolCalls
@@ -3371,12 +3401,34 @@ class ChatViewModel: ObservableObject {
                 }
             } catch {
                 if error is CancellationError || Task.isCancelled {
+                    if let materializedSnapshot = activeSnapshotPublisher?.flushIfDirty() {
+                        await MainActor.run {
+                            guard snapshotPublicationFence.accept(materializedSnapshot.id) else { return }
+                            self.applyStreamSnapshot(
+                                materializedSnapshot.snapshot,
+                                streamChatId: streamChatId,
+                                requireActiveStream: false,
+                                persistImmediately: true
+                            )
+                        }
+                    }
                     if recoverySessionMayHaveStarted,
                        !recoveryRegistrationAttempted,
                        let attempt = recoveryAttempt {
                         await ChatRecoveryCoordinator.shared.deleteSession(attempt: attempt)
                     }
                     return
+                }
+
+                if let materializedSnapshot = activeSnapshotPublisher?.flushIfDirty() {
+                    await MainActor.run {
+                        guard snapshotPublicationFence.accept(materializedSnapshot.id) else { return }
+                        self.applyStreamSnapshot(
+                            materializedSnapshot.snapshot,
+                            streamChatId: streamChatId,
+                            requireActiveStream: false
+                        )
+                    }
                 }
 
                 #if DEBUG
@@ -3517,14 +3569,20 @@ class ChatViewModel: ObservableObject {
     /// Applies one throttled streaming snapshot to the streaming chat's last
     /// message. Snapshots are immutable values produced by the stream task's
     /// processor, so this never reads live parsing state.
-    private func applyStreamSnapshot(_ snapshot: StreamingResponseProcessor.Snapshot, streamChatId: String) {
-        guard let location = findChatLocation(streamChatId) else { return }
+    @discardableResult
+    private func applyStreamSnapshot(
+        _ snapshot: StreamingResponseProcessor.Snapshot,
+        streamChatId: String,
+        requireActiveStream: Bool = true,
+        persistImmediately: Bool = false
+    ) -> Bool {
+        guard let location = findChatLocation(streamChatId) else { return false }
         var chat = chat(at: location)
         guard
-              chat.hasActiveStream,
+              (!requireActiveStream || chat.hasActiveStream),
               !chat.messages.isEmpty,
               let lastIndex = chat.messages.indices.last else {
-            return
+            return false
         }
 
         chat.messages[lastIndex].content = snapshot.responseContent
@@ -3533,6 +3591,10 @@ class ChatViewModel: ObservableObject {
         chat.messages[lastIndex].thinkingChunks = snapshot.thinkingChunks
         chat.messages[lastIndex].isThinking = snapshot.isThinking
         chat.messages[lastIndex].generationTimeSeconds = snapshot.generationTimeSeconds
+        chat.messages[lastIndex].thinkingDuration = snapshot.generationTimeSeconds
+        if let webSearchBeforeThinking = snapshot.webSearchBeforeThinking {
+            chat.messages[lastIndex].webSearchBeforeThinking = webSearchBeforeThinking
+        }
         chat.messages[lastIndex].contentChunks = snapshot.contentChunks
         chat.messages[lastIndex].segments = snapshot.segments.isEmpty ? nil : snapshot.segments
         chat.messages[lastIndex].webSearches = snapshot.webSearches.isEmpty ? nil : snapshot.webSearches
@@ -3551,7 +3613,14 @@ class ChatViewModel: ObservableObject {
             chat.messages[lastIndex].annotations = snapshot.collectedAnnotations
         }
 
-        self.updateChat(chat, throttleForStreaming: true)
+        if persistImmediately {
+            self.updateChat(chat)
+        } else if requireActiveStream {
+            self.updateChat(chat, throttleForStreaming: true)
+        } else {
+            self.updateChat(chat, persist: false)
+        }
+        return true
     }
 
     /// Formats a user-friendly error message from the caught error

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -3131,6 +3131,12 @@ class ChatViewModel: ObservableObject {
                             if parsed.events.isEmpty {
                                 outcome = processor.process(parsed)
                             } else {
+                                trailingFlushTask?.cancel()
+                                if let trailingFlushTask {
+                                    await trailingFlushTask.value
+                                }
+                                trailingFlushTask = nil
+                                snapshotPublisher.cancelTrailing()
                                 // Keep every processor mutation for an event-bearing
                                 // chunk in one transaction so a trailing snapshot
                                 // cannot observe partially-applied search state.
@@ -3187,7 +3193,6 @@ class ChatViewModel: ObservableObject {
                                     trailingFlushTask = nil
                                 }
                                 if let materializedSnapshot = publication.materializedSnapshot {
-                                    let thoughtsForSummary = pendingSummaryThoughts.take()
                                     let viewModel = self
                                     let applied = await MainActor.run {
                                         guard let self = viewModel else { return false }
@@ -3198,6 +3203,7 @@ class ChatViewModel: ObservableObject {
                                             materializedSnapshot.snapshot,
                                             streamChatId: streamChatId
                                         )
+                                        let thoughtsForSummary = applied ? pendingSummaryThoughts.take() : nil
                                         if applied, let thoughtsForSummary {
                                             summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
                                                 guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }
@@ -3223,7 +3229,6 @@ class ChatViewModel: ObservableObject {
                                               let materializedSnapshot = snapshotPublisher.publishTrailing(scheduledFor: flushTime) else {
                                             return
                                         }
-                                        let thoughtsForSummary = pendingSummaryThoughts.take()
                                         let applied = await MainActor.run {
                                             guard let self = viewModel else { return false }
                                             guard snapshotPublicationFence.accept(materializedSnapshot.id) else {
@@ -3233,6 +3238,7 @@ class ChatViewModel: ObservableObject {
                                                 materializedSnapshot.snapshot,
                                                 streamChatId: streamChatId
                                             )
+                                            let thoughtsForSummary = applied ? pendingSummaryThoughts.take() : nil
                                             if applied, let thoughtsForSummary {
                                                 summaryService.generateSummary(thoughts: thoughtsForSummary) { [weak self] summary in
                                                     guard self?.streamState.isStreaming(chatId: streamChatId) == true else { return }

--- a/TinfoilChatTests/StreamingResponseProcessorTests.swift
+++ b/TinfoilChatTests/StreamingResponseProcessorTests.swift
@@ -78,6 +78,162 @@ struct StreamingResponseProcessorTests {
     }
 }
 
+@Suite("Lazy streaming snapshot publication")
+struct LazyStreamingSnapshotPublisherTests {
+    @Test("fast stream cancels trailing and builds leading and final snapshots")
+    func fastStreamCancelsTrailingSnapshot() {
+        var latestValue = 0
+        var materializationCount = 0
+        let publisher = LazySnapshotPublisher(
+            interval: Constants.Streaming.uiUpdateInterval
+        ) {
+            materializationCount += 1
+            return latestValue
+        }
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        for value in 1...100 {
+            latestValue = value
+            publisher.markDirty()
+            _ = publisher.acceptUpdate(
+                at: start.addingTimeInterval(TimeInterval(value - 1) / 10_000),
+                scheduleTrailing: true
+            )
+        }
+
+        publisher.cancelTrailing()
+        #expect(publisher.finish().snapshot == 100)
+        #expect(materializationCount == 2)
+    }
+
+    @Test("trailing publication materializes the latest state")
+    func latestStateWinsTrailingPublication() throws {
+        var latestValue = "first"
+        let start = Date(timeIntervalSinceReferenceDate: 2_000)
+
+        var materializationCount = 0
+        let countingPublisher = LazySnapshotPublisher(
+            interval: Constants.Streaming.uiUpdateInterval
+        ) {
+            materializationCount += 1
+            return latestValue
+        }
+
+        countingPublisher.markDirty()
+        #expect(countingPublisher.acceptUpdate(
+            at: start,
+            scheduleTrailing: true
+        ).materializedSnapshot?.snapshot == "first")
+        latestValue = "intermediate"
+        countingPublisher.markDirty()
+        let scheduled = countingPublisher.acceptUpdate(
+            at: start.addingTimeInterval(0.01),
+            scheduleTrailing: true
+        )
+        latestValue = "latest"
+        countingPublisher.markDirty()
+        _ = countingPublisher.acceptUpdate(
+            at: start.addingTimeInterval(0.02),
+            scheduleTrailing: true
+        )
+
+        let fireTime = try #require(scheduled.trailingFireTime)
+        #expect(countingPublisher.publishTrailing(scheduledFor: fireTime)?.snapshot == "latest")
+        #expect(materializationCount == 2)
+    }
+
+    @Test("cancellation flushes the latest dirty state once")
+    func cancellationFlushesOnce() {
+        var latestValue = 1
+        var materializationCount = 0
+        let publisher = LazySnapshotPublisher(
+            interval: Constants.Streaming.uiUpdateInterval
+        ) {
+            materializationCount += 1
+            return latestValue
+        }
+        let start = Date(timeIntervalSinceReferenceDate: 3_000)
+
+        publisher.markDirty()
+        _ = publisher.acceptUpdate(at: start, scheduleTrailing: true)
+        latestValue = 2
+        publisher.markDirty()
+        _ = publisher.acceptUpdate(
+            at: start.addingTimeInterval(0.01),
+            scheduleTrailing: true
+        )
+
+        #expect(publisher.flushIfDirty()?.snapshot == 2)
+        #expect(publisher.flushIfDirty() == nil)
+        #expect(materializationCount == 2)
+    }
+
+    @Test("recovery throttle skips intermediate builds and finishes exactly")
+    func recoveryThrottleSkipsIntermediateBuilds() {
+        var content = ""
+        var materializationCount = 0
+        let publisher = LazySnapshotPublisher(
+            interval: Constants.Streaming.uiUpdateInterval
+        ) {
+            materializationCount += 1
+            return content
+        }
+        let start = Date(timeIntervalSinceReferenceDate: 4_000)
+
+        let interval = Constants.Streaming.uiUpdateInterval
+        let updateTimes: [TimeInterval] = [
+            0,
+            interval / 2,
+            interval,
+            interval * 1.5,
+            interval * 2,
+        ]
+        for updateTime in updateTimes {
+            content += "x"
+            publisher.markDirty()
+            _ = publisher.acceptUpdate(
+                at: start.addingTimeInterval(updateTime),
+                scheduleTrailing: false
+            )
+        }
+
+        let finalContent = publisher.finish().snapshot
+        #expect(finalContent == String(repeating: "x", count: updateTimes.count))
+        #expect(materializationCount == 4)
+    }
+
+    @Test("publication fence rejects an older delayed snapshot")
+    func publicationFenceRejectsOlderSnapshot() throws {
+        var latestValue = 1
+        let publisher = LazySnapshotPublisher(
+            interval: Constants.Streaming.uiUpdateInterval
+        ) { latestValue }
+        let fence = SnapshotPublicationFence()
+        let start = Date(timeIntervalSinceReferenceDate: 5_000)
+
+        publisher.markDirty()
+        _ = publisher.acceptUpdate(at: start, scheduleTrailing: true)
+        latestValue = 2
+        publisher.markDirty()
+        let scheduled = publisher.acceptUpdate(
+            at: start.addingTimeInterval(0.01),
+            scheduleTrailing: true
+        )
+        let fireTime = try #require(scheduled.trailingFireTime)
+        let older = try #require(publisher.publishTrailing(scheduledFor: fireTime))
+        latestValue = 3
+        publisher.markDirty()
+        let newer = try #require(publisher.acceptUpdate(
+            at: start.addingTimeInterval(0.2),
+            scheduleTrailing: true
+        ).materializedSnapshot)
+
+        #expect(newer.id > older.id)
+        #expect(fence.accept(newer.id))
+        #expect(!fence.accept(older.id))
+    }
+}
+
 @Suite("Streaming thinking segments")
 struct StreamingThinkingSegmentTests {
 


### PR DESCRIPTION
## Summary
- defer trailing stream snapshot construction until the publication actually fires
- serialize processor access so delayed publication sees complete event/text state
- throttle recovery snapshot materialization while always publishing an authoritative final snapshot
- flush latest accepted state on cancellation and errors without allowing stale trailing publications to overwrite newer content

## Behavior
- keeps the existing 10 Hz UI publication limit
- preserves exact final, partial-cancel, retry, search, tool, timeline, and recovery state
- uses monotonic publication IDs to reject out-of-order delayed snapshots
- keeps completed Markdown and persistence behavior unchanged

## Testing
- adds deterministic materialization-count, trailing/final, cancellation, recovery, and out-of-order publication tests
- `git diff --check`
- static concurrency/order review completed
- builds and tests were not run from the CLI per `AGENTS.md`; please validate in Xcode

## Stack
- depends on #262

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Materializes only the current iOS streaming snapshot at publish time and fences delayed publications to preserve ordered UI updates. Keeps the 10 Hz UI limit, flushes the latest state on cancel/error, and avoids trailing updates overwriting newer content.

- Streaming
  - Adds `SynchronizedStreamingResponseProcessor`, `LazySnapshotPublisher`, `SnapshotPublicationIDs`, `SnapshotPublicationFence`, and `PendingStreamingSummary` to serialize mutations, publish at 10 Hz, materialize trailing snapshots from the latest state, and reject out-of-order delayed updates; finalization now uses `finishAndSnapshot`.
  - Updates `ChatViewModel` and `ChatRecoveryCoordinator` to apply event-bearing chunks atomically, coalesce summary requests, cancel/supersede trailing flushes, and flush exactly one latest snapshot on cancel/error (persist immediately on cancel); sets `thinkingDuration` and only sets `webSearchBeforeThinking` when present.
  - Adds deterministic tests for leading/trailing publication, latest-state trailing materialization, single-shot cancellation flush, recovery throttling, and fence rejection of older snapshots.

- Sync and attachments
  - Bounds chat upload concurrency (`Constants.Sync.maxConcurrentChatUploads = 2`) with a FIFO `UploadCoalescer`; `enqueueAndWait` now returns `Bool`; `clear` cancels stale workers. Introduces `PendingChatBackupBatch` for cancellable iteration and per-chat errors.
  - Bounds image download concurrency (`Constants.Attachments.maxConcurrentImageDownloads = 3`) via `CloudStorageService.downloadImages`; `loadImages(in:)` now throws and preserves ID->base64 mapping; cancels stale image loads on chat switch.
  - Adds tests for bounded image downloads, FIFO upload queueing, and batch backup reporting/cancellation.

<sup>Written for commit fc25f57638e4ff903b20cc2b6e497f5030e9b0d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

