### PR TITLE
Send clearer images to models

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -521,7 +521,7 @@ enum Constants {
     }
 
     enum Attachments {
-        static let maxImageDimension: CGFloat = 768
+        static let maxImageDimension: CGFloat = 1536
         static let imageCompressionQuality: CGFloat = 0.85
         static let maxFileSizeBytes = SharedImportConfiguration.maximumDocumentSizeBytes
         static let maxImageSizeBytes = SharedImportConfiguration.maximumImageSizeBytes


### PR DESCRIPTION
## Summary
- increase the maximum stored image dimension from 768px to 1536px
- preserve existing JPEG compression and thumbnail sizing

## Validation
- `git diff --check`
- build and tests not run per repository instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the max stored image dimension from 768px to 1536px so models receive clearer inputs. Previously we downscaled images to 768px; now we downscale to 1536px while keeping JPEG compression and thumbnail sizing unchanged.

**Review and rollout**
- Change is limited to `Constants.Attachments.maxImageDimension`; no API or schema changes.
- Expect larger uploads and storage per image; `maxImageSizeBytes` still applies.
- No migration or client action required.

<sup>Written for commit 3e5b7ca954285d90b873a6236c11ed34ea70fd49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

