### PR TITLE
Hydrate iOS chats only when selected

### DIFF
--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -411,11 +411,18 @@ struct PaginatedChatsResult {
     let chats: [StoredChat]
     let hasMore: Bool
     let nextToken: String?
+    let failed: Bool
     
-    init(chats: [StoredChat], hasMore: Bool = false, nextToken: String? = nil) {
+    init(
+        chats: [StoredChat],
+        hasMore: Bool = false,
+        nextToken: String? = nil,
+        failed: Bool = false
+    ) {
         self.chats = chats
         self.hasMore = hasMore
         self.nextToken = nextToken
+        self.failed = failed
     }
 }
 

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -552,7 +552,7 @@ struct ProfileSyncStatus: Codable {
 
 /// Tracks deleted chats to prevent resurrection during sync.
 /// IDs persist for the lifetime of the app session — they are only
-/// removed explicitly via `removeFromDeleted` or `clear`.
+/// removed when account state is cleared.
 @MainActor
 class DeletedChatsTracker {
     static let shared = DeletedChatsTracker()
@@ -569,11 +569,6 @@ class DeletedChatsTracker {
     /// Check if a chat was deleted this session
     func isDeleted(_ chatId: String) -> Bool {
         return deletedChats.contains(chatId)
-    }
-    
-    /// Remove from deleted tracking (e.g., after successful cloud deletion)
-    func removeFromDeleted(_ chatId: String) {
-        deletedChats.remove(chatId)
     }
     
     /// Clear all tracked deletions (e.g., on logout)

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -412,17 +412,20 @@ struct PaginatedChatsResult {
     let hasMore: Bool
     let nextToken: String?
     let failed: Bool
+    let cancelled: Bool
     
     init(
         chats: [StoredChat],
         hasMore: Bool = false,
         nextToken: String? = nil,
-        failed: Bool = false
+        failed: Bool = false,
+        cancelled: Bool = false
     ) {
         self.chats = chats
         self.hasMore = hasMore
         self.nextToken = nextToken
         self.failed = failed
+        self.cancelled = cancelled
     }
 }
 

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -170,7 +170,16 @@ enum ChatPaginationPersistence {
                 )
                 guard !Task.isCancelled else { break }
                 guard !DeletedChatsTracker.shared.isDeleted(chat.id) else {
-                    outcomes.append(.deleted(chat.id))
+                    do {
+                        try await loadingService.deleteChat(
+                            id: chat.id,
+                            userId: userId,
+                            storage: .cloud
+                        )
+                        outcomes.append(.deleted(chat.id))
+                    } catch {
+                        outcomes.append(.failed(chat.id))
+                    }
                     continue
                 }
                 if result == .applied {
@@ -218,7 +227,14 @@ enum RemoteSearchPersistence {
                 storage: .cloud
             )
             try validateOperation()
-            guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
+            if DeletedChatsTracker.shared.isDeleted(remoteChat.id) {
+                try await loadingService.deleteChat(
+                    id: remoteChat.id,
+                    userId: userId,
+                    storage: .cloud
+                )
+                return .deleted
+            }
             return .chat(local)
         }
 
@@ -236,7 +252,14 @@ enum RemoteSearchPersistence {
             return .deleted
         }
         try validateOperation()
-        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
+        if DeletedChatsTracker.shared.isDeleted(remoteChat.id) {
+            try await loadingService.deleteChat(
+                id: remoteChat.id,
+                userId: userId,
+                storage: .cloud
+            )
+            return .deleted
+        }
         if result == .applied {
             return .chat(remoteChat)
         }
@@ -246,7 +269,14 @@ enum RemoteSearchPersistence {
             storage: .cloud
         )
         try validateOperation()
-        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
+        if DeletedChatsTracker.shared.isDeleted(remoteChat.id) {
+            try await loadingService.deleteChat(
+                id: remoteChat.id,
+                userId: userId,
+                storage: .cloud
+            )
+            return .deleted
+        }
         return .chat(local)
     }
 }

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -69,6 +69,10 @@ struct FileChatLoadingService: ChatLoadingService {
     }
 
     func saveChat(_ chat: Chat, userId: String, storage: ChatStorageTab) async throws {
+        if storage == .cloud,
+           await MainActor.run(body: { DeletedChatsTracker.shared.isDeleted(chat.id) }) {
+            throw EncryptedFileStorage.SaveError.remotelyDeleted
+        }
         try await fileStorage(for: storage).saveChat(chat, userId: userId)
     }
 
@@ -209,6 +213,18 @@ enum DeleteAllChatsCoordinator {
             await recoverFromFailure()
             throw error
         }
+    }
+}
+
+struct DeleteAllOperationalRestoration: Equatable {
+    let reloadEncryptionKey: Bool
+    let ensureUsableChat: Bool
+
+    static func resolve(inMemoryWasCleared: Bool, hasCurrentChat: Bool) -> Self {
+        Self(
+            reloadEncryptionKey: inMemoryWasCleared,
+            ensureUsableChat: inMemoryWasCleared || !hasCurrentChat
+        )
     }
 }
 
@@ -440,36 +456,49 @@ enum AuthoritativeCloudIndexReconciliation {
         let summaries: [ChatListSummary]
         let materializedChats: [Chat]
         let removedSelectedChat: Bool
+        let removedCurrentChat: Bool
     }
 
     static func reconcile(
         indexedSummaries: [ChatListSummary],
         authoritativeIds: Set<String>,
+        tombstonedIds: Set<String> = [],
         materializedChats: [Chat],
         selectedId: String?,
+        currentId: String? = nil,
         streamingIds: Set<String>,
         recoveryIds: Set<String>,
         operationIds: Set<String>
     ) -> Result {
         let retained = materializedChats.filter { chat in
-            authoritativeIds.contains(chat.id)
+            !tombstonedIds.contains(chat.id)
+                && (authoritativeIds.contains(chat.id)
                 || chat.isBlankChat
                 || chat.isTemporary
                 || chat.locallyModified
                 || chat.hasActiveStream
                 || streamingIds.contains(chat.id)
                 || recoveryIds.contains(chat.id)
-                || operationIds.contains(chat.id)
+                || operationIds.contains(chat.id))
         }
         let transient = retained.map(ChatListSummary.init(from:))
-        let selectedWasRemoved = selectedId.map { selectedId in
-            !authoritativeIds.contains(selectedId)
-                && !retained.contains { $0.id == selectedId }
-        } == true
+        let indexed = indexedSummaries.filter { !tombstonedIds.contains($0.id) }
+        func shouldRemoveIdentity(_ id: String?) -> Bool {
+            guard let id, !retained.contains(where: { $0.id == id }) else { return false }
+            let materialized = materializedChats.first { $0.id == id }
+            let summary = indexedSummaries.first { $0.id == id }
+            let isProtectedTransient = materialized?.isBlankChat == true
+                || materialized?.isTemporary == true
+                || summary?.isBlankChat == true
+                || summary?.isTemporary == true
+            guard !isProtectedTransient else { return false }
+            return tombstonedIds.contains(id) || !authoritativeIds.contains(id)
+        }
         return Result(
-            summaries: ChatSummaryState.reconcilingIndex(indexedSummaries, withTransient: transient),
+            summaries: ChatSummaryState.reconcilingIndex(indexed, withTransient: transient),
             materializedChats: retained,
-            removedSelectedChat: selectedWasRemoved
+            removedSelectedChat: shouldRemoveIdentity(selectedId),
+            removedCurrentChat: shouldRemoveIdentity(currentId)
         )
     }
 }

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -1,0 +1,282 @@
+import Foundation
+
+enum ChatLoadingError: Error, Equatable, Sendable {
+    case chatNotFound(id: String, storage: ChatStorageTab)
+}
+
+struct ChatSelectionFence {
+    private(set) var generation = 0
+    private(set) var selectedId: String?
+
+    mutating func begin(id: String) -> Int {
+        generation += 1
+        selectedId = id
+        return generation
+    }
+
+    mutating func invalidate() {
+        generation += 1
+        selectedId = nil
+    }
+
+    func accepts(id: String, generation: Int) -> Bool {
+        self.generation == generation && selectedId == id
+    }
+}
+
+struct ChatMutationGate {
+    private(set) var activeChatIds: Set<String> = []
+
+    mutating func begin(chatId: String) -> Bool {
+        activeChatIds.insert(chatId).inserted
+    }
+
+    mutating func end(chatId: String) {
+        activeChatIds.remove(chatId)
+    }
+}
+
+protocol ChatLoadingService {
+    func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry]
+    func loadChat(id: String, userId: String, storage: ChatStorageTab) async throws -> Chat
+    func saveChat(_ chat: Chat, userId: String, storage: ChatStorageTab) async throws
+    func deleteChat(id: String, userId: String, storage: ChatStorageTab) async throws
+}
+
+struct FileChatLoadingService: ChatLoadingService {
+    func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry] {
+        try await fileStorage(for: storage).loadIndex(userId: userId)
+    }
+
+    func loadChat(id: String, userId: String, storage: ChatStorageTab) async throws -> Chat {
+        guard let chat = try await fileStorage(for: storage).loadChat(chatId: id, userId: userId) else {
+            throw ChatLoadingError.chatNotFound(id: id, storage: storage)
+        }
+        return chat
+    }
+
+    func saveChat(_ chat: Chat, userId: String, storage: ChatStorageTab) async throws {
+        try await fileStorage(for: storage).saveChat(chat, userId: userId)
+    }
+
+    func deleteChat(id: String, userId: String, storage: ChatStorageTab) async throws {
+        try await fileStorage(for: storage).deleteChat(chatId: id, userId: userId)
+    }
+
+    private func fileStorage(for storage: ChatStorageTab) -> EncryptedFileStorage {
+        switch storage {
+        case .cloud: return .cloud
+        case .local: return .local
+        }
+    }
+}
+
+enum ChatPaginationPersistence {
+    @MainActor
+    static func saveCloudChats(
+        _ chats: [Chat],
+        userId: String,
+        loadingService: any ChatLoadingService
+    ) async -> (saved: [Chat], failedIds: [String]) {
+        var saved: [Chat] = []
+        var failedIds: [String] = []
+        for chat in chats {
+            guard !Task.isCancelled else { break }
+            do {
+                try await loadingService.saveChat(chat, userId: userId, storage: .cloud)
+                guard !Task.isCancelled else { break }
+                saved.append(chat)
+            } catch {
+                guard !Task.isCancelled else { break }
+                failedIds.append(chat.id)
+            }
+        }
+        return (saved, failedIds)
+    }
+}
+
+struct ChatPaginationPageState: Equatable {
+    let token: String?
+    let hasMore: Bool
+}
+
+enum ChatPaginationCoordinator {
+    static func state(
+        original: ChatPaginationPageState,
+        next: ChatPaginationPageState,
+        allRowsPersisted: Bool,
+        pageFailed: Bool = false
+    ) -> ChatPaginationPageState {
+        allRowsPersisted && !pageFailed ? next : original
+    }
+}
+
+enum AnonymousChatMigrationPolicy {
+    static func hasChatsRemaining(allSucceeded: Bool) -> Bool {
+        !allSucceeded
+    }
+}
+
+enum ChatDeleteSelectionResolution: Equatable {
+    case unchanged
+    case restore
+    case clearAndReplace
+
+    static func resolve(
+        deletionOwnedSelection: Bool,
+        deletionSucceeded: Bool,
+        deletionGeneration: Int,
+        currentGeneration: Int,
+        deletedId: String,
+        currentSelectedId: String?
+    ) -> Self {
+        guard deletionOwnedSelection,
+              deletionGeneration == currentGeneration,
+              currentSelectedId == deletedId || currentSelectedId == nil
+        else {
+            return .unchanged
+        }
+        return deletionSucceeded ? .clearAndReplace : .restore
+    }
+}
+
+enum ChatProjectStorageTransition {
+    @MainActor
+    static func persist(
+        _ movedChat: Chat,
+        wasLocal: Bool,
+        userId: String,
+        loadingService: any ChatLoadingService,
+        validateAccount: () throws -> Void
+    ) async throws {
+        try await loadingService.saveChat(movedChat, userId: userId, storage: .cloud)
+        do {
+            try validateAccount()
+        } catch {
+            if wasLocal {
+                try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
+                try validateAccount()
+            }
+            throw error
+        }
+        guard wasLocal else { return }
+
+        do {
+            try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .local)
+        } catch {
+            try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
+            try validateAccount()
+            throw error
+        }
+        try validateAccount()
+    }
+}
+
+enum ChatSummaryState {
+    static func page(
+        from entries: [ChatIndexEntry],
+        excluding excludedIds: Set<String> = [],
+        filter: ((ChatIndexEntry) -> Bool)? = nil,
+        limit: Int? = nil
+    ) -> (summaries: [ChatListSummary], totalEntries: Int) {
+        let sorted = entries
+            .filter { !excludedIds.contains($0.id) }
+            .filter { filter?($0) ?? true }
+            .sorted { $0.updatedAt > $1.updatedAt }
+        let pageEntries = limit.map { Array(sorted.prefix($0)) } ?? sorted
+        return (pageEntries.map(ChatListSummary.init(from:)), sorted.count)
+    }
+
+    static func upserting(_ summary: ChatListSummary, into summaries: [ChatListSummary]) -> [ChatListSummary] {
+        var result = summary.isBlankChat
+            ? summaries.filter { !$0.isBlankChat }
+            : summaries
+        if let index = result.firstIndex(where: { $0.id == summary.id }) {
+            result[index] = summary
+        } else {
+            result.append(summary)
+        }
+        return sorted(result)
+    }
+
+    static func removing(id: String, from summaries: [ChatListSummary]) -> [ChatListSummary] {
+        summaries.filter { $0.id != id }
+    }
+
+    static func reconcilingIndex(
+        _ indexed: [ChatListSummary],
+        withTransient transient: [ChatListSummary]
+    ) -> [ChatListSummary] {
+        var byId = Dictionary(indexed.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
+        for summary in transient {
+            if let indexedSummary = byId[summary.id] {
+                if summary.isBlankChat
+                    || summary.isTemporary
+                    || summary.updatedAt >= indexedSummary.updatedAt {
+                    byId[summary.id] = summary
+                }
+            } else {
+                byId[summary.id] = summary
+            }
+        }
+        return sorted(Array(byId.values))
+    }
+
+    static func cloudIndexSummaries(
+        from entries: [ChatIndexEntry],
+        loadedRootIds: Set<String>,
+        firstPageLimit: Int
+    ) -> (summaries: [ChatListSummary], totalRootEntries: Int, firstPageIds: Set<String>) {
+        let root = entries
+            .filter(\.isCloudDisplayable)
+            .sorted { $0.updatedAt > $1.updatedAt }
+        let firstPageIds = Set(root.prefix(firstPageLimit).map(\.id))
+        let retainedRootIds = firstPageIds.union(loadedRootIds)
+        let rootSummaries = root
+            .filter { retainedRootIds.contains($0.id) }
+            .map(ChatListSummary.init(from:))
+        let projectSummaries = entries
+            .filter { entry in
+                entry.projectId != nil
+                    && !entry.isLocalOnly
+                    && (entry.messageCount > 0 || entry.decryptionFailed || entry.titleState != .placeholder)
+            }
+            .map(ChatListSummary.init(from:))
+        return (
+            reconcilingIndex(rootSummaries, withTransient: projectSummaries),
+            root.count,
+            firstPageIds
+        )
+    }
+
+    static func orderedUniqueIds(indexedIds: [String], materializedIds: [String]) -> [String] {
+        var seen = Set<String>()
+        return (indexedIds + materializedIds).filter { seen.insert($0).inserted }
+    }
+
+    private static func sorted(_ summaries: [ChatListSummary]) -> [ChatListSummary] {
+        summaries.sorted {
+            if $0.isBlankChat != $1.isBlankChat { return $0.isBlankChat }
+            return $0.updatedAt > $1.updatedAt
+        }
+    }
+}
+
+enum MaterializedChatWorkingSet {
+    static func retained(
+        _ chats: [Chat],
+        selectedId: String?,
+        streamingIds: Set<String>,
+        recoveryIds: Set<String>,
+        operationIds: Set<String> = []
+    ) -> [Chat] {
+        chats.filter { chat in
+            chat.id == selectedId
+                || chat.isBlankChat
+                || chat.hasActiveStream
+                || streamingIds.contains(chat.id)
+                || recoveryIds.contains(chat.id)
+                || operationIds.contains(chat.id)
+        }
+    }
+}

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -47,6 +47,12 @@ protocol ChatLoadingService {
     func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry]
     func loadChat(id: String, userId: String, storage: ChatStorageTab) async throws -> Chat
     func saveChat(_ chat: Chat, userId: String, storage: ChatStorageTab) async throws
+    func applyRemoteChatIfFreshResult(
+        _ chat: Chat,
+        userId: String,
+        expectedLocalUpdatedAt: Date?,
+        allowLocallyModified: Bool
+    ) async throws -> RevisionApplyResult
     func deleteChat(id: String, userId: String, storage: ChatStorageTab) async throws
 }
 
@@ -66,6 +72,20 @@ struct FileChatLoadingService: ChatLoadingService {
         try await fileStorage(for: storage).saveChat(chat, userId: userId)
     }
 
+    func applyRemoteChatIfFreshResult(
+        _ chat: Chat,
+        userId: String,
+        expectedLocalUpdatedAt: Date?,
+        allowLocallyModified: Bool
+    ) async throws -> RevisionApplyResult {
+        try await EncryptedFileStorage.cloud.applyRemoteChatIfFreshResult(
+            chat,
+            userId: userId,
+            expectedLocalUpdatedAt: expectedLocalUpdatedAt,
+            allowLocallyModified: allowLocallyModified
+        )
+    }
+
     func deleteChat(id: String, userId: String, storage: ChatStorageTab) async throws {
         try await fileStorage(for: storage).deleteChat(chatId: id, userId: userId)
     }
@@ -79,26 +99,137 @@ struct FileChatLoadingService: ChatLoadingService {
 }
 
 enum ChatPaginationPersistence {
+    struct Result {
+        let summaries: [ChatListSummary]
+        let failedIds: [String]
+    }
+
     @MainActor
     static func saveCloudChats(
         _ chats: [Chat],
         userId: String,
         loadingService: any ChatLoadingService
-    ) async -> (saved: [Chat], failedIds: [String]) {
-        var saved: [Chat] = []
+    ) async -> Result {
+        let localEntries: [ChatIndexEntry]
+        do {
+            localEntries = try await loadingService.loadIndex(userId: userId, storage: .cloud)
+        } catch {
+            return Result(summaries: [], failedIds: chats.map(\.id))
+        }
+        let localById = Dictionary(
+            localEntries.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        var summaries: [ChatListSummary] = []
         var failedIds: [String] = []
         for chat in chats {
             guard !Task.isCancelled else { break }
             do {
-                try await loadingService.saveChat(chat, userId: userId, storage: .cloud)
+                let result = try await loadingService.applyRemoteChatIfFreshResult(
+                    chat,
+                    userId: userId,
+                    expectedLocalUpdatedAt: localById[chat.id]?.updatedAt,
+                    allowLocallyModified: false
+                )
                 guard !Task.isCancelled else { break }
-                saved.append(chat)
+                if result == .applied {
+                    summaries.append(ChatListSummary(from: chat))
+                } else if let existing = localById[chat.id] {
+                    summaries.append(ChatListSummary(from: existing))
+                } else {
+                    failedIds.append(chat.id)
+                }
             } catch {
                 guard !Task.isCancelled else { break }
                 failedIds.append(chat.id)
             }
         }
-        return (saved, failedIds)
+        return Result(summaries: summaries, failedIds: failedIds)
+    }
+}
+
+enum RemoteSearchPersistence {
+    @MainActor
+    static func resolve(
+        _ remoteChat: Chat,
+        userId: String,
+        loadingService: any ChatLoadingService,
+        validateOperation: @MainActor () throws -> Void = {}
+    ) async throws -> Chat {
+        try validateOperation()
+        let index = try await loadingService.loadIndex(userId: userId, storage: .cloud)
+        try validateOperation()
+        if index.contains(where: { $0.id == remoteChat.id }) {
+            let local = try await loadingService.loadChat(
+                id: remoteChat.id,
+                userId: userId,
+                storage: .cloud
+            )
+            try validateOperation()
+            return local
+        }
+
+        let result = try await loadingService.applyRemoteChatIfFreshResult(
+            remoteChat,
+            userId: userId,
+            expectedLocalUpdatedAt: nil,
+            allowLocallyModified: false
+        )
+        try validateOperation()
+        if result == .applied {
+            return remoteChat
+        }
+        let local = try await loadingService.loadChat(
+            id: remoteChat.id,
+            userId: userId,
+            storage: .cloud
+        )
+        try validateOperation()
+        return local
+    }
+}
+
+enum DeleteAllChatsCoordinator {
+    @MainActor
+    static func quiesceAndDeleteCloud(
+        closeSaveAdmission: () -> Void,
+        stopProducers: () async -> Void,
+        drainSavesAndBackups: () async -> Void,
+        quiesceUploads: () async throws -> Void,
+        deleteCloud: () async throws -> Void,
+        recoverFromFailure: () async -> Void
+    ) async throws {
+        closeSaveAdmission()
+        await stopProducers()
+        await drainSavesAndBackups()
+        do {
+            try await quiesceUploads()
+            try await deleteCloud()
+        } catch {
+            await recoverFromFailure()
+            throw error
+        }
+    }
+}
+
+struct RecoveryUpdateAdmission {
+    static func accepts(
+        accountIsCurrent: Bool,
+        isAccountTeardownInProgress: Bool,
+        wasSelected: Bool,
+        isStillSelected: Bool,
+        wasMutating: Bool,
+        isMutating: Bool,
+        identityExists: Bool,
+        isStreaming: Bool
+    ) -> Bool {
+        accountIsCurrent
+            && !isAccountTeardownInProgress
+            && (!wasSelected || isStillSelected)
+            && !wasMutating
+            && !isMutating
+            && identityExists
+            && !isStreaming
     }
 }
 
@@ -301,5 +432,44 @@ enum MaterializedChatWorkingSet {
                 || recoveryIds.contains(chat.id)
                 || operationIds.contains(chat.id)
         }
+    }
+}
+
+enum AuthoritativeCloudIndexReconciliation {
+    struct Result {
+        let summaries: [ChatListSummary]
+        let materializedChats: [Chat]
+        let removedSelectedChat: Bool
+    }
+
+    static func reconcile(
+        indexedSummaries: [ChatListSummary],
+        authoritativeIds: Set<String>,
+        materializedChats: [Chat],
+        selectedId: String?,
+        streamingIds: Set<String>,
+        recoveryIds: Set<String>,
+        operationIds: Set<String>
+    ) -> Result {
+        let retained = materializedChats.filter { chat in
+            authoritativeIds.contains(chat.id)
+                || chat.isBlankChat
+                || chat.isTemporary
+                || chat.locallyModified
+                || chat.hasActiveStream
+                || streamingIds.contains(chat.id)
+                || recoveryIds.contains(chat.id)
+                || operationIds.contains(chat.id)
+        }
+        let transient = retained.map(ChatListSummary.init(from:))
+        let selectedWasRemoved = selectedId.map { selectedId in
+            !authoritativeIds.contains(selectedId)
+                && !retained.contains { $0.id == selectedId }
+        } == true
+        return Result(
+            summaries: ChatSummaryState.reconcilingIndex(indexedSummaries, withTransient: transient),
+            materializedChats: retained,
+            removedSelectedChat: selectedWasRemoved
+        )
     }
 }

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -36,6 +36,13 @@ struct ChatMutationGate {
     }
 }
 
+struct FailedChatHydration: Equatable {
+    let id: String
+    let storage: ChatStorageTab
+
+    var isLocalOnly: Bool { storage == .local }
+}
+
 protocol ChatLoadingService {
     func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry]
     func loadChat(id: String, userId: String, storage: ChatStorageTab) async throws -> Chat
@@ -105,9 +112,10 @@ enum ChatPaginationCoordinator {
         original: ChatPaginationPageState,
         next: ChatPaginationPageState,
         allRowsPersisted: Bool,
-        pageFailed: Bool = false
+        pageFailed: Bool = false,
+        pageCancelled: Bool = false
     ) -> ChatPaginationPageState {
-        allRowsPersisted && !pageFailed ? next : original
+        allRowsPersisted && !pageFailed && !pageCancelled ? next : original
     }
 }
 
