### PR TITLE
Fix prompt reset when entering temporary chat

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1732,6 +1732,7 @@ class ChatViewModel: ObservableObject {
                 modelType: model,
                 userId: currentUserId,
                 isLocalOnly: true,
+                promptPresetId: currentChat?.promptPresetId,
                 webSearchEnabled: SettingsManager.shared.webSearchAvailable
             )
             temp.isTemporary = true


### PR DESCRIPTION
## Summary
- carry the selected prompt preset into newly created temporary chats
- keep temporary chat behavior unchanged when no prompt is selected

## Testing
- not run per repository instructions; build and test in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the selected prompt preset when opening a temporary chat. Previously, temporary chats always reset to no preset; now they inherit `promptPresetId` from the current chat. If no preset is selected, behavior is unchanged.

- Single-line change in `ChatViewModel`: pass `promptPresetId: currentChat?.promptPresetId` when constructing the temporary chat.
- No API/schema changes or migrations. Verify: selecting a preset and opening a temporary chat keeps it; with no preset selected, temporary chat starts as before.

<sup>Written for commit a98a953063aa1b547dc6a4e16602c78c9faa8e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

