### PR TITLE
Fix cloud access after signing back in

### DIFF
--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4584,6 +4584,9 @@ class ChatViewModel: ObservableObject {
 
                     // Initialize encryption - this will load existing key from keychain
                     let key = try await EncryptionService.shared.initialize()
+                    guard self.currentUserId == userId,
+                          self.isSignInInProgress,
+                          self.isProjectAccountActive else { return }
                     self.encryptionKey = key
 
                     // Ensure the current key is authorized for cloud writes.
@@ -4591,6 +4594,9 @@ class ChatViewModel: ObservableObject {
                     // authorization record yet.
                     if !CloudKeyAuthorizationStore.shared.hasAuthorizedCurrentPrimaryKey(userId: userId) {
                         let validation = await CloudKeyPreflightValidator.shared.validateCurrentPrimaryKey()
+                        guard self.currentUserId == userId,
+                              self.isSignInInProgress,
+                              self.isProjectAccountActive else { return }
                         if validation.canWrite {
                             _ = CloudKeyAuthorizationStore.shared.authorizeCurrentPrimaryKey(mode: .validated, userId: userId)
                         }
@@ -4600,21 +4606,35 @@ class ChatViewModel: ObservableObject {
                     // key can never sync or migrate. Converge silently via
                     // passkey when possible; otherwise prompt the user to
                     // recover so this stale device enters v2.
-                    if SettingsManager.shared.isCloudSyncEnabled,
-                       await self.passkeyManager.resolveKeyMismatchAtLaunch() == .manualRecoveryRequired {
-                        await MainActor.run {
-                            self.cloudSyncOnboardingMode = .recovery
-                            self.showCloudSyncOnboarding = true
+                    if SettingsManager.shared.isCloudSyncEnabled {
+                        let mismatchResult = await self.passkeyManager.resolveKeyMismatchAtLaunch()
+                        guard self.currentUserId == userId,
+                              self.isSignInInProgress,
+                              self.isProjectAccountActive else { return }
+                        if mismatchResult == .manualRecoveryRequired {
+                            await MainActor.run {
+                                self.cloudSyncOnboardingMode = .recovery
+                                self.showCloudSyncOnboarding = true
+                            }
                         }
                     }
 
                     // Check passkey state for users who already have keys
                     await self.passkeyManager.checkPasskeyStateForExistingKey()
+                    guard self.currentUserId == userId,
+                          self.isSignInInProgress,
+                          self.isProjectAccountActive else { return }
 
                     // Retry decryption for any previously failed chats now that key is loaded
                     let decryptedCount = await cloudSync.retryDecryptionWithNewKey(onProgress: nil)
+                    guard self.currentUserId == userId,
+                          self.isSignInInProgress,
+                          self.isProjectAccountActive else { return }
                     if decryptedCount > 0 {
-                        let result = await loadFirstPageOfChats(userId: self.currentUserId, filter: \.isCloudDisplayable)
+                        let result = await loadFirstPageOfChats(userId: userId, filter: \.isCloudDisplayable)
+                        guard self.currentUserId == userId,
+                              self.isSignInInProgress,
+                              self.isProjectAccountActive else { return }
                         await MainActor.run {
                             self.chats = result.chats
                             // Refresh currentChat to show decrypted content

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4519,7 +4519,9 @@ class ChatViewModel: ObservableObject {
                     // Sign-out clears account-bound token providers, so restore them
                     // before passkey recovery or any other enclave request.
                     try await self.cloudSync.initialize()
-                    guard self.currentUserId == userId, self.hasChatAccess else {
+                    guard self.currentUserId == userId,
+                          self.hasChatAccess,
+                          self.isProjectAccountActive else {
                         if self.currentUserId == userId {
                             self.isSignInInProgress = false
                         }
@@ -4530,6 +4532,9 @@ class ChatViewModel: ObservableObject {
                     // not the cloud encryption key, so they're available regardless
                     // of cloud sync setup state.
                     let allLocal = await loadAllLocalChats(userId: userId)
+                    guard self.currentUserId == userId,
+                          self.isSignInInProgress,
+                          self.isProjectAccountActive else { return }
                     await MainActor.run {
                         self.localChats = allLocal
                         normalizeLocalChatsArray()
@@ -4549,6 +4554,9 @@ class ChatViewModel: ObservableObject {
                     // If no cloud key exists, try passkey recovery before falling back
                     if !EncryptionService.shared.hasEncryptionKey() {
                         let passkeyResult = await self.passkeyManager.attemptPasskeyKeyRecovery()
+                        guard self.currentUserId == userId,
+                              self.isSignInInProgress,
+                              self.isProjectAccountActive else { return }
                         switch passkeyResult {
                         case .success, .newUserSetupDone:
                             break

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -4516,10 +4516,20 @@ class ChatViewModel: ObservableObject {
             // IMPORTANT: Do NOT auto-generate a key here; allow UI to prompt the user
             Task {
                 do {
+                    // Sign-out clears account-bound token providers, so restore them
+                    // before passkey recovery or any other enclave request.
+                    try await self.cloudSync.initialize()
+                    guard self.currentUserId == userId, self.hasChatAccess else {
+                        if self.currentUserId == userId {
+                            self.isSignInInProgress = false
+                        }
+                        return
+                    }
+
                     // Always load local chats first — they use the device key,
                     // not the cloud encryption key, so they're available regardless
                     // of cloud sync setup state.
-                    let allLocal = await loadAllLocalChats(userId: self.currentUserId)
+                    let allLocal = await loadAllLocalChats(userId: userId)
                     await MainActor.run {
                         self.localChats = allLocal
                         normalizeLocalChatsArray()


### PR DESCRIPTION
## Summary
- restore cloud authentication before passkey recovery after signing back in
- prevent the recovery flow from continuing if the authenticated account changes
- load local chats using the user captured for the sign-in flow

## Testing
- not run; project instructions require building and testing in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores cloud sync and enforces user scoping after signing back in so recovery and enclave requests run under the intended account and stale updates stop. Previously, sign-out cleared token providers and flows could continue under a stale or switched user; now we reinitialize sync and gate each step on account and sign-in state.

- Initialize cloud with `await cloudSync.initialize()` before any passkey recovery or enclave request.
- Re-check after async steps and abort on mismatch: require `currentUserId == userId`, `hasChatAccess`, and `isProjectAccountActive`; later steps also require `isSignInInProgress`. If aborting with the same user, set `isSignInInProgress = false`.
- Load local chats via `loadAllLocalChats(userId: userId)`; refresh cloud chats via `loadFirstPageOfChats(userId: userId)` only after guards pass.
- Gate mismatch resolution, passkey state checks, decryption retries, and onboarding toggles to stop stale account recovery updates.
- No API or storage changes; verify sign-out → sign-in → recovery, account switch mid-flow, and sign-out during recovery.

<sup>Written for commit d45b8e45046ed7e6b07a14ee46cad645e4e38a9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