@@ -154,8 +162,7 @@ enum ChatProjectStorageTransition {
             try validateAccount()
         } catch {
             if wasLocal {
-                try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
-                try validateAccount()
+                try? await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
             }
             throw error
         }
@@ -164,11 +171,10 @@ enum ChatProjectStorageTransition {
         do {
             try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .local)
         } catch {
+            let localDeleteError = error
             try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
-            try validateAccount()
-            throw error
+            throw localDeleteError
         }
-        try validateAccount()
     }
 }
 

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -149,6 +149,15 @@ enum ChatDeleteSelectionResolution: Equatable {
 }
 
 enum ChatProjectStorageTransition {
+    struct RollbackError: LocalizedError {
+        let primary: any Error
+        let rollback: any Error
+
+        var errorDescription: String? {
+            "\(primary.localizedDescription) Cleanup also failed: \(rollback.localizedDescription)"
+        }
+    }
+
     @MainActor
     static func persist(
         _ movedChat: Chat,
@@ -162,7 +171,11 @@ enum ChatProjectStorageTransition {
             try validateAccount()
         } catch {
             if wasLocal {
-                try? await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
+                do {
+                    try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
+                } catch let rollbackError {
+                    throw RollbackError(primary: error, rollback: rollbackError)
+                }
             }
             throw error
         }
@@ -172,7 +185,11 @@ enum ChatProjectStorageTransition {
             try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .local)
         } catch {
             let localDeleteError = error
-            try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
+            do {
+                try await loadingService.deleteChat(id: movedChat.id, userId: userId, storage: .cloud)
+            } catch let rollbackError {
+                throw RollbackError(primary: localDeleteError, rollback: rollbackError)
+            }
             throw localDeleteError
         }
     }

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -103,9 +103,35 @@ struct FileChatLoadingService: ChatLoadingService {
 }
 
 enum ChatPaginationPersistence {
+    enum RowOutcome: Equatable {
+        case applied(ChatListSummary)
+        case retained(ChatListSummary)
+        case deleted(String)
+        case failed(String)
+    }
+
     struct Result {
-        let summaries: [ChatListSummary]
-        let failedIds: [String]
+        let outcomes: [RowOutcome]
+
+        var summaries: [ChatListSummary] {
+            outcomes.compactMap { outcome in
+                switch outcome {
+                case .applied(let summary), .retained(let summary): summary
+                case .deleted, .failed: nil
+                }
+            }
+        }
+
+        var failedIds: [String] {
+            outcomes.compactMap { outcome in
+                guard case .failed(let id) = outcome else { return nil }
+                return id
+            }
+        }
+
+        var safelyPersistedCount: Int {
+            outcomes.count - failedIds.count
+        }
     }
 
     @MainActor
@@ -118,16 +144,23 @@ enum ChatPaginationPersistence {
         do {
             localEntries = try await loadingService.loadIndex(userId: userId, storage: .cloud)
         } catch {
-            return Result(summaries: [], failedIds: chats.map(\.id))
+            return Result(outcomes: chats.map {
+                DeletedChatsTracker.shared.isDeleted($0.id)
+                    ? .deleted($0.id)
+                    : .failed($0.id)
+            })
         }
         let localById = Dictionary(
             localEntries.map { ($0.id, $0) },
             uniquingKeysWith: { _, latest in latest }
         )
-        var summaries: [ChatListSummary] = []
-        var failedIds: [String] = []
+        var outcomes: [RowOutcome] = []
         for chat in chats {
             guard !Task.isCancelled else { break }
+            if DeletedChatsTracker.shared.isDeleted(chat.id) {
+                outcomes.append(.deleted(chat.id))
+                continue
+            }
             do {
                 let result = try await loadingService.applyRemoteChatIfFreshResult(
                     chat,
@@ -136,33 +169,48 @@ enum ChatPaginationPersistence {
                     allowLocallyModified: false
                 )
                 guard !Task.isCancelled else { break }
+                guard !DeletedChatsTracker.shared.isDeleted(chat.id) else {
+                    outcomes.append(.deleted(chat.id))
+                    continue
+                }
                 if result == .applied {
-                    summaries.append(ChatListSummary(from: chat))
+                    outcomes.append(.applied(ChatListSummary(from: chat)))
                 } else if let existing = localById[chat.id] {
-                    summaries.append(ChatListSummary(from: existing))
+                    outcomes.append(.retained(ChatListSummary(from: existing)))
                 } else {
-                    failedIds.append(chat.id)
+                    outcomes.append(.failed(chat.id))
                 }
             } catch {
                 guard !Task.isCancelled else { break }
-                failedIds.append(chat.id)
+                outcomes.append(
+                    DeletedChatsTracker.shared.isDeleted(chat.id)
+                        ? .deleted(chat.id)
+                        : .failed(chat.id)
+                )
             }
         }
-        return Result(summaries: summaries, failedIds: failedIds)
+        return Result(outcomes: outcomes)
     }
 }
 
 enum RemoteSearchPersistence {
+    enum Result {
+        case chat(Chat)
+        case deleted
+    }
+
     @MainActor
     static func resolve(
         _ remoteChat: Chat,
         userId: String,
         loadingService: any ChatLoadingService,
         validateOperation: @MainActor () throws -> Void = {}
-    ) async throws -> Chat {
+    ) async throws -> Result {
         try validateOperation()
+        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
         let index = try await loadingService.loadIndex(userId: userId, storage: .cloud)
         try validateOperation()
+        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
         if index.contains(where: { $0.id == remoteChat.id }) {
             let local = try await loadingService.loadChat(
                 id: remoteChat.id,
@@ -170,18 +218,27 @@ enum RemoteSearchPersistence {
                 storage: .cloud
             )
             try validateOperation()
-            return local
+            guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
+            return .chat(local)
         }
 
-        let result = try await loadingService.applyRemoteChatIfFreshResult(
-            remoteChat,
-            userId: userId,
-            expectedLocalUpdatedAt: nil,
-            allowLocallyModified: false
-        )
+        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
+        let result: RevisionApplyResult
+        do {
+            result = try await loadingService.applyRemoteChatIfFreshResult(
+                remoteChat,
+                userId: userId,
+                expectedLocalUpdatedAt: nil,
+                allowLocallyModified: false
+            )
+        } catch {
+            guard DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { throw error }
+            return .deleted
+        }
         try validateOperation()
+        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
         if result == .applied {
-            return remoteChat
+            return .chat(remoteChat)
         }
         let local = try await loadingService.loadChat(
             id: remoteChat.id,
@@ -189,7 +246,8 @@ enum RemoteSearchPersistence {
             storage: .cloud
         )
         try validateOperation()
-        return local
+        guard !DeletedChatsTracker.shared.isDeleted(remoteChat.id) else { return .deleted }
+        return .chat(local)
     }
 }
 
@@ -219,11 +277,13 @@ enum DeleteAllChatsCoordinator {
 struct DeleteAllOperationalRestoration: Equatable {
     let reloadEncryptionKey: Bool
     let ensureUsableChat: Bool
+    let restartSignIn: Bool
 
     static func resolve(inMemoryWasCleared: Bool, hasCurrentChat: Bool) -> Self {
         Self(
             reloadEncryptionKey: inMemoryWasCleared,
-            ensureUsableChat: inMemoryWasCleared || !hasCurrentChat
+            ensureUsableChat: inMemoryWasCleared || !hasCurrentChat,
+            restartSignIn: true
         )
     }
 }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1298,14 +1298,14 @@ class CloudSyncService: ObservableObject {
                     continuationToken: continuationToken
                 )
                 guard generation == accountGeneration else {
-                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
                 }
                 return result
             }
-            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
         }
         guard generation == accountGeneration else {
-            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
         }
         
         do {
@@ -1317,7 +1317,7 @@ class CloudSyncService: ObservableObject {
                 includeContent: true
             )
             guard generation == accountGeneration else {
-                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
             }
             
             // Process remote chats in parallel
@@ -1328,13 +1328,13 @@ class CloudSyncService: ObservableObject {
             // fetch metadata and store encrypted placeholders. Decryption will be attempted per-chat.
             _ = try? await encryptionService.initialize()
             guard generation == accountGeneration else {
-                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
             }
 
             // Process chats sequentially to avoid connection exhaustion
             for remoteChat in chatsToProcess {
                 guard generation == accountGeneration else {
-                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
                 }
                 // Skip recently deleted chats
                 if deletedChatsTracker.isDeleted(remoteChat.id) {
@@ -1352,12 +1352,12 @@ class CloudSyncService: ObservableObject {
 
                 if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
                     guard generation == accountGeneration else {
-                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
                     }
                     downloadedChats.append(decrypted.chat)
                 } else {
                     guard generation == accountGeneration else {
-                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
                     }
                     let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
                     downloadedChats.append(placeholder)
@@ -1382,11 +1382,11 @@ class CloudSyncService: ObservableObject {
                     continuationToken: continuationToken
                 )
                 guard generation == accountGeneration else {
-                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
                 }
                 return result
             }
-            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil)
+            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
         }
     }
     

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1298,14 +1298,14 @@ class CloudSyncService: ObservableObject {
                     continuationToken: continuationToken
                 )
                 guard generation == accountGeneration else {
-                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
                 }
                 return result
             }
             return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
         }
         guard generation == accountGeneration else {
-            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+            return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
         }
         
         do {
@@ -1317,7 +1317,7 @@ class CloudSyncService: ObservableObject {
                 includeContent: true
             )
             guard generation == accountGeneration else {
-                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
             }
             
             // Process remote chats in parallel
@@ -1328,13 +1328,13 @@ class CloudSyncService: ObservableObject {
             // fetch metadata and store encrypted placeholders. Decryption will be attempted per-chat.
             _ = try? await encryptionService.initialize()
             guard generation == accountGeneration else {
-                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
             }
 
             // Process chats sequentially to avoid connection exhaustion
             for remoteChat in chatsToProcess {
                 guard generation == accountGeneration else {
-                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
                 }
                 // Skip recently deleted chats
                 if deletedChatsTracker.isDeleted(remoteChat.id) {
@@ -1352,12 +1352,12 @@ class CloudSyncService: ObservableObject {
 
                 if let decrypted = await decryptRemoteChat(remoteChat, content: content) {
                     guard generation == accountGeneration else {
-                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
                     }
                     downloadedChats.append(decrypted.chat)
                 } else {
                     guard generation == accountGeneration else {
-                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                        return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
                     }
                     let placeholder = createEncryptedPlaceholder(remoteChat: remoteChat)
                     downloadedChats.append(placeholder)
@@ -1382,7 +1382,7 @@ class CloudSyncService: ObservableObject {
                     continuationToken: continuationToken
                 )
                 guard generation == accountGeneration else {
-                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, failed: true)
+                    return PaginatedChatsResult(chats: [], hasMore: false, nextToken: nil, cancelled: true)
                 }
                 return result
             }

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -1896,7 +1896,6 @@ class CloudSyncService: ObservableObject {
             )
             guard pending.generation == accountGeneration else { throw CancellationError() }
             deferredRemoteDeletes.removeValue(forKey: chatId)
-            deletedChatsTracker.removeFromDeleted(chatId)
             return false
         }
         try await EncryptedFileStorage.cloud.clearRemoteDeleteTombstone(
@@ -2418,7 +2417,6 @@ class CloudSyncService: ObservableObject {
             userId: userId
         )
         deferredRemoteDeletes.removeValue(forKey: chatId)
-        deletedChatsTracker.removeFromDeleted(chatId)
     }
 
     private func uploadAndMarkSynced(_ upload: PreparedChatUpload) async throws {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -370,7 +370,7 @@ actor UploadCoalescer {
         return .failed(lastError ?? UploadCoalescerError.requiredUploadNotPrepared)
     }
 
-    func clear() {
+    func clear() async {
         generation += 1
         let waiters = states.values.flatMap(\.waiters)
         let throwingWaiters = states.values.flatMap(\.throwingWaiters)
@@ -388,6 +388,9 @@ actor UploadCoalescer {
         tasks.forEach { $0.cancel() }
         waiters.forEach { $0.resume() }
         throwingWaiters.forEach { $0.continuation.resume(throwing: CancellationError()) }
+        for task in tasks {
+            await task.value
+        }
     }
 }
 
@@ -512,6 +515,8 @@ class CloudSyncService: ObservableObject {
     /// failed removal is retried on the next sync cycle.
     private var deferredRemoteDeletes: [String: DeferredRemoteDelete] = [:]
     private var accountGeneration = 0
+    private var uploadsSuspended = false
+    private var bulkDeleteAccount: UploadAccount?
     private let cloudStorage = CloudStorageService.shared
     private let encryptionService = EncryptionService.shared
     private let deletedChatsTracker = DeletedChatsTracker.shared
@@ -712,6 +717,7 @@ class CloudSyncService: ObservableObject {
         ensureLatestUpload: Bool = false,
         allowWhileStreaming: Bool = false
     ) async {
+        guard !uploadsSuspended else { return }
         let generation = accountGeneration
 
         beginPendingUpload(chatId)
@@ -733,6 +739,7 @@ class CloudSyncService: ObservableObject {
         _ chatId: String,
         allowWhileStreaming: Bool
     ) async throws {
+        guard !uploadsSuspended else { throw CancellationError() }
         let generation = accountGeneration
         beginPendingUpload(chatId)
         defer { endPendingUpload(chatId, generation: generation) }
@@ -746,6 +753,7 @@ class CloudSyncService: ObservableObject {
     }
 
     func backupChatAndWait(_ chatId: String, requiredTurnId: String) async throws {
+        guard !uploadsSuspended else { throw CancellationError() }
         let generation = accountGeneration
         _ = try CloudUploadGate.allowsWrite(required: true)
         guard let userId = await getCurrentUserId(),
@@ -885,6 +893,7 @@ class CloudSyncService: ObservableObject {
         idempotencyKey: String,
         allowWhileStreaming: Bool
     ) async throws -> UploadAttempt? {
+        guard !uploadsSuspended else { throw CancellationError() }
         let generation = accountGeneration
         // Direct backupChat calls reach here without going through
         // syncAllChats, so the upgrade gate must be enforced in this
@@ -1488,6 +1497,7 @@ class CloudSyncService: ObservableObject {
     
     /// Sync all chats (upload local changes, download remote changes)
     func syncAllChats() async -> SyncResult {
+        guard !uploadsSuspended else { return SyncResult() }
         let generation = accountGeneration
         guard !isSyncing else {
             return SyncResult()
@@ -2176,6 +2186,8 @@ class CloudSyncService: ObservableObject {
     /// revision checkpoint — or none at all.
     func clearSyncStatus(forUser userId: String?) async {
         await handleLocalStoreWipe(forUser: userId)
+        uploadsSuspended = false
+        bulkDeleteAccount = nil
         lastSyncDate = nil
         // The health gate is per-account state: key problems and even the
         // sticky upgradeRequired gate must not block the NEXT account
@@ -2215,17 +2227,58 @@ class CloudSyncService: ObservableObject {
     }
 
     // MARK: - Delete Operations
+
+    func quiesceUploadsForBulkDelete(userId: String) async throws {
+        guard await cloudStorage.isAuthenticated(),
+              await getCurrentUserId() == userId else {
+            throw CloudStorageError.authenticationRequired
+        }
+        uploadsSuspended = true
+        accountGeneration += 1
+        let account = UploadAccount(generation: accountGeneration, userId: userId)
+        bulkDeleteAccount = account
+        emptyRemoteRegistration?.cancel()
+        emptyRemoteRegistration = nil
+        isSyncing = false
+        syncStatus = ""
+        pendingUploadCounts.removeAll()
+        pendingUploadChatIds.removeAll()
+        await uploadCoalescer.clear()
+        guard bulkDeleteAccount == account,
+              await getCurrentUserId() == userId else {
+            uploadsSuspended = false
+            bulkDeleteAccount = nil
+            throw CancellationError()
+        }
+    }
+
+    func resumeUploadsAfterBulkDelete(userId: String) async {
+        guard bulkDeleteAccount?.userId == userId,
+              await getCurrentUserId() == userId else { return }
+        uploadsSuspended = false
+        bulkDeleteAccount = nil
+    }
     
     /// Delete a chat from cloud storage
     /// Bulk-delete every chat the user owns from cloud storage. Returns the
     /// number of rows deleted. Callers are responsible for tombstoning local
     /// IDs only after this succeeds, mirroring the webapp's ordering.
     @discardableResult
-    func deleteAllFromCloud() async throws -> Int {
-        guard await cloudStorage.isAuthenticated() else {
+    func deleteAllFromCloud(userId: String) async throws -> Int {
+        guard let account = bulkDeleteAccount,
+              account.userId == userId,
+              account.generation == accountGeneration,
+              await getCurrentUserId() == userId,
+              await cloudStorage.isAuthenticated() else {
             throw CloudStorageError.authenticationRequired
         }
-        return try await cloudStorage.deleteAllChats()
+        let deleted = try await cloudStorage.deleteAllChats()
+        guard bulkDeleteAccount == account,
+              account.generation == accountGeneration,
+              await getCurrentUserId() == userId else {
+            throw CancellationError()
+        }
+        return deleted
     }
 
     func deleteFromCloud(_ chatId: String) async throws {

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -9,6 +9,15 @@ import Foundation
 import Combine
 import ClerkKit
 
+extension Notification.Name {
+    static let cloudChatRemoteDeleteCompleted = Notification.Name("cloudChatRemoteDeleteCompleted")
+}
+
+enum CloudRemoteDeleteNotificationKey {
+    static let chatId = "chatId"
+    static let userId = "userId"
+}
+
 // MARK: - Helper Functions
 
 /// Create properly configured ISO8601DateFormatter that handles JavaScript's toISOString() format
@@ -1896,6 +1905,14 @@ class CloudSyncService: ObservableObject {
         )
         guard pending.generation == accountGeneration else { throw CancellationError() }
         deferredRemoteDeletes.removeValue(forKey: chatId)
+        NotificationCenter.default.post(
+            name: .cloudChatRemoteDeleteCompleted,
+            object: nil,
+            userInfo: [
+                CloudRemoteDeleteNotificationKey.chatId: chatId,
+                CloudRemoteDeleteNotificationKey.userId: pending.userId
+            ]
+        )
         return true
     }
 

--- a/TinfoilChat/Services/RevisionSyncState.swift
+++ b/TinfoilChat/Services/RevisionSyncState.swift
@@ -291,7 +291,7 @@ enum ProjectMetadataUploadPolicy {
     }
 }
 
-enum RevisionApplyResult: Equatable {
+enum RevisionApplyResult: Equatable, Sendable {
     case applied
     case locallyModified
     case refused

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import OpenAI
 import AVFoundation
 
-enum ChatStorageTab: String {
+enum ChatStorageTab: String, Sendable, Hashable {
     case cloud
     case local
 }
@@ -146,19 +146,25 @@ func recoveryScanHasStalled(lastProgressAt: Date?, now: Date) -> Bool {
 @MainActor
 class ChatViewModel: ObservableObject {
     // Published properties for UI updates
-    @Published var chats: [Chat] = []
-    @Published var localChats: [Chat] = []
-    var cloudSidebarSummaries: [ChatListSummary] {
-        chats.map { ChatListSummary(from: $0) }
+    @Published var chats: [Chat] = [] {
+        didSet { chats.forEach { upsertSummary(for: $0) } }
     }
-    var localSidebarSummaries: [ChatListSummary] {
-        localChats.map { ChatListSummary(from: $0) }
+    @Published var localChats: [Chat] = [] {
+        didSet { localChats.forEach { upsertSummary(for: $0) } }
     }
+    @Published private(set) var cloudSidebarSummaries: [ChatListSummary] = []
+    @Published private(set) var localSidebarSummaries: [ChatListSummary] = []
+    @Published private(set) var selectedChatId: String?
+    @Published private(set) var hydratingChatId: String?
+    @Published private(set) var chatHydrationError: String?
     @Published var currentChat: Chat? {
         didSet {
             if currentChat?.id != oldValue?.id {
                 selectedChatImageTask?.cancel()
                 selectedChatImageTask = nil
+            }
+            if hydratingChatId == nil {
+                selectedChatId = currentChat?.id
             }
             let enabled = currentChat?.webSearchEnabled
                 ?? SettingsManager.shared.webSearchAvailable
@@ -283,6 +289,7 @@ class ChatViewModel: ObservableObject {
     private var acceptsChatSaves = true
     private var hasPerformedInitialSync: Bool = false  // Track if initial sync has been done
     private var hasAnonymousChatsToSync: Bool = false  // Track if we have anonymous chats to sync
+    private var isRetryingAnonymousChatReencryption = false
     
     // Pagination properties
     @Published var isLoadingMore: Bool = false
@@ -310,6 +317,7 @@ class ChatViewModel: ObservableObject {
     {
         didSet { persistPaginationStateIfPossible() }
     }
+    private var loadedCloudRootSummaryIds: Set<String> = []
     
     // IMPORTANT: Pagination token edge cases to handle:
     // 1. Token should NOT be reset during auto-sync operations
@@ -418,6 +426,11 @@ class ChatViewModel: ObservableObject {
     private var recoveryScanTimer: Timer?
     private var recoveryScanTask: Task<Void, Never>?
     private var selectedChatImageTask: Task<Void, Never>?
+    private var chatSelectionTask: Task<Void, Never>?
+    private var chatSelectionFence = ChatSelectionFence()
+    private var chatMutationGate = ChatMutationGate()
+    private let chatLoadingService: any ChatLoadingService
+    private var materializationOperationIds: Set<String> = []
     private var recoveryScanGeneration = 0
     private var recoveryScanLastProgressAt: Date?
     private var recoveryScansSuspended = false
@@ -463,6 +476,8 @@ class ChatViewModel: ObservableObject {
                     localChat.isLocalOnly = true
                     localChats = [localChat]
                     currentChat = localChat
+                    selectedChatId = localChat.id
+                    upsertSummary(for: localChat)
                     activeStorageTab = .local
                 }
                 Task { await refreshFavoriteChats() }
@@ -475,6 +490,16 @@ class ChatViewModel: ObservableObject {
     
     var messages: [Message] {
         currentChat?.messages ?? []
+    }
+
+    var isCurrentChatHydrated: Bool {
+        hydratingChatId == nil
+            && selectedChatId != nil
+            && currentChat?.id == selectedChatId
+    }
+
+    var canUseCurrentChatActions: Bool {
+        isCurrentChatHydrated
     }
 
     var isLoading: Bool {
@@ -517,9 +542,9 @@ class ChatViewModel: ObservableObject {
         activeProject != nil
     }
 
-    var activeProjectChats: [Chat] {
+    var activeProjectChats: [ChatListSummary] {
         guard let projectId = activeProject?.id else { return [] }
-        return chats
+        return cloudSidebarSummaries
             .filter { $0.projectId == projectId && !$0.isTemporary && !$0.isBlankChat && !$0.decryptionFailed }
             .sorted { $0.updatedAt > $1.updatedAt }
     }
@@ -810,7 +835,11 @@ class ChatViewModel: ObservableObject {
         }
     }
     
-    init(authManager: AuthManager? = nil) {
+    init(
+        authManager: AuthManager? = nil,
+        chatLoadingService: any ChatLoadingService = FileChatLoadingService()
+    ) {
+        self.chatLoadingService = chatLoadingService
         // Initialize with last selected model from AppConfig (which now persists)
         // The app should ensure AppConfig is initialized before creating ChatViewModel
         guard let model = AppConfig.shared.currentModel ?? AppConfig.shared.availableModels.first else {
@@ -858,6 +887,8 @@ class ChatViewModel: ObservableObject {
         let newChat = Chat.create(modelType: currentModel)
         currentChat = newChat
         chats = [newChat]
+        selectedChatId = newChat.id
+        cloudSidebarSummaries = [ChatListSummary(from: newChat)]
         isWebSearchEnabled = newChat.webSearchEnabled
         
         // Load any previously persisted pagination state (per-user)
@@ -904,6 +935,7 @@ class ChatViewModel: ObservableObject {
         recoveryScanTimer = nil
         recoveryScanTask?.cancel()
         selectedChatImageTask?.cancel()
+        chatSelectionTask?.cancel()
 
         // Stop stream update timers
         streamUpdateTimers.values.forEach { $0.invalidate() }
@@ -1045,11 +1077,17 @@ class ChatViewModel: ObservableObject {
                    (currentChat.hasActiveStream || self.streamingTracker.isStreaming(currentChat.id)) {
                     return
                 }
+
+                guard let syncContext = await self.retryPendingAnonymousChatReencryptionForCurrentAccount()
+                else {
+                    return
+                }
                 
                 
                 // Perform sync in background
                 // Use smart sync for periodic sync (checks if sync is needed first)
                 let syncResult = await self.cloudSync.smartSync()
+                guard self.isCurrentSignIn(syncContext.token, userId: syncContext.userId) else { return }
 
                 // Update last sync date after successful sync
                 self.lastSyncDate = Date()
@@ -1136,8 +1174,14 @@ class ChatViewModel: ObservableObject {
                     return
                 }
 
+                guard let syncContext = await self.retryPendingAnonymousChatReencryptionForCurrentAccount()
+                else {
+                    return
+                }
+
                 // Perform immediate sync when returning from background
                 let syncResult = await self.cloudSync.syncAllChats()
+                guard self.isCurrentSignIn(syncContext.token, userId: syncContext.userId) else { return }
                 // Update last sync date
                 self.lastSyncDate = Date()
 
@@ -1535,7 +1579,7 @@ class ChatViewModel: ObservableObject {
 
     func enterProject(projectId: String) async {
         let accountGeneration = projectListAccountGeneration
-        guard await loadProject(projectId: projectId) else { return }
+        guard await loadActiveProject(projectId: projectId) else { return }
         guard isCurrentProjectAccount(accountGeneration) else { return }
         createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
     }
@@ -1545,11 +1589,12 @@ class ChatViewModel: ObservableObject {
     /// the shared project context nor report success.
     private var projectLoadGeneration = 0
 
-    /// Loads a project and makes it the active context. A search result is
-    /// published with that context only after all project resources load.
+    /// Loads a project and makes it the active context only after all project
+    /// resources load.
     @discardableResult
-    func loadProject(projectId: String, searchResultChat: Chat? = nil) async -> Bool {
-        guard hasChatAccess, isProjectAccountActive else { return false }
+    func loadActiveProject(projectId: String) async -> Bool {
+        guard hasChatAccess, isProjectAccountActive, !Task.isCancelled else { return false }
+        let accountGeneration = projectListAccountGeneration
 
         projectLoadGeneration += 1
         let generation = projectLoadGeneration
@@ -1557,49 +1602,70 @@ class ChatViewModel: ObservableObject {
         isLoadingProject = true
         projectError = nil
         var loaded = false
+        defer {
+            if generation == projectLoadGeneration {
+                isLoadingProject = false
+            }
+        }
         do {
             let project = try await projectStorage.getProject(projectId)
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
             guard let project else {
                 throw CloudStorageError.downloadFailed
             }
 
             let documents = try await projectStorage.listDocuments(projectId: projectId, includeContent: true)
-            guard generation == projectLoadGeneration else { return false }
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
             let syncResult = await cloudSync.smartSync(projectId: projectId)
-            let existingProjectChats = chats.filter {
-                $0.projectId == projectId
-                    && !$0.isTemporary
-                    && !$0.isBlankChat
-                    && !$0.decryptionFailed
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
+            if syncResult.downloaded > 0 || syncResult.uploaded > 0,
+               let userId = currentUserId {
+                let index = try await chatLoadingService.loadIndex(userId: userId, storage: .cloud)
+                guard !Task.isCancelled,
+                      generation == projectLoadGeneration,
+                      isCurrentProjectAccount(accountGeneration),
+                      currentUserId == userId else { return false }
+                let result = ChatSummaryState.cloudIndexSummaries(
+                    from: index,
+                    loadedRootIds: loadedCloudRootSummaryIds,
+                    firstPageLimit: Constants.Pagination.chatsPerPage
+                )
+                guard !Task.isCancelled,
+                      generation == projectLoadGeneration,
+                      isCurrentProjectAccount(accountGeneration) else { return false }
+                loadedCloudRootSummaryIds.formUnion(result.firstPageIds)
+                guard !Task.isCancelled,
+                      generation == projectLoadGeneration,
+                      isCurrentProjectAccount(accountGeneration) else { return false }
+                reconcileSummaries(result.summaries, storage: .cloud)
             }
-            let loadedProjectChats: [Chat]
-            if syncResult.downloaded > 0 || syncResult.uploaded > 0 || existingProjectChats.isEmpty {
-                loadedProjectChats = await loadProjectChatsFromStorage(projectId: projectId)
-            } else {
-                loadedProjectChats = existingProjectChats
-            }
-            guard generation == projectLoadGeneration else { return false }
-            if let searchResultChat,
-               pendingSearchResultChatId != searchResultChat.id {
-                isLoadingProject = false
-                return false
-            }
-
-            mergeProjectChats(loadedProjectChats)
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
             projectDocuments = documents
-            if let searchResultChat {
-                selectChat(searchResultChat)
-                isViewingProjectChat = true
-            } else {
-                isViewingProjectChat = false
-            }
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
+            isViewingProjectChat = false
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
             activeProject = project
             loaded = true
+        } catch is CancellationError {
+            return false
         } catch {
-            guard generation == projectLoadGeneration else { return false }
+            guard !Task.isCancelled,
+                  generation == projectLoadGeneration,
+                  isCurrentProjectAccount(accountGeneration) else { return false }
             projectError = error.localizedDescription
         }
-        isLoadingProject = false
         return loaded
     }
 
@@ -1618,9 +1684,50 @@ class ChatViewModel: ObservableObject {
         createNewChat(isLocalOnly: false, projectId: projectId, focusInput: false)
     }
 
-    func openProjectChat(_ chat: Chat) {
-        selectChat(chat)
+    func openProjectChat(_ chat: ChatListSummary) {
+        _ = selectChat(id: chat.id, isLocalOnly: false)
         isViewingProjectChat = true
+    }
+
+    func openSummaryChat(id: String, projectId: String?, isLocalOnly: Bool) {
+        guard let projectId, activeProject?.id != projectId else {
+            if projectId == nil {
+                beginSelection(id: id)
+            }
+            if projectId == nil, activeProject != nil {
+                activeProject = nil
+                projectDocuments = []
+                projectError = nil
+                isViewingProjectChat = false
+            }
+            _ = selectChat(id: id, isLocalOnly: isLocalOnly)
+            if projectId != nil { isViewingProjectChat = true }
+            return
+        }
+
+        beginSelection(id: id)
+        let selectionGeneration = chatSelectionFence.generation
+        pendingSearchResultChatId = id
+        chatSelectionTask = Task {
+            let loaded = await loadActiveProject(projectId: projectId)
+            guard !Task.isCancelled, loaded else {
+                failSelection(id: id, generation: selectionGeneration)
+                return
+            }
+            guard !Task.isCancelled,
+                  pendingSearchResultChatId == id,
+                  activeProject?.id == projectId
+            else {
+                failSelection(id: id, generation: selectionGeneration)
+                return
+            }
+            chatSelectionTask = nil
+            guard selectChat(id: id, isLocalOnly: isLocalOnly), !Task.isCancelled else {
+                failSelection(id: id, generation: selectionGeneration)
+                return
+            }
+            isViewingProjectChat = true
+        }
     }
 
     func startNewProjectChat() {
@@ -1640,35 +1747,44 @@ class ChatViewModel: ObservableObject {
     /// chats leave any active project first.
     func openSearchResult(_ chat: Chat) {
         if let projectId = chat.projectId {
+            beginSelection(id: chat.id)
+            let selectionGeneration = chatSelectionFence.generation
             pendingSearchResultChatId = chat.id
-            Task {
+            chatSelectionTask = Task {
                 if activeProject?.id != projectId {
-                    // loadProject (not enterProject) so no blank chat is
+                    // loadActiveProject (not enterProject) so no blank chat is
                     // selected along the way, which would clear the pending
                     // token below before it could be checked.
-                    await loadProject(projectId: projectId, searchResultChat: chat)
-                    return
-                }
-                // A newer selection during the load supersedes this one:
-                // leave it in charge, and drop the just-loaded project
-                // context if that selection lives outside it so the
-                // project page doesn't cover the chosen chat.
-                guard pendingSearchResultChatId == chat.id else {
-                    if activeProject?.id == projectId, currentChat?.projectId != projectId {
-                        activeProject = nil
-                        projectDocuments = []
-                        projectError = nil
-                        isViewingProjectChat = false
+                    let loaded = await loadActiveProject(projectId: projectId)
+                    guard !Task.isCancelled, loaded else {
+                        failSelection(id: chat.id, generation: selectionGeneration)
+                        return
                     }
+                }
+                // A newer selection during the load supersedes this one
+                // and remains in charge.
+                guard !Task.isCancelled,
+                      pendingSearchResultChatId == chat.id else {
+                    failSelection(id: chat.id, generation: selectionGeneration)
                     return
                 }
                 // The load can also fail (e.g. a deleted project), leaving
                 // some other context in place; never open the chat under
                 // the wrong project or none at all.
-                guard activeProject?.id == projectId else { return }
-                openProjectChat(chat)
+                guard !Task.isCancelled, activeProject?.id == projectId else {
+                    failSelection(id: chat.id, generation: selectionGeneration)
+                    return
+                }
+                chatSelectionTask = nil
+                selectChat(chat)
+                guard !Task.isCancelled else {
+                    failSelection(id: chat.id, generation: selectionGeneration)
+                    return
+                }
+                isViewingProjectChat = true
             }
         } else {
+            beginSelection(id: chat.id)
             pendingSearchResultChatId = nil
             if activeProject != nil {
                 activeProject = nil
@@ -1797,11 +1913,21 @@ class ChatViewModel: ObservableObject {
     }
 
     private func updateChatProject(chatId: String, projectId: String?) async {
-        guard hasChatAccess, isProjectAccountActive else { return }
+        guard hasChatAccess, isProjectAccountActive, let userId = currentUserId else { return }
         let accountGeneration = projectListAccountGeneration
+        guard chatMutationGate.begin(chatId: chatId) else { return }
+        defer { chatMutationGate.end(chatId: chatId) }
 
         let wasCurrent = currentChat?.id == chatId
-        guard var chat = chatForProjectMove(chatId) else { return }
+        guard var chat = await materializeChatForOperation(id: chatId),
+              currentUserId == userId else { return }
+        var didCommitStorageTransition = false
+        defer {
+            materializationOperationIds.remove(chatId)
+            if didCommitStorageTransition {
+                evictInactiveMaterializedChats()
+            }
+        }
         let wasLocal = chat.isLocalOnly
         let hasPendingLocalRecovery = wasLocal && (
             recoveryAttempts[chatId] != nil || chat.pendingRecoveries?.isEmpty == false
@@ -1818,16 +1944,34 @@ class ChatViewModel: ObservableObject {
         chat.locallyModified = true
         chat.updatedAt = Date()
 
+        do {
+            try await ChatProjectStorageTransition.persist(
+                chat,
+                wasLocal: wasLocal,
+                userId: userId,
+                loadingService: chatLoadingService,
+                validateAccount: { [weak self] in
+                    guard self?.currentUserId == userId,
+                          self?.isCurrentProjectAccount(accountGeneration) == true
+                    else { throw CancellationError() }
+                }
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            guard currentUserId == userId,
+                  isCurrentProjectAccount(accountGeneration) else { return }
+            syncErrors.append(error.localizedDescription)
+            return
+        }
+        guard currentUserId == userId,
+              isCurrentProjectAccount(accountGeneration) else { return }
+
+        removeSummary(id: chatId, isLocalOnly: wasLocal)
         if wasLocal {
             localChats.removeAll { $0.id == chatId }
-            chats.insert(chat, at: min(1, chats.count))
-            if let userId = currentUserId {
-                try? await EncryptedFileStorage.local.deleteChat(chatId: chatId, userId: userId)
-                guard isCurrentProjectAccount(accountGeneration) else { return }
-            }
-        } else {
-            replaceChat(chat)
         }
+        replaceChat(chat)
 
         if wasCurrent {
             currentChat = chat
@@ -1835,8 +1979,7 @@ class ChatViewModel: ObservableObject {
         if let favoriteIndex = favoriteChats.firstIndex(where: { $0.id == chatId }) {
             favoriteChats[favoriteIndex] = chat
         }
-
-        saveChat(chat)
+        didCommitStorageTransition = true
 
         // The upload itself carries the project membership (the enclave
         // stamps the row's project_id from the chat push metadata), so
@@ -1844,14 +1987,19 @@ class ChatViewModel: ObservableObject {
         // can't land right now the chat stays locallyModified and the
         // next sync retries it, like any other offline edit.
         await cloudSync.backupChat(chatId, ensureLatestUpload: true)
-        guard isCurrentProjectAccount(accountGeneration) else { return }
-        if let projectId {
-            await loadProjectChatsIntoMemory(
-                projectId: projectId,
-                accountGeneration: accountGeneration
-            )
+        guard currentUserId == userId,
+              isCurrentProjectAccount(accountGeneration) else { return }
+        do {
+            _ = try await refreshCloudSummaryIndex(userId: userId)
+            guard currentUserId == userId,
+                  isCurrentProjectAccount(accountGeneration) else { return }
+        } catch is CancellationError {
+        } catch {
             guard isCurrentProjectAccount(accountGeneration) else { return }
+            syncErrors.append(error.localizedDescription)
         }
+        guard currentUserId == userId,
+              isCurrentProjectAccount(accountGeneration) else { return }
 
         if wasCurrent, activeProject?.id != projectId {
             createNewChat(isLocalOnly: false, projectId: activeProject?.id)
@@ -1896,45 +2044,38 @@ class ChatViewModel: ObservableObject {
         shouldFocusInput = true
     }
 
-    private func chatForProjectMove(_ chatId: String) -> Chat? {
+    private func materializeChatForOperation(id chatId: String) async -> Chat? {
+        materializationOperationIds.insert(chatId)
         if let location = findChatLocation(chatId) {
             return chat(at: location)
         }
-        return nil
-    }
-
-    private func loadProjectChatsIntoMemory(
-        projectId: String,
-        accountGeneration: Int
-    ) async {
-        let projectChats = await loadProjectChatsFromStorage(projectId: projectId)
-        guard isCurrentProjectAccount(accountGeneration) else { return }
-        mergeProjectChats(projectChats)
-    }
-
-    private func mergeProjectChats(_ projectChats: [Chat]) {
-        for projectChat in projectChats {
-            if let index = chats.firstIndex(where: { $0.id == projectChat.id }) {
-                chats[index] = projectChat
-            } else {
-                chats.append(projectChat)
-            }
+        guard let userId = currentUserId else {
+            materializationOperationIds.remove(chatId)
+            return nil
         }
-        chats.sort { $0.updatedAt > $1.updatedAt }
-    }
-
-    private func loadProjectChatsFromStorage(projectId: String) async -> [Chat] {
-        guard let userId = currentUserId else { return [] }
-        let index = await Chat.loadChatIndex(userId: userId)
-        let ids = index
-            .filter {
-                $0.projectId == projectId &&
-                ($0.messageCount > 0 || $0.decryptionFailed || $0.titleState != .placeholder)
+        let isLocal = localSidebarSummaries.contains { $0.id == chatId }
+        let existsInCloud = cloudSidebarSummaries.contains { $0.id == chatId }
+        guard isLocal || existsInCloud else {
+            materializationOperationIds.remove(chatId)
+            return nil
+        }
+        do {
+            let chat = try await chatLoadingService.loadChat(
+                id: chatId,
+                userId: userId,
+                storage: isLocal ? .local : .cloud
+            )
+            guard currentUserId == userId else {
+                materializationOperationIds.remove(chatId)
+                return nil
             }
-            .sorted { $0.updatedAt > $1.updatedAt }
-            .map(\.id)
-        return await Chat.loadChats(chatIds: ids, userId: userId)
-            .sorted { $0.updatedAt > $1.updatedAt }
+            return chat
+        } catch {
+            materializationOperationIds.remove(chatId)
+            guard currentUserId == userId else { return nil }
+            syncErrors.append(error.localizedDescription)
+            return nil
+        }
     }
 
     /// Toggles temporary (incognito) chat mode. When enabled, the current chat
@@ -1962,8 +2103,12 @@ class ChatViewModel: ObservableObject {
 
             if let previousId,
                let restored = chats.first(where: { $0.id == previousId })
-                                ?? localChats.first(where: { $0.id == previousId }) {
+                                 ?? localChats.first(where: { $0.id == previousId }) {
                 selectChat(restored)
+            } else if let previousId,
+                      let summary = (cloudSidebarSummaries + localSidebarSummaries)
+                        .first(where: { $0.id == previousId }) {
+                _ = selectChat(id: summary.id, isLocalOnly: summary.isLocalOnly)
             } else {
                 createNewChat()
             }
@@ -2003,13 +2148,99 @@ class ChatViewModel: ObservableObject {
     func selectChat(id: String, isLocalOnly: Bool) -> Bool {
         let preferredSource = isLocalOnly ? localChats : chats
         let fallbackSource = isLocalOnly ? chats : localChats
-        guard let chat = preferredSource.first(where: { $0.id == id })
-            ?? fallbackSource.first(where: { $0.id == id }) else { return false }
-        selectChat(chat)
+        if let chat = preferredSource.first(where: { $0.id == id })
+            ?? fallbackSource.first(where: { $0.id == id }) {
+            selectChat(chat)
+            return true
+        }
+        let preferredSummaries = isLocalOnly ? localSidebarSummaries : cloudSidebarSummaries
+        let fallbackSummaries = isLocalOnly ? cloudSidebarSummaries : localSidebarSummaries
+        let storage: ChatStorageTab
+        if preferredSummaries.contains(where: { $0.id == id }) {
+            storage = isLocalOnly ? .local : .cloud
+        } else if fallbackSummaries.contains(where: { $0.id == id }) {
+            storage = isLocalOnly ? .cloud : .local
+        } else {
+            return false
+        }
+        guard let userId = currentUserId else {
+            return false
+        }
+
+        beginSelection(id: id)
+        let generation = chatSelectionFence.generation
+        let loadingService = chatLoadingService
+        chatSelectionTask = Task { [weak self, loadingService] in
+            do {
+                let chat = try await loadingService.loadChat(
+                    id: id,
+                    userId: userId,
+                    storage: storage
+                )
+                guard let self,
+                      !Task.isCancelled,
+                      self.chatSelectionFence.accepts(id: id, generation: generation),
+                      self.currentUserId == userId
+                else {
+                    return
+                }
+                self.installSelectedChat(chat, generation: generation)
+            } catch is CancellationError {
+            } catch {
+                guard let self,
+                      self.chatSelectionFence.accepts(id: id, generation: generation),
+                      self.currentUserId == userId
+                else {
+                    return
+                }
+                self.failSelection(id: id, generation: generation)
+                self.syncErrors.append(error.localizedDescription)
+            }
+        }
         return true
     }
 
     func selectChat(_ chat: Chat) {
+        projectLoadGeneration += 1
+        let generation = chatSelectionFence.begin(id: chat.id)
+        chatSelectionTask?.cancel()
+        chatSelectionTask = nil
+        selectedChatId = chat.id
+        hydratingChatId = nil
+        chatHydrationError = nil
+        installSelectedChat(chat, generation: generation)
+    }
+
+    private func beginSelection(id: String) {
+        projectLoadGeneration += 1
+        _ = chatSelectionFence.begin(id: id)
+        chatSelectionTask?.cancel()
+        selectedChatImageTask?.cancel()
+        pendingSearchResultChatId = nil
+        selectedChatId = id
+        hydratingChatId = id
+        chatHydrationError = nil
+        currentChat = nil
+        evictInactiveMaterializedChats()
+    }
+
+    private func failSelection(id: String, generation: Int) {
+        guard chatSelectionFence.accepts(id: id, generation: generation) else { return }
+        chatSelectionFence.invalidate()
+        chatSelectionTask?.cancel()
+        chatSelectionTask = nil
+        selectedChatImageTask?.cancel()
+        selectedChatImageTask = nil
+        hydratingChatId = nil
+        selectedChatId = nil
+        currentChat = nil
+        pendingSearchResultChatId = nil
+        chatHydrationError = "Couldn't load conversation"
+    }
+
+    private func installSelectedChat(_ chat: Chat, generation: Int) {
+        guard chatSelectionFence.accepts(id: chat.id, generation: generation),
+              selectedChatId == chat.id else { return }
         selectedChatImageTask?.cancel()
         // Any explicit selection supersedes a search hit whose project
         // is still loading.
@@ -2050,6 +2281,10 @@ class ChatViewModel: ObservableObject {
         }
 
         currentChat = chatToSelect
+        hydratingChatId = nil
+        chatHydrationError = nil
+        upsertSummary(for: chatToSelect)
+        evictInactiveMaterializedChats()
 
         // Update the current model to match the chat's model
         if currentModel != chatToSelect.modelType {
@@ -2137,19 +2372,31 @@ class ChatViewModel: ObservableObject {
         guard hasChatAccess else { return }
 
         let isLocal: Bool
-        if localChats.contains(where: { $0.id == id }) {
+        if localSidebarSummaries.contains(where: { $0.id == id }) {
             isLocal = true
-        } else if chats.contains(where: { $0.id == id }) {
+        } else if cloudSidebarSummaries.contains(where: { $0.id == id }) {
             isLocal = false
         } else {
             return
         }
 
-        let userId = currentUserId
+        guard let userId = currentUserId else { return }
+        guard chatMutationGate.begin(chatId: id) else { return }
         let storageGeneration = favoriteStorageGeneration
         let deletionToken = UUID()
         favoriteDeletionTokens[id] = deletionToken
         let exactHydrationTask = cancelExactFavoriteHydration(chatId: id)
+        let deletionOwnedSelection = selectedChatId == id
+        if deletionOwnedSelection {
+            chatSelectionFence.invalidate()
+            chatSelectionTask?.cancel()
+            chatSelectionTask = nil
+            selectedChatImageTask?.cancel()
+            selectedChatImageTask = nil
+            hydratingChatId = nil
+            chatHydrationError = nil
+        }
+        let deletionGeneration = chatSelectionFence.generation
         discardMessageQueue(chatId: id)
         let canceledStreamTask = cancelGeneration(
             chatId: id,
@@ -2158,6 +2405,7 @@ class ChatViewModel: ObservableObject {
 
         // Delete from file storage and cloud
         Task {
+            defer { chatMutationGate.end(chatId: id) }
             defer {
                 if ChatFavorites.operationIsCurrent(
                     deletionToken,
@@ -2171,13 +2419,31 @@ class ChatViewModel: ObservableObject {
                   currentUserId == userId,
                   hasChatAccess else { return }
             await canceledStreamTask?.value
+            guard storageGeneration == favoriteStorageGeneration,
+                  currentUserId == userId,
+                  hasChatAccess else { return }
             await drainPendingSaves()
+            guard storageGeneration == favoriteStorageGeneration,
+                  currentUserId == userId,
+                  hasChatAccess else { return }
 
             if !isLocal && SettingsManager.shared.isCloudSyncEnabled {
                 do {
                     try await cloudSync.deleteFromCloud(id)
+                    guard storageGeneration == favoriteStorageGeneration,
+                          currentUserId == userId,
+                          hasChatAccess else { return }
                 } catch {
-                    syncErrors.append("Failed to delete chat: \(error.localizedDescription)")
+                    guard storageGeneration == favoriteStorageGeneration,
+                          currentUserId == userId,
+                          hasChatAccess else { return }
+                    restoreSelectionAfterDeleteFailure(
+                        id: id,
+                        isLocalOnly: isLocal,
+                        deletionOwnedSelection: deletionOwnedSelection,
+                        deletionGeneration: deletionGeneration,
+                        error: error
+                    )
                     return
                 }
             } else if !isLocal {
@@ -2188,31 +2454,93 @@ class ChatViewModel: ObservableObject {
             guard storageGeneration == favoriteStorageGeneration,
                   currentUserId == userId,
                   hasChatAccess else { return }
-            await Chat.deleteChatFromStorage(chatId: id, userId: userId)
-            guard storageGeneration == favoriteStorageGeneration,
-                  currentUserId == userId,
-                  hasChatAccess else { return }
+            do {
+                try await chatLoadingService.deleteChat(
+                    id: id,
+                    userId: userId,
+                    storage: isLocal ? .local : .cloud
+                )
+                guard storageGeneration == favoriteStorageGeneration,
+                      currentUserId == userId,
+                      hasChatAccess else { return }
+            } catch {
+                guard storageGeneration == favoriteStorageGeneration,
+                      currentUserId == userId,
+                      hasChatAccess else { return }
+                restoreSelectionAfterDeleteFailure(
+                    id: id,
+                    isLocalOnly: isLocal,
+                    deletionOwnedSelection: deletionOwnedSelection,
+                    deletionGeneration: deletionGeneration,
+                    error: error
+                )
+                return
+            }
             ChatRecoveryDraftStore.shared.discard(chatId: id)
             favoriteLoadGeneration += 1
             ProfileManager.shared.unpinChat(id)
             favoriteChats.removeAll { $0.id == id }
             Task { await refreshFavoriteChats() }
 
+            let selectionResolution = ChatDeleteSelectionResolution.resolve(
+                deletionOwnedSelection: deletionOwnedSelection,
+                deletionSucceeded: true,
+                deletionGeneration: deletionGeneration,
+                currentGeneration: chatSelectionFence.generation,
+                deletedId: id,
+                currentSelectedId: selectedChatId
+            )
+            if selectionResolution == .clearAndReplace {
+                selectedChatId = nil
+                hydratingChatId = nil
+                currentChat = nil
+            }
+
             if let index = localChats.firstIndex(where: { $0.id == id }) {
                 localChats.remove(at: index)
             } else if let index = chats.firstIndex(where: { $0.id == id }) {
                 chats.remove(at: index)
             }
+            removeSummary(id: id, isLocalOnly: isLocal)
 
-            // If the deleted chat was the current chat, select another one
-            if currentChat?.id == id {
-                let activeList = isLocal ? localChats : chats
-                if let first = activeList.first {
-                    currentChat = first
+            // If the deleted chat was selected, select another one
+            if selectionResolution == .clearAndReplace {
+                let activeSummaries = isLocal ? localSidebarSummaries : cloudSidebarSummaries
+                if let first = activeSummaries.first(where: { !$0.isBlankChat }) {
+                    _ = selectChat(id: first.id, isLocalOnly: isLocal)
+                } else if let blank = activeSummaries.first(where: \.isBlankChat) {
+                    _ = selectChat(id: blank.id, isLocalOnly: isLocal)
                 } else {
                     createNewChat(isLocalOnly: isLocal)
                 }
             }
+        }
+    }
+
+    private func restoreSelectionAfterDeleteFailure(
+        id: String,
+        isLocalOnly: Bool,
+        deletionOwnedSelection: Bool,
+        deletionGeneration: Int,
+        error: Error
+    ) {
+        syncErrors.append("Failed to delete chat: \(error.localizedDescription)")
+        guard ChatDeleteSelectionResolution.resolve(
+            deletionOwnedSelection: deletionOwnedSelection,
+            deletionSucceeded: false,
+            deletionGeneration: deletionGeneration,
+            currentGeneration: chatSelectionFence.generation,
+            deletedId: id,
+            currentSelectedId: selectedChatId
+        ) == .restore else { return }
+
+        let summaries = isLocalOnly ? localSidebarSummaries : cloudSidebarSummaries
+        if summaries.contains(where: { $0.id == id }),
+           selectChat(id: id, isLocalOnly: isLocalOnly) {
+            return
+        }
+        if let currentChat, currentChat.id == id {
+            selectChat(currentChat)
         }
     }
     
@@ -2225,6 +2553,66 @@ class ChatViewModel: ObservableObject {
             return (isLocal: false, index: index)
         }
         return nil
+    }
+
+    private func upsertSummary(for chat: Chat) {
+        let summary = ChatListSummary(from: chat)
+        if chat.isLocalOnly {
+            localSidebarSummaries = ChatSummaryState.upserting(summary, into: localSidebarSummaries)
+            cloudSidebarSummaries = ChatSummaryState.removing(id: chat.id, from: cloudSidebarSummaries)
+        } else {
+            cloudSidebarSummaries = ChatSummaryState.upserting(summary, into: cloudSidebarSummaries)
+            localSidebarSummaries = ChatSummaryState.removing(id: chat.id, from: localSidebarSummaries)
+        }
+    }
+
+    private func removeSummary(id: String, isLocalOnly: Bool) {
+        if isLocalOnly {
+            localSidebarSummaries = ChatSummaryState.removing(id: id, from: localSidebarSummaries)
+        } else {
+            cloudSidebarSummaries = ChatSummaryState.removing(id: id, from: cloudSidebarSummaries)
+        }
+    }
+
+    private func reconcileSummaries(
+        _ indexed: [ChatListSummary],
+        storage: ChatStorageTab
+    ) {
+        switch storage {
+        case .cloud:
+            let transient = chats.map(ChatListSummary.init(from:))
+            cloudSidebarSummaries = ChatSummaryState.reconcilingIndex(indexed, withTransient: transient)
+        case .local:
+            let transient = localChats.map(ChatListSummary.init(from:))
+            localSidebarSummaries = ChatSummaryState.reconcilingIndex(indexed, withTransient: transient)
+        }
+    }
+
+    private func activeRecoveryChatIds() -> Set<String> {
+        Set(recoveryAttempts.keys).union(
+            (chats + localChats).compactMap { chat in
+                chat.pendingRecoveries?.isEmpty == false ? chat.id : nil
+            }
+        )
+    }
+
+    private func evictInactiveMaterializedChats() {
+        let streamingIds = streamState.activeChatIds
+        let recoveryIds = activeRecoveryChatIds()
+        chats = MaterializedChatWorkingSet.retained(
+            chats,
+            selectedId: selectedChatId,
+            streamingIds: streamingIds,
+            recoveryIds: recoveryIds,
+            operationIds: materializationOperationIds
+        )
+        localChats = MaterializedChatWorkingSet.retained(
+            localChats,
+            selectedId: selectedChatId,
+            streamingIds: streamingIds,
+            recoveryIds: recoveryIds,
+            operationIds: materializationOperationIds
+        )
     }
 
     /// Returns the chat for a given location tuple.
@@ -2272,29 +2660,56 @@ class ChatViewModel: ObservableObject {
                 chats.insert(updatedChat, at: min(1, chats.count))
             }
         }
+        upsertSummary(for: updatedChat)
     }
 
     /// Updates a chat's title
-    func updateChatTitle(_ id: String, newTitle: String) {
+    func updateChatTitle(_ id: String, newTitle: String) async {
         // Allow updating chat titles for all authenticated users
-        guard hasChatAccess else { return }
+        guard hasChatAccess, let userId = currentUserId else { return }
+        guard chatMutationGate.begin(chatId: id) else { return }
+        defer { chatMutationGate.end(chatId: id) }
 
-        if let updated = updateChatInPlace(id, update: { chat in
-            let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty {
-                chat.title = Chat.placeholderTitle
-                chat.titleState = .placeholder
-            } else {
-                chat.title = trimmed
-                chat.titleState = .manual
+        guard var chat = await materializeChatForOperation(id: id),
+              currentUserId == userId else { return }
+        var didCommitTitle = false
+        defer {
+            materializationOperationIds.remove(id)
+            if didCommitTitle {
+                evictInactiveMaterializedChats()
             }
-            chat.locallyModified = true
-            chat.updatedAt = Date()
-        }) {
-            if let favoriteIndex = favoriteChats.firstIndex(where: { $0.id == id }) {
-                favoriteChats[favoriteIndex] = updated
-            }
-            saveChat(updated)
+        }
+
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            chat.title = Chat.placeholderTitle
+            chat.titleState = .placeholder
+        } else {
+            chat.title = trimmed
+            chat.titleState = .manual
+        }
+        chat.locallyModified = true
+        chat.updatedAt = Date()
+
+        do {
+            try await chatLoadingService.saveChat(
+                chat,
+                userId: userId,
+                storage: chat.isLocalOnly ? .local : .cloud
+            )
+        } catch {
+            guard currentUserId == userId else { return }
+            syncErrors.append(error.localizedDescription)
+            return
+        }
+        guard currentUserId == userId else { return }
+
+        replaceChat(chat)
+        if currentChat?.id == id { currentChat = chat }
+        didCommitTitle = true
+        if !chat.isLocalOnly && SettingsManager.shared.isCloudSyncEnabled {
+            await cloudSync.backupChat(id, ensureLatestUpload: true)
+            guard currentUserId == userId else { return }
         }
     }
 
@@ -2359,6 +2774,7 @@ class ChatViewModel: ObservableObject {
     /// can keep the draft in the input when it wasn't.
     @discardableResult
     func sendMessage(text: String) -> Bool {
+        guard canUseCurrentChatActions else { return false }
         let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasAttachments = !pendingAttachments.isEmpty
         guard hasText || hasAttachments else { return false }
@@ -4345,14 +4761,12 @@ class ChatViewModel: ObservableObject {
         let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
         guard currentUserId == userId, decryptedCount > 0 else { return }
 
-        let result = await loadFirstPageOfChats(userId: userId, filter: \.isCloudDisplayable)
-        guard currentUserId == userId else { return }
-        chats = result.chats
-        if let currentId = currentChat?.id,
-           let refreshed = result.chats.first(where: { $0.id == currentId }) {
-            currentChat = refreshed
+        do {
+            _ = try await refreshCloudSummaryIndex(userId: userId)
+        } catch is CancellationError {
+        } catch {
+            syncErrors.append(error.localizedDescription)
         }
-        normalizeChatsArray()
     }
 
     private func endStreamingAndBackup(chatId: String) {
@@ -4374,7 +4788,12 @@ class ChatViewModel: ObservableObject {
                 await self.cloudSync.backupChat(latestChat.id)
             }
 
-            if let syncedChat = await Chat.loadChat(chatId: latestChat.id, userId: self.currentUserId) {
+            if let userId = self.currentUserId,
+               let syncedChat = try? await self.chatLoadingService.loadChat(
+                   id: latestChat.id,
+                   userId: userId,
+                   storage: isLocal ? .local : .cloud
+               ) {
                 if isLocal {
                     if let idx = self.localChats.firstIndex(where: { $0.id == latestChat.id }) {
                         self.localChats[idx] = syncedChat
@@ -4434,9 +4853,11 @@ class ChatViewModel: ObservableObject {
                 webSearchEnabled: webSearchEnabled
             )
             result.insert(blankChat, at: 0)
+            upsertSummary(for: blankChat)
 
             if wasCurrentChatBlank {
                 currentChat = blankChat
+                selectedChatId = blankChat.id
             }
         }
 
@@ -4759,19 +5180,13 @@ class ChatViewModel: ObservableObject {
         // If user upgraded to premium, load saved chats if any
         if isAuthenticated && hasActiveSubscription && chats.count <= 1 {
             Task {
-                let result = await loadFirstPageOfChats(userId: currentUserId, filter: \.isCloudDisplayable)
-                guard !result.chats.isEmpty else { return }
-                let previouslySelectedId = self.currentChat?.id
-                self.chats = result.chats
-
-                // Preserve existing selection when possible so we don't jump to a blank chat
-                if let chatId = previouslySelectedId,
-                   let location = self.findChatLocation(chatId) {
-                            self.currentChat = self.chat(at: location)
-                        } else if self.currentChat == nil {
-                            self.currentChat = self.chats.first
+                guard let userId = currentUserId else { return }
+                do {
+                    _ = try await refreshCloudSummaryIndex(userId: userId)
+                } catch is CancellationError {
+                } catch {
+                    syncErrors.append(error.localizedDescription)
                 }
-
                 self.ensureBlankChatAtTop()
                 self.scanPendingRecoveries()
             }
@@ -4784,6 +5199,11 @@ class ChatViewModel: ObservableObject {
         // the auth manager's cleanup) clear the authenticated state, after
         // which currentUserId no longer resolves this user.
         let signingOutUserId = currentUserId
+        chatSelectionFence.invalidate()
+        chatSelectionTask?.cancel()
+        chatSelectionTask = nil
+        hydratingChatId = nil
+        chatHydrationError = nil
 
         clearHydratedFavorites()
         isAccountTeardownInProgress = true
@@ -4839,6 +5259,7 @@ class ChatViewModel: ObservableObject {
         isPaginationActive = false
         hasLoadedInitialPage = false
         hasAttemptedLoadMore = false
+        loadedCloudRootSummaryIds = []
 
         // Reset passkey state
         await passkeyManager.reset()
@@ -4848,10 +5269,14 @@ class ChatViewModel: ObservableObject {
         // full sign-out cleanup, so no content persists across accounts.
         chats = []
         localChats = []
+        cloudSidebarSummaries = []
+        localSidebarSummaries = []
         activeStorageTab = .cloud
         let newChat = Chat.create(modelType: currentModel)
         currentChat = newChat
+        selectedChatId = newChat.id
         chats = [newChat]
+        cloudSidebarSummaries = [ChatListSummary(from: newChat)]
 
     }
     
@@ -4877,7 +5302,12 @@ class ChatViewModel: ObservableObject {
         ChatRecoveryDraftStore.shared.clearAll()
         chats.removeAll()
         localChats.removeAll()
+        cloudSidebarSummaries.removeAll()
+        localSidebarSummaries.removeAll()
         currentChat = nil
+        selectedChatId = nil
+        hydratingChatId = nil
+        chatHydrationError = nil
 
         // Clear from file storage (both local and cloud stores),
         // fencing in-flight sync before the deletion.
@@ -4896,6 +5326,7 @@ class ChatViewModel: ObservableObject {
         isPaginationActive = false
         hasLoadedInitialPage = false
         hasAttemptedLoadMore = false
+        loadedCloudRootSummaryIds = []
         
         // Clear encryption key reference
         encryptionKey = nil
@@ -4957,6 +5388,110 @@ class ChatViewModel: ObservableObject {
         default:
             break
         }
+    }
+
+    private func retryPendingAnonymousChatReencryption(
+        userId: String,
+        token: AccountOperationFence.Token
+    ) async -> Bool {
+        guard hasAnonymousChatsToSync else { return true }
+        guard !isRetryingAnonymousChatReencryption else { return false }
+        guard isCurrentSignIn(token, userId: userId) else { return false }
+
+        isRetryingAnonymousChatReencryption = true
+        defer { isRetryingAnonymousChatReencryption = false }
+
+        let cloudIndex: [ChatIndexEntry]
+        do {
+            cloudIndex = try await chatLoadingService.loadIndex(userId: userId, storage: .cloud)
+        } catch {
+            guard isCurrentSignIn(token, userId: userId) else { return false }
+            syncErrors.append(error.localizedDescription)
+            return false
+        }
+        guard isCurrentSignIn(token, userId: userId) else { return false }
+
+        let chatIds = ChatSummaryState.orderedUniqueIds(
+            indexedIds: cloudIndex.map(\.id),
+            materializedIds: chats
+                .filter { !$0.isLocalOnly && $0.userId == userId }
+                .map(\.id)
+        )
+        var allSucceeded = true
+        for chatId in chatIds {
+            guard isCurrentSignIn(token, userId: userId) else { return false }
+            let succeeded = await retryAnonymousChatReencryption(
+                chatId: chatId,
+                userId: userId,
+                token: token
+            )
+            guard isCurrentSignIn(token, userId: userId) else { return false }
+            if !succeeded {
+                allSucceeded = false
+            }
+        }
+
+        guard isCurrentSignIn(token, userId: userId) else { return false }
+        hasAnonymousChatsToSync = AnonymousChatMigrationPolicy.hasChatsRemaining(
+            allSucceeded: allSucceeded
+        )
+        return allSucceeded
+    }
+
+    private func retryAnonymousChatReencryption(
+        chatId: String,
+        userId: String,
+        token: AccountOperationFence.Token
+    ) async -> Bool {
+        guard chatMutationGate.begin(chatId: chatId) else { return false }
+        defer { chatMutationGate.end(chatId: chatId) }
+        guard isCurrentSignIn(token, userId: userId) else { return false }
+
+        var chat: Chat
+        if let materialized = chats.first(where: { $0.id == chatId }) {
+            chat = materialized
+        } else {
+            do {
+                chat = try await chatLoadingService.loadChat(
+                    id: chatId,
+                    userId: userId,
+                    storage: .cloud
+                )
+            } catch {
+                guard isCurrentSignIn(token, userId: userId) else { return false }
+                syncErrors.append(error.localizedDescription)
+                return false
+            }
+            guard isCurrentSignIn(token, userId: userId) else { return false }
+        }
+
+        chat.locallyModified = true
+        chat.syncVersion = 0
+        do {
+            try await chatLoadingService.saveChat(chat, userId: userId, storage: .cloud)
+        } catch {
+            guard isCurrentSignIn(token, userId: userId) else { return false }
+            syncErrors.append(error.localizedDescription)
+            return false
+        }
+        return isCurrentSignIn(token, userId: userId)
+    }
+
+    private func retryPendingAnonymousChatReencryptionForCurrentAccount() async -> (
+        userId: String,
+        token: AccountOperationFence.Token
+    )? {
+        guard let userId = currentUserId,
+              let token = activeSignInToken,
+              isCurrentSignIn(token, userId: userId)
+        else {
+            return nil
+        }
+        if hasAnonymousChatsToSync {
+            _ = await retryPendingAnonymousChatReencryption(userId: userId, token: token)
+        }
+        guard isCurrentSignIn(token, userId: userId) else { return nil }
+        return (userId, token)
     }
 
     /// Handle sign-in by loading user's saved chats and triggering sync
@@ -5045,7 +5580,8 @@ class ChatViewModel: ObservableObject {
                 guard isCurrentSignIn(token, userId: userId) else { return }
             }
 
-            // Mark that we have anonymous chats that need to be synced after encryption setup
+            // These saves are already locallyModified with syncVersion zero, so normal sync
+            // keeps retrying them independently of the re-encryption pass tracked here.
             guard isCurrentSignIn(token, userId: userId) else { return }
             hasAnonymousChatsToSync = true
         }
@@ -5073,16 +5609,15 @@ class ChatViewModel: ObservableObject {
             // Always load local chats first — they use the device key,
             // not the cloud encryption key, so they're available regardless
             // of cloud sync setup state.
-            let allLocal = await loadAllLocalChats(userId: userId)
+            try await refreshLocalSummaryIndex(userId: userId)
             guard isCurrentSignIn(token, userId: userId) else { return }
-            localChats = allLocal
             normalizeLocalChatsArray()
             if currentChat == nil, let first = localChats.first {
-                currentChat = first
+                selectChat(first)
             }
             // Auto-enable local-only mode when local chats with messages exist,
             // but only if the user has never explicitly set the preference
-            let hasNonEmptyLocalChats = localChats.contains { !$0.messages.isEmpty }
+            let hasNonEmptyLocalChats = localSidebarSummaries.contains { !$0.isBlankChat }
             let userHasSetPreference = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.localOnlyModeEnabled) != nil
             if hasNonEmptyLocalChats && !userHasSetPreference {
                 SettingsManager.shared.isLocalOnlyModeEnabled = true
@@ -5154,32 +5689,15 @@ class ChatViewModel: ObservableObject {
             let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
             guard isCurrentSignIn(token, userId: userId) else { return }
             if decryptedCount > 0 {
-                let result = await loadFirstPageOfChats(userId: userId, filter: \.isCloudDisplayable)
+                _ = try await refreshCloudSummaryIndex(userId: userId)
                 guard isCurrentSignIn(token, userId: userId) else { return }
-                chats = result.chats
-                // Refresh currentChat to show decrypted content
-                if let currentId = currentChat?.id,
-                   let refreshed = result.chats.first(where: { $0.id == currentId }) {
-                    currentChat = refreshed
-                }
-                normalizeChatsArray()
             }
 
             // If we have anonymous chats to sync, force re-encryption with proper key
             guard isCurrentSignIn(token, userId: userId) else { return }
             if hasAnonymousChatsToSync {
-                // Force all cloud chats to be marked for sync
-                let cloudChats = (try? await EncryptedFileStorage.cloud.loadAllChats(userId: userId)) ?? []
+                _ = await retryPendingAnonymousChatReencryption(userId: userId, token: token)
                 guard isCurrentSignIn(token, userId: userId) else { return }
-                for var chat in cloudChats {
-                    guard isCurrentSignIn(token, userId: userId) else { return }
-                    chat.locallyModified = true
-                    chat.syncVersion = 0
-                    try? await EncryptedFileStorage.cloud.saveChat(chat, userId: userId)
-                    guard isCurrentSignIn(token, userId: userId) else { return }
-                }
-                guard isCurrentSignIn(token, userId: userId) else { return }
-                hasAnonymousChatsToSync = false
             }
 
             // Local chats were already loaded above the early return.
@@ -5274,12 +5792,14 @@ class ChatViewModel: ObservableObject {
             try? await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
         }
         chats = []
+        cloudSidebarSummaries = []
+        loadedCloudRootSummaryIds = []
         hasMoreChats = false
         paginationToken = nil
         // If the current chat was a cloud chat, switch to a local one
         if let current = currentChat, !current.isLocalOnly {
             if let first = localChats.first {
-                currentChat = first
+                selectChat(first)
             } else {
                 createNewChat()
             }
@@ -5304,26 +5824,22 @@ class ChatViewModel: ObservableObject {
             guard isCurrentSignIn(token, userId: userId) else { return }
 
             // Load and display synced chats from file index (cloud chats only, paginated)
-            let result = await loadFirstPageOfChats(
-                userId: userId,
-                filter: \.isCloudDisplayable
-            )
+            let totalEntries = try await refreshCloudSummaryIndex(userId: userId)
             guard isCurrentSignIn(token, userId: userId) else { return }
 
-            chats = result.chats
             normalizeChatsArray()
 
             // Only select the first chat if we don't have a current chat selected
             if currentChat == nil, let first = chats.first {
-                currentChat = first
+                selectChat(first)
             }
 
             // Mark that we've loaded the initial page
             hasLoadedInitialPage = true
-            isPaginationActive = result.totalEntries > 0
+            isPaginationActive = totalEntries > 0
 
             // Set hasMoreChats based on total count
-            hasMoreChats = result.totalEntries > Constants.Pagination.chatsPerPage
+            hasMoreChats = totalEntries > Constants.Pagination.chatsPerPage
 
             await refreshCurrentCloudChatFromStorage(userId: userId)
             guard isCurrentSignIn(token, userId: userId) else { return }
@@ -5406,19 +5922,14 @@ class ChatViewModel: ObservableObject {
             
             // Setup pagination after sync
             await setupPaginationForAppRestart(userId: userId, token: token)
-            
+            guard isCurrentAccountOperation(token, userId: userId) else { return }
+
             // Load and display cloud chats after sync from file index
-            let result = await loadFirstPageOfChats(
-                userId: userId,
-                filter: \.isCloudDisplayable
-            )
-            await MainActor.run {
-                self.chats = result.chats
-                normalizeChatsArray()
-            }
-            if let userId = currentUserId {
-                await refreshCurrentCloudChatFromStorage(userId: userId)
-            }
+            _ = try await refreshCloudSummaryIndex(userId: userId)
+            guard isCurrentAccountOperation(token, userId: userId) else { return }
+            normalizeChatsArray()
+            await refreshCurrentCloudChatFromStorage(userId: userId)
+            guard isCurrentAccountOperation(token, userId: userId) else { return }
             scanPendingRecoveries()
         } catch {
             #if DEBUG
@@ -5427,35 +5938,39 @@ class ChatViewModel: ObservableObject {
         }
     }
     
-    /// Loads the first page of chats from file storage, sorted newest-first.
-    /// Returns the loaded chats and the total number of matching index entries
-    /// (useful for determining whether more pages exist).
-    /// Loads ALL chats from the local-only store (no pagination). Used when cloud sync is disabled.
-    private func loadAllLocalChats(userId: String?) async -> [Chat] {
-        guard let userId = userId else { return [] }
-        return ((try? await EncryptedFileStorage.local.loadAllChats(userId: userId)) ?? [])
-            .sorted { $0.updatedAt > $1.updatedAt }
+    private func loadSummaryPage(
+        userId: String,
+        storage: ChatStorageTab,
+        excluding excludedIds: Set<String> = [],
+        filter: ((ChatIndexEntry) -> Bool)? = nil,
+        limit: Int? = nil
+    ) async throws -> (summaries: [ChatListSummary], totalEntries: Int) {
+        let index = try await chatLoadingService.loadIndex(userId: userId, storage: storage)
+        return ChatSummaryState.page(
+            from: index,
+            excluding: excludedIds,
+            filter: filter,
+            limit: limit
+        )
     }
 
-    private func loadFirstPageOfChats(
-        userId: String?,
-        excluding excludedIds: Set<String> = [],
-        filter: ((ChatIndexEntry) -> Bool)? = nil
-    ) async -> (chats: [Chat], totalEntries: Int) {
-        guard let userId = userId else { return ([], 0) }
-        let performanceToken = PerformanceInstrumentation.shared.begin(.firstChatPageLoad)
-        defer { PerformanceInstrumentation.shared.end(performanceToken) }
-        let index = await Chat.loadChatIndex(userId: userId)
-        let filtered = index
-            .filter { !excludedIds.contains($0.id) }
-            .filter { filter?($0) ?? true }
-            .sorted { $0.updatedAt > $1.updatedAt }
-        let firstPageIds = filtered.prefix(Constants.Pagination.chatsPerPage).map(\.id)
+    private func refreshLocalSummaryIndex(userId: String) async throws {
+        let result = try await loadSummaryPage(userId: userId, storage: .local)
+        guard currentUserId == userId else { throw CancellationError() }
+        reconcileSummaries(result.summaries, storage: .local)
+    }
 
-        let chats = await Chat.loadChats(chatIds: firstPageIds, userId: userId)
-            .sorted { $0.updatedAt > $1.updatedAt }
-
-        return (chats, filtered.count)
+    private func refreshCloudSummaryIndex(userId: String) async throws -> Int {
+        let index = try await chatLoadingService.loadIndex(userId: userId, storage: .cloud)
+        let result = ChatSummaryState.cloudIndexSummaries(
+            from: index,
+            loadedRootIds: loadedCloudRootSummaryIds,
+            firstPageLimit: Constants.Pagination.chatsPerPage
+        )
+        guard currentUserId == userId else { throw CancellationError() }
+        loadedCloudRootSummaryIds.formUnion(result.firstPageIds)
+        reconcileSummaries(result.summaries, storage: .cloud)
+        return result.totalRootEntries
     }
 
     private func refreshCurrentCloudChatFromStorage(userId: String) async {
@@ -5503,8 +6018,22 @@ class ChatViewModel: ObservableObject {
     
     /// Load more chats (called when user scrolls to bottom)
     func loadMoreChats() async {
+        guard let userId = currentUserId else { return }
+        let operationTask = Task { [weak self] in
+            guard let self, !Task.isCancelled, self.currentUserId == userId else { return }
+            await self.performLoadMoreChats(userId: userId)
+        }
+        guard let operationToken = accountOperationTracker.begin(task: operationTask) else {
+            operationTask.cancel()
+            return
+        }
+        defer { accountOperationTracker.end(operationToken) }
+        await operationTask.value
+    }
+
+    private func performLoadMoreChats(userId: String) async {
         // Prevent duplicate loads
-        guard !isLoadingMore else {
+        guard !Task.isCancelled, currentUserId == userId, !isLoadingMore else {
             return
         }
         
@@ -5522,11 +6051,10 @@ class ChatViewModel: ObservableObject {
             // Don't change hasMoreChats - the sync logic should have set it correctly
             return
         }
-        
-        await MainActor.run {
-            self.isLoadingMore = true
-            self.hasAttemptedLoadMore = true  // Track that user has loaded additional pages
-        }
+        let originalPageState = ChatPaginationPageState(token: token, hasMore: hasMoreChats)
+        isLoadingMore = true
+        hasAttemptedLoadMore = true  // Track that user has loaded additional pages
+        defer { isLoadingMore = false }
         
         // Load next page with the token
         let result = await cloudSync.loadChatsWithPagination(
@@ -5534,39 +6062,40 @@ class ChatViewModel: ObservableObject {
             continuationToken: token,
             loadLocal: false  // Don't fall back to local when paginating
         )
-        
-        await MainActor.run {
-            // Convert and append new chats - filter out any that fail to convert
-            let newChats = result.chats.compactMap { storedChat -> Chat? in
-                if let chat = storedChat.toChat() {
-                    return chat
-                } else {
-                    #if DEBUG
-                    print("Warning: Could not convert StoredChat to Chat during pagination - skipping chat \(storedChat.id)")
-                    #endif
-                    return nil
-                }
-            }
+        guard !Task.isCancelled, currentUserId == userId else { return }
 
-            // Filter out any duplicates
-            let existingIds = Set(self.chats.map { $0.id })
-            let uniqueNewChats = newChats.filter { !existingIds.contains($0.id) }
-
-            // DON'T save paginated chats to storage - keep them in memory only
-            // Only append to the visible chats array
-            if !uniqueNewChats.isEmpty {
-                self.chats.append(contentsOf: uniqueNewChats)
-                self.chats.sort { chat1, chat2 in
-                    if chat1.isBlankChat { return true }
-                    if chat2.isBlankChat { return false }
-                    return chat1.updatedAt > chat2.updatedAt
-                }
+        let convertedChats = result.chats.compactMap { $0.toChat() }
+        let conversionFailures = result.chats.count - convertedChats.count
+        let persisted = await ChatPaginationPersistence.saveCloudChats(
+            convertedChats,
+            userId: userId,
+            loadingService: chatLoadingService
+        )
+        guard !Task.isCancelled, currentUserId == userId else { return }
+        for chat in persisted.saved {
+            cloudSidebarSummaries = ChatSummaryState.upserting(
+                ChatListSummary(from: chat),
+                into: cloudSidebarSummaries
+            )
+            if chat.projectId == nil {
+                loadedCloudRootSummaryIds.insert(chat.id)
             }
-            
-            // Update pagination state
-            self.hasMoreChats = result.hasMore
-            self.paginationToken = result.nextToken
-            self.isLoadingMore = false
+        }
+
+        let allRowsPersisted = !result.failed
+            && conversionFailures == 0
+            && persisted.failedIds.isEmpty
+            && persisted.saved.count == result.chats.count
+        let pageState = ChatPaginationCoordinator.state(
+            original: originalPageState,
+            next: ChatPaginationPageState(token: result.nextToken, hasMore: result.hasMore),
+            allRowsPersisted: allRowsPersisted,
+            pageFailed: result.failed
+        )
+        paginationToken = pageState.token
+        hasMoreChats = pageState.hasMore
+        if !allRowsPersisted {
+            syncErrors.append("Couldn't load more conversations. Try again.")
         }
     }
     
@@ -5581,118 +6110,29 @@ class ChatViewModel: ObservableObject {
             guard isCurrentSignIn(token, userId: userId) else { return }
         }
 
-        // IMPORTANT: Preserve pagination token before updating
         let savedPaginationToken = self.paginationToken
         let savedIsPaginationActive = self.isPaginationActive
-
-        let initiallyProtectedIds = Set(chats.filter {
-            $0.locallyModified || $0.hasActiveStream || streamingTracker.isStreaming($0.id)
-        }.map(\.id))
-
-        // Load first page of cloud chats from files, excluding locally modified ones
-        let result = await loadFirstPageOfChats(userId: userId, excluding: initiallyProtectedIds, filter: \.isCloudDisplayable)
-        guard currentUserId == userId else { return }
-        if let token {
-            guard isCurrentSignIn(token, userId: userId) else { return }
-        }
-
-        // Re-read protected state after the storage await so a new edit or stream
-        // that started while loading cannot be replaced by the disk snapshot.
-        let currentChatId = self.currentChat?.id
-        let locallyModifiedChats = chats.filter {
-            initiallyProtectedIds.contains($0.id)
-                || $0.locallyModified
-                || $0.hasActiveStream
-                || streamingTracker.isStreaming($0.id)
-        }
-        let locallyModifiedIds = Set(locallyModifiedChats.map { $0.id })
-
-        // Combine: locally modified chats + synced chats from files
-        let syncedChatsFromStorage = result.chats.filter { !locallyModifiedIds.contains($0.id) }
-        let sortedChats = (locallyModifiedChats + syncedChatsFromStorage).sorted { $0.updatedAt > $1.updatedAt }
-
-        // Keep track of currently loaded chat IDs to preserve pagination
-        let currentlyLoadedIds = Set(chats.map { $0.id })
-        
-        // Separate chats into categories
-        let twoMinutesAgo = Date().addingTimeInterval(-Constants.Pagination.recentChatThresholdSeconds)
-        let unsavedChats = sortedChats.filter { $0.isBlankChat }
-        let recentChats = sortedChats.filter {
-            $0.createdAt >= twoMinutesAgo &&
-            !$0.isBlankChat
-        }
-        let syncedChats = sortedChats.filter {
-            !$0.isBlankChat &&
-            $0.createdAt < twoMinutesAgo
-        }
-        
-        // Build the updated chat list
-        var updatedChats: [Chat] = []
-        
-        // 1. Add all unsaved chats (blank/temporary)
-        updatedChats.append(contentsOf: unsavedChats)
-        
-        // 2. Add recent chats (last 2 minutes)
-        updatedChats.append(contentsOf: recentChats)
-        
-        // 3. For synced chats, preserve pagination state
-        if hasAttemptedLoadMore && currentlyLoadedIds.count > Constants.Pagination.chatsPerPage {
-            // User has loaded more pages - preserve all currently loaded synced chats
-            let syncedChatsToShow = syncedChats.filter { chat in
-                // Keep if it was already loaded OR if it's in the first page positions OR if it's the current chat
-                currentlyLoadedIds.contains(chat.id) ||
-                syncedChats.firstIndex(where: { $0.id == chat.id }) ?? Int.max < Constants.Pagination.chatsPerPage ||
-                (currentChatId != nil && chat.id == currentChatId)
+        do {
+            let totalEntries = try await refreshCloudSummaryIndex(userId: userId)
+            if let token {
+                guard isCurrentSignIn(token, userId: userId) else { return }
             }
-            updatedChats.append(contentsOf: syncedChatsToShow)
-        } else {
-            // Only first page loaded - include first page AND current chat if it exists
-            var syncedChatsToShow = Array(syncedChats.prefix(Constants.Pagination.chatsPerPage))
-            if let currentChatId = currentChatId,
-               let currentChat = syncedChats.first(where: { $0.id == currentChatId }),
-               !syncedChatsToShow.contains(where: { $0.id == currentChatId }) {
-                syncedChatsToShow.append(currentChat)
+            evictInactiveMaterializedChats()
+            let loadedRootCount = cloudSidebarSummaries.filter {
+                !$0.isBlankChat && $0.projectId == nil
+            }.count
+            if totalEntries > loadedRootCount {
+                hasMoreChats = true
+            } else if paginationToken == nil && totalEntries <= Constants.Pagination.chatsPerPage {
+                hasMoreChats = false
             }
-            updatedChats.append(contentsOf: syncedChatsToShow)
-        }
-        
-        // Sort non-blank chats by latest activity before normalization
-        updatedChats.sort { chat1, chat2 in
-            if chat1.isBlankChat { return true }
-            if chat2.isBlankChat { return false }
-            return chat1.updatedAt > chat2.updatedAt
-        }
-
-        // Set chats and normalize to ensure exactly one blank chat at position 0
-        self.chats = updatedChats
-        normalizeChatsArray()
-
-        // IMPORTANT: Always update currentChat to point to the instance in the chats array
-        // This ensures currentChat is never stale and always references a chat that's in the array
-        if let currentChatId = currentChatId,
-           let updatedChat = self.chats.first(where: { $0.id == currentChatId }) {
-            self.currentChat = updatedChat
-        }
-        
-        // Update hasMoreChats conservatively to preserve server-provided pagination
-        let displayedSyncedChats = chats.filter { !$0.isBlankChat }.count
-        // Use total entries from result + locally modified count as a proxy for total index size
-        let totalIndexEntries = result.totalEntries + locallyModifiedChats.count
-
-        // Set to true if we clearly have more in the index than are displayed
-        if totalIndexEntries > displayedSyncedChats {
-            self.hasMoreChats = true
-        } else if self.paginationToken == nil && totalIndexEntries <= Constants.Pagination.chatsPerPage {
-            // Only set to false when not using remote pagination and we are certain the total fits on one page
-            self.hasMoreChats = false
-        }
-        // Otherwise, preserve existing hasMoreChats which may have been set from remote list
-        
-        // IMPORTANT: Restore pagination state that was saved at the beginning
-        // This ensures the pagination token doesn't get lost during sync
-        if savedIsPaginationActive {
-            self.paginationToken = savedPaginationToken
-            self.isPaginationActive = savedIsPaginationActive
+            if savedIsPaginationActive {
+                paginationToken = savedPaginationToken
+                isPaginationActive = savedIsPaginationActive
+            }
+        } catch is CancellationError {
+        } catch {
+            syncErrors.append(error.localizedDescription)
         }
         await refreshCurrentCloudChatFromStorage(userId: userId)
         if let token {
@@ -5704,19 +6144,18 @@ class ChatViewModel: ObservableObject {
     /// Reset pagination and reload all chats from storage (used after sync)
     @MainActor
     private func resetPaginationAndReloadChats() async {
-        let result = await loadFirstPageOfChats(
-            userId: currentUserId,
-            filter: \.isCloudDisplayable
-        )
-        self.chats = result.chats
-        normalizeChatsArray()
-        self.hasMoreChats = result.totalEntries > Constants.Pagination.chatsPerPage
+        guard let userId = currentUserId else { return }
+        do {
+            let totalEntries = try await refreshCloudSummaryIndex(userId: userId)
+            hasMoreChats = totalEntries > Constants.Pagination.chatsPerPage
+        } catch is CancellationError {
+        } catch {
+            syncErrors.append(error.localizedDescription)
+        }
     }
     
     /// Perform a full sync with the cloud
     func performFullSync() async {
-        guard let userId = currentUserId else { return }
-        let token = currentAccountOperationToken(userId: userId)
         // Gate sync when cloud sync is disabled
         if !SettingsManager.shared.isCloudSyncEnabled {
             return
@@ -5727,6 +6166,12 @@ class ChatViewModel: ObservableObject {
             return
         }
 
+        guard let syncContext = await retryPendingAnonymousChatReencryptionForCurrentAccount()
+        else {
+            return
+        }
+        let userId = syncContext.userId
+        let token = syncContext.token
         guard isCurrentSignIn(token, userId: userId) else { return }
         let syncId = UUID()
         activeFullSyncId = syncId
@@ -5763,14 +6208,18 @@ class ChatViewModel: ObservableObject {
         await loadProjects()
         guard isCurrentSignIn(token, userId: userId) else { return }
         
-        // Re-load localChats from the local-only store
-        let freshLocal = await loadAllLocalChats(userId: userId)
+        do {
+            try await refreshLocalSummaryIndex(userId: userId)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            syncErrors.append(error.localizedDescription)
+        }
         guard isCurrentSignIn(token, userId: userId) else { return }
 
-        localChats = freshLocal
         lastSyncDate = Date()
         ensureBlankChatAtTop()
-
         if !result.errors.isEmpty {
             syncErrors = result.errors
         }
@@ -5899,7 +6348,7 @@ class ChatViewModel: ObservableObject {
                 } else {
                     // Select the most recent chat
                     if let mostRecent = chats.first {
-                        currentChat = mostRecent
+                        selectChat(mostRecent)
                     }
                 }
             }
@@ -6029,10 +6478,13 @@ class ChatViewModel: ObservableObject {
         }
         
         // Reload cloud chats after decryption
-        let result = await loadFirstPageOfChats(userId: currentUserId, filter: \.isCloudDisplayable)
-        await MainActor.run {
-            self.chats = result.chats
-            normalizeChatsArray()
+        if let userId = currentUserId {
+            do {
+                _ = try await refreshCloudSummaryIndex(userId: userId)
+            } catch is CancellationError {
+            } catch {
+                syncErrors.append(error.localizedDescription)
+            }
         }
     }
     

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2230,7 +2230,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func retryFailedChatHydration() {
-        guard let failedChatHydration, chatHydrationError != nil else { return }
+        guard canRetryFailedChatHydration, let failedChatHydration else { return }
         _ = selectChat(id: failedChatHydration.id, isLocalOnly: failedChatHydration.isLocalOnly)
     }
 
@@ -4827,7 +4827,13 @@ class ChatViewModel: ObservableObject {
                 }
             } catch is CancellationError {
             } catch {
-                guard self.currentUserId == userId else { return }
+                let summaryExists = isLocal
+                    ? self.localSidebarSummaries.contains { $0.id == latestChat.id }
+                    : self.cloudSidebarSummaries.contains { $0.id == latestChat.id }
+                guard self.currentUserId == userId,
+                      !self.chatMutationGate.activeChatIds.contains(latestChat.id),
+                      summaryExists
+                else { return }
                 self.syncErrors.append(error.localizedDescription)
             }
         }
@@ -6093,8 +6099,6 @@ class ChatViewModel: ObservableObject {
             loadLocal: false  // Don't fall back to local when paginating
         )
         guard !Task.isCancelled, currentUserId == userId else { return }
-        guard !result.cancelled else { return }
-
         let convertedChats = result.chats.compactMap { $0.toChat() }
         let conversionFailures = result.chats.count - convertedChats.count
         let persisted = await ChatPaginationPersistence.saveCloudChats(
@@ -6121,7 +6125,8 @@ class ChatViewModel: ObservableObject {
             original: originalPageState,
             next: ChatPaginationPageState(token: result.nextToken, hasMore: result.hasMore),
             allRowsPersisted: allRowsPersisted,
-            pageFailed: result.failed
+            pageFailed: result.failed,
+            pageCancelled: result.cancelled
         )
         paginationToken = pageState.token
         hasMoreChats = pageState.hasMore

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -157,6 +157,7 @@ class ChatViewModel: ObservableObject {
     @Published private(set) var selectedChatId: String?
     @Published private(set) var hydratingChatId: String?
     @Published private(set) var chatHydrationError: String?
+    var canRetryFailedChatHydration: Bool { failedChatHydration != nil && chatHydrationError != nil }
     @Published var currentChat: Chat? {
         didSet {
             if currentChat?.id != oldValue?.id {
@@ -428,6 +429,7 @@ class ChatViewModel: ObservableObject {
     private var selectedChatImageTask: Task<Void, Never>?
     private var chatSelectionTask: Task<Void, Never>?
     private var chatSelectionFence = ChatSelectionFence()
+    private var failedChatHydration: FailedChatHydration?
     private var chatMutationGate = ChatMutationGate()
     private let chatLoadingService: any ChatLoadingService
     private var materializationOperationIds: Set<String> = []
@@ -2193,6 +2195,7 @@ class ChatViewModel: ObservableObject {
                 else {
                     return
                 }
+                self.failedChatHydration = FailedChatHydration(id: id, storage: storage)
                 self.failSelection(id: id, generation: generation)
                 self.syncErrors.append(error.localizedDescription)
             }
@@ -2202,6 +2205,7 @@ class ChatViewModel: ObservableObject {
 
     func selectChat(_ chat: Chat) {
         projectLoadGeneration += 1
+        failedChatHydration = nil
         let generation = chatSelectionFence.begin(id: chat.id)
         chatSelectionTask?.cancel()
         chatSelectionTask = nil
@@ -2213,6 +2217,7 @@ class ChatViewModel: ObservableObject {
 
     private func beginSelection(id: String) {
         projectLoadGeneration += 1
+        failedChatHydration = nil
         _ = chatSelectionFence.begin(id: id)
         chatSelectionTask?.cancel()
         selectedChatImageTask?.cancel()
@@ -2222,6 +2227,11 @@ class ChatViewModel: ObservableObject {
         chatHydrationError = nil
         currentChat = nil
         evictInactiveMaterializedChats()
+    }
+
+    func retryFailedChatHydration() {
+        guard let failedChatHydration, chatHydrationError != nil else { return }
+        _ = selectChat(id: failedChatHydration.id, isLocalOnly: failedChatHydration.isLocalOnly)
     }
 
     private func failSelection(id: String, generation: Int) {
@@ -4770,7 +4780,8 @@ class ChatViewModel: ObservableObject {
     }
 
     private func endStreamingAndBackup(chatId: String) {
-        guard authManager?.isAuthenticated == true else { return }
+        guard authManager?.isAuthenticated == true,
+              let userId = currentUserId else { return }
 
         streamingTracker.endStreaming(chatId)
 
@@ -4784,16 +4795,24 @@ class ChatViewModel: ObservableObject {
         let isLocal = location.isLocal
         Task { @MainActor in
             await saveTask?.value
+            guard self.currentUserId == userId else { return }
             if SettingsManager.shared.isCloudSyncEnabled && !latestChat.isLocalOnly {
                 await self.cloudSync.backupChat(latestChat.id)
+                guard self.currentUserId == userId else { return }
             }
 
-            if let userId = self.currentUserId,
-               let syncedChat = try? await self.chatLoadingService.loadChat(
-                   id: latestChat.id,
-                   userId: userId,
-                   storage: isLocal ? .local : .cloud
-               ) {
+            do {
+                let syncedChat = try await self.chatLoadingService.loadChat(
+                    id: latestChat.id,
+                    userId: userId,
+                    storage: isLocal ? .local : .cloud
+                )
+                guard self.currentUserId == userId,
+                      let currentLocation = self.findChatLocation(latestChat.id),
+                      currentLocation.isLocal == isLocal
+                else {
+                    return
+                }
                 if isLocal {
                     if let idx = self.localChats.firstIndex(where: { $0.id == latestChat.id }) {
                         self.localChats[idx] = syncedChat
@@ -4806,6 +4825,10 @@ class ChatViewModel: ObservableObject {
                 if self.currentChat?.id == latestChat.id {
                     self.currentChat = syncedChat
                 }
+            } catch is CancellationError {
+            } catch {
+                guard self.currentUserId == userId else { return }
+                self.syncErrors.append(error.localizedDescription)
             }
         }
     }
@@ -6070,6 +6093,7 @@ class ChatViewModel: ObservableObject {
             loadLocal: false  // Don't fall back to local when paginating
         )
         guard !Task.isCancelled, currentUserId == userId else { return }
+        guard !result.cancelled else { return }
 
         let convertedChats = result.chats.compactMap { $0.toChat() }
         let conversionFailures = result.chats.count - convertedChats.count

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -424,6 +424,7 @@ class ChatViewModel: ObservableObject {
     private var recoverySessionCleanupTasks: [String: Task<Void, Never>] = [:]
     private var thinkingSummaryServices: [String: ThinkingSummaryService] = [:]
     private var autoSyncTimer: Timer?
+    private var autoSyncTask: Task<Void, Never>?
     private var recoveryScanTimer: Timer?
     private var recoveryScanTask: Task<Void, Never>?
     private var selectedChatImageTask: Task<Void, Never>?
@@ -933,6 +934,7 @@ class ChatViewModel: ObservableObject {
         // Stop sync timers
         autoSyncTimer?.invalidate()
         autoSyncTimer = nil
+        autoSyncTask?.cancel()
         recoveryScanTimer?.invalidate()
         recoveryScanTimer = nil
         recoveryScanTask?.cancel()
@@ -985,16 +987,42 @@ class ChatViewModel: ObservableObject {
                           ChatRecoveryNotificationKey.storage
                       ] as? String,
                       let storage = ChatRecoveryStorage(rawValue: storageValue),
-                      !self.streamingTracker.isStreaming(chatId),
-                      let recovered = try? await storage.fileStorage.loadChat(
-                          chatId: chatId,
-                          userId: userId
-                      )
+                      !self.streamingTracker.isStreaming(chatId)
                 else {
                     return
                 }
-                guard self.currentUserId == userId,
-                      !self.streamingTracker.isStreaming(chatId)
+                let accountToken = self.currentAccountOperationToken(userId: userId)
+                let wasSelected = self.selectedChatId == chatId
+                let selectionGeneration = self.chatSelectionFence.generation
+                let wasMutating = self.chatMutationGate.activeChatIds.contains(chatId)
+                guard let recovered = try? await storage.fileStorage.loadChat(
+                           chatId: chatId,
+                           userId: userId
+                       )
+                else {
+                    return
+                }
+                let identityExists: Bool
+                switch storage {
+                case .cloud:
+                    identityExists = self.cloudSidebarSummaries.contains { $0.id == chatId }
+                        || self.chats.contains { $0.id == chatId }
+                case .local:
+                    identityExists = self.localSidebarSummaries.contains { $0.id == chatId }
+                        || self.localChats.contains { $0.id == chatId }
+                }
+                guard RecoveryUpdateAdmission.accepts(
+                    accountIsCurrent: self.isCurrentAccountOperation(accountToken, userId: userId),
+                    isAccountTeardownInProgress: self.isAccountTeardownInProgress,
+                    wasSelected: wasSelected,
+                    isStillSelected: self.selectedChatId == chatId
+                        && self.chatSelectionFence.generation == selectionGeneration,
+                    wasMutating: wasMutating,
+                    isMutating: self.chatMutationGate.activeChatIds.contains(chatId),
+                    identityExists: identityExists
+                        && !DeletedChatsTracker.shared.isDeleted(chatId),
+                    isStreaming: self.streamingTracker.isStreaming(chatId)
+                )
                 else {
                     return
                 }
@@ -1057,67 +1085,72 @@ class ChatViewModel: ObservableObject {
         // Create timer that fires at regular intervals
         autoSyncTimer = Timer.scheduledTimer(withTimeInterval: Constants.Sync.chatSyncIntervalSeconds, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                guard let self = self else { return }
-                
-                // Gate auto-sync if no encryption key is set
-                if !EncryptionService.shared.hasEncryptionKey() {
-                    return
-                }
+                guard let self, self.acceptsChatSaves else { return }
+                self.autoSyncTask?.cancel()
+                self.autoSyncTask = Task { @MainActor in
 
-                // Only sync if authenticated
-                guard self.authManager?.isAuthenticated == true else {
-                    return
-                }
-                
-                // Skip auto-sync if actively sending a message or streaming
-                if !self.streamState.activeChatIds.isEmpty {
-                    return
-                }
-                
-                // Skip if current chat has active stream
-                if let currentChat = self.currentChat, 
-                   (currentChat.hasActiveStream || self.streamingTracker.isStreaming(currentChat.id)) {
-                    return
-                }
-
-                guard let syncContext = await self.retryPendingAnonymousChatReencryptionForCurrentAccount()
-                else {
-                    return
-                }
-                
-                
-                // Perform sync in background
-                // Use smart sync for periodic sync (checks if sync is needed first)
-                let syncResult = await self.cloudSync.smartSync()
-                guard self.isCurrentSignIn(syncContext.token, userId: syncContext.userId) else { return }
-
-                // Update last sync date after successful sync
-                self.lastSyncDate = Date()
-
-                // If chats were downloaded or deleted remotely, reload the chat list
-                if syncResult.downloaded > 0 || syncResult.deleted > 0 {
-                    // Use intelligent update that preserves pagination
-                    await self.updateChatsAfterSync()
-
-                    // Force UI update
-                    self.objectWillChange.send()
-
-                    // Restore current chat selection if it still exists
-                    if let currentChatId = self.currentChat?.id,
-                       let location = self.findChatLocation(currentChatId) {
-                        self.currentChat = self.chat(at: location)
+                    // Gate auto-sync if no encryption key is set
+                    if !EncryptionService.shared.hasEncryptionKey() {
+                        return
                     }
 
-                }
-                // Also backup current chat if it has changes
-                if let currentChat = await MainActor.run(body: { self.currentChat }),
-                   !currentChat.messages.isEmpty,
-                   !currentChat.hasActiveStream {
-                    await self.cloudSync.backupChat(currentChat.id)
-                }
+                    // Only sync if authenticated
+                    guard self.authManager?.isAuthenticated == true else {
+                        return
+                    }
 
-                // Sync profile settings periodically
-                await ProfileManager.shared.syncFromCloud()
+                    // Skip auto-sync if actively sending a message or streaming
+                    if !self.streamState.activeChatIds.isEmpty {
+                        return
+                    }
+
+                    // Skip if current chat has active stream
+                    if let currentChat = self.currentChat,
+                       (currentChat.hasActiveStream || self.streamingTracker.isStreaming(currentChat.id)) {
+                        return
+                    }
+
+                    guard let syncContext = await self.retryPendingAnonymousChatReencryptionForCurrentAccount()
+                    else {
+                        return
+                    }
+
+
+                    // Perform sync in background
+                    // Use smart sync for periodic sync (checks if sync is needed first)
+                    let syncResult = await self.cloudSync.smartSync()
+                    guard !Task.isCancelled,
+                          self.isCurrentSignIn(syncContext.token, userId: syncContext.userId)
+                    else { return }
+
+                    // Update last sync date after successful sync
+                    self.lastSyncDate = Date()
+
+                    // If chats were downloaded or deleted remotely, reload the chat list
+                    if syncResult.downloaded > 0 || syncResult.deleted > 0 {
+                        // Use intelligent update that preserves pagination
+                        await self.updateChatsAfterSync()
+
+                        // Force UI update
+                        self.objectWillChange.send()
+
+                        // Restore current chat selection if it still exists
+                        if let currentChatId = self.currentChat?.id,
+                           let location = self.findChatLocation(currentChatId) {
+                            self.currentChat = self.chat(at: location)
+                        }
+
+                    }
+                    // Also backup current chat if it has changes
+                    if let currentChat = await MainActor.run(body: { self.currentChat }),
+                       !currentChat.messages.isEmpty,
+                       !currentChat.hasActiveStream {
+                        await self.cloudSync.backupChat(currentChat.id)
+                    }
+
+                    // Sync profile settings periodically
+                    await ProfileManager.shared.syncFromCloud()
+                }
             }
         }
         // Ensure the timer fires during UI interactions (scrolling, modal sheets)
@@ -1748,53 +1781,79 @@ class ChatViewModel: ObservableObject {
     /// conversation keeps its documents and instructions, and root
     /// chats leave any active project first.
     func openSearchResult(_ chat: Chat) {
-        if let projectId = chat.projectId {
-            beginSelection(id: chat.id)
-            let selectionGeneration = chatSelectionFence.generation
-            pendingSearchResultChatId = chat.id
-            chatSelectionTask = Task {
-                if activeProject?.id != projectId {
+        guard let userId = currentUserId else { return }
+        beginSelection(id: chat.id)
+        let selectionGeneration = chatSelectionFence.generation
+        pendingSearchResultChatId = chat.id
+        let loadingService = chatLoadingService
+        chatSelectionTask = Task { [weak self, loadingService] in
+            let persisted: Chat
+            do {
+                persisted = try await RemoteSearchPersistence.resolve(
+                    chat,
+                    userId: userId,
+                    loadingService: loadingService,
+                    validateOperation: { [weak self] in
+                        guard let self,
+                              !Task.isCancelled,
+                              self.currentUserId == userId,
+                              self.chatSelectionFence.accepts(
+                                  id: chat.id,
+                                  generation: selectionGeneration
+                              ) else {
+                            throw CancellationError()
+                        }
+                    }
+                )
+            } catch {
+                guard let self,
+                      self.currentUserId == userId,
+                      self.chatSelectionFence.accepts(
+                          id: chat.id,
+                          generation: selectionGeneration
+                      ) else { return }
+                self.failSelection(id: chat.id, generation: selectionGeneration)
+                return
+            }
+            guard let self,
+                  !Task.isCancelled,
+                  self.currentUserId == userId,
+                  self.pendingSearchResultChatId == chat.id,
+                  self.chatSelectionFence.accepts(
+                      id: chat.id,
+                      generation: selectionGeneration
+                  ) else { return }
+
+            if let projectId = persisted.projectId {
+                if self.activeProject?.id != projectId {
                     // loadActiveProject (not enterProject) so no blank chat is
                     // selected along the way, which would clear the pending
                     // token below before it could be checked.
-                    let loaded = await loadActiveProject(projectId: projectId)
+                    let loaded = await self.loadActiveProject(projectId: projectId)
                     guard !Task.isCancelled, loaded else {
-                        failSelection(id: chat.id, generation: selectionGeneration)
+                        self.failSelection(id: chat.id, generation: selectionGeneration)
                         return
                     }
                 }
-                // A newer selection during the load supersedes this one
-                // and remains in charge.
-                guard !Task.isCancelled,
-                      pendingSearchResultChatId == chat.id else {
-                    failSelection(id: chat.id, generation: selectionGeneration)
+                guard self.currentUserId == userId,
+                      self.pendingSearchResultChatId == chat.id,
+                      self.chatSelectionFence.accepts(
+                          id: chat.id,
+                          generation: selectionGeneration
+                      ),
+                      self.activeProject?.id == projectId else {
+                    self.failSelection(id: chat.id, generation: selectionGeneration)
                     return
                 }
-                // The load can also fail (e.g. a deleted project), leaving
-                // some other context in place; never open the chat under
-                // the wrong project or none at all.
-                guard !Task.isCancelled, activeProject?.id == projectId else {
-                    failSelection(id: chat.id, generation: selectionGeneration)
-                    return
-                }
-                chatSelectionTask = nil
-                selectChat(chat)
-                guard !Task.isCancelled else {
-                    failSelection(id: chat.id, generation: selectionGeneration)
-                    return
-                }
-                isViewingProjectChat = true
+                self.isViewingProjectChat = true
+            } else if self.activeProject != nil {
+                self.activeProject = nil
+                self.projectDocuments = []
+                self.projectError = nil
+                self.isViewingProjectChat = false
             }
-        } else {
-            beginSelection(id: chat.id)
-            pendingSearchResultChatId = nil
-            if activeProject != nil {
-                activeProject = nil
-                projectDocuments = []
-                projectError = nil
-                isViewingProjectChat = false
-            }
-            selectChat(chat)
+            self.chatSelectionTask = nil
+            self.installSelectedChat(persisted, generation: selectionGeneration)
         }
     }
 
@@ -2586,10 +2645,52 @@ class ChatViewModel: ObservableObject {
 
     private func reconcileSummaries(
         _ indexed: [ChatListSummary],
-        storage: ChatStorageTab
+        storage: ChatStorageTab,
+        authoritativeIds: Set<String>? = nil
     ) {
         switch storage {
         case .cloud:
+            if let authoritativeIds {
+                let result = AuthoritativeCloudIndexReconciliation.reconcile(
+                    indexedSummaries: indexed,
+                    authoritativeIds: authoritativeIds,
+                    materializedChats: chats,
+                    selectedId: selectedChatId,
+                    streamingIds: streamState.activeChatIds,
+                    recoveryIds: activeRecoveryChatIds(),
+                    operationIds: materializationOperationIds
+                        .union(chatMutationGate.activeChatIds)
+                )
+                chats = result.materializedChats
+                cloudSidebarSummaries = result.summaries
+                if result.removedSelectedChat {
+                    if let selectedChatId {
+                        discardMessageQueue(chatId: selectedChatId)
+                    }
+                    chatSelectionFence.invalidate()
+                    chatSelectionTask?.cancel()
+                    chatSelectionTask = nil
+                    selectedChatImageTask?.cancel()
+                    selectedChatImageTask = nil
+                    selectedChatId = nil
+                    hydratingChatId = nil
+                    currentChat = nil
+                    let replacementSummaries = activeProject == nil
+                        ? cloudSidebarSummaries
+                        : activeProjectChats
+                    if let next = replacementSummaries.first(where: { !$0.isBlankChat })
+                        ?? replacementSummaries.first(where: \.isBlankChat) {
+                        _ = selectChat(id: next.id, isLocalOnly: false)
+                    } else {
+                        createNewChat(
+                            isLocalOnly: false,
+                            projectId: activeProject?.id,
+                            focusInput: false
+                        )
+                    }
+                }
+                return
+            }
             let transient = chats.map(ChatListSummary.init(from:))
             cloudSidebarSummaries = ChatSummaryState.reconcilingIndex(indexed, withTransient: transient)
         case .local:
@@ -5789,7 +5890,14 @@ class ChatViewModel: ObservableObject {
     /// the user can retry without partial-deletion side effects.
     @MainActor
     func deleteAllChats() async throws {
-        let localIds = chats.map(\.id) + localChats.map(\.id)
+        guard let userId = currentUserId else { return }
+        let allChatIds = Set(
+            cloudSidebarSummaries.map(\.id)
+                + localSidebarSummaries.map(\.id)
+                + chats.map(\.id)
+                + localChats.map(\.id)
+                + [currentChat?.id].compactMap { $0 }
+        )
 
         // When the cloud backup is in play (key present, or sync enabled but
         // the key is missing) this must succeed or throw: skipping it would
@@ -5798,23 +5906,76 @@ class ChatViewModel: ObservableObject {
         // wipe.
         let isAuthenticated = authManager?.isAuthenticated == true
         let hasKey = EncryptionService.shared.hasEncryptionKey()
-        if isAuthenticated && (hasKey || SettingsManager.shared.isCloudSyncEnabled) {
-            try await cloudSync.deleteAllFromCloud()
-        }
+        let shouldDeleteCloud = isAuthenticated
+            && (hasKey || SettingsManager.shared.isCloudSyncEnabled)
+        try await DeleteAllChatsCoordinator.quiesceAndDeleteCloud(
+            closeSaveAdmission: {
+                self.acceptsChatSaves = false
+            },
+            stopProducers: {
+                self.autoSyncTimer?.invalidate()
+                self.autoSyncTimer = nil
+                let autoSyncTask = self.autoSyncTask
+                self.autoSyncTask = nil
+                autoSyncTask?.cancel()
+                self.recoveryScanTimer?.invalidate()
+                self.recoveryScanTimer = nil
+                let streamTasks = self.cancelAllGenerations()
+                await self.accountOperationTracker.closeAndWait()
+                await autoSyncTask?.value
+                await self.suspendRecoveryScans()
+                await self.drainStreamTasks(streamTasks)
+                let cleanupTasks = Array(self.recoverySessionCleanupTasks.values)
+                self.recoverySessionCleanupTasks.values.forEach { $0.cancel() }
+                self.recoverySessionCleanupTasks.removeAll()
+                for task in cleanupTasks {
+                    await task.value
+                }
+            },
+            drainSavesAndBackups: {
+                await self.drainPendingSaves()
+            },
+            quiesceUploads: {
+                guard shouldDeleteCloud else { return }
+                try await self.cloudSync.quiesceUploadsForBulkDelete(userId: userId)
+            },
+            deleteCloud: {
+                guard shouldDeleteCloud else { return }
+                try await self.cloudSync.deleteAllFromCloud(userId: userId)
+            },
+            recoverFromFailure: {
+                await self.cloudSync.resumeUploadsAfterBulkDelete(userId: userId)
+                guard self.currentUserId == userId else { return }
+                self.acceptsChatSaves = true
+                self.accountOperationTracker.reopen()
+                self.recoveryScansSuspended = false
+                self.setupAutoSyncTimer()
+            }
+        )
 
         clearHydratedFavorites()
         ProfileManager.shared.clearPinnedChats()
 
         // Tombstone so an in-flight sync pass can't resurrect wiped chats
-        for id in localIds {
+        for id in allChatIds {
             DeletedChatsTracker.shared.markAsDeleted(id)
         }
 
-        await clearAllChatsFromDevice()
+        await clearAllChatsFromDevice(
+            resumeRecoveryScans: false,
+            reopenAccountOperations: false
+        )
+        try await EncryptedFileStorage.local.deleteAllChats(userId: userId)
+        try await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
+        await cloudSync.resumeUploadsAfterBulkDelete(userId: userId)
+        acceptsChatSaves = true
+        accountOperationTracker.reopen()
         // The device wipe clears the in-memory key reference; restore it so
         // newly created chats keep syncing.
         reloadEncryptionKey()
         createNewChat()
+        recoveryScansSuspended = false
+        setupAutoSyncTimer()
     }
 
     /// Removes all cloud (non-local) chats from the device
@@ -6005,7 +6166,11 @@ class ChatViewModel: ObservableObject {
         )
         guard currentUserId == userId else { throw CancellationError() }
         loadedCloudRootSummaryIds.formUnion(result.firstPageIds)
-        reconcileSummaries(result.summaries, storage: .cloud)
+        reconcileSummaries(
+            result.summaries,
+            storage: .cloud,
+            authoritativeIds: Set(index.map(\.id))
+        )
         return result.totalRootEntries
     }
 
@@ -6107,20 +6272,20 @@ class ChatViewModel: ObservableObject {
             loadingService: chatLoadingService
         )
         guard !Task.isCancelled, currentUserId == userId else { return }
-        for chat in persisted.saved {
+        for summary in persisted.summaries {
             cloudSidebarSummaries = ChatSummaryState.upserting(
-                ChatListSummary(from: chat),
+                summary,
                 into: cloudSidebarSummaries
             )
-            if chat.projectId == nil {
-                loadedCloudRootSummaryIds.insert(chat.id)
+            if summary.projectId == nil {
+                loadedCloudRootSummaryIds.insert(summary.id)
             }
         }
 
         let allRowsPersisted = !result.failed
             && conversionFailures == 0
             && persisted.failedIds.isEmpty
-            && persisted.saved.count == result.chats.count
+            && persisted.summaries.count == result.chats.count
         let pageState = ChatPaginationCoordinator.state(
             original: originalPageState,
             next: ChatPaginationPageState(token: result.nextToken, hasMore: result.hasMore),

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -5271,6 +5271,13 @@ class ChatViewModel: ObservableObject {
         localChats = []
         cloudSidebarSummaries = []
         localSidebarSummaries = []
+        projectLoadGeneration += 1
+        projects = []
+        activeProject = nil
+        projectDocuments = []
+        projectError = nil
+        isViewingProjectChat = false
+        pendingSearchResultChatId = nil
         activeStorageTab = .cloud
         let newChat = Chat.create(modelType: currentModel)
         currentChat = newChat

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1824,9 +1824,9 @@ class ChatViewModel: ObservableObject {
         pendingSearchResultChatId = chat.id
         let loadingService = chatLoadingService
         chatSelectionTask = Task { [weak self, loadingService] in
-            let persisted: Chat
+            let persistenceResult: RemoteSearchPersistence.Result
             do {
-                persisted = try await RemoteSearchPersistence.resolve(
+                persistenceResult = try await RemoteSearchPersistence.resolve(
                     chat,
                     userId: userId,
                     loadingService: loadingService,
@@ -1843,6 +1843,16 @@ class ChatViewModel: ObservableObject {
                     }
                 )
             } catch {
+                guard let self,
+                      self.currentUserId == userId,
+                      self.chatSelectionFence.accepts(
+                          id: chat.id,
+                          generation: selectionGeneration
+                      ) else { return }
+                self.failSelection(id: chat.id, generation: selectionGeneration)
+                return
+            }
+            guard case .chat(let persisted) = persistenceResult else {
                 guard let self,
                       self.currentUserId == userId,
                       self.chatSelectionFence.accepts(
@@ -6075,6 +6085,12 @@ class ChatViewModel: ObservableObject {
             }
         }
         recoveryScansSuspended = false
+        if restoration.restartSignIn {
+            let canceledSignInTask = cancelSignInOperation()
+            await canceledSignInTask?.value
+            guard currentUserId == userId else { return }
+            handleSignIn()
+        }
         setupAutoSyncTimer()
     }
 
@@ -6385,7 +6401,7 @@ class ChatViewModel: ObservableObject {
         let allRowsPersisted = !result.failed
             && conversionFailures == 0
             && persisted.failedIds.isEmpty
-            && persisted.summaries.count == result.chats.count
+            && persisted.safelyPersistedCount == result.chats.count
         let pageState = ChatPaginationCoordinator.state(
             original: originalPageState,
             next: ChatPaginationPageState(token: result.nextToken, hasMore: result.hasMore),

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -442,6 +442,7 @@ class ChatViewModel: ObservableObject {
     private var willResignActiveObserver: NSObjectProtocol?
     private var sharedSettingsObserver: NSObjectProtocol?
     private var chatRecoveryObserver: NSObjectProtocol?
+    private var cloudRemoteDeleteObserver: NSObjectProtocol?
     private var networkStatusCancellable: AnyCancellable?
     private var streamUpdateTimers: [String: Timer] = [:]
     private var pendingStreamUpdates: [String: Chat] = [:]
@@ -902,6 +903,7 @@ class ChatViewModel: ObservableObject {
         setupAppLifecycleObservers()
         setupSharedSettingsObserver()
         setupChatRecoveryObserver()
+        setupCloudRemoteDeleteObserver()
 
         // Setup network status observer for automatic retry on reconnection
         setupNetworkStatusObserver()
@@ -965,6 +967,41 @@ class ChatViewModel: ObservableObject {
         }
         if let observer = chatRecoveryObserver {
             NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = cloudRemoteDeleteObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func setupCloudRemoteDeleteObserver() {
+        cloudRemoteDeleteObserver = NotificationCenter.default.addObserver(
+            forName: .cloudChatRemoteDeleteCompleted,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in
+                guard let self,
+                      let chatId = notification.userInfo?[
+                          CloudRemoteDeleteNotificationKey.chatId
+                      ] as? String,
+                      let userId = notification.userInfo?[
+                          CloudRemoteDeleteNotificationKey.userId
+                      ] as? String,
+                      self.currentUserId == userId,
+                      DeletedChatsTracker.shared.isDeleted(chatId)
+                else {
+                    return
+                }
+                let authoritativeIds = Set(
+                    self.cloudSidebarSummaries.map(\.id) + self.chats.map(\.id)
+                        + [self.currentChat?.id, self.selectedChatId].compactMap { $0 }
+                )
+                self.reconcileSummaries(
+                    self.cloudSidebarSummaries,
+                    storage: .cloud,
+                    authoritativeIds: authoritativeIds
+                )
+            }
         }
     }
 
@@ -2211,6 +2248,9 @@ class ChatViewModel: ObservableObject {
         let fallbackSource = isLocalOnly ? chats : localChats
         if let chat = preferredSource.first(where: { $0.id == id })
             ?? fallbackSource.first(where: { $0.id == id }) {
+            guard chat.isLocalOnly || !DeletedChatsTracker.shared.isDeleted(id) else {
+                return false
+            }
             selectChat(chat)
             return true
         }
@@ -2222,6 +2262,9 @@ class ChatViewModel: ObservableObject {
         } else if fallbackSummaries.contains(where: { $0.id == id }) {
             storage = isLocalOnly ? .cloud : .local
         } else {
+            return false
+        }
+        guard storage == .local || !DeletedChatsTracker.shared.isDeleted(id) else {
             return false
         }
         guard let userId = currentUserId else {
@@ -2263,6 +2306,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func selectChat(_ chat: Chat) {
+        guard chat.isLocalOnly || !DeletedChatsTracker.shared.isDeleted(chat.id) else { return }
         projectLoadGeneration += 1
         failedChatHydration = nil
         let generation = chatSelectionFence.begin(id: chat.id)
@@ -2309,6 +2353,7 @@ class ChatViewModel: ObservableObject {
 
     private func installSelectedChat(_ chat: Chat, generation: Int) {
         guard chatSelectionFence.accepts(id: chat.id, generation: generation),
+              chat.isLocalOnly || !DeletedChatsTracker.shared.isDeleted(chat.id),
               selectedChatId == chat.id else { return }
         selectedChatImageTask?.cancel()
         // Any explicit selection supersedes a search hit whose project
@@ -2651,11 +2696,20 @@ class ChatViewModel: ObservableObject {
         switch storage {
         case .cloud:
             if let authoritativeIds {
+                let candidateIds = Set(
+                    indexed.map(\.id) + chats.map(\.id)
+                        + [currentChat?.id, selectedChatId].compactMap { $0 }
+                )
+                let tombstonedIds = Set(candidateIds.filter {
+                    DeletedChatsTracker.shared.isDeleted($0)
+                })
                 let result = AuthoritativeCloudIndexReconciliation.reconcile(
                     indexedSummaries: indexed,
                     authoritativeIds: authoritativeIds,
+                    tombstonedIds: tombstonedIds,
                     materializedChats: chats,
                     selectedId: selectedChatId,
+                    currentId: currentChat?.id,
                     streamingIds: streamState.activeChatIds,
                     recoveryIds: activeRecoveryChatIds(),
                     operationIds: materializationOperationIds
@@ -2663,9 +2717,14 @@ class ChatViewModel: ObservableObject {
                 )
                 chats = result.materializedChats
                 cloudSidebarSummaries = result.summaries
-                if result.removedSelectedChat {
-                    if let selectedChatId {
-                        discardMessageQueue(chatId: selectedChatId)
+                if result.removedSelectedChat || result.removedCurrentChat {
+                    let removedIds = Set([
+                        result.removedSelectedChat ? selectedChatId : nil,
+                        result.removedCurrentChat ? currentChat?.id : nil
+                    ].compactMap { $0 })
+                    for chatId in removedIds {
+                        discardMessageQueue(chatId: chatId)
+                        _ = cancelGeneration(chatId: chatId, announce: false)
                     }
                     chatSelectionFence.invalidate()
                     chatSelectionTask?.cancel()
@@ -2752,6 +2811,8 @@ class ChatViewModel: ObservableObject {
     /// Replaces a chat in whichever array (localChats or chats) it belongs to.
     /// If the chat isn't in either array, inserts it into the appropriate one.
     private func replaceChat(_ updatedChat: Chat) {
+        guard updatedChat.isLocalOnly
+            || !DeletedChatsTracker.shared.isDeleted(updatedChat.id) else { return }
         if let favoriteIndex = favoriteChats.firstIndex(where: { $0.id == updatedChat.id }) {
             if ChatFavorites.isPinnable(updatedChat) {
                 favoriteChats[favoriteIndex] = updatedChat
@@ -5087,6 +5148,7 @@ class ChatViewModel: ObservableObject {
     /// Saves a single chat to per-chat file storage and triggers cloud backup
     private func saveChat(_ chat: Chat, shouldBackup: Bool = true) {
         guard acceptsChatSaves else { return }
+        guard chat.isLocalOnly || !DeletedChatsTracker.shared.isDeleted(chat.id) else { return }
         guard !chat.isTemporary else { return }
         guard hasChatAccess else { return }
         guard !chat.messages.isEmpty || chat.decryptionFailed else { return }
@@ -5120,6 +5182,7 @@ class ChatViewModel: ObservableObject {
     ) async {
         guard acceptsChatSaves else { return }
         guard isCurrentSignIn(token, userId: userId) else { return }
+        guard chat.isLocalOnly || !DeletedChatsTracker.shared.isDeleted(chat.id) else { return }
         guard !chat.isTemporary else { return }
         guard !chat.messages.isEmpty || chat.decryptionFailed else { return }
 
@@ -5154,7 +5217,13 @@ class ChatViewModel: ObservableObject {
         storage: ChatRecoveryStorage,
         turnId: String
     ) async throws {
+        if storage == .cloud, DeletedChatsTracker.shared.isDeleted(chat.id) {
+            throw ChatRecoverySyncError.chatMissing
+        }
         await drainPendingSaves()
+        if storage == .cloud, DeletedChatsTracker.shared.isDeleted(chat.id) {
+            throw ChatRecoverySyncError.chatMissing
+        }
         if try await storage.fileStorage.containsRecoverySnapshot(
             chatId: chat.id,
             userId: userId,
@@ -5944,36 +6013,67 @@ class ChatViewModel: ObservableObject {
                 try await self.cloudSync.deleteAllFromCloud(userId: userId)
             },
             recoverFromFailure: {
-                await self.cloudSync.resumeUploadsAfterBulkDelete(userId: userId)
-                guard self.currentUserId == userId else { return }
-                self.acceptsChatSaves = true
-                self.accountOperationTracker.reopen()
-                self.recoveryScansSuspended = false
-                self.setupAutoSyncTimer()
+                await self.restoreDeleteAllOperationalState(
+                    userId: userId,
+                    inMemoryWasCleared: false
+                )
             }
         )
 
         clearHydratedFavorites()
         ProfileManager.shared.clearPinnedChats()
 
-        // Tombstone so an in-flight sync pass can't resurrect wiped chats
-        for id in allChatIds {
-            DeletedChatsTracker.shared.markAsDeleted(id)
+        var inMemoryWasCleared = false
+        var cleanupError: Error?
+        do {
+            // Tombstone so an in-flight sync pass can't resurrect wiped chats
+            for id in allChatIds {
+                DeletedChatsTracker.shared.markAsDeleted(id)
+            }
+
+            await clearAllChatsFromDevice(
+                resumeRecoveryScans: false,
+                reopenAccountOperations: false
+            )
+            inMemoryWasCleared = true
+            try await EncryptedFileStorage.local.deleteAllChats(userId: userId)
+            try await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
+        } catch {
+            cleanupError = error
         }
 
-        await clearAllChatsFromDevice(
-            resumeRecoveryScans: false,
-            reopenAccountOperations: false
+        await restoreDeleteAllOperationalState(
+            userId: userId,
+            inMemoryWasCleared: inMemoryWasCleared
         )
-        try await EncryptedFileStorage.local.deleteAllChats(userId: userId)
-        try await EncryptedFileStorage.cloud.deleteAllChats(userId: userId)
+        if let cleanupError {
+            throw cleanupError
+        }
+    }
+
+    private func restoreDeleteAllOperationalState(
+        userId: String,
+        inMemoryWasCleared: Bool
+    ) async {
         await cloudSync.resumeUploadsAfterBulkDelete(userId: userId)
+        guard currentUserId == userId else { return }
+
+        let restoration = DeleteAllOperationalRestoration.resolve(
+            inMemoryWasCleared: inMemoryWasCleared,
+            hasCurrentChat: currentChat != nil
+        )
         acceptsChatSaves = true
         accountOperationTracker.reopen()
-        // The device wipe clears the in-memory key reference; restore it so
-        // newly created chats keep syncing.
-        reloadEncryptionKey()
-        createNewChat()
+        if restoration.reloadEncryptionKey {
+            reloadEncryptionKey()
+        }
+        if restoration.ensureUsableChat {
+            if currentChat == nil {
+                createNewChat()
+            } else {
+                ensureBlankChatAtTop()
+            }
+        }
         recoveryScansSuspended = false
         setupAutoSyncTimer()
     }

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -252,10 +252,16 @@ struct ChatListView: View {
                     Text(viewModel.chatHydrationError ?? "Loading conversation...")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
+                    if viewModel.chatHydrationError != nil && viewModel.canRetryFailedChatHydration {
+                        Button("Try Again") {
+                            viewModel.retryFailedChatHydration()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.chatBackground(isDarkMode: isDarkMode))
-                .accessibilityElement(children: .combine)
+                .accessibilityElement(children: .contain)
                 .accessibilityLabel(viewModel.chatHydrationError ?? "Loading conversation")
             }
         }

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -243,6 +243,22 @@ struct ChatListView: View {
             viewModel.isScrollInteractionActive = false
             scrollToUserTrigger = UUID()
         }
+        .overlay {
+            if viewModel.hydratingChatId != nil || viewModel.chatHydrationError != nil {
+                VStack(spacing: 12) {
+                    if viewModel.hydratingChatId != nil {
+                        ProgressView()
+                    }
+                    Text(viewModel.chatHydrationError ?? "Loading conversation...")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.chatBackground(isDarkMode: isDarkMode))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(viewModel.chatHydrationError ?? "Loading conversation")
+            }
+        }
     }
 
     private func pruneRecoveryDrafts() {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -395,7 +395,7 @@ struct ChatSidebar: View {
             ForEach(Array(displayedChats.enumerated()), id: \.element.id) { _, chat in
                 ChatListItem(
                     chat: chat,
-                    isSelected: viewModel.currentChat?.id == chat.id,
+                    isSelected: viewModel.selectedChatId == chat.id,
                     isEditing: editingChatId == chat.id,
                     editingTitle: $editingTitle,
                     createdTimeString: chat.isBlankChat ? "" : relativeTimeString(from: chat.createdAt),
@@ -406,6 +406,14 @@ struct ChatSidebar: View {
                     isPinned: profileManager.isChatPinned(chat.id),
                     onSelect: {
                         if isChatSearchActive {
+                            if !chatSearch.available {
+                                viewModel.openSummaryChat(
+                                    id: chat.id,
+                                    projectId: chat.projectId,
+                                    isLocalOnly: chat.isLocalOnly
+                                )
+                                return
+                            }
                             guard let fullChat = resolveSidebarSearchChat(
                                 id: chat.id,
                                 remoteResults: chatSearch.results,
@@ -418,8 +426,10 @@ struct ChatSidebar: View {
                     },
                     onEdit: {
                         if editingChatId == chat.id {
-                            viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
-                            editingChatId = nil
+                            Task {
+                                await viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
+                                editingChatId = nil
+                            }
                         } else {
                             startEditing(chat)
                         }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -426,9 +426,13 @@ struct ChatSidebar: View {
                     },
                     onEdit: {
                         if editingChatId == chat.id {
+                            let editedChatId = chat.id
+                            let editedTitle = editingTitle
                             Task {
-                                await viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
-                                editingChatId = nil
+                                await viewModel.updateChatTitle(editedChatId, newTitle: editedTitle)
+                                if editingChatId == editedChatId {
+                                    editingChatId = nil
+                                }
                             }
                         } else {
                             startEditing(chat)

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -371,6 +371,7 @@ struct ChatContainer: View {
                         )
                     }
                     .accessibilityLabel(viewModel.isTemporaryMode ? "Exit temporary chat" : "Start temporary chat")
+                    .disabled(!viewModel.canUseCurrentChatActions)
                     .accessibleHitTarget()
                 }
             }
@@ -383,6 +384,7 @@ struct ChatContainer: View {
                             .foregroundColor(toolbarContentColor)
                     }
                     .accessibilityLabel("New chat")
+                    .disabled(!viewModel.canUseCurrentChatActions)
                     .accessibleHitTarget()
                 }
             }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -178,6 +178,7 @@ struct MessageInputView: View {
     /// an attachment is still processing or the previous response is being
     /// recovered; voice greys out while a recording is being transcribed.
     private var isTrailingActionDisabled: Bool {
+        guard viewModel.canUseCurrentChatActions else { return true }
         switch trailingAction {
         case .voice: return viewModel.isTranscribing
         case .send:
@@ -245,6 +246,7 @@ struct MessageInputView: View {
             .onChange(of: messageText) { _, newValue in
                 messageTextHasNonWhitespace = hasNonWhitespaceContent(newValue)
             }
+            .disabled(!viewModel.canUseCurrentChatActions)
             .onChange(of: textHeight) { _, newHeight in
                 guard let isInputExpanded else { return }
                 let expanded = newHeight > Layout.minimumHeight + 1

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -140,7 +140,7 @@ struct ProjectPage: View {
         }
     }
 
-    private func chatRow(_ chat: Chat) -> some View {
+    private func chatRow(_ chat: ChatListSummary) -> some View {
         Button {
             viewModel.openProjectChat(chat)
         } label: {
@@ -245,7 +245,7 @@ struct ProjectPage: View {
         }
     }
 
-    private func timestampText(for chat: Chat) -> Text {
+    private func timestampText(for chat: ChatListSummary) -> Text {
         let created = relativeTimeString(from: chat.createdAt)
         let updated = relativeTimeString(from: chat.updatedAt)
         let createdText = Text(created)

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -29,6 +29,7 @@ private actor RecordingChatLoadingService: ChatLoadingService {
     private var failingSaveIds: Set<String> = []
     private var failingDeleteIds: [ChatStorageTab: Set<String>] = [:]
     private var applyResults: [String: RevisionApplyResult] = [:]
+    private var tombstoneOnApplyIds: Set<String> = []
 
     func setIndex(_ entries: [ChatIndexEntry], storage: ChatStorageTab) {
         indexes[storage] = entries
@@ -52,6 +53,10 @@ private actor RecordingChatLoadingService: ChatLoadingService {
 
     func setApplyResult(_ result: RevisionApplyResult, chatId: String) {
         applyResults[chatId] = result
+    }
+
+    func setTombstoneOnApplyIds(_ ids: Set<String>) {
+        tombstoneOnApplyIds = ids
     }
 
     func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry] {
@@ -93,6 +98,9 @@ private actor RecordingChatLoadingService: ChatLoadingService {
                 indexes[.cloud]?[index] = ChatIndexEntry(from: chat)
             } else {
                 indexes[.cloud, default: []].append(ChatIndexEntry(from: chat))
+            }
+            if tombstoneOnApplyIds.contains(chat.id) {
+                DeletedChatsTracker.shared.markAsDeleted(chat.id)
             }
         }
         return result
@@ -275,6 +283,7 @@ struct LazyChatHydrationTests {
         let paginationService = RecordingChatLoadingService()
         let paginationChat = makeChat(id: "deleted-pagination", updatedAt: Date())
         DeletedChatsTracker.shared.markAsDeleted(paginationChat.id)
+        defer { DeletedChatsTracker.shared.removeFromDeleted(paginationChat.id) }
 
         let page = await ChatPaginationPersistence.saveCloudChats(
             [paginationChat],
@@ -291,6 +300,7 @@ struct LazyChatHydrationTests {
         let searchService = RecordingChatLoadingService()
         let searchChat = makeChat(id: "deleted-search", updatedAt: Date())
         DeletedChatsTracker.shared.markAsDeleted(searchChat.id)
+        defer { DeletedChatsTracker.shared.removeFromDeleted(searchChat.id) }
         let searchResult = try await RemoteSearchPersistence.resolve(
             searchChat,
             userId: "user",
@@ -302,6 +312,25 @@ struct LazyChatHydrationTests {
             return
         }
         #expect(await searchService.counts().saves == 0)
+    }
+
+    @Test
+    @MainActor
+    func tombstoneArrivingDuringPaginationApplyRollsBackStoredChat() async {
+        let service = RecordingChatLoadingService()
+        let chat = makeChat(id: "delete-race", updatedAt: Date())
+        await service.setTombstoneOnApplyIds([chat.id])
+        defer { DeletedChatsTracker.shared.removeFromDeleted(chat.id) }
+
+        let result = await ChatPaginationPersistence.saveCloudChats(
+            [chat],
+            userId: "user",
+            loadingService: service
+        )
+
+        #expect(result.outcomes == [.deleted(chat.id)])
+        #expect(await service.savedChat(id: chat.id, storage: .cloud) == nil)
+        #expect(await service.deletedStorages() == [.cloud])
     }
 
     @Test

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -572,6 +572,47 @@ struct LazyChatHydrationTests {
     }
 
     @Test
+    func tombstoneExcludesDirtyStreamingSelectionAndRequiresReplacement() {
+        var tombstoned = makeChat(id: "tombstoned", updatedAt: Date())
+        tombstoned.locallyModified = true
+        tombstoned.hasActiveStream = true
+
+        let result = AuthoritativeCloudIndexReconciliation.reconcile(
+            indexedSummaries: [ChatListSummary(from: tombstoned)],
+            authoritativeIds: [tombstoned.id],
+            tombstonedIds: [tombstoned.id],
+            materializedChats: [tombstoned],
+            selectedId: tombstoned.id,
+            currentId: tombstoned.id,
+            streamingIds: [tombstoned.id],
+            recoveryIds: [tombstoned.id],
+            operationIds: [tombstoned.id]
+        )
+
+        #expect(result.summaries.isEmpty)
+        #expect(result.materializedChats.isEmpty)
+        #expect(result.removedSelectedChat)
+        #expect(result.removedCurrentChat)
+    }
+
+    @Test
+    func deleteAllRestorationRecoversOperationalStateAfterClearedMemory() {
+        let afterCleanupFailure = DeleteAllOperationalRestoration.resolve(
+            inMemoryWasCleared: true,
+            hasCurrentChat: false
+        )
+        let afterCloudFailure = DeleteAllOperationalRestoration.resolve(
+            inMemoryWasCleared: false,
+            hasCurrentChat: true
+        )
+
+        #expect(afterCleanupFailure.reloadEncryptionKey)
+        #expect(afterCleanupFailure.ensureUsableChat)
+        #expect(!afterCloudFailure.reloadEncryptionKey)
+        #expect(!afterCloudFailure.ensureUsableChat)
+    }
+
+    @Test
     @MainActor
     func remoteSearchPersistsNewChatAndUsesLocalContentOnFreshnessConflict() async throws {
         let service = RecordingChatLoadingService()

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -367,6 +367,33 @@ struct LazyChatHydrationTests {
     }
 
     @Test
+    @MainActor
+    func failedProjectRollbackPreservesBothErrors() async {
+        let service = RecordingChatLoadingService()
+        var moved = makeChat(id: "rollback", updatedAt: Date())
+        moved.isLocalOnly = false
+        moved.projectId = "project"
+        await service.setFailingDeleteIds([moved.id], storage: .local)
+        await service.setFailingDeleteIds([moved.id], storage: .cloud)
+
+        do {
+            try await ChatProjectStorageTransition.persist(
+                moved,
+                wasLocal: true,
+                userId: "user",
+                loadingService: service,
+                validateAccount: {}
+            )
+            Issue.record("Expected project rollback to fail")
+        } catch let error as ChatProjectStorageTransition.RollbackError {
+            #expect(!error.primary.localizedDescription.isEmpty)
+            #expect(!error.rollback.localizedDescription.isEmpty)
+        } catch {
+            Issue.record("Expected both project transition errors to be preserved")
+        }
+    }
+
+    @Test
     func throwingTitleSaveLeavesOriginalValueUncommitted() async {
         let service = RecordingChatLoadingService()
         let original = makeChat(id: "title", updatedAt: Date())

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -219,6 +219,32 @@ struct LazyChatHydrationTests {
     }
 
     @Test
+    func cancelledPaginationResultRetainsOriginalPageStateWithoutFailure() {
+        let result = PaginatedChatsResult(chats: [], cancelled: true)
+        let original = ChatPaginationPageState(token: "current", hasMore: true)
+
+        let resolved = ChatPaginationCoordinator.state(
+            original: original,
+            next: ChatPaginationPageState(token: result.nextToken, hasMore: result.hasMore),
+            allRowsPersisted: true,
+            pageFailed: result.failed,
+            pageCancelled: result.cancelled
+        )
+
+        #expect(resolved == original)
+        #expect(result.cancelled)
+        #expect(!result.failed)
+    }
+
+    @Test
+    func failedHydrationRetainsRetryIdentityAndStorage() {
+        let failedHydration = FailedChatHydration(id: "chat", storage: .local)
+
+        #expect(failedHydration.id == "chat")
+        #expect(failedHydration.isLocalOnly)
+    }
+
+    @Test
     func anonymousMigrationFailureRemainsPendingUntilLaterSuccess() {
         var hasChatsRemaining = AnonymousChatMigrationPolicy.hasChatsRemaining(allSucceeded: false)
         #expect(hasChatsRemaining)
@@ -285,6 +311,8 @@ struct LazyChatHydrationTests {
         )
 
         #expect(resolved == original)
+        #expect(result.failed)
+        #expect(!result.cancelled)
     }
 
     @Test
@@ -353,16 +381,6 @@ struct LazyChatHydrationTests {
 
         #expect(await service.savedChat(id: original.id, storage: .cloud)?.title == original.title)
         #expect(await service.counts().deletes == 0)
-    }
-
-    @Test
-    func deletingUnmaterializedIdentityDoesNotLoadChat() async throws {
-        let service = RecordingChatLoadingService()
-
-        try await service.deleteChat(id: "delete", userId: "user", storage: .cloud)
-
-        #expect(await service.counts().loads == 0)
-        #expect(await service.counts().deletes == 1)
     }
 
     @Test

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -6,6 +6,19 @@ private enum LazyHydrationTestError: Error, Sendable {
     case corrupt
 }
 
+@MainActor
+private final class DeleteAllEventRecorder {
+    private var events: [String] = []
+
+    func append(_ event: String) {
+        events.append(event)
+    }
+
+    func recorded() -> [String] {
+        events
+    }
+}
+
 private actor RecordingChatLoadingService: ChatLoadingService {
     private var indexes: [ChatStorageTab: [ChatIndexEntry]] = [:]
     private var storedChats: [ChatStorageTab: [String: Chat]] = [:]
@@ -15,6 +28,7 @@ private actor RecordingChatLoadingService: ChatLoadingService {
     private var shouldThrowCorrupt = false
     private var failingSaveIds: Set<String> = []
     private var failingDeleteIds: [ChatStorageTab: Set<String>] = [:]
+    private var applyResults: [String: RevisionApplyResult] = [:]
 
     func setIndex(_ entries: [ChatIndexEntry], storage: ChatStorageTab) {
         indexes[storage] = entries
@@ -36,6 +50,10 @@ private actor RecordingChatLoadingService: ChatLoadingService {
         failingDeleteIds[storage] = ids
     }
 
+    func setApplyResult(_ result: RevisionApplyResult, chatId: String) {
+        applyResults[chatId] = result
+    }
+
     func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry] {
         indexes[storage] ?? []
     }
@@ -53,6 +71,31 @@ private actor RecordingChatLoadingService: ChatLoadingService {
         saveCalls.append((chat.id, storage))
         if failingSaveIds.contains(chat.id) { throw LazyHydrationTestError.corrupt }
         storedChats[storage, default: [:]][chat.id] = chat
+    }
+
+    func applyRemoteChatIfFreshResult(
+        _ chat: Chat,
+        userId: String,
+        expectedLocalUpdatedAt: Date?,
+        allowLocallyModified: Bool
+    ) async throws -> RevisionApplyResult {
+        saveCalls.append((chat.id, .cloud))
+        if failingSaveIds.contains(chat.id) { throw LazyHydrationTestError.corrupt }
+        let existing = indexes[.cloud]?.first { $0.id == chat.id }
+        let result = applyResults[chat.id] ?? RevisionApplyPolicy.contentResult(
+            existing: existing,
+            expectedUpdatedAt: expectedLocalUpdatedAt,
+            allowLocallyModified: allowLocallyModified
+        )
+        if result == .applied {
+            storedChats[.cloud, default: [:]][chat.id] = chat
+            if let index = indexes[.cloud]?.firstIndex(where: { $0.id == chat.id }) {
+                indexes[.cloud]?[index] = ChatIndexEntry(from: chat)
+            } else {
+                indexes[.cloud, default: []].append(ChatIndexEntry(from: chat))
+            }
+        }
+        return result
     }
 
     func deleteChat(id: String, userId: String, storage: ChatStorageTab) async throws {
@@ -198,10 +241,32 @@ struct LazyChatHydrationTests {
             loadingService: service
         )
 
-        #expect(result.saved.map(\.id) == [saved.id])
+        #expect(result.summaries.map(\.id) == [saved.id])
         #expect(result.failedIds == [failed.id])
         #expect(await service.savedChat(id: saved.id, storage: .cloud) != nil)
         #expect(await service.savedChat(id: failed.id, storage: .cloud) == nil)
+    }
+
+    @Test
+    func paginationConflictKeepsLocallyModifiedContentAndSummary() async {
+        let service = RecordingChatLoadingService()
+        var local = makeChat(id: "conflict", updatedAt: Date(timeIntervalSince1970: 1))
+        local.title = "Local edit"
+        local.locallyModified = true
+        var remote = makeChat(id: local.id, updatedAt: Date(timeIntervalSince1970: 2))
+        remote.title = "Remote edit"
+        await service.setIndex([ChatIndexEntry(from: local)], storage: .cloud)
+        await service.setChat(local, storage: .cloud)
+
+        let result = await ChatPaginationPersistence.saveCloudChats(
+            [remote],
+            userId: "user",
+            loadingService: service
+        )
+
+        #expect(result.failedIds.isEmpty)
+        #expect(result.summaries.first?.title == local.title)
+        #expect(await service.savedChat(id: local.id, storage: .cloud)?.title == local.title)
     }
 
     @Test
@@ -430,6 +495,113 @@ struct LazyChatHydrationTests {
         )
 
         #expect(Set(retained.map(\.id)) == [current.id, stream.id, recovery.id, dirty.id])
+    }
+
+    @Test
+    @MainActor
+    func deleteAllQuiescesBeforeCloudDeletion() async throws {
+        let recorder = DeleteAllEventRecorder()
+
+        try await DeleteAllChatsCoordinator.quiesceAndDeleteCloud(
+            closeSaveAdmission: { recorder.append("close") },
+            stopProducers: { recorder.append("stop") },
+            drainSavesAndBackups: { recorder.append("drain") },
+            quiesceUploads: { recorder.append("quiesce") },
+            deleteCloud: { recorder.append("delete") },
+            recoverFromFailure: { recorder.append("recover") }
+        )
+
+        #expect(recorder.recorded() == ["close", "stop", "drain", "quiesce", "delete"])
+    }
+
+    @Test
+    func recoveryUpdateRejectsStaleOrUnsafeIdentity() {
+        #expect(!RecoveryUpdateAdmission.accepts(
+            accountIsCurrent: false,
+            isAccountTeardownInProgress: false,
+            wasSelected: true,
+            isStillSelected: true,
+            wasMutating: false,
+            isMutating: false,
+            identityExists: true,
+            isStreaming: false
+        ))
+        #expect(!RecoveryUpdateAdmission.accepts(
+            accountIsCurrent: true,
+            isAccountTeardownInProgress: false,
+            wasSelected: true,
+            isStillSelected: true,
+            wasMutating: false,
+            isMutating: true,
+            identityExists: true,
+            isStreaming: false
+        ))
+        #expect(!RecoveryUpdateAdmission.accepts(
+            accountIsCurrent: true,
+            isAccountTeardownInProgress: false,
+            wasSelected: true,
+            isStillSelected: true,
+            wasMutating: false,
+            isMutating: false,
+            identityExists: false,
+            isStreaming: false
+        ))
+    }
+
+    @Test
+    func authoritativeIndexRemovesCleanSelectionButRetainsDirtyAndStreamingChats() {
+        let clean = makeChat(id: "clean", updatedAt: Date())
+        var dirty = makeChat(id: "dirty", updatedAt: Date())
+        dirty.locallyModified = true
+        var streaming = makeChat(id: "streaming", updatedAt: Date())
+        streaming.hasActiveStream = true
+
+        let result = AuthoritativeCloudIndexReconciliation.reconcile(
+            indexedSummaries: [],
+            authoritativeIds: [],
+            materializedChats: [clean, dirty, streaming],
+            selectedId: clean.id,
+            streamingIds: [streaming.id],
+            recoveryIds: [],
+            operationIds: []
+        )
+
+        #expect(result.removedSelectedChat)
+        #expect(Set(result.materializedChats.map(\.id)) == [dirty.id, streaming.id])
+        #expect(Set(result.summaries.map(\.id)) == [dirty.id, streaming.id])
+    }
+
+    @Test
+    @MainActor
+    func remoteSearchPersistsNewChatAndUsesLocalContentOnFreshnessConflict() async throws {
+        let service = RecordingChatLoadingService()
+        let remote = makeChat(id: "remote-search", updatedAt: Date())
+
+        let persisted = try await RemoteSearchPersistence.resolve(
+            remote,
+            userId: "user",
+            loadingService: service
+        )
+        let reopened = try await service.loadChat(
+            id: remote.id,
+            userId: "user",
+            storage: .cloud
+        )
+        #expect(persisted.id == remote.id)
+        #expect(reopened.id == remote.id)
+
+        let conflictService = RecordingChatLoadingService()
+        var local = remote
+        local.title = "Local authority"
+        local.locallyModified = true
+        await conflictService.setChat(local, storage: .cloud)
+        await conflictService.setApplyResult(.locallyModified, chatId: remote.id)
+        let resolved = try await RemoteSearchPersistence.resolve(
+            remote,
+            userId: "user",
+            loadingService: conflictService
+        )
+        #expect(resolved.title == local.title)
     }
 
     @Test

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -270,6 +270,41 @@ struct LazyChatHydrationTests {
     }
 
     @Test
+    @MainActor
+    func tombstonedPaginationAndSearchRowsNeverApplyOrPublish() async throws {
+        let paginationService = RecordingChatLoadingService()
+        let paginationChat = makeChat(id: "deleted-pagination", updatedAt: Date())
+        DeletedChatsTracker.shared.markAsDeleted(paginationChat.id)
+
+        let page = await ChatPaginationPersistence.saveCloudChats(
+            [paginationChat],
+            userId: "user",
+            loadingService: paginationService
+        )
+
+        #expect(page.outcomes == [.deleted(paginationChat.id)])
+        #expect(page.summaries.isEmpty)
+        #expect(page.failedIds.isEmpty)
+        #expect(page.safelyPersistedCount == 1)
+        #expect(await paginationService.counts().saves == 0)
+
+        let searchService = RecordingChatLoadingService()
+        let searchChat = makeChat(id: "deleted-search", updatedAt: Date())
+        DeletedChatsTracker.shared.markAsDeleted(searchChat.id)
+        let searchResult = try await RemoteSearchPersistence.resolve(
+            searchChat,
+            userId: "user",
+            loadingService: searchService
+        )
+
+        guard case .deleted = searchResult else {
+            Issue.record("Expected tombstoned search result to be skipped")
+            return
+        }
+        #expect(await searchService.counts().saves == 0)
+    }
+
+    @Test
     func paginationPartialFailureRetainsOriginalPageState() {
         let original = ChatPaginationPageState(token: "current", hasMore: true)
         let next = ChatPaginationPageState(token: "next", hasMore: false)
@@ -608,8 +643,10 @@ struct LazyChatHydrationTests {
 
         #expect(afterCleanupFailure.reloadEncryptionKey)
         #expect(afterCleanupFailure.ensureUsableChat)
+        #expect(afterCleanupFailure.restartSignIn)
         #expect(!afterCloudFailure.reloadEncryptionKey)
         #expect(!afterCloudFailure.ensureUsableChat)
+        #expect(afterCloudFailure.restartSignIn)
     }
 
     @Test
@@ -618,11 +655,15 @@ struct LazyChatHydrationTests {
         let service = RecordingChatLoadingService()
         let remote = makeChat(id: "remote-search", updatedAt: Date())
 
-        let persisted = try await RemoteSearchPersistence.resolve(
+        let persistenceResult = try await RemoteSearchPersistence.resolve(
             remote,
             userId: "user",
             loadingService: service
         )
+        guard case .chat(let persisted) = persistenceResult else {
+            Issue.record("Expected remote search chat to persist")
+            return
+        }
         let reopened = try await service.loadChat(
             id: remote.id,
             userId: "user",
@@ -637,11 +678,15 @@ struct LazyChatHydrationTests {
         local.locallyModified = true
         await conflictService.setChat(local, storage: .cloud)
         await conflictService.setApplyResult(.locallyModified, chatId: remote.id)
-        let resolved = try await RemoteSearchPersistence.resolve(
+        let conflictResult = try await RemoteSearchPersistence.resolve(
             remote,
             userId: "user",
             loadingService: conflictService
         )
+        guard case .chat(let resolved) = conflictResult else {
+            Issue.record("Expected local search conflict to resolve")
+            return
+        }
         #expect(resolved.title == local.title)
     }
 

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -1,0 +1,432 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+private enum LazyHydrationTestError: Error, Sendable {
+    case corrupt
+}
+
+private actor RecordingChatLoadingService: ChatLoadingService {
+    private var indexes: [ChatStorageTab: [ChatIndexEntry]] = [:]
+    private var storedChats: [ChatStorageTab: [String: Chat]] = [:]
+    private var loadCalls: [(String, ChatStorageTab)] = []
+    private var saveCalls: [(String, ChatStorageTab)] = []
+    private var deleteCalls: [(String, ChatStorageTab)] = []
+    private var shouldThrowCorrupt = false
+    private var failingSaveIds: Set<String> = []
+    private var failingDeleteIds: [ChatStorageTab: Set<String>] = [:]
+
+    func setIndex(_ entries: [ChatIndexEntry], storage: ChatStorageTab) {
+        indexes[storage] = entries
+    }
+
+    func setChat(_ chat: Chat, storage: ChatStorageTab) {
+        storedChats[storage, default: [:]][chat.id] = chat
+    }
+
+    func setCorruptLoad() {
+        shouldThrowCorrupt = true
+    }
+
+    func setFailingSaveIds(_ ids: Set<String>) {
+        failingSaveIds = ids
+    }
+
+    func setFailingDeleteIds(_ ids: Set<String>, storage: ChatStorageTab) {
+        failingDeleteIds[storage] = ids
+    }
+
+    func loadIndex(userId: String, storage: ChatStorageTab) async throws -> [ChatIndexEntry] {
+        indexes[storage] ?? []
+    }
+
+    func loadChat(id: String, userId: String, storage: ChatStorageTab) async throws -> Chat {
+        loadCalls.append((id, storage))
+        if shouldThrowCorrupt { throw LazyHydrationTestError.corrupt }
+        guard let chat = storedChats[storage]?[id] else {
+            throw ChatLoadingError.chatNotFound(id: id, storage: storage)
+        }
+        return chat
+    }
+
+    func saveChat(_ chat: Chat, userId: String, storage: ChatStorageTab) async throws {
+        saveCalls.append((chat.id, storage))
+        if failingSaveIds.contains(chat.id) { throw LazyHydrationTestError.corrupt }
+        storedChats[storage, default: [:]][chat.id] = chat
+    }
+
+    func deleteChat(id: String, userId: String, storage: ChatStorageTab) async throws {
+        deleteCalls.append((id, storage))
+        if failingDeleteIds[storage]?.contains(id) == true { throw LazyHydrationTestError.corrupt }
+        storedChats[storage]?[id] = nil
+    }
+
+    func counts() -> (loads: Int, saves: Int, deletes: Int) {
+        (loadCalls.count, saveCalls.count, deleteCalls.count)
+    }
+
+    func lastLoad() -> (String, ChatStorageTab)? { loadCalls.last }
+    func savedChat(id: String, storage: ChatStorageTab) -> Chat? { storedChats[storage]?[id] }
+    func deletedStorages() -> [ChatStorageTab] { deleteCalls.map(\.1) }
+}
+
+struct LazyChatHydrationTests {
+    @Test
+    func publishesThousandIndexSummariesWithoutLoadingFullChats() async throws {
+        let service = RecordingChatLoadingService()
+        let entries = (0..<1_000).map { index in
+            ChatIndexEntry(from: makeChat(id: "chat-\(index)", updatedAt: Date(timeIntervalSince1970: Double(index))))
+        }
+        await service.setIndex(entries, storage: .cloud)
+
+        let loadedIndex = try await service.loadIndex(userId: "user", storage: .cloud)
+        let result = ChatSummaryState.page(from: loadedIndex)
+
+        #expect(result.summaries.count == 1_000)
+        #expect(result.totalEntries == 1_000)
+        #expect(await service.counts().loads == 0)
+    }
+
+    @Test
+    func hydrationUsesTheRequestedStoreAndSurfacesMissingOrCorruptLoads() async throws {
+        let service = RecordingChatLoadingService()
+        let cloudChat = makeChat(id: "cloud", updatedAt: Date())
+        await service.setChat(cloudChat, storage: .cloud)
+
+        let loaded = try await service.loadChat(id: cloudChat.id, userId: "user", storage: .cloud)
+        #expect(loaded.id == cloudChat.id)
+        #expect(await service.lastLoad()?.1 == .cloud)
+
+        do {
+            _ = try await service.loadChat(id: "missing", userId: "user", storage: .local)
+            Issue.record("Expected an explicit missing-chat failure")
+        } catch let error as ChatLoadingError {
+            #expect(error == .chatNotFound(id: "missing", storage: .local))
+        }
+
+        await service.setCorruptLoad()
+        await #expect(throws: LazyHydrationTestError.self) {
+            _ = try await service.loadChat(id: cloudChat.id, userId: "user", storage: .cloud)
+        }
+    }
+
+    @Test
+    func newerSelectionSuppressesAnOlderHydration() {
+        var fence = ChatSelectionFence()
+        let generationA = fence.begin(id: "A")
+        let generationB = fence.begin(id: "B")
+
+        #expect(!fence.accepts(id: "A", generation: generationA))
+        #expect(fence.accepts(id: "B", generation: generationB))
+    }
+
+    @Test
+    func invalidatingSelectionRejectsHydrationCompletion() {
+        var fence = ChatSelectionFence()
+        let generation = fence.begin(id: "delete")
+
+        fence.invalidate()
+
+        #expect(!fence.accepts(id: "delete", generation: generation))
+        #expect(fence.selectedId == nil)
+    }
+
+    @Test
+    func newerTransientSummaryOverridesOlderIndexSummary() {
+        let older = makeChat(id: "chat", updatedAt: Date(timeIntervalSince1970: 1))
+        var newer = older
+        newer.title = "New title"
+        newer.updatedAt = Date(timeIntervalSince1970: 2)
+
+        let reconciled = ChatSummaryState.reconcilingIndex(
+            [ChatListSummary(from: older)],
+            withTransient: [ChatListSummary(from: newer)]
+        )
+
+        #expect(reconciled.first?.title == "New title")
+    }
+
+    @Test
+    func blankUpsertReplacesExistingBlankForStorage() {
+        let oldBlank = makeBlankChat(id: "old-blank")
+        let newBlank = makeBlankChat(id: "new-blank")
+        let regular = makeChat(id: "regular", updatedAt: Date())
+
+        let summaries = ChatSummaryState.upserting(
+            ChatListSummary(from: newBlank),
+            into: [ChatListSummary(from: oldBlank), ChatListSummary(from: regular)]
+        )
+
+        #expect(summaries.filter(\.isBlankChat).map(\.id) == [newBlank.id])
+        #expect(summaries.contains { $0.id == regular.id })
+    }
+
+    @Test
+    func refreshedCloudIndexPreservesLoadedRootIdsAndProjects() {
+        var entries = (0..<5).map { index in
+            ChatIndexEntry(from: makeChat(
+                id: "root-\(index)",
+                updatedAt: Date(timeIntervalSince1970: Double(index))
+            ))
+        }
+        var projectChat = makeChat(id: "project", updatedAt: Date(timeIntervalSince1970: 10))
+        projectChat.projectId = "project-id"
+        entries.append(ChatIndexEntry(from: projectChat))
+
+        let result = ChatSummaryState.cloudIndexSummaries(
+            from: entries,
+            loadedRootIds: ["root-0"],
+            firstPageLimit: 2
+        )
+        let ids = Set(result.summaries.map(\.id))
+
+        #expect(ids == ["root-4", "root-3", "root-0", "project"])
+        #expect(result.firstPageIds == ["root-4", "root-3"])
+        #expect(result.totalRootEntries == 5)
+    }
+
+    @Test
+    func paginationPersistenceReturnsOnlySuccessfullySavedChats() async {
+        let service = RecordingChatLoadingService()
+        let saved = makeChat(id: "saved", updatedAt: Date())
+        let failed = makeChat(id: "failed", updatedAt: Date())
+        await service.setFailingSaveIds([failed.id])
+
+        let result = await ChatPaginationPersistence.saveCloudChats(
+            [saved, failed],
+            userId: "user",
+            loadingService: service
+        )
+
+        #expect(result.saved.map(\.id) == [saved.id])
+        #expect(result.failedIds == [failed.id])
+        #expect(await service.savedChat(id: saved.id, storage: .cloud) != nil)
+        #expect(await service.savedChat(id: failed.id, storage: .cloud) == nil)
+    }
+
+    @Test
+    func paginationPartialFailureRetainsOriginalPageState() {
+        let original = ChatPaginationPageState(token: "current", hasMore: true)
+        let next = ChatPaginationPageState(token: "next", hasMore: false)
+
+        let resolved = ChatPaginationCoordinator.state(
+            original: original,
+            next: next,
+            allRowsPersisted: false
+        )
+
+        #expect(resolved == original)
+    }
+
+    @Test
+    func anonymousMigrationFailureRemainsPendingUntilLaterSuccess() {
+        var hasChatsRemaining = AnonymousChatMigrationPolicy.hasChatsRemaining(allSucceeded: false)
+        #expect(hasChatsRemaining)
+
+        hasChatsRemaining = AnonymousChatMigrationPolicy.hasChatsRemaining(allSucceeded: true)
+        #expect(!hasChatsRemaining)
+    }
+
+    @Test
+    func deleteFailureRestoresSelectedConversation() {
+        #expect(ChatDeleteSelectionResolution.resolve(
+            deletionOwnedSelection: true,
+            deletionSucceeded: false,
+            deletionGeneration: 2,
+            currentGeneration: 2,
+            deletedId: "deleted",
+            currentSelectedId: "deleted"
+        ) == .restore)
+        #expect(ChatDeleteSelectionResolution.resolve(
+            deletionOwnedSelection: true,
+            deletionSucceeded: true,
+            deletionGeneration: 2,
+            currentGeneration: 2,
+            deletedId: "deleted",
+            currentSelectedId: "deleted"
+        ) == .clearAndReplace)
+    }
+
+    @Test
+    func newerSelectionIsNotOverriddenByDeleteCompletion() {
+        let resolution = ChatDeleteSelectionResolution.resolve(
+            deletionOwnedSelection: true,
+            deletionSucceeded: true,
+            deletionGeneration: 2,
+            currentGeneration: 3,
+            deletedId: "deleted",
+            currentSelectedId: "newer"
+        )
+
+        #expect(resolution == .unchanged)
+    }
+
+    @Test
+    func mutationGateRejectsConcurrentOperationForSameChat() {
+        var gate = ChatMutationGate()
+
+        #expect(gate.begin(chatId: "chat"))
+        #expect(!gate.begin(chatId: "chat"))
+        #expect(gate.begin(chatId: "other"))
+        gate.end(chatId: "chat")
+        #expect(gate.begin(chatId: "chat"))
+    }
+
+    @Test
+    func failedEmptyPaginationResultRetainsOriginalPageState() {
+        let result = PaginatedChatsResult(chats: [], failed: true)
+        let original = ChatPaginationPageState(token: "current", hasMore: true)
+
+        let resolved = ChatPaginationCoordinator.state(
+            original: original,
+            next: ChatPaginationPageState(token: result.nextToken, hasMore: result.hasMore),
+            allRowsPersisted: true,
+            pageFailed: result.failed
+        )
+
+        #expect(resolved == original)
+    }
+
+    @Test
+    @MainActor
+    func throwingProjectSaveDoesNotDeleteOriginalStorage() async {
+        let service = RecordingChatLoadingService()
+        var moved = makeChat(id: "move", updatedAt: Date())
+        moved.isLocalOnly = false
+        await service.setChat(makeChat(id: moved.id, updatedAt: moved.updatedAt), storage: .local)
+        await service.setFailingSaveIds([moved.id])
+
+        await #expect(throws: LazyHydrationTestError.self) {
+            try await ChatProjectStorageTransition.persist(
+                moved,
+                wasLocal: true,
+                userId: "user",
+                loadingService: service,
+                validateAccount: {}
+            )
+        }
+
+        #expect(await service.savedChat(id: moved.id, storage: .local) != nil)
+        #expect(await service.savedChat(id: moved.id, storage: .cloud) == nil)
+        #expect(await service.counts().deletes == 0)
+    }
+
+    @Test
+    @MainActor
+    func failedLocalProjectDeleteCompensatesCloudWrite() async {
+        let service = RecordingChatLoadingService()
+        var original = makeChat(id: "move", updatedAt: Date())
+        original.isLocalOnly = true
+        var moved = original
+        moved.isLocalOnly = false
+        moved.projectId = "project"
+        await service.setChat(original, storage: .local)
+        await service.setFailingDeleteIds([moved.id], storage: .local)
+
+        await #expect(throws: LazyHydrationTestError.self) {
+            try await ChatProjectStorageTransition.persist(
+                moved,
+                wasLocal: true,
+                userId: "user",
+                loadingService: service,
+                validateAccount: {}
+            )
+        }
+
+        #expect(await service.savedChat(id: moved.id, storage: .local) != nil)
+        #expect(await service.savedChat(id: moved.id, storage: .cloud) == nil)
+        #expect(await service.deletedStorages() == [.local, .cloud])
+    }
+
+    @Test
+    func throwingTitleSaveLeavesOriginalValueUncommitted() async {
+        let service = RecordingChatLoadingService()
+        let original = makeChat(id: "title", updatedAt: Date())
+        var proposed = original
+        proposed.title = "Updated"
+        await service.setChat(original, storage: .cloud)
+        await service.setFailingSaveIds([original.id])
+
+        await #expect(throws: LazyHydrationTestError.self) {
+            try await service.saveChat(proposed, userId: "user", storage: .cloud)
+        }
+
+        #expect(await service.savedChat(id: original.id, storage: .cloud)?.title == original.title)
+        #expect(await service.counts().deletes == 0)
+    }
+
+    @Test
+    func deletingUnmaterializedIdentityDoesNotLoadChat() async throws {
+        let service = RecordingChatLoadingService()
+
+        try await service.deleteChat(id: "delete", userId: "user", storage: .cloud)
+
+        #expect(await service.counts().loads == 0)
+        #expect(await service.counts().deletes == 1)
+    }
+
+    @Test
+    func workingSetRetainsCurrentStreamRecoveryAndDirtyChats() {
+        let current = makeChat(id: "current", updatedAt: Date())
+        var stream = makeChat(id: "stream", updatedAt: Date())
+        stream.hasActiveStream = true
+        let recovery = makeChat(id: "recovery", updatedAt: Date())
+        var dirty = makeChat(id: "dirty", updatedAt: Date())
+        dirty.locallyModified = true
+        var inactive = makeChat(id: "inactive", updatedAt: Date())
+        inactive.locallyModified = false
+
+        let retained = MaterializedChatWorkingSet.retained(
+            [current, stream, recovery, dirty, inactive],
+            selectedId: current.id,
+            streamingIds: [stream.id],
+            recoveryIds: [recovery.id],
+            operationIds: [dirty.id]
+        )
+
+        #expect(Set(retained.map(\.id)) == [current.id, stream.id, recovery.id, dirty.id])
+    }
+
+    @Test
+    func summaryPagePreservesIndexFilterOrderAndCount() {
+        let entries = (0..<80).map { index -> ChatIndexEntry in
+            var chat = makeChat(id: "chat-\(index)", updatedAt: Date(timeIntervalSince1970: Double(index)))
+            chat.projectId = index.isMultiple(of: 3) ? "project" : nil
+            return ChatIndexEntry(from: chat)
+        }
+
+        let page = ChatSummaryState.page(
+            from: entries,
+            filter: \.isCloudDisplayable,
+            limit: 20
+        )
+
+        #expect(page.totalEntries == entries.filter(\.isCloudDisplayable).count)
+        #expect(page.summaries.count == 20)
+        #expect(page.summaries.map(\.updatedAt) == page.summaries.map(\.updatedAt).sorted(by: >))
+    }
+
+    private func makeChat(id: String, updatedAt: Date) -> Chat {
+        var chat = Chat(
+            id: id,
+            title: id,
+            messages: [Message(role: .user, content: id)],
+            createdAt: updatedAt,
+            modelType: ChatSearchServiceTests.testModel,
+            updatedAt: updatedAt
+        )
+        chat.locallyModified = false
+        return chat
+    }
+
+    private func makeBlankChat(id: String) -> Chat {
+        Chat(
+            id: id,
+            title: Chat.placeholderTitle,
+            messages: [],
+            createdAt: Date(),
+            modelType: ChatSearchServiceTests.testModel,
+            updatedAt: Date()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- publish cloud, local, and project sidebar rows from encrypted chat indexes without decrypting full histories at startup
- materialize only selected, streaming, recovery, blank, or explicitly mutated chats
- add cancellable generation-safe selection with explicit loading/error UI and disabled message actions until hydration completes
- persist paginated rows before publishing summaries and preserve loaded pages across sync refreshes
- make title/project/delete mutations transactional against real stored chats

## Safety invariants
- no partial or summary-shaped Chat values are ever saved
- stale A→B loads and delete-vs-hydration completions cannot install the wrong chat
- pagination never advances past failed download persistence
- title/project backup happens only after a throwing local save succeeds
- current/streaming/recovery chats remain materialized; inactive chats are evicted
- anonymous chat re-encryption remains retryable through sign-in, periodic, foreground, and full sync

## Testing
- adds index-only startup, selection fence, storage routing, reconciliation, pagination persistence, mutation gate, delete failure, project transition, and anonymous retry policy tests
- `git diff --check`
- multiple static blocker/regression review passes completed
- builds and tests were not run from the CLI per `AGENTS.md`; please validate in Xcode

## Stack
- depends on #264

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates iOS chats only when selected to cut startup time and memory. Previously all chats decrypted at launch; now the sidebar renders from encrypted indexes and chats hydrate on selection, with actions disabled until hydration completes and a loading/error overlay with retry.

- Publishes paginated summary rows from encrypted indexes; persists pages before publishing; preserves loaded pages across sync; stops pagination on persistence failure; surfaces cancelled/failed page flags.
- Materializes only selected, streaming, recovery, or explicitly mutated chats; maintains ordered streaming snapshots; evicts inactive ones; adds a generation‑safe selection fence and per‑chat mutation gate to block stale installs and concurrent mutations.
- Cloud sync, deletion, and search: honors authoritative deletions and prevents resurrection; keeps deleted IDs until account state is cleared; posts `cloudChatRemoteDeleteCompleted` (keys: `chatId`, `userId`) on remote delete; rolls back tombstoned remote writes; remote search persistence is tombstone‑aware and prefers local on freshness conflicts; clears project state during account teardown.
- Bulk delete: suspends uploads via `quiesceUploadsForBulkDelete(userId:)`; guards `deleteAllFromCloud(userId:)` by the active account and matching `userId`; resumes with `resumeUploadsAfterBulkDelete(userId:)`; resets suspension on account teardown; makes `UploadCoalescer.clear()` async and drains tasks. Required migration: call `quiesceUploadsForBulkDelete(userId:)` → `deleteAllFromCloud(userId:)` → `resumeUploadsAfterBulkDelete(userId:)` in order; await `uploadCoalescer.clear()`.
- UI: sidebar and project pages render `ChatListSummary` rows; search can open a summary‑only chat; overlays show loading/errors with Try Again; message input and toolbar buttons disable until hydration completes; selection stays stable during chat moves.
- Tests add `LazyChatHydrationTests` covering pagination persistence/cancellation, authoritative index reconciliation, tombstone rollbacks, remote search persistence, delete‑all coordination, lazy hydration edge cases, and error ordering.

<sup>Written for commit 4e2374f112d5f6f73e3d242215ae93d10a3c91cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

