### PR TITLE
Fix stale chat content after sync

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4763,6 +4763,9 @@ class ChatViewModel: ObservableObject {
                 // Set hasMoreChats based on total count
                 self.hasMoreChats = result.totalEntries > Constants.Pagination.chatsPerPage
             }
+            if let userId = currentUserId {
+                await refreshCurrentCloudChatFromStorage(userId: userId)
+            }
             
             // Setup pagination token
             await setupPaginationForAppRestart()
@@ -4882,6 +4885,9 @@ class ChatViewModel: ObservableObject {
                 self.chats = result.chats
                 normalizeChatsArray()
             }
+            if let userId = currentUserId {
+                await refreshCurrentCloudChatFromStorage(userId: userId)
+            }
             scanPendingRecoveries()
         } catch {
             #if DEBUG
@@ -4917,6 +4923,38 @@ class ChatViewModel: ObservableObject {
             .sorted { $0.updatedAt > $1.updatedAt }
 
         return (chats, filtered.count)
+    }
+
+    private func refreshCurrentCloudChatFromStorage(userId: String) async {
+        guard let current = currentChat,
+              !current.isBlankChat,
+              !current.isLocalOnly,
+              !current.hasActiveStream,
+              !streamingTracker.isStreaming(current.id) else { return }
+
+        let chatId = current.id
+        let expectedUpdatedAt = current.updatedAt
+        let expectedModelType = current.modelType
+        await drainPendingSaves()
+        guard currentUserId == userId,
+              currentChat?.id == chatId,
+              currentChat?.updatedAt == expectedUpdatedAt,
+              currentChat?.modelType == expectedModelType,
+              !streamingTracker.isStreaming(chatId),
+              let stored = try? await EncryptedFileStorage.cloud.loadChat(
+                  chatId: chatId,
+                  userId: userId
+              ) else { return }
+        guard currentUserId == userId,
+              currentChat?.id == chatId,
+              currentChat?.updatedAt == expectedUpdatedAt,
+              currentChat?.modelType == expectedModelType,
+              !streamingTracker.isStreaming(chatId) else { return }
+
+        var refreshed = stored
+        refreshed.modelType = expectedModelType
+        replaceChat(refreshed)
+        currentChat = refreshed
     }
 
     /// Clean up chats beyond first page (called on app launch to ensure clean state)
@@ -5003,18 +5041,28 @@ class ChatViewModel: ObservableObject {
         let savedPaginationToken = self.paginationToken
         let savedIsPaginationActive = self.isPaginationActive
 
-        // IMPORTANT: Preserve the current chat ID so it stays in the array even if beyond first page
-        let currentChatId = self.currentChat?.id
-
-        // IMPORTANT: Preserve locally modified chats and chats with active streams
-        let locallyModifiedChats = chats.filter { $0.locallyModified || $0.hasActiveStream || streamingTracker.isStreaming($0.id) }
-        let locallyModifiedIds = Set(locallyModifiedChats.map { $0.id })
+        let initiallyProtectedIds = Set(chats.filter {
+            $0.locallyModified || $0.hasActiveStream || streamingTracker.isStreaming($0.id)
+        }.map(\.id))
 
         // Load first page of cloud chats from files, excluding locally modified ones
-        let result = await loadFirstPageOfChats(userId: userId, excluding: locallyModifiedIds, filter: \.isCloudDisplayable)
+        let result = await loadFirstPageOfChats(userId: userId, excluding: initiallyProtectedIds, filter: \.isCloudDisplayable)
+        guard currentUserId == userId else { return }
+
+        // Re-read protected state after the storage await so a new edit or stream
+        // that started while loading cannot be replaced by the disk snapshot.
+        let currentChatId = self.currentChat?.id
+        let locallyModifiedChats = chats.filter {
+            initiallyProtectedIds.contains($0.id)
+                || $0.locallyModified
+                || $0.hasActiveStream
+                || streamingTracker.isStreaming($0.id)
+        }
+        let locallyModifiedIds = Set(locallyModifiedChats.map { $0.id })
 
         // Combine: locally modified chats + synced chats from files
-        let sortedChats = (locallyModifiedChats + result.chats).sorted { $0.updatedAt > $1.updatedAt }
+        let syncedChatsFromStorage = result.chats.filter { !locallyModifiedIds.contains($0.id) }
+        let sortedChats = (locallyModifiedChats + syncedChatsFromStorage).sorted { $0.updatedAt > $1.updatedAt }
 
         // Keep track of currently loaded chat IDs to preserve pagination
         let currentlyLoadedIds = Set(chats.map { $0.id })
@@ -5099,6 +5147,7 @@ class ChatViewModel: ObservableObject {
             self.paginationToken = savedPaginationToken
             self.isPaginationActive = savedIsPaginationActive
         }
+        await refreshCurrentCloudChatFromStorage(userId: userId)
         scanPendingRecoveries()
     }
     

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4944,7 +4944,8 @@ class ChatViewModel: ObservableObject {
               let stored = try? await EncryptedFileStorage.cloud.loadChat(
                   chatId: chatId,
                   userId: userId
-              ) else { return }
+              ),
+              stored.updatedAt >= expectedUpdatedAt else { return }
         guard currentUserId == userId,
               currentChat?.id == chatId,
               currentChat?.updatedAt == expectedUpdatedAt,
@@ -4954,6 +4955,10 @@ class ChatViewModel: ObservableObject {
         var refreshed = stored
         refreshed.modelType = expectedModelType
         replaceChat(refreshed)
+        chats.sort { left, right in
+            if left.isBlankChat != right.isBlankChat { return left.isBlankChat }
+            return left.updatedAt > right.updatedAt
+        }
         currentChat = refreshed
     }
 


### PR DESCRIPTION
## Summary
- reload the selected cloud chat from authoritative storage after sync
- preserve edits and active streams that begin while chat storage reloads
- prevent account changes from applying an earlier account's chat list

## Testing
- not run (project instructions require Xcode testing by the user)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates stale chat content after cloud sync by safely reloading the open cloud chat from storage and preserving chat ordering. Previously the chat list refreshed but the open chat could show pre-sync content; now it refreshes the open cloud chat without losing local edits or disrupting active streams.

- Adds refreshCurrentCloudChatFromStorage(userId:) that verifies user, chat id, updatedAt, modelType, and streaming state, drains pending saves, loads only if newer, replaces the current chat, and resorts chats to maintain recency order.
- Triggers the refresh after the initial chat load, after loading the first page from storage, and after the merge completes.
- Hardens merge: captures initially protected chats (edited/streaming), rechecks protection after awaiting storage, excludes protected chats from disk results, and verifies currentUserId before applying.
- No behavior change for local-only chats or active streams.

<sup>Written for commit a10c0a19e0f3cf5ded523dd85347c84cc94d375c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

