### PR TITLE
Add synced chat favorites

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -254,6 +254,10 @@ enum Constants {
         static let homeSuggestionCount = 3
     }
 
+    enum ChatFavorites {
+        static let maxPinnedChats = 20
+    }
+
     enum AddToChatSheet {
         static let height: CGFloat = 324
         static let heightWithContext: CGFloat = 368

--- a/TinfoilChat/Models/ChatFavorites.swift
+++ b/TinfoilChat/Models/ChatFavorites.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum ChatFavorites {
+    static func normalize(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return ids.filter { id in
+            !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && seen.insert(id).inserted
+        }
+        .prefix(Constants.ChatFavorites.maxPinnedChats)
+        .map { $0 }
+    }
+
+    static func resolve<Value>(
+        ids: [String],
+        from values: [Value],
+        id: (Value) -> String
+    ) -> [Value] {
+        let valuesById = Dictionary(values.map { (id($0), $0) }, uniquingKeysWith: { first, _ in first })
+        return ids.compactMap { valuesById[$0] }
+    }
+
+    static func removing(_ ids: [String], confirmedMissing: Set<String>) -> [String] {
+        ids.filter { !confirmedMissing.contains($0) }
+    }
+
+    static func persistenceRemainsCurrent(
+        expectedGeneration: Int,
+        currentGeneration: Int,
+        expectedUserId: String,
+        currentUserId: String?
+    ) -> Bool {
+        expectedGeneration == currentGeneration && expectedUserId == currentUserId
+    }
+
+    static func operationIsCurrent<Token: Equatable>(
+        _ token: Token,
+        currentToken: Token?
+    ) -> Bool {
+        token == currentToken
+    }
+
+    static func isPinnable(_ chat: Chat) -> Bool {
+        !chat.isLocalOnly
+            && !chat.isTemporary
+            && !chat.isBlankChat
+            && !chat.decryptionFailed
+            && !chat.dataCorrupted
+    }
+}

--- a/TinfoilChat/Models/ChatFavorites.swift
+++ b/TinfoilChat/Models/ChatFavorites.swift
@@ -3,9 +3,10 @@ import Foundation
 enum ChatFavorites {
     static func normalize(_ ids: [String]) -> [String] {
         var seen = Set<String>()
-        return ids.filter { id in
-            !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                && seen.insert(id).inserted
+        return ids.compactMap { id in
+            let normalizedId = id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedId.isEmpty, seen.insert(normalizedId).inserted else { return nil }
+            return normalizedId
         }
         .prefix(Constants.ChatFavorites.maxPinnedChats)
         .map { $0 }

--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -517,6 +517,7 @@ struct ProfileData: Codable {
     var genUIEnabled: Bool?
     var chatFont: String?
     var projectUploadPreference: String?
+    var pinnedChatIds: [String]?
     
     // Metadata
     var version: Int?

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -37,6 +37,8 @@ class ProfileManager: ObservableObject {
 
     // Preset ids pinned as homescreen favorites (built-in or custom)
     @Published var favoritePromptPresetIds: [String] = []
+
+    @Published private(set) var pinnedChatIds: [String]? = nil
     
     // Sync state
     @Published var isSyncing: Bool = false
@@ -232,6 +234,7 @@ class ProfileManager: ObservableObject {
             genUIEnabled: SettingsManager.shared.genUIEnabled,
             chatFont: chatFont,
             projectUploadPreference: projectUploadPreference,
+            pinnedChatIds: pinnedChatIds,
             version: lastSyncedVersion,  // Will be incremented by ProfileSyncService
             updatedAt: localProfileChangedAt(),
             fieldClocks: localFieldClocks,
@@ -307,6 +310,9 @@ class ProfileManager: ObservableObject {
         }
         if let projectUploadPreference = profile.projectUploadPreference {
             self.projectUploadPreference = projectUploadPreference
+        }
+        if let pinnedChatIds = profile.pinnedChatIds {
+            self.pinnedChatIds = ChatFavorites.normalize(pinnedChatIds)
         }
         if let version = profile.version {
             self.lastSyncedVersion = version
@@ -419,6 +425,14 @@ class ProfileManager: ObservableObject {
                 self?.saveToKeychain()
             }
             .store(in: &cancellables)
+
+        $pinnedChatIds
+            .dropFirst()
+            .sink { [weak self] _ in
+                guard !(self?.isApplyingProfile ?? false) else { return }
+                self?.saveToKeychain()
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Prompt Presets
@@ -508,6 +522,30 @@ class ProfileManager: ObservableObject {
         } else if canAddFavorite {
             favoritePromptPresetIds.append(id)
         }
+    }
+
+    func isChatPinned(_ id: String) -> Bool {
+        pinnedChatIds?.contains(id) == true
+    }
+
+    func pinChat(_ id: String) {
+        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        pinnedChatIds = ChatFavorites.normalize([id] + (pinnedChatIds ?? []))
+    }
+
+    func unpinChat(_ id: String) {
+        guard pinnedChatIds?.contains(id) == true else { return }
+        pinnedChatIds = pinnedChatIds?.filter { $0 != id }
+    }
+
+    func removePinnedChats(_ ids: Set<String>) {
+        guard let pinnedChatIds,
+              pinnedChatIds.contains(where: { ids.contains($0) }) else { return }
+        self.pinnedChatIds = ChatFavorites.removing(pinnedChatIds, confirmedMissing: ids)
+    }
+
+    func clearPinnedChats() {
+        pinnedChatIds = []
     }
 
     /// Duplicate a built-in or user preset into a new editable user preset.
@@ -829,7 +867,8 @@ class ProfileManager: ObservableObject {
                p1.piiCheckEnabled != p2.piiCheckEnabled ||
                p1.genUIEnabled != p2.genUIEnabled ||
                p1.chatFont != p2.chatFont ||
-               p1.projectUploadPreference != p2.projectUploadPreference
+               p1.projectUploadPreference != p2.projectUploadPreference ||
+               p1.pinnedChatIds != p2.pinnedChatIds
     }
 
     func sharedSettingsDidChange() {
@@ -912,7 +951,7 @@ class ProfileManager: ObservableObject {
         return !result.isEmpty
     }
     
-    private func applyDefaultProfile() {
+    private func applyDefaultProfile(pinnedChatIds: [String]? = nil) {
         isApplyingProfile = true
         isDarkMode = true
         themeMode = nil
@@ -926,11 +965,12 @@ class ProfileManager: ObservableObject {
         customSystemPrompt = ""
         customPromptPresets = []
         favoritePromptPresetIds = []
+        self.pinnedChatIds = pinnedChatIds
         isApplyingProfile = false
     }
 
     func resetProfile() {
-        applyDefaultProfile()
+        applyDefaultProfile(pinnedChatIds: [])
         persistProfileToKeychain(createProfileData())
         markLocalProfileChanged()
         debounceCloudSync()

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -29,7 +29,7 @@ enum ProfileMerge {
         "thinkingEnabled", "webSearchAvailable",
         "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont",
-        "projectUploadPreference",
+        "projectUploadPreference", "pinnedChatIds",
     ]
 
     private static let isoFormatter: ISO8601DateFormatter = {
@@ -58,8 +58,16 @@ enum ProfileMerge {
     /// True when the profile carries user content worth protecting.
     static func isProfilePopulated(_ p: ProfileData?) -> Bool {
         guard let p = p else { return false }
+        if hasSubstantiveContent(p) { return true }
+        if let favs = p.favoritePromptPresetIds, !favs.isEmpty { return true }
+        if let pinnedChatIds = p.pinnedChatIds, !pinnedChatIds.isEmpty { return true }
+        return false
+    }
+
+    private static func hasSubstantiveContent(_ p: ProfileData?) -> Bool {
+        guard let p else { return false }
         func nonEmpty(_ s: String?) -> Bool {
-            guard let s = s else { return false }
+            guard let s else { return false }
             return !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
         if nonEmpty(p.nickname) || nonEmpty(p.profession)
@@ -68,7 +76,6 @@ enum ProfileMerge {
         }
         if let traits = p.traits, !traits.isEmpty { return true }
         if let presets = p.customPromptPresets, !presets.isEmpty { return true }
-        if let favs = p.favoritePromptPresetIds, !favs.isEmpty { return true }
         return false
     }
 
@@ -201,7 +208,7 @@ enum ProfileMerge {
         // On the fallback path there is no per-field signal to trust, so
         // a single empty/default remote could clobber every populated
         // local field at once (the data-loss incident). Refuse it.
-        if fallback && !isProfilePopulated(remote) && isProfilePopulated(local) {
+        if fallback && !hasSubstantiveContent(remote) && isProfilePopulated(local) {
             return (local, false)
         }
 

--- a/TinfoilChat/Services/ProfileSyncService.swift
+++ b/TinfoilChat/Services/ProfileSyncService.swift
@@ -22,6 +22,7 @@ enum ProfileSyncError: LocalizedError {
     }
 }
 
+
 /// Service for managing profile synchronization with cloud.
 @MainActor
 class ProfileSyncService: ObservableObject {
@@ -53,6 +54,7 @@ class ProfileSyncService: ObservableObject {
         "favoritePromptPresetIds", "reasoningEffort",
         "thinkingEnabled", "webSearchAvailable", "codeExecutionEnabled",
         "piiCheckEnabled", "genUIEnabled", "chatFont", "projectUploadPreference",
+        "pinnedChatIds",
         "version", "updatedAt", "fieldClocks", "clockVersion",
     ]
 
@@ -367,4 +369,3 @@ class ProfileSyncService: ObservableObject {
         }
     }
 }
-

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -659,17 +659,15 @@ class ChatViewModel: ObservableObject {
             return
         }
 
-        var resolved = (chats + favoriteChats).filter(ChatFavorites.isPinnable)
-        let resolvedIds = Set(resolved.map(\.id))
-        let missingIds = ids.filter { !resolvedIds.contains($0) }
-        let stored = await Chat.loadChats(chatIds: missingIds, userId: userId)
+        let stored = await Chat.loadChats(chatIds: ids, userId: userId)
             .filter(ChatFavorites.isPinnable)
         guard isCurrentFavoriteHydration(generation: generation, userId: userId) else { return }
-        resolved.append(contentsOf: stored)
 
-        let storedIds = Set(stored.map(\.id))
+        var resolved = (chats + stored).filter(ChatFavorites.isPinnable)
+        let resolvedIds = Set(resolved.map(\.id))
+        let missingIds = ids.filter { !resolvedIds.contains($0) }
         var confirmedMissingIds = Set<String>()
-        for id in missingIds where !storedIds.contains(id) {
+        for id in missingIds {
             guard isCurrentFavoriteHydration(generation: generation, userId: userId) else { return }
             guard let operation = beginExactFavoriteHydration(
                 chatId: id,

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -260,6 +260,7 @@ class ChatViewModel: ObservableObject {
     @Published private(set) var isPasskeyRecoverySkipped: Bool = false
     private let passkeyManager = PasskeyManager.shared
     private let cloudSync = CloudSyncService.shared
+    private let cloudStorage = CloudStorageService.shared
     private let streamingTracker = StreamingTracker.shared
     private let projectStorage = ProjectStorageService.shared
     private var isSignInInProgress: Bool = false  // Prevent duplicate sign-in flows
@@ -367,6 +368,7 @@ class ChatViewModel: ObservableObject {
     @Published var projects: [Project] = []
     @Published var activeProject: Project?
     @Published var projectDocuments: [ProjectDocument] = []
+    @Published private(set) var favoriteChats: [Chat] = []
     @Published var isLoadingProjects: Bool = false
     @Published var isLoadingProject: Bool = false
     @Published var isUploadingProjectDocument: Bool = false
@@ -374,6 +376,19 @@ class ChatViewModel: ObservableObject {
     private var projectListLoadGeneration = 0
     private var latestAppliedProjectListLoadGeneration = 0
     private var projectListAccountGeneration = 0
+    private var favoriteLoadGeneration = 0
+    private var favoriteStorageGeneration = 0
+    private enum ExactFavoriteHydrationResult {
+        case found(Chat)
+        case confirmedMissing
+        case unavailable
+    }
+    private struct ExactFavoriteHydrationOperation {
+        let token: UUID
+        let task: Task<ExactFavoriteHydrationResult, Never>
+    }
+    private var exactFavoriteHydrationOperations: [String: ExactFavoriteHydrationOperation] = [:]
+    private var favoriteDeletionTokens: [String: UUID] = [:]
     private var isProjectAccountActive = false
 
     // Private properties
@@ -413,6 +428,7 @@ class ChatViewModel: ObservableObject {
             
             // When auth becomes available and authenticated, restore persisted pagination state immediately
             if authManager?.isAuthenticated == true {
+                clearHydratedFavorites()
                 isProjectAccountActive = true
                 loadPersistedPaginationState()
 
@@ -429,7 +445,9 @@ class ChatViewModel: ObservableObject {
                     currentChat = localChat
                     activeStorageTab = .local
                 }
+                Task { await refreshFavoriteChats() }
             } else {
+                clearHydratedFavorites()
                 clearProjectState()
             }
         }
@@ -484,6 +502,206 @@ class ChatViewModel: ObservableObject {
         return chats
             .filter { $0.projectId == projectId && !$0.isTemporary && !$0.isBlankChat && !$0.decryptionFailed }
             .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    func isChatPinned(_ chatId: String) -> Bool {
+        ProfileManager.shared.isChatPinned(chatId)
+    }
+
+    func canPinChat(_ chat: Chat) -> Bool {
+        ChatFavorites.isPinnable(chat)
+    }
+
+    func toggleChatPin(_ chat: Chat) {
+        favoriteLoadGeneration += 1
+        if isChatPinned(chat.id) {
+            ProfileManager.shared.unpinChat(chat.id)
+            favoriteChats.removeAll { $0.id == chat.id }
+        } else {
+            guard canPinChat(chat) else { return }
+            ProfileManager.shared.pinChat(chat.id)
+            favoriteChats = ChatFavorites.resolve(
+                ids: ProfileManager.shared.pinnedChatIds ?? [],
+                from: [chat] + favoriteChats,
+                id: \.id
+            )
+        }
+        Task { await refreshFavoriteChats() }
+    }
+
+    private func clearHydratedFavorites() {
+        favoriteLoadGeneration += 1
+        favoriteStorageGeneration += 1
+        exactFavoriteHydrationOperations.values.forEach { $0.task.cancel() }
+        exactFavoriteHydrationOperations.removeAll()
+        favoriteDeletionTokens.removeAll()
+        favoriteChats = []
+    }
+
+    private func isCurrentFavoriteHydration(generation: Int, userId: String) -> Bool {
+        generation == favoriteLoadGeneration
+            && currentUserId == userId
+            && hasChatAccess
+    }
+
+    private func isCurrentFavoriteStorage(generation: Int, userId: String) -> Bool {
+        ChatFavorites.persistenceRemainsCurrent(
+            expectedGeneration: generation,
+            currentGeneration: favoriteStorageGeneration,
+            expectedUserId: userId,
+            currentUserId: currentUserId
+        ) && hasChatAccess
+    }
+
+    private func beginExactFavoriteHydration(
+        chatId: String,
+        userId: String,
+        generation: Int,
+        storageGeneration: Int
+    ) -> ExactFavoriteHydrationOperation? {
+        guard favoriteDeletionTokens[chatId] == nil else { return nil }
+        let previousTask = exactFavoriteHydrationOperations[chatId]?.task
+        previousTask?.cancel()
+        let token = UUID()
+        let task: Task<ExactFavoriteHydrationResult, Never> = Task { @MainActor [weak self] in
+            _ = await previousTask?.value
+            guard !Task.isCancelled, let self else { return .unavailable }
+            return await self.hydrateExactFavorite(
+                chatId: chatId,
+                userId: userId,
+                generation: generation,
+                storageGeneration: storageGeneration
+            )
+        }
+        let operation = ExactFavoriteHydrationOperation(token: token, task: task)
+        exactFavoriteHydrationOperations[chatId] = operation
+        return operation
+    }
+
+    private func cancelExactFavoriteHydration(chatId: String) -> Task<ExactFavoriteHydrationResult, Never>? {
+        favoriteLoadGeneration += 1
+        guard let operation = exactFavoriteHydrationOperations.removeValue(forKey: chatId) else {
+            return nil
+        }
+        operation.task.cancel()
+        return operation.task
+    }
+
+    private func hydrateExactFavorite(
+        chatId: String,
+        userId: String,
+        generation: Int,
+        storageGeneration: Int
+    ) async -> ExactFavoriteHydrationResult {
+        guard !Task.isCancelled,
+              isCurrentFavoriteHydration(generation: generation, userId: userId) else {
+            return .unavailable
+        }
+        do {
+            guard let downloaded = try await cloudStorage.downloadChat(chatId) else {
+                guard !Task.isCancelled,
+                      isCurrentFavoriteHydration(generation: generation, userId: userId) else {
+                    return .unavailable
+                }
+                return .confirmedMissing
+            }
+            guard !Task.isCancelled,
+                  isCurrentFavoriteHydration(generation: generation, userId: userId),
+                  let chat = downloaded.toChat(),
+                  ChatFavorites.isPinnable(chat) else {
+                return .unavailable
+            }
+            let applyResult = (try? await EncryptedFileStorage.cloud.applyRemoteChatIfFreshResult(
+                chat,
+                userId: userId,
+                expectedLocalUpdatedAt: nil
+            )) ?? .refused
+            guard !Task.isCancelled,
+                  isCurrentFavoriteStorage(generation: storageGeneration, userId: userId) else {
+                return .unavailable
+            }
+            let hydratedChat: Chat?
+            if applyResult == .applied {
+                hydratedChat = chat
+            } else {
+                hydratedChat = try? await EncryptedFileStorage.cloud.loadChat(
+                    chatId: chatId,
+                    userId: userId
+                )
+            }
+            guard !Task.isCancelled,
+                  isCurrentFavoriteStorage(generation: storageGeneration, userId: userId),
+                  isCurrentFavoriteHydration(generation: generation, userId: userId),
+                  let hydratedChat,
+                  ChatFavorites.isPinnable(hydratedChat) else {
+                return .unavailable
+            }
+            return .found(hydratedChat)
+        } catch {
+            return .unavailable
+        }
+    }
+
+    func refreshFavoriteChats() async {
+        favoriteLoadGeneration += 1
+        let generation = favoriteLoadGeneration
+        let storageGeneration = favoriteStorageGeneration
+        guard hasChatAccess,
+              SettingsManager.shared.isCloudSyncEnabled,
+              let userId = currentUserId else {
+            favoriteChats = []
+            return
+        }
+
+        let ids = ProfileManager.shared.pinnedChatIds ?? []
+        guard !ids.isEmpty else {
+            favoriteChats = []
+            return
+        }
+
+        var resolved = (chats + favoriteChats).filter(ChatFavorites.isPinnable)
+        let resolvedIds = Set(resolved.map(\.id))
+        let missingIds = ids.filter { !resolvedIds.contains($0) }
+        let stored = await Chat.loadChats(chatIds: missingIds, userId: userId)
+            .filter(ChatFavorites.isPinnable)
+        guard isCurrentFavoriteHydration(generation: generation, userId: userId) else { return }
+        resolved.append(contentsOf: stored)
+
+        let storedIds = Set(stored.map(\.id))
+        var confirmedMissingIds = Set<String>()
+        for id in missingIds where !storedIds.contains(id) {
+            guard isCurrentFavoriteHydration(generation: generation, userId: userId) else { return }
+            guard let operation = beginExactFavoriteHydration(
+                chatId: id,
+                userId: userId,
+                generation: generation,
+                storageGeneration: storageGeneration
+            ) else { continue }
+            let result = await operation.task.value
+            if ChatFavorites.operationIsCurrent(
+                operation.token,
+                currentToken: exactFavoriteHydrationOperations[id]?.token
+            ) {
+                exactFavoriteHydrationOperations.removeValue(forKey: id)
+            }
+            guard isCurrentFavoriteHydration(generation: generation, userId: userId) else { return }
+            switch result {
+            case .found(let hydratedChat):
+                resolved.append(hydratedChat)
+            case .confirmedMissing:
+                confirmedMissingIds.insert(id)
+            case .unavailable:
+                break
+            }
+        }
+
+        guard isCurrentFavoriteHydration(generation: generation, userId: userId) else { return }
+        ProfileManager.shared.removePinnedChats(confirmedMissingIds)
+        let favorites = ChatFavorites.resolve(ids: ids, from: resolved, id: \.id)
+        for chat in favorites {
+            replaceChat(chat)
+        }
+        favoriteChats = favorites
     }
     
     // Computed property to check if user has premium access
@@ -650,6 +868,7 @@ class ChatViewModel: ObservableObject {
 
         // Setup Tinfoil client immediately
         setupTinfoilClient()
+        Task { await refreshFavoriteChats() }
     }
     
     deinit {
@@ -753,6 +972,8 @@ class ChatViewModel: ObservableObject {
         if let thinkingEnabled = profile.thinkingEnabled {
             self.thinkingEnabled = thinkingEnabled
         }
+        favoriteLoadGeneration += 1
+        Task { await refreshFavoriteChats() }
     }
     
     /// Setup auto-sync timer to sync every 30 seconds
@@ -1585,6 +1806,9 @@ class ChatViewModel: ObservableObject {
         if wasCurrent {
             currentChat = chat
         }
+        if let favoriteIndex = favoriteChats.firstIndex(where: { $0.id == chatId }) {
+            favoriteChats[favoriteIndex] = chat
+        }
 
         saveChat(chat)
 
@@ -1871,6 +2095,10 @@ class ChatViewModel: ObservableObject {
         }
 
         let userId = currentUserId
+        let storageGeneration = favoriteStorageGeneration
+        let deletionToken = UUID()
+        favoriteDeletionTokens[id] = deletionToken
+        let exactHydrationTask = cancelExactFavoriteHydration(chatId: id)
         discardMessageQueue(chatId: id)
         let canceledStreamTask = cancelGeneration(
             chatId: id,
@@ -1879,6 +2107,18 @@ class ChatViewModel: ObservableObject {
 
         // Delete from file storage and cloud
         Task {
+            defer {
+                if ChatFavorites.operationIsCurrent(
+                    deletionToken,
+                    currentToken: favoriteDeletionTokens[id]
+                ) {
+                    favoriteDeletionTokens.removeValue(forKey: id)
+                }
+            }
+            _ = await exactHydrationTask?.value
+            guard storageGeneration == favoriteStorageGeneration,
+                  currentUserId == userId,
+                  hasChatAccess else { return }
             await canceledStreamTask?.value
             await drainPendingSaves()
 
@@ -1894,8 +2134,18 @@ class ChatViewModel: ObservableObject {
                 DeletedChatsTracker.shared.markAsDeleted(id)
             }
 
+            guard storageGeneration == favoriteStorageGeneration,
+                  currentUserId == userId,
+                  hasChatAccess else { return }
             await Chat.deleteChatFromStorage(chatId: id, userId: userId)
+            guard storageGeneration == favoriteStorageGeneration,
+                  currentUserId == userId,
+                  hasChatAccess else { return }
             ChatRecoveryDraftStore.shared.discard(chatId: id)
+            favoriteLoadGeneration += 1
+            ProfileManager.shared.unpinChat(id)
+            favoriteChats.removeAll { $0.id == id }
+            Task { await refreshFavoriteChats() }
 
             if let index = localChats.firstIndex(where: { $0.id == id }) {
                 localChats.remove(at: index)
@@ -1952,6 +2202,13 @@ class ChatViewModel: ObservableObject {
     /// Replaces a chat in whichever array (localChats or chats) it belongs to.
     /// If the chat isn't in either array, inserts it into the appropriate one.
     private func replaceChat(_ updatedChat: Chat) {
+        if let favoriteIndex = favoriteChats.firstIndex(where: { $0.id == updatedChat.id }) {
+            if ChatFavorites.isPinnable(updatedChat) {
+                favoriteChats[favoriteIndex] = updatedChat
+            } else {
+                favoriteChats.remove(at: favoriteIndex)
+            }
+        }
         if let index = localChats.firstIndex(where: { $0.id == updatedChat.id }) {
             localChats[index] = updatedChat
         } else if let index = chats.firstIndex(where: { $0.id == updatedChat.id }) {
@@ -1983,6 +2240,9 @@ class ChatViewModel: ObservableObject {
             chat.locallyModified = true
             chat.updatedAt = Date()
         }) {
+            if let favoriteIndex = favoriteChats.firstIndex(where: { $0.id == id }) {
+                favoriteChats[favoriteIndex] = updated
+            }
             saveChat(updated)
         }
     }
@@ -4297,6 +4557,7 @@ class ChatViewModel: ObservableObject {
         // which currentUserId no longer resolves this user.
         let signingOutUserId = currentUserId
 
+        clearHydratedFavorites()
         clearProjectState()
 
         // Allow a new sign-in flow after sign-out
@@ -4360,6 +4621,7 @@ class ChatViewModel: ObservableObject {
     
     /// Clear all local chats and reset to fresh state
     func clearAllChatsFromDevice(resumeRecoveryScans: Bool = true) async {
+        clearHydratedFavorites()
         let canceledStreamTasks = cancelAllGenerations()
         await suspendRecoveryScans()
 
@@ -4402,6 +4664,7 @@ class ChatViewModel: ObservableObject {
     /// signed-out session still has a usable chat. Must run before the auth
     /// manager clears its authenticated state so currentUserId still resolves.
     func wipeLocalChatsForSignOut() async {
+        clearHydratedFavorites()
         // Drain the queued disk saves first; the queue is chained, so
         // awaiting the latest task flushes every earlier one. Otherwise a
         // detached save kicked off by handleSignOut could land after the
@@ -4695,6 +4958,9 @@ class ChatViewModel: ObservableObject {
             try await cloudSync.deleteAllFromCloud()
         }
 
+        clearHydratedFavorites()
+        ProfileManager.shared.clearPinnedChats()
+
         // Tombstone so an in-flight sync pass can't resurrect wiped chats
         for id in localIds {
             DeletedChatsTracker.shared.markAsDeleted(id)
@@ -4710,6 +4976,7 @@ class ChatViewModel: ObservableObject {
     /// Removes all cloud (non-local) chats from the device
     @MainActor
     func deleteNonLocalChats() async {
+        clearHydratedFavorites()
         // Delete all cloud chats from storage (the cloud store only has
         // cloud chats), fencing in-flight sync before the deletion.
         if let userId = currentUserId {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -502,6 +502,7 @@ struct ChatSidebar: View {
                             syncFailed: syncHealth.failedChats[chat.id] != nil,
                             isGenerating: viewModel.isChatStreaming(chat.id),
                             isPinned: true,
+                            showPinnedIndicator: false,
                             onSelect: { viewModel.openSearchResult(chat) },
                             onEdit: {
                                 if editingChatId == chat.id {
@@ -862,6 +863,7 @@ struct ChatListItem: View {
     var syncFailed: Bool = false
     var isGenerating: Bool = false
     var isPinned: Bool = false
+    var showPinnedIndicator: Bool = true
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -901,7 +903,7 @@ struct ChatListItem: View {
                                     .foregroundColor(.secondary)
                                     .accessibilityHidden(true)
                             }
-                            if isPinned {
+                            if isPinned && showPinnedIndicator {
                                 Image(systemName: "pin.fill")
                                     .font(.caption)
                                     .foregroundColor(.secondary)

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -40,6 +40,7 @@ struct ChatSidebar: View {
     @State private var showDeleteAlert: Bool = false
 
     @State private var isTabSwitching: Bool = false
+    @State private var isFavoritesExpanded: Bool = true
     @State private var isProjectsExpanded: Bool = false
     @State private var isChatsExpanded: Bool = true
     @State private var chatSearchTerm: String = ""
@@ -47,6 +48,7 @@ struct ChatSidebar: View {
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var cloudSync = CloudSyncService.shared
     @ObservedObject private var syncHealth = SyncHealthStore.shared
+    @ObservedObject private var profileManager = ProfileManager.shared
 
     private var activeTab: ChatStorageTab {
         viewModel.activeStorageTab
@@ -251,9 +253,13 @@ struct ChatSidebar: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     if authManager.isAuthenticated && settings.isCloudSyncEnabled {
-                        projectsSection
+                        favoritesSection
                             .padding(.horizontal, 16)
                             .padding(.top, 16)
+
+                        projectsSection
+                            .padding(.horizontal, 16)
+                            .padding(.top, 8)
                     }
 
                     chatsSectionHeader
@@ -386,6 +392,7 @@ struct ChatSidebar: View {
                     isSyncing: !chat.isBlankChat && cloudSync.pendingUploadChatIds.contains(chat.id),
                     syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
                     isGenerating: viewModel.isChatStreaming(chat.id),
+                    isPinned: profileManager.isChatPinned(chat.id),
                     onSelect: {
                         if isChatSearchActive {
                             viewModel.openSearchResult(chat)
@@ -405,6 +412,16 @@ struct ChatSidebar: View {
                     showEditDelete: authManager.isAuthenticated
                 )
                 .contextMenu {
+                    if viewModel.canPinChat(chat) || profileManager.isChatPinned(chat.id) {
+                        Button {
+                            viewModel.toggleChatPin(chat)
+                        } label: {
+                            Label(
+                                profileManager.isChatPinned(chat.id) ? "Unpin" : "Pin",
+                                systemImage: profileManager.isChatPinned(chat.id) ? "pin.slash" : "pin"
+                            )
+                        }
+                    }
                     if authManager.isAuthenticated && !chat.isBlankChat && !chat.decryptionFailed {
                         ForEach(viewModel.projects.filter { $0.decryptionFailed != true }) { project in
                             Button {
@@ -435,6 +452,101 @@ struct ChatSidebar: View {
                     .padding(.vertical, 16)
                 } else {
                     loadMoreButton
+                }
+            }
+        }
+    }
+
+    private var favoritesSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isFavoritesExpanded.toggle()
+                }
+            } label: {
+                HStack {
+                    Label("Favorites", systemImage: "pin")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.caption)
+                        .rotationEffect(.degrees(isFavoritesExpanded ? 0 : -90))
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Favorites")
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityValue(isFavoritesExpanded ? "Expanded" : "Collapsed")
+
+            if isFavoritesExpanded {
+                if viewModel.favoriteChats.isEmpty {
+                    Text("Pin cloud chats for quick access.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 14)
+                } else {
+                    ForEach(viewModel.favoriteChats) { chat in
+                        ChatListItem(
+                            chat: chat,
+                            isSelected: viewModel.currentChat?.id == chat.id,
+                            isEditing: editingChatId == chat.id,
+                            editingTitle: $editingTitle,
+                            createdTimeString: relativeTimeString(from: chat.createdAt),
+                            updatedTimeString: updatedTimeString(for: chat),
+                            isSyncing: cloudSync.pendingUploadChatIds.contains(chat.id),
+                            syncFailed: syncHealth.failedChats[chat.id] != nil,
+                            isGenerating: viewModel.isChatStreaming(chat.id),
+                            isPinned: true,
+                            onSelect: { viewModel.openSearchResult(chat) },
+                            onEdit: {
+                                if editingChatId == chat.id {
+                                    viewModel.updateChatTitle(chat.id, newTitle: editingTitle)
+                                    editingChatId = nil
+                                } else {
+                                    startEditing(chat)
+                                }
+                            },
+                            onDelete: { confirmDelete(chat) },
+                            showEditDelete: true
+                        )
+                        .contextMenu {
+                            Button {
+                                viewModel.toggleChatPin(chat)
+                            } label: {
+                                Label("Unpin", systemImage: "pin.slash")
+                            }
+
+                            if chat.projectId != nil {
+                                Button {
+                                    Task {
+                                        await viewModel.removeChatFromProject(chatId: chat.id)
+                                    }
+                                } label: {
+                                    Label("Remove from Project", systemImage: "arrow.uturn.left")
+                                }
+                            }
+
+                            ForEach(viewModel.projects.filter {
+                                $0.decryptionFailed != true && $0.id != chat.projectId
+                            }) { project in
+                                Button {
+                                    Task {
+                                        await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
+                                    }
+                                } label: {
+                                    Label(
+                                        chat.projectId == nil ? "Add to \(project.name)" : "Move to \(project.name)",
+                                        systemImage: "folder"
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -749,6 +861,7 @@ struct ChatListItem: View {
     var isSyncing: Bool = false
     var syncFailed: Bool = false
     var isGenerating: Bool = false
+    var isPinned: Bool = false
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -784,6 +897,12 @@ struct ChatListItem: View {
                         HStack(spacing: 4) {
                             if chat.projectId != nil {
                                 Image(systemName: "folder")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .accessibilityHidden(true)
+                            }
+                            if isPinned {
+                                Image(systemName: "pin.fill")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                     .accessibilityHidden(true)
@@ -885,6 +1004,9 @@ struct ChatListItem: View {
         var components = [chat.title.isEmpty ? "Untitled chat" : chat.title]
         if chat.projectId != nil {
             components.append("Project chat")
+        }
+        if isPinned {
+            components.append("Favorite")
         }
         if chat.isBlankChat {
             components.append("New chat")

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -160,6 +160,7 @@ struct ProjectPage: View {
                     Image(systemName: "pin.fill")
                         .font(.caption)
                         .foregroundColor(.secondary)
+                        .accessibilityLabel("Pinned")
                 }
                 Image(systemName: "chevron.right")
                     .font(.caption.weight(.semibold))

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ProjectPage: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
+    @ObservedObject private var profileManager = ProfileManager.shared
 
     @State private var deletingChatId: String?
     @State private var showDeleteChatAlert = false
@@ -155,12 +156,30 @@ struct ProjectPage: View {
                     }
                 }
                 Spacer()
+                if profileManager.isChatPinned(chat.id) {
+                    Image(systemName: "pin.fill")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
                 Image(systemName: "chevron.right")
                     .font(.caption.weight(.semibold))
                     .foregroundColor(.secondary)
             }
         }
         .accessibilityHint("Opens chat")
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            if viewModel.canPinChat(chat) || profileManager.isChatPinned(chat.id) {
+                Button {
+                    viewModel.toggleChatPin(chat)
+                } label: {
+                    Label(
+                        profileManager.isChatPinned(chat.id) ? "Unpin" : "Pin",
+                        systemImage: profileManager.isChatPinned(chat.id) ? "pin.slash" : "pin"
+                    )
+                }
+                .tint(.blue)
+            }
+        }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
                 deletingChatId = chat.id
@@ -179,6 +198,17 @@ struct ProjectPage: View {
             .tint(.orange)
         }
         .contextMenu {
+            if viewModel.canPinChat(chat) || profileManager.isChatPinned(chat.id) {
+                Button {
+                    viewModel.toggleChatPin(chat)
+                } label: {
+                    Label(
+                        profileManager.isChatPinned(chat.id) ? "Unpin" : "Pin",
+                        systemImage: profileManager.isChatPinned(chat.id) ? "pin.slash" : "pin"
+                    )
+                }
+            }
+
             Button {
                 Task {
                     await viewModel.removeChatFromProject(chatId: chat.id)

--- a/TinfoilChatTests/ChatFavoritesTests.swift
+++ b/TinfoilChatTests/ChatFavoritesTests.swift
@@ -24,7 +24,9 @@ struct ChatFavoritesTests {
     @Test("normalization keeps newest unique ids within the cap")
     func normalizesPinnedIds() {
         let ids = (0...Constants.ChatFavorites.maxPinnedChats).map { "chat-\($0)" }
-        let normalized = ChatFavorites.normalize([ids[0], ids[0], ""] + Array(ids.dropFirst()))
+        let normalized = ChatFavorites.normalize([
+            " \(ids[0]) ", ids[0], "\n",
+        ] + Array(ids.dropFirst()))
 
         #expect(normalized.count == Constants.ChatFavorites.maxPinnedChats)
         #expect(normalized.first == ids[0])

--- a/TinfoilChatTests/ChatFavoritesTests.swift
+++ b/TinfoilChatTests/ChatFavoritesTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Pinned chat favorites")
+struct ChatFavoritesTests {
+    @Test("profile JSON preserves missing and explicit empty pins")
+    func profileJSONCompatibility() throws {
+        let missing = try JSONDecoder().decode(ProfileData.self, from: Data("{}".utf8))
+        let empty = try JSONDecoder().decode(
+            ProfileData.self,
+            from: Data(#"{"pinnedChatIds":[]}"#.utf8)
+        )
+
+        #expect(missing.pinnedChatIds == nil)
+        #expect(empty.pinnedChatIds == [])
+
+        let encoded = try JSONEncoder().encode(ProfileData(pinnedChatIds: ["chat-a"]))
+        let object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(object["pinnedChatIds"] as? [String] == ["chat-a"])
+        #expect(object["pinned_chat_ids"] == nil)
+    }
+
+    @Test("normalization keeps newest unique ids within the cap")
+    func normalizesPinnedIds() {
+        let ids = (0...Constants.ChatFavorites.maxPinnedChats).map { "chat-\($0)" }
+        let normalized = ChatFavorites.normalize([ids[0], ids[0], ""] + Array(ids.dropFirst()))
+
+        #expect(normalized.count == Constants.ChatFavorites.maxPinnedChats)
+        #expect(normalized.first == ids[0])
+        #expect(Set(normalized).count == normalized.count)
+    }
+
+    @Test("resolution follows pin order and skips unavailable ids")
+    func resolvesInPinnedOrder() {
+        struct Favorite: Equatable {
+            let id: String
+        }
+        let values = [Favorite(id: "chat-b"), Favorite(id: "chat-a")]
+
+        let resolved = ChatFavorites.resolve(
+            ids: ["chat-a", "missing", "chat-b"],
+            from: values,
+            id: \.id
+        )
+
+        #expect(resolved == [Favorite(id: "chat-a"), Favorite(id: "chat-b")])
+    }
+
+    @Test("pruning removes only authoritatively missing ids")
+    func prunesConfirmedMissingIds() {
+        let pruned = ChatFavorites.removing(
+            ["available", "missing", "transient"],
+            confirmedMissing: ["missing"]
+        )
+
+        #expect(pruned == ["available", "transient"])
+    }
+
+    @Test("persistence fencing rejects generation and account changes")
+    func fencesFavoritePersistence() {
+        let generation = 3
+        let nextGeneration = generation + 1
+        #expect(ChatFavorites.persistenceRemainsCurrent(
+            expectedGeneration: generation,
+            currentGeneration: generation,
+            expectedUserId: "user-a",
+            currentUserId: "user-a"
+        ))
+        #expect(!ChatFavorites.persistenceRemainsCurrent(
+            expectedGeneration: generation,
+            currentGeneration: nextGeneration,
+            expectedUserId: "user-a",
+            currentUserId: "user-a"
+        ))
+        #expect(!ChatFavorites.persistenceRemainsCurrent(
+            expectedGeneration: generation,
+            currentGeneration: generation,
+            expectedUserId: "user-a",
+            currentUserId: "user-b"
+        ))
+    }
+
+    @Test("only the current per-chat operation owns cleanup")
+    func coordinatesPerChatOperationCleanup() {
+        #expect(ChatFavorites.operationIsCurrent("current", currentToken: "current"))
+        #expect(!ChatFavorites.operationIsCurrent("stale", currentToken: "current"))
+        #expect(!ChatFavorites.operationIsCurrent("stale", currentToken: nil as String?))
+    }
+}

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -90,6 +90,46 @@ struct ProfileMergeTests {
         #expect(result.adoptedRemote == false)
     }
 
+    @Test("pins-only remote cannot bypass the destructive fallback guard")
+    func pinsOnlyRemoteGuard() {
+        var local = ProfileData(nickname: "real-user", profession: "Engineer")
+        local.updatedAt = "2024-01-01T00:00:00.000Z"
+        var remote = ProfileData(pinnedChatIds: ["chat-a"])
+        remote.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(local: local, remote: remote)
+
+        #expect(result.merged.nickname == "real-user")
+        #expect(result.merged.profession == "Engineer")
+        #expect(result.adoptedRemote == false)
+    }
+
+    @Test("preset favorites-only remote cannot bypass the fallback guard")
+    func presetFavoritesOnlyRemoteGuard() {
+        var local = ProfileData(customSystemPrompt: "Keep this")
+        local.updatedAt = "2024-01-01T00:00:00.000Z"
+        var remote = ProfileData(favoritePromptPresetIds: ["preset-a"])
+        remote.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(local: local, remote: remote)
+
+        #expect(result.merged.customSystemPrompt == "Keep this")
+        #expect(result.adoptedRemote == false)
+    }
+
+    @Test("fallback explicit clear does not wipe pins-only local content")
+    func pinsOnlyFallbackClearGuard() {
+        var local = ProfileData(pinnedChatIds: ["chat-a"])
+        local.updatedAt = "2024-01-01T00:00:00.000Z"
+        var remote = ProfileData(pinnedChatIds: [])
+        remote.updatedAt = "2024-01-02T00:00:00.000Z"
+
+        let result = ProfileMerge.mergeProfiles(local: local, remote: remote)
+
+        #expect(result.merged.pinnedChatIds == ["chat-a"])
+        #expect(result.adoptedRemote == false)
+    }
+
     @Test("does not carry untrusted local clocks into the merged output")
     func dropsUntrustedLocalClocks() {
         var local = ProfileData(nickname: "local", profession: "local-job")
@@ -138,6 +178,8 @@ struct ProfileMergeTests {
     func populated() {
         #expect(ProfileMerge.isProfilePopulated(ProfileData(nickname: "x")) == true)
         #expect(ProfileMerge.isProfilePopulated(ProfileData(traits: ["a"])) == true)
+        #expect(ProfileMerge.isProfilePopulated(ProfileData(pinnedChatIds: ["chat-a"])) == true)
+        #expect(ProfileMerge.isProfilePopulated(ProfileData(favoritePromptPresetIds: ["preset-a"])) == true)
         #expect(ProfileMerge.isProfilePopulated(nil) == false)
         #expect(
             ProfileMerge.isProfilePopulated(
@@ -271,6 +313,51 @@ struct ProfileMergeTests {
 
         #expect(result.merged.nickname == "Grace")
         #expect(result.conflicts == ["nickname"])
+    }
+
+    @Test("merges pinned chat ids as one ordered field")
+    func mergesPinnedChatsAtomically() {
+        var local = ProfileData(pinnedChatIds: ["local", "shared"])
+        local.fieldClocks = ["pinnedChatIds": EditClock(v: 2, w: "A")]
+        var remote = ProfileData(pinnedChatIds: ["remote", "shared"])
+        remote.fieldClocks = ["pinnedChatIds": EditClock(v: 3, w: "B")]
+
+        let result = ProfileMerge.mergeProfiles(
+            local: trusted(local), remote: trusted(remote)
+        )
+
+        #expect(result.merged.pinnedChatIds == ["remote", "shared"])
+        #expect(result.adoptedRemote)
+    }
+
+    @Test("remote omission does not clear pinned chats")
+    func preservesPinnedChatsOnRemoteOmission() {
+        let baseline = ProfileData(pinnedChatIds: ["chat-a"])
+        let local = ProfileData(pinnedChatIds: ["chat-a"])
+        var remote = ProfileData(nickname: "Ada")
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline, local: local, remote: remote
+        )
+
+        #expect(result.merged.pinnedChatIds == ["chat-a"])
+        #expect(result.conflicts.isEmpty)
+    }
+
+    @Test("explicit empty pinned chats clears the field")
+    func appliesExplicitPinnedChatClear() {
+        let baseline = ProfileData(pinnedChatIds: ["chat-a"])
+        let local = baseline
+        var remote = ProfileData(pinnedChatIds: [])
+        remote.version = 2
+
+        let result = ProfileMerge.mergeProfiles(
+            baseline: baseline, local: local, remote: remote
+        )
+
+        #expect(result.merged.pinnedChatIds == [])
+        #expect(result.conflicts.isEmpty)
     }
 }
 

--- a/TinfoilChatTests/RevisionSyncTests.swift
+++ b/TinfoilChatTests/RevisionSyncTests.swift
@@ -573,6 +573,31 @@ struct RevisionSyncTests {
         ) == .refused)
     }
 
+    @MainActor
+    @Test func exactHydrationAppliesOnlyWhenNoCurrentEntryExists() {
+        var current = ChatSearchServiceTests.makeChat(id: "favorite", title: "Current")
+        current.locallyModified = false
+        let entry = ChatIndexEntry(from: current)
+
+        #expect(RevisionApplyPolicy.contentResult(
+            existing: nil,
+            expectedUpdatedAt: nil,
+            allowLocallyModified: false
+        ) == .applied)
+        #expect(RevisionApplyPolicy.contentResult(
+            existing: entry,
+            expectedUpdatedAt: nil,
+            allowLocallyModified: false
+        ) == .refused)
+
+        current.locallyModified = true
+        #expect(RevisionApplyPolicy.contentResult(
+            existing: ChatIndexEntry(from: current),
+            expectedUpdatedAt: nil,
+            allowLocallyModified: false
+        ) == .locallyModified)
+    }
+
     @Test func projectMetadataUploadsOnlyForCreatesOrIntentionalMoves() {
         #expect(ProjectMetadataUploadPolicy.shouldInclude(
             syncVersion: 0,


### PR DESCRIPTION
## Summary
- add a Favorites section and pin actions for standalone and project chats
- hydrate pinned chats by ID and open project favorites with their full project context
- synchronize a lightweight ordered `pinnedChatIds` profile field with account, merge, and deletion safeguards

## Testing
- `git diff --check`
- `bash scripts/check-release-settings.sh`
- `plutil -lint TinfoilChat.xcodeproj/project.pbxproj`
- `xmllint --noout TinfoilChat.xcodeproj/xcshareddata/xcschemes/TinfoilChat.xcscheme`

Swift tests were not run because repository instructions require running them in Xcode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds synced chat favorites so users can pin up to 20 eligible cloud chats and access them from a Favorites section; pins sync across devices via an ordered `pinnedChatIds` profile field. Favorite chat rows in the sidebar are simplified to emphasize quick open and pin/unpin.

- UI: Adds a Favorites section in the sidebar and pin indicators on project pages. Provides pin/unpin via context menus and swipe actions. Marks pinned chats with “Favorite” in accessibility. Suppresses duplicate pin icon within the Favorites list.
- Storage/sync: Adds optional `pinnedChatIds` to profile JSON and sync allowlist. `ProfileManager` normalizes (trim, unique, cap), persists, and saves to keychain. Reset/device wipe clear pins; deleting a chat unpins it.
- Merge: Treats `pinnedChatIds` as one atomic ordered field. Remote omission does not clear pins; explicit empty clears when not on the fallback path. The fallback guard rejects pins-only remotes to prevent data loss.
- Hydration: `ChatViewModel` resolves pins from in-memory and local storage, then downloads exact chats from cloud. Prunes confirmed-missing IDs and updates pins. Uses generation/account fences and per-chat tokens to prevent races; applies downloaded content only when no current entry exists. Favorites are cleared on sign-out and wipes and refreshed on auth/profile changes.

<sup>Written for commit e1e106a2e04a7f1ace0ce04e88a5e2527c9634f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

