### PR TITLE
Render the iOS chat sidebar from summaries

### DIFF
--- a/TinfoilChat/Models/ChatListSummary.swift
+++ b/TinfoilChat/Models/ChatListSummary.swift
@@ -1,0 +1,42 @@
+//
+//  ChatListSummary.swift
+//  TinfoilChat
+//
+
+import Foundation
+
+struct ChatListSummary: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let createdAt: Date
+    let updatedAt: Date
+    let projectId: String?
+    let isLocalOnly: Bool
+    let decryptionFailed: Bool
+    let isBlankChat: Bool
+    let isTemporary: Bool
+
+    init(from chat: Chat) {
+        id = chat.id
+        title = chat.title
+        createdAt = chat.createdAt
+        updatedAt = chat.updatedAt
+        projectId = chat.projectId
+        isLocalOnly = chat.isLocalOnly
+        decryptionFailed = chat.decryptionFailed
+        isBlankChat = chat.isBlankChat
+        isTemporary = chat.isTemporary
+    }
+
+    init(from entry: ChatIndexEntry) {
+        id = entry.id
+        title = entry.title
+        createdAt = entry.createdAt
+        updatedAt = entry.updatedAt
+        projectId = entry.projectId
+        isLocalOnly = entry.isLocalOnly
+        decryptionFailed = entry.decryptionFailed
+        isBlankChat = entry.messageCount == 0 && !entry.decryptionFailed
+        isTemporary = false
+    }
+}

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -148,6 +148,12 @@ class ChatViewModel: ObservableObject {
     // Published properties for UI updates
     @Published var chats: [Chat] = []
     @Published var localChats: [Chat] = []
+    var cloudSidebarSummaries: [ChatListSummary] {
+        chats.map { ChatListSummary(from: $0) }
+    }
+    var localSidebarSummaries: [ChatListSummary] {
+        localChats.map { ChatListSummary(from: $0) }
+    }
     @Published var currentChat: Chat? {
         didSet {
             if currentChat?.id != oldValue?.id {
@@ -1993,6 +1999,14 @@ class ChatViewModel: ObservableObject {
     }
 
     /// Selects a chat as the current chat
+    @discardableResult
+    func selectChat(id: String, isLocalOnly: Bool) -> Bool {
+        let source = isLocalOnly ? localChats : chats
+        guard let chat = source.first(where: { $0.id == id }) else { return false }
+        selectChat(chat)
+        return true
+    }
+
     func selectChat(_ chat: Chat) {
         selectedChatImageTask?.cancel()
         // Any explicit selection supersedes a search hit whose project

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2001,8 +2001,10 @@ class ChatViewModel: ObservableObject {
     /// Selects a chat as the current chat
     @discardableResult
     func selectChat(id: String, isLocalOnly: Bool) -> Bool {
-        let source = isLocalOnly ? localChats : chats
-        guard let chat = source.first(where: { $0.id == id }) else { return false }
+        let preferredSource = isLocalOnly ? localChats : chats
+        let fallbackSource = isLocalOnly ? chats : localChats
+        guard let chat = preferredSource.first(where: { $0.id == id })
+            ?? fallbackSource.first(where: { $0.id == id }) else { return false }
         selectChat(chat)
         return true
     }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -12,12 +12,21 @@ import SafariServices
 /// Search results, unlike the root list, do surface project chats (the
 /// index covers every synced chat and the webapp shows them too); only
 /// temporary and undecryptable chats are excluded.
-func isSearchResultSidebarChat(_ chat: Chat) -> Bool {
+func isSearchResultSidebarChat(_ chat: ChatListSummary) -> Bool {
     !chat.isTemporary && !chat.decryptionFailed
 }
 
-func isRootSidebarChat(_ chat: Chat) -> Bool {
+func isRootSidebarChat(_ chat: ChatListSummary) -> Bool {
     isSearchResultSidebarChat(chat) && chat.projectId == nil
+}
+
+func resolveSidebarSearchChat(
+    id: String,
+    remoteResults: [Chat],
+    loadedChats: [Chat]
+) -> Chat? {
+    remoteResults.first(where: { $0.id == id })
+        ?? loadedChats.first(where: { $0.id == id })
 }
 
 func isSidebarChatSearchEnabled(
@@ -54,18 +63,18 @@ struct ChatSidebar: View {
         viewModel.activeStorageTab
     }
 
-    private var filteredChats: [Chat] {
-        let source: [Chat]
+    private var filteredChats: [ChatListSummary] {
+        let source: [ChatListSummary]
         if authManager.isAuthenticated && settings.isCloudSyncEnabled {
             switch activeTab {
             case .cloud:
-                source = viewModel.chats
+                source = viewModel.cloudSidebarSummaries
             case .local:
-                source = viewModel.localChats
+                source = viewModel.localSidebarSummaries
             }
         } else {
             // When cloud sync is off, all chats are local
-            source = viewModel.localChats
+            source = viewModel.localSidebarSummaries
         }
         // Temporary and project chats are never listed in the root chat
         // sidebar. Chats that failed to decrypt are hidden entirely; they
@@ -90,7 +99,7 @@ struct ChatSidebar: View {
             && !chatSearchTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var searchResultChats: [Chat] {
+    private var searchResultChats: [ChatListSummary] {
         guard isChatSearchActive else { return [] }
         // Enclave unavailable (older deploy, no eligible key): degrade
         // to filtering the locally loaded titles so the box still does
@@ -101,16 +110,18 @@ struct ChatSidebar: View {
             let needle = chatSearchTerm
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .lowercased()
-            return viewModel.chats.filter {
+            return viewModel.cloudSidebarSummaries.filter {
                 isSearchResultSidebarChat($0)
                     && !$0.isBlankChat
                     && $0.title.lowercased().contains(needle)
             }
         }
-        return chatSearch.results.filter(isSearchResultSidebarChat)
+        return chatSearch.results
+            .map { ChatListSummary(from: $0) }
+            .filter(isSearchResultSidebarChat)
     }
 
-    private var displayedChats: [Chat] {
+    private var displayedChats: [ChatListSummary] {
         isChatSearchActive ? searchResultChats : filteredChats
     }
 
@@ -149,7 +160,7 @@ struct ChatSidebar: View {
 
     /// Empty when the updated time would read the same as the created
     /// time, so rows don't repeat "14m ago · Updated 14m ago".
-    private func updatedTimeString(for chat: Chat) -> String {
+    private func updatedTimeString(for chat: ChatListSummary) -> String {
         let created = relativeTimeString(from: chat.createdAt)
         let updated = relativeTimeString(from: chat.updatedAt)
         guard updated != created else { return "" }
@@ -395,9 +406,14 @@ struct ChatSidebar: View {
                     isPinned: profileManager.isChatPinned(chat.id),
                     onSelect: {
                         if isChatSearchActive {
-                            viewModel.openSearchResult(chat)
+                            guard let fullChat = resolveSidebarSearchChat(
+                                id: chat.id,
+                                remoteResults: chatSearch.results,
+                                loadedChats: viewModel.chats
+                            ) else { return }
+                            viewModel.openSearchResult(fullChat)
                         } else {
-                            viewModel.selectChat(chat)
+                            viewModel.selectChat(id: chat.id, isLocalOnly: chat.isLocalOnly)
                         }
                     },
                     onEdit: {
@@ -828,12 +844,12 @@ struct ChatSidebar: View {
         }
     }
 
-    private func startEditing(_ chat: Chat) {
+    private func startEditing(_ chat: ChatListSummary) {
         editingChatId = chat.id
         editingTitle = chat.title
     }
     
-    private func confirmDelete(_ chat: Chat) {
+    private func confirmDelete(_ chat: ChatListSummary) {
         deletingChatId = chat.id
         showDeleteAlert = true
     }
@@ -853,7 +869,7 @@ private extension View {
 }
 
 struct ChatListItem: View {
-    let chat: Chat
+    let chat: ChatListSummary
     let isSelected: Bool
     let isEditing: Bool
     @Binding var editingTitle: String

--- a/TinfoilChatTests/ChatListSummaryTests.swift
+++ b/TinfoilChatTests/ChatListSummaryTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ChatListSummaryTests {
+    @Test
+    func convertsChatSidebarFields() {
+        let createdAt = Date(timeIntervalSince1970: 100)
+        let updatedAt = Date(timeIntervalSince1970: 200)
+        var chat = Chat(
+            id: "local-chat",
+            title: "Local notes",
+            createdAt: createdAt,
+            modelType: ChatSearchServiceTests.testModel,
+            updatedAt: updatedAt,
+            isLocalOnly: true,
+            projectId: "project-1"
+        )
+        chat.decryptionFailed = true
+        chat.isTemporary = true
+
+        let summary = ChatListSummary(from: chat)
+
+        #expect(summary.id == chat.id)
+        #expect(summary.title == chat.title)
+        #expect(summary.createdAt == createdAt)
+        #expect(summary.updatedAt == updatedAt)
+        #expect(summary.projectId == "project-1")
+        #expect(summary.isLocalOnly)
+        #expect(summary.decryptionFailed)
+        #expect(!summary.isBlankChat)
+        #expect(summary.isTemporary)
+    }
+
+    @Test
+    func convertsIndexEntrySidebarFieldsWithoutChangingSchema() {
+        let createdAt = Date(timeIntervalSince1970: 300)
+        let updatedAt = Date(timeIntervalSince1970: 400)
+        var chat = Chat(
+            id: "indexed-chat",
+            title: "Indexed notes",
+            createdAt: createdAt,
+            modelType: ChatSearchServiceTests.testModel,
+            updatedAt: updatedAt,
+            isLocalOnly: true,
+            projectId: "project-2"
+        )
+        chat.decryptionFailed = true
+        let entry = ChatIndexEntry(from: chat)
+
+        let summary = ChatListSummary(from: entry)
+
+        #expect(summary.id == entry.id)
+        #expect(summary.title == entry.title)
+        #expect(summary.createdAt == createdAt)
+        #expect(summary.updatedAt == updatedAt)
+        #expect(summary.projectId == "project-2")
+        #expect(summary.isLocalOnly)
+        #expect(summary.decryptionFailed)
+        #expect(!summary.isBlankChat)
+        #expect(!summary.isTemporary)
+    }
+
+    @Test
+    func preservesBlankStateFromIndexMetadata() {
+        let chat = ChatSearchServiceTests.makeChat(id: "blank", title: "New Chat")
+        let entry = ChatIndexEntry(from: chat)
+
+        #expect(ChatListSummary(from: chat).isBlankChat)
+        #expect(ChatListSummary(from: entry).isBlankChat)
+    }
+}

--- a/TinfoilChatTests/ChatSearchControllerTests.swift
+++ b/TinfoilChatTests/ChatSearchControllerTests.swift
@@ -176,14 +176,47 @@ struct ChatSearchControllerTests {
         temporary.isTemporary = true
         var encrypted = ChatSearchServiceTests.makeChat(id: "encrypted", title: "Encrypted")
         encrypted.decryptionFailed = true
+        let blank = ChatSearchServiceTests.makeChat(id: "blank", title: "New Chat")
 
-        let visible = [root, project, temporary, encrypted]
+        let summaries = [root, project, temporary, encrypted, blank]
+            .map { ChatListSummary(from: $0) }
+        let visible = summaries
             .filter(isSearchResultSidebarChat)
             .map(\.id)
-        #expect(visible == ["root", "project"])
+        #expect(visible == ["root", "project", "blank"])
 
         // The root chat list itself still excludes project chats.
-        #expect([root, project].filter(isRootSidebarChat).map(\.id) == ["root"])
+        #expect(summaries.filter(isRootSidebarChat).map(\.id) == ["root", "blank"])
+        #expect(summaries.first(where: { $0.id == "blank" })?.isBlankChat == true)
+    }
+
+    @Test
+    func sidebarSearchSelectionPrefersRemoteResultsThenLoadedChats() {
+        let loaded = ChatSearchServiceTests.makeChat(id: "loaded", title: "Loaded")
+        let remote = ChatSearchServiceTests.makeChat(id: "remote", title: "Remote")
+        let staleLoadedCopy = ChatSearchServiceTests.makeChat(id: "remote", title: "Stale")
+
+        #expect(
+            resolveSidebarSearchChat(
+                id: "remote",
+                remoteResults: [remote],
+                loadedChats: [loaded, staleLoadedCopy]
+            )?.title == "Remote"
+        )
+        #expect(
+            resolveSidebarSearchChat(
+                id: "loaded",
+                remoteResults: [],
+                loadedChats: [loaded]
+            )?.title == "Loaded"
+        )
+        #expect(
+            resolveSidebarSearchChat(
+                id: "missing",
+                remoteResults: [remote],
+                loadedChats: [loaded]
+            ) == nil
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- introduce a schema-neutral sidebar summary model derived from existing chats and encrypted index entries
- render cloud, local, search, row actions, timestamps, and accessibility without passing full Chat values through sidebar views
- add identity-based selection that resolves the authoritative full chat before opening it
- make search selection independent of mutable search availability

## Scope
- startup still eagerly loads full chats in this transition PR
- no persisted Chat/ChatIndexEntry/cloud schema changes
- no partial or shell Chat values
- lazy hydration lands in the next stacked PR after presentation parity is validated

## Testing
- adds Chat and ChatIndexEntry summary conversion tests
- updates root/search/project/blank/decryption filtering parity
- adds remote-first and loaded-chat fallback search selection tests
- `git diff --check`
- static behavior review completed
- builds and tests were not run from the CLI per `AGENTS.md`; please validate in Xcode

## Stack
- depends on #263

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the iOS chat sidebar from summaries instead of full chats to decouple UI from storage and keep selection stable as chats move between cloud and local. Previously the sidebar passed `Chat`; now it renders `ChatListSummary` and selects by id with remote-first search resolution to avoid stale copies and tab flips.

- Introduces `ChatListSummary` derived from `Chat` and `ChatIndexEntry`; no storage schema changes.
- Sidebar reads `cloudSidebarSummaries`/`localSidebarSummaries`. Root and search include blank chats; project chats appear only in search; temporary and undecryptable chats are hidden.
- Adds `selectChat(id:isLocalOnly)` with cross-source fallback and `resolveSidebarSearchChat` that prefers remote results, then loaded, to keep selection steady during chat moves.
- When the encrypted index is unavailable, search degrades to local title filtering.
- Tests cover summary conversion (including blank-state from index metadata), filtering parity, and remote-first search selection precedence.

<sup>Written for commit 027cf09c7e049be635ab6d5386e360730752ed34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

