### PR TITLE
Fix signed-out paywall and recipe text layout

### DIFF
--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -292,15 +292,16 @@ class AuthManager: ObservableObject {
     }
     
     /// Fetches subscription status directly from the API
-    func fetchSubscriptionStatus() async {
-        guard let clerk = clerk else { return }
-        guard let session = clerk.session else { return }
-        guard let token = try? await session.getToken() ?? session.lastActiveToken?.jwt else { return }
+    @discardableResult
+    func fetchSubscriptionStatus() async -> Bool {
+        guard let clerk = clerk else { return false }
+        guard let session = clerk.session else { return false }
+        guard let token = try? await session.getToken() ?? session.lastActiveToken?.jwt else { return false }
         
         do {
             let apiURL = "\(Constants.API.baseURL)/api/app/user-metadata"
             
-            guard let url = URL(string: apiURL) else { return }
+            guard let url = URL(string: apiURL) else { return false }
             
             var request = URLRequest(url: url)
             request.httpMethod = "GET"
@@ -310,7 +311,7 @@ class AuthManager: ObservableObject {
             let (data, response) = try await URLSession.shared.data(for: request)
             
             guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else { return }
+                  httpResponse.statusCode == 200 else { return false }
             
             if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                let publicMetadata = json["public_metadata"] as? [String: Any],
@@ -350,9 +351,12 @@ class AuthManager: ObservableObject {
                         }
                     }
                 }
+                return true
             }
+            return false
         } catch {
             // Handle error silently - subscription status will remain unchanged
+            return false
         }
     }
     

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -10,6 +10,8 @@ import ClerkKit
 import UIKit
 
 struct ModularAuthenticationView: View {
+  var onAuthenticated: (() -> Void)? = nil
+
   @Environment(Clerk.self) private var clerk
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var authManager: AuthManager
@@ -20,6 +22,8 @@ struct ModularAuthenticationView: View {
   @State private var isSignUp = false
   @State private var isInVerificationMode = false
   @State private var isKeyboardVisible = false
+  @State private var hasCompletedAuthentication = false
+  @State private var notificationObservers: [NSObjectProtocol] = []
   
   var body: some View {
     NavigationView {
@@ -125,7 +129,7 @@ struct ModularAuthenticationView: View {
       authenticationForms
     }
     .onChange(of: clerk.user != nil) { _, isSignedIn in
-      if isSignedIn {
+      if isSignedIn && onAuthenticated == nil {
         dismiss()
       }
     }
@@ -138,7 +142,7 @@ struct ModularAuthenticationView: View {
           errorMessage: $errorMessage,
           isLoading: $isLoading,
           isSignUp: $isSignUp,
-          onDismiss: { DispatchQueue.main.async { self.dismiss() } }
+          onDismiss: { DispatchQueue.main.async { completeAuthentication() } }
         )
         .onPreferenceChange(VerificationModePreferenceKey.self) { inVerificationMode in
           isInVerificationMode = inVerificationMode
@@ -156,7 +160,7 @@ struct ModularAuthenticationView: View {
         SignInView(
           errorMessage: $errorMessage,
           isLoading: $isLoading,
-          onDismiss: { DispatchQueue.main.async { self.dismiss() } }
+          onDismiss: { DispatchQueue.main.async { completeAuthentication() } }
         )
         .onPreferenceChange(VerificationModePreferenceKey.self) { inVerificationMode in
           isInVerificationMode = inVerificationMode
@@ -286,7 +290,7 @@ struct ModularAuthenticationView: View {
       await authManager.initializeAuthState()
       // Post notification to close sidebar and go to main chat view
       NotificationCenter.default.post(name: NSNotification.Name("AuthenticationCompleted"), object: nil)
-      dismiss()
+      completeAuthentication()
     } else {
       errorMessage = "Sign-in could not be completed. Please try again."
     }
@@ -296,7 +300,7 @@ struct ModularAuthenticationView: View {
   
   private func setupNotifications() {
     // Listen for auth completion notification to close this view
-    NotificationCenter.default.addObserver(
+    notificationObservers.append(NotificationCenter.default.addObserver(
       forName: NSNotification.Name("DismissAuthView"),
       object: nil,
       queue: .main
@@ -304,10 +308,10 @@ struct ModularAuthenticationView: View {
       DispatchQueue.main.async {
         self.dismiss()
       }
-    }
+    })
     
     // Listen for auth state check notification
-    NotificationCenter.default.addObserver(
+    notificationObservers.append(NotificationCenter.default.addObserver(
       forName: NSNotification.Name("CheckAuthState"),
       object: nil,
       queue: .main
@@ -317,13 +321,13 @@ struct ModularAuthenticationView: View {
           await authManager.initializeAuthState()
           // Post notification to close sidebar and go to main chat view
           NotificationCenter.default.post(name: NSNotification.Name("AuthenticationCompleted"), object: nil)
-          self.dismiss()
+          completeAuthentication()
         }
       }
-    }
+    })
     
     // Keyboard appearance notifications
-    NotificationCenter.default.addObserver(
+    notificationObservers.append(NotificationCenter.default.addObserver(
       forName: UIResponder.keyboardWillShowNotification,
       object: nil,
       queue: .main
@@ -331,9 +335,9 @@ struct ModularAuthenticationView: View {
       withAnimation(.easeOut(duration: 0.25)) {
         isKeyboardVisible = true
       }
-    }
+    })
     
-    NotificationCenter.default.addObserver(
+    notificationObservers.append(NotificationCenter.default.addObserver(
       forName: UIResponder.keyboardWillHideNotification,
       object: nil,
       queue: .main
@@ -341,35 +345,13 @@ struct ModularAuthenticationView: View {
       withAnimation(.easeIn(duration: 0.25)) {
         isKeyboardVisible = false
       }
-    }
+    })
   }
   
   private func cleanupNotifications() {
     // Remove notification observers
-    NotificationCenter.default.removeObserver(
-      self,
-      name: NSNotification.Name("DismissAuthView"),
-      object: nil
-    )
-    
-    NotificationCenter.default.removeObserver(
-      self,
-      name: NSNotification.Name("CheckAuthState"),
-      object: nil
-    )
-    
-    // Remove keyboard observers
-    NotificationCenter.default.removeObserver(
-      self,
-      name: UIResponder.keyboardWillShowNotification,
-      object: nil
-    )
-    
-    NotificationCenter.default.removeObserver(
-      self,
-      name: UIResponder.keyboardWillHideNotification,
-      object: nil
-    )
+    notificationObservers.forEach { NotificationCenter.default.removeObserver($0) }
+    notificationObservers.removeAll()
     
     // Ensure auth state is refreshed when this view disappears
     if clerk.user != nil && !authManager.isAuthenticated {
@@ -385,6 +367,17 @@ struct ModularAuthenticationView: View {
   // Function to dismiss keyboard
   private func dismissKeyboard() {
     UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+  }
+
+  private func completeAuthentication() {
+    guard !hasCompletedAuthentication else { return }
+    hasCompletedAuthentication = true
+
+    if let onAuthenticated {
+      onAuthenticated()
+    } else {
+      dismiss()
+    }
   }
 }
 

--- a/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
+++ b/TinfoilChat/Views/Authentication/ModularAuthenticationView.swift
@@ -130,7 +130,7 @@ struct ModularAuthenticationView: View {
     }
     .onChange(of: clerk.user != nil) { _, isSignedIn in
       if isSignedIn && onAuthenticated == nil {
-        dismiss()
+        completeAuthentication()
       }
     }
   }

--- a/TinfoilChat/Views/AuthenticationView.swift
+++ b/TinfoilChat/Views/AuthenticationView.swift
@@ -10,8 +10,10 @@ import ClerkKit
 
 // Forward to the modular implementation
 struct AuthenticationView: View {
+    var onAuthenticated: (() -> Void)? = nil
+
     var body: some View {
-        ModularAuthenticationView()
+        ModularAuthenticationView(onAuthenticated: onAuthenticated)
     }
 }
 

--- a/TinfoilChat/Views/GatedPaywallView.swift
+++ b/TinfoilChat/Views/GatedPaywallView.swift
@@ -20,10 +20,11 @@ struct GatedPaywallView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var gateState: GateState = .preparing
     @State private var showAuthentication = false
+    @State private var authenticationCompleted = false
 
     private enum GateState: Equatable {
         case preparing
-        case signInRequired
+        case awaitingAuthentication
         case ready
         case failed
     }
@@ -38,20 +39,9 @@ struct GatedPaywallView: View {
             case .ready:
                 PaywallView(displayCloseButton: true)
                     .onPurchaseCompleted { _ in onPurchaseCompleted() }
-            case .signInRequired:
-                VStack(spacing: 16) {
-                    Text("Sign in to view subscription options and continue chatting.")
-                        .font(.subheadline)
-                        .multilineTextAlignment(.center)
-                    Button("Sign In") { showAuthentication = true }
-                        .buttonStyle(.borderedProminent)
-                        .tint(Color.accentPrimary)
-                        .foregroundStyle(.black)
-                    Button("Close") { dismiss() }
-                        .buttonStyle(.plain)
-                        .foregroundColor(.secondary)
-                }
-                .padding(32)
+            case .awaitingAuthentication:
+                ProgressView()
+                    .controlSize(.large)
             case .failed:
                 VStack(spacing: 16) {
                     Text("Unable to load subscription options. Please try again.")
@@ -69,22 +59,40 @@ struct GatedPaywallView: View {
             }
         }
         .sheet(isPresented: $showAuthentication, onDismiss: {
-            gateState = .preparing
+            if authenticationCompleted {
+                authenticationCompleted = false
+                gateState = .preparing
+            } else {
+                dismiss()
+            }
         }) {
-            AuthenticationView()
+            AuthenticationView {
+                authenticationCompleted = true
+                showAuthentication = false
+            }
                 .environment(Clerk.shared)
                 .environmentObject(authManager)
-        }
-        .onChange(of: authManager.localUserId) { _, userId in
-            if userId != nil && gateState == .signInRequired {
-                gateState = .preparing
-            }
         }
     }
 
     private func prepare() async {
-        guard let clerkUserId = authManager.localUserId else {
-            gateState = .signInRequired
+        if !Clerk.shared.isLoaded {
+            do {
+                try await Clerk.shared.refreshClient()
+            } catch {
+                gateState = .failed
+                return
+            }
+        }
+
+        guard Clerk.shared.isLoaded else {
+            gateState = .failed
+            return
+        }
+
+        guard let clerkUserId = Clerk.shared.user?.id else {
+            gateState = .awaitingAuthentication
+            showAuthentication = true
             return
         }
         gateState = await RevenueCatManager.shared.ensureLoggedIn(clerkUserId) ? .ready : .failed

--- a/TinfoilChat/Views/GatedPaywallView.swift
+++ b/TinfoilChat/Views/GatedPaywallView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Tinfoil. All rights reserved.
 
 import SwiftUI
+import ClerkKit
 import RevenueCatUI
 
 /// Wraps the RevenueCat paywall and blocks it until the current Clerk user
@@ -18,40 +19,72 @@ struct GatedPaywallView: View {
     @EnvironmentObject private var authManager: AuthManager
     @Environment(\.dismiss) private var dismiss
     @State private var gateState: GateState = .preparing
+    @State private var showAuthentication = false
 
-    private enum GateState {
+    private enum GateState: Equatable {
         case preparing
+        case signInRequired
         case ready
         case failed
     }
 
     var body: some View {
-        switch gateState {
-        case .preparing:
-            ProgressView()
-                .controlSize(.large)
-                .task { await prepare() }
-        case .ready:
-            PaywallView(displayCloseButton: true)
-                .onPurchaseCompleted { _ in onPurchaseCompleted() }
-        case .failed:
-            VStack(spacing: 16) {
-                Text("Unable to load subscription options. Please check your connection and try again.")
-                    .font(.subheadline)
-                    .multilineTextAlignment(.center)
-                Button("Retry") { gateState = .preparing }
-                    .buttonStyle(.borderedProminent)
-                Button("Close") { dismiss() }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.secondary)
+        Group {
+            switch gateState {
+            case .preparing:
+                ProgressView()
+                    .controlSize(.large)
+                    .task { await prepare() }
+            case .ready:
+                PaywallView(displayCloseButton: true)
+                    .onPurchaseCompleted { _ in onPurchaseCompleted() }
+            case .signInRequired:
+                VStack(spacing: 16) {
+                    Text("Sign in to view subscription options and continue chatting.")
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                    Button("Sign In") { showAuthentication = true }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Color.accentPrimary)
+                        .foregroundStyle(.black)
+                    Button("Close") { dismiss() }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.secondary)
+                }
+                .padding(32)
+            case .failed:
+                VStack(spacing: 16) {
+                    Text("Unable to load subscription options. Please try again.")
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                    Button("Retry") { gateState = .preparing }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Color.accentPrimary)
+                        .foregroundStyle(.black)
+                    Button("Close") { dismiss() }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.secondary)
+                }
+                .padding(32)
             }
-            .padding(32)
+        }
+        .sheet(isPresented: $showAuthentication, onDismiss: {
+            gateState = .preparing
+        }) {
+            AuthenticationView()
+                .environment(Clerk.shared)
+                .environmentObject(authManager)
+        }
+        .onChange(of: authManager.localUserId) { _, userId in
+            if userId != nil && gateState == .signInRequired {
+                gateState = .preparing
+            }
         }
     }
 
     private func prepare() async {
         guard let clerkUserId = authManager.localUserId else {
-            gateState = .failed
+            gateState = .signInRequired
             return
         }
         gateState = await RevenueCatManager.shared.ensureLoggedIn(clerkUserId) ? .ready : .failed

--- a/TinfoilChat/Views/GatedPaywallView.swift
+++ b/TinfoilChat/Views/GatedPaywallView.swift
@@ -95,6 +95,11 @@ struct GatedPaywallView: View {
             showAuthentication = true
             return
         }
+
+        if authManager.hasActiveSubscription {
+            dismiss()
+            return
+        }
         gateState = await RevenueCatManager.shared.ensureLoggedIn(clerkUserId) ? .ready : .failed
     }
 }

--- a/TinfoilChat/Views/GatedPaywallView.swift
+++ b/TinfoilChat/Views/GatedPaywallView.swift
@@ -9,6 +9,13 @@ import SwiftUI
 import ClerkKit
 import RevenueCatUI
 
+func shouldDismissGatedPaywall(
+    subscriptionRefreshSucceeded: Bool,
+    hasActiveSubscription: Bool
+) -> Bool {
+    subscriptionRefreshSucceeded && hasActiveSubscription
+}
+
 /// Wraps the RevenueCat paywall and blocks it until the current Clerk user
 /// is logged in to RevenueCat. Purchases made while the SDK is still
 /// anonymous produce webhooks without a user identifier that the backend
@@ -96,7 +103,11 @@ struct GatedPaywallView: View {
             return
         }
 
-        if authManager.hasActiveSubscription {
+        let refreshedSubscription = await authManager.fetchSubscriptionStatus()
+        if shouldDismissGatedPaywall(
+            subscriptionRefreshSucceeded: refreshedSubscription,
+            hasActiveSubscription: authManager.hasActiveSubscription
+        ) {
             dismiss()
             return
         }

--- a/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
+++ b/TinfoilChat/Views/GenUI/Widgets/RecipeCardWidget.swift
@@ -324,15 +324,21 @@ private struct RecipeCardView: View {
                 Image(systemName: checked ? "checkmark.square.fill" : "square")
                     .foregroundColor(checked ? recipeAccent : GenUIStyle.mutedText(isDarkMode))
                     .font(.subheadline)
-                ingredientText(ingredient, checked: checked)
-                .font(.subheadline)
-                .strikethrough(checked)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                if let note = ingredient.note, !note.isEmpty {
-                    Text("(\(note))")
-                        .font(.caption)
-                        .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                VStack(alignment: .leading, spacing: 2) {
+                    ingredientText(ingredient, checked: checked)
+                        .font(.subheadline)
+                        .strikethrough(checked)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let note = ingredient.note, !note.isEmpty {
+                        Text("(\(note))")
+                            .font(.caption)
+                            .foregroundColor(GenUIStyle.mutedText(isDarkMode))
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .buttonStyle(.plain)

--- a/TinfoilChatTests/GatedPaywallTests.swift
+++ b/TinfoilChatTests/GatedPaywallTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import TinfoilChat
+
+@Suite("Gated paywall")
+struct GatedPaywallTests {
+    @Test("dismissal requires current active subscription metadata")
+    func currentActiveSubscription() {
+        #expect(shouldDismissGatedPaywall(subscriptionRefreshSucceeded: true, hasActiveSubscription: true))
+        #expect(!shouldDismissGatedPaywall(subscriptionRefreshSucceeded: false, hasActiveSubscription: true))
+        #expect(!shouldDismissGatedPaywall(subscriptionRefreshSucceeded: true, hasActiveSubscription: false))
+    }
+}


### PR DESCRIPTION
## Summary
- present authentication immediately when a signed-out user opens subscription options, then continue to the paywall only when they do not already subscribe
- keep paywall recovery actions legible in dark mode and clean up authentication observers reliably
- allow recipe ingredients and notes to wrap across multiple lines instead of truncating

## Testing
- not run (project instructions require validation in Xcode)