### PR TITLE
Polish chat input controls and backgrounds

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -254,6 +254,11 @@ enum Constants {
         static let homeSuggestionCount = 3
     }
 
+    enum AddToChatSheet {
+        static let height: CGFloat = 324
+        static let heightWithContext: CGFloat = 368
+    }
+
     enum Pagination {
         static let chatsPerPage = 20
         static let projectsPerPage = 20

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -40,6 +40,7 @@ struct ChatContainer: View {
     
     // Sidebar constants
     private let sidebarWidth: CGFloat = 300
+    private let toolbarPrimaryLabelHeight: CGFloat = 22
 
     private let backgroundTimeThreshold: TimeInterval = 300 // 5 minutes in seconds
 
@@ -53,6 +54,19 @@ struct ChatContainer: View {
 
     private var toolbarContentColor: Color {
         colorScheme == .dark ? Color.white : Color.black
+    }
+
+    private var showsPrimaryToolbarLabel: Bool {
+        if viewModel.activeProject != nil || viewModel.isTemporaryMode {
+            return true
+        }
+        if isSidebarOpen {
+            return true
+        }
+        return authManager.isAuthenticated
+            && settings.isCloudSyncEnabled
+            && settings.isLocalOnlyModeEnabled
+            && viewModel.activeStorageTab == .local
     }
     
     var body: some View {
@@ -275,7 +289,7 @@ struct ChatContainer: View {
                     Image(colorScheme == .dark ? "logo-white" : "logo-dark")
                         .resizable()
                         .scaledToFit()
-                        .frame(height: 22)
+                        .frame(height: toolbarPrimaryLabelHeight)
                         .opacity(isSidebarOpen && viewModel.activeProject == nil ? 1 : 0)
                         .accessibilityLabel("Tinfoil")
                         .accessibilityHidden(!(isSidebarOpen && viewModel.activeProject == nil))
@@ -317,6 +331,7 @@ struct ChatContainer: View {
                         .accessibilityHidden(isSidebarOpen || isVerificationBadgeExpanded)
                     }
                 }
+                .frame(height: showsPrimaryToolbarLabel ? toolbarPrimaryLabelHeight : 0)
 
                     if let presetId = viewModel.currentChat?.promptPresetId,
                        let preset = profileManager.promptPreset(for: presetId),

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -427,7 +427,10 @@ struct ChatContainer: View {
             viewModel: viewModel,
             messageText: $messageText
         )
-        .background(Color.chatBackground(isDarkMode: colorScheme == .dark))
+        .background(
+            Color.chatBackground(isDarkMode: colorScheme == .dark)
+                .ignoresSafeArea(edges: .bottom)
+        )
         .ignoresSafeArea(edges: .top)
     }
     

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -327,7 +327,13 @@ struct MessageInputView: View {
                     }
                 )
                 .environmentObject(authManager)
-                .presentationDetents([.height(showContextIndicator ? 324 : 280)])
+                .presentationDetents([
+                    .height(
+                        showContextIndicator
+                            ? Constants.AddToChatSheet.heightWithContext
+                            : Constants.AddToChatSheet.height
+                    )
+                ])
                 .presentationBackground(Color.sheetBackground(isDarkMode: isDarkMode))
             }
             .sheet(isPresented: $viewModel.showRateLimitPaywall) {
@@ -626,7 +632,7 @@ struct MessageInputView: View {
                 .frame(width: 24, height: 24)
         }
         .disabled(viewModel.isProcessingAttachment)
-        .accessibilityLabel("Add attachment")
+        .accessibilityLabel("Add to chat")
         .accessibleHitTarget()
         .padding(.leading, 8)
     }
@@ -1140,17 +1146,35 @@ private final class FloatingRecordingBubbleView: UIView {
     }
 }
 
-/// Bottom sheet presented from the "+" button with attachment options and web search toggle
+/// Bottom sheet presented from the "+" button with attachment options and chat features
 struct AddToSheetView: View {
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
     @EnvironmentObject private var authManager: AuthManager
     @ObservedObject private var settings = SettingsManager.shared
+    @ObservedObject private var profileManager = ProfileManager.shared
     let isDarkMode: Bool
     let contextUsage: ContextUsage?
     let onCamera: () -> Void
     let onPhotos: () -> Void
     let onFiles: () -> Void
     @Environment(\.dismiss) private var dismiss
+
+    private var selectedPrompt: PromptPreset? {
+        profileManager.promptPreset(for: viewModel.currentChat?.promptPresetId)
+    }
+
+    private var promptDisplay: (name: String, icon: String) {
+        if let selectedPrompt {
+            return (selectedPrompt.name, selectedPrompt.iconName)
+        }
+        if viewModel.currentChat?.promptPresetId != nil {
+            return ("Unavailable", "exclamationmark.triangle")
+        }
+        if profileManager.isUsingCustomPrompt || settings.isUsingCustomPrompt {
+            return ("Custom Prompt", "square.and.pencil")
+        }
+        return ("Default", "text.quote")
+    }
 
     var body: some View {
         NavigationStack {
@@ -1192,6 +1216,27 @@ struct AddToSheetView: View {
                     .tint(.green)
                     .padding(.horizontal, 20)
                 }
+
+                NavigationLink {
+                    PromptLibraryView(
+                        activePresetId: viewModel.currentChat?.promptPresetId,
+                        onSelectPreset: { viewModel.setPromptPreset($0) }
+                    )
+                } label: {
+                    HStack {
+                        Label("Prompt", systemImage: promptDisplay.icon)
+                        Spacer()
+                        Text(promptDisplay.name)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .foregroundColor(.primary)
+                .padding(.horizontal, 20)
+                .accessibilityValue(promptDisplay.name)
 
                 if let contextUsage {
                     HStack {

--- a/TinfoilChat/Views/ReasoningEffortSelector.swift
+++ b/TinfoilChat/Views/ReasoningEffortSelector.swift
@@ -4,7 +4,7 @@
 //
 //  Icon-only pill that opens a menu for picking reasoning effort and (for
 //  models that support it) toggling thinking on/off. The button label is
-//  intentionally just the lightbulb icon — the current effort/state is
+//  intentionally just the controls icon — the current effort/state is
 //  surfaced via the menu's checkmarks rather than the button text.
 //
 //   - Toggle-only (e.g. Gemma): tapping the icon flips `thinkingEnabled`
@@ -140,14 +140,12 @@ struct ReasoningEffortSelector: View {
     }
 
     /// Shared icon-only pill body used by both the toggle button and the
-    /// effort menu. Uses the SF Symbols `lightbulb`/`lightbulb.slash`
-    /// glyph pair — the system-provided slash variant adapts to both
-    /// light and dark modes natively, so no manual overlay is needed.
+    /// effort menu. Uses the SF Symbols `slider.horizontal.3` glyph.
     @ViewBuilder
     private func iconLabel(active: Bool) -> some View {
-        let pill = Image(systemName: active ? "lightbulb" : "lightbulb.slash")
+        let pill = Image(systemName: "slider.horizontal.3")
             .font(.system(size: 12, weight: .semibold))
-            .foregroundColor(active ? .primary : .primary.opacity(0.9))
+            .foregroundColor(active ? .primary : .secondary.opacity(0.45))
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
             .background(Color.secondary.opacity(0.12))


### PR DESCRIPTION
## Summary
- use a sliders icon for reasoning controls with a distinct inactive state
- match the dark chat background in the keyboard safe area
- show the active prompt in the add menu and allow switching prompts
- vertically center standalone prompt labels in the chat toolbar

## Testing
- Not run; project instructions require building and testing in Xcode