### PR TITLE
Disable Clerk telemetry on iOS

### DIFF
--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -23,7 +23,10 @@ struct TinfoilChatApp: App {
 
     init() {
         StorageKeysMigration.migrateIfNeeded()
-        Clerk.configure(publishableKey: AppConfig.shared.clerkPublishableKey)
+        Clerk.configure(
+            publishableKey: AppConfig.shared.clerkPublishableKey,
+            options: Clerk.Options(telemetryEnabled: false)
+        )
         _clerk = State(initialValue: Clerk.shared)
         // Build the profile manager before any view can read it. Its
         // initializer applies the stored profile, which writes shared


### PR DESCRIPTION
## Summary
- explicitly disable Clerk SDK telemetry during app initialization
- preserve all existing authentication behavior and SDK defaults

## Testing
- not run; repository instructions require building and testing in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables `Clerk` telemetry on iOS at app startup. Previously telemetry was enabled by default; now it is off, reducing outbound diagnostic data without changing authentication flows.

**Review and rollout**
- Change is in `TinfoilChatApp.swift`: `Clerk.configure(..., options: Clerk.Options(telemetryEnabled: false))`.
- Verify sign-in, sign-up, and sign-out in a local Xcode build.
- Expect fewer `Clerk` network calls; any telemetry-based analytics or support data from `Clerk` will not be available on iOS.
- No migration required.

<sup>Written for commit f96d8092861a90fb8218504c234cb4319aed8092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

