### PR TITLE
Fix Sentry issues affecting iOS 2.6.x

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -757,8 +757,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/textual";
 			requirement = {
-				kind = revision;
-				revision = 2d8e31a176e0531fc93421a8820521b645239979;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.11;
 			};
 		};
 		99EAB0022FC0000200EAB002 /* XCRemoteSwiftPackageReference "encrypted-http-body-protocol" */ = {

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -757,8 +757,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/textual";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.9;
+				kind = revision;
+				revision = 2d8e31a176e0531fc93421a8820521b645239979;
 			};
 		};
 		99EAB0022FC0000200EAB002 /* XCRemoteSwiftPackageReference "encrypted-http-body-protocol" */ = {
@@ -773,8 +773,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
+				kind = revision;
+				revision = 457fbf7d5c2e0b2d8282cbc9e1e1d14810574b85;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -773,8 +773,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
-				kind = revision;
-				revision = 1df43c4a83e00cbe4692c98b102bade4128ba890;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.1;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -774,7 +774,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = revision;
-				revision = 4f98ba4281e56cf2428ba094237be5a691ba89ed;
+				revision = 1df43c4a83e00cbe4692c98b102bade4128ba890;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -774,7 +774,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = revision;
-				revision = 457fbf7d5c2e0b2d8282cbc9e1e1d14810574b85;
+				revision = ef6e0ddd139837d970cd7bcf2f6f423226a32ca8;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -774,7 +774,7 @@
 			repositoryURL = "https://github.com/tinfoilsh/tinfoil-swift";
 			requirement = {
 				kind = revision;
-				revision = ef6e0ddd139837d970cd7bcf2f6f423226a32ca8;
+				revision = 4f98ba4281e56cf2428ba094237be5a691ba89ed;
 			};
 		};
 		99F154672F4F60C500E9174E /* XCRemoteSwiftPackageReference "clerk-ios" */ = {

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,7 +159,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "4f98ba4281e56cf2428ba094237be5a691ba89ed"
+        "revision" : "1df43c4a83e00cbe4692c98b102bade4128ba890"
       }
     }
   ],

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "e6731067a510f6d45bdec8e090698c380a90144d",
-        "version" : "0.0.10"
+        "revision" : "2d8e31a176e0531fc93421a8820521b645239979"
       }
     },
     {
@@ -159,8 +158,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "08f8ccd153e98a6d413f9dae0bcb53d540cdd122",
-        "version" : "0.7.0"
+        "revision" : "457fbf7d5c2e0b2d8282cbc9e1e1d14810574b85"
       }
     }
   ],

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,7 +158,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "457fbf7d5c2e0b2d8282cbc9e1e1d14810574b85"
+        "revision" : "ef6e0ddd139837d970cd7bcf2f6f423226a32ca8"
       }
     }
   ],

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,7 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "1df43c4a83e00cbe4692c98b102bade4128ba890"
+        "revision" : "8d686f61d970a09dec6fd5b702f59fd8245cfd72",
+        "version" : "0.7.1"
       }
     }
   ],

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,7 +159,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/tinfoil-swift",
       "state" : {
-        "revision" : "ef6e0ddd139837d970cd7bcf2f6f423226a32ca8"
+        "revision" : "4f98ba4281e56cf2428ba094237be5a691ba89ed"
       }
     }
   ],

--- a/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TinfoilChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,7 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tinfoilsh/textual",
       "state" : {
-        "revision" : "2d8e31a176e0531fc93421a8820521b645239979"
+        "revision" : "5b20cd9fc3a06a326cf97fd3c5b8a1dfa3ca2c38",
+        "version" : "0.0.11"
       }
     },
     {

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -121,6 +121,11 @@ enum Constants {
         static let maxThinkingChunkCharacters = 8_000
     }
 
+    enum Observability {
+        static let traceSampleRate = 0.1
+        static let profileSessionSampleRate: Float = 0.1
+    }
+
     enum MessageMetadata {
         static let encryptedFontSize: CGFloat = 10
         static let iconSize: CGFloat = 10

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -111,6 +111,11 @@ enum Constants {
         /// content; users can still select large messages via the full-text
         /// selection sheet.
         static let maxInlineSelectionCharacters = 10_000
+        /// Parsed responses are retained only while they are likely to remain
+        /// visible, preventing long chat sessions from duplicating transcripts
+        /// in an unbounded render cache.
+        static let markdownCacheEntryLimit = 64
+        static let markdownCacheCostLimitBytes = 16 * 1_024 * 1_024
         /// Thinking/reasoning chunks larger than this are hard-split so no
         /// single Text view forces an unbounded CoreText layout pass.
         static let maxThinkingChunkCharacters = 8_000

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -201,6 +201,7 @@ enum Constants {
         static let maxPendingPerChat = 8
         static let maxConcurrentScans = 3
         static let maxMutationAttempts = 4
+        static let maxResponseRetryAttempts = 4
         static let retryBaseDelayNanoseconds: UInt64 = 100_000_000
         static let retryMaxDelayNanoseconds: UInt64 = 10_000_000_000
         static let maxCiphertextBytes = 4_096

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -952,13 +952,14 @@ actor ChatRecoveryCoordinator {
                     response = recoveredResponse
                     break
                 } catch {
+                    let chatIsStreaming = await isChatStreaming(chatId)
                     guard scanIsCurrent(
                         accountGeneration: accountGeneration,
                         scanGeneration: scanGeneration,
                         userId: userId
                     ),
                           !cancelledTurns.contains(key),
-                          !(await isChatStreaming(chatId))
+                          !chatIsStreaming
                     else {
                         return
                     }

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -3,6 +3,17 @@ import Foundation
 @preconcurrency import OpenAI
 import Security
 
+func shouldRetryRecoveryResponse(statusCode: Int) -> Bool {
+    (500..<600).contains(statusCode)
+}
+
+func shouldRetryRecoveryError(_ error: Error) -> Bool {
+    guard case ChatRecoveryClientError.httpStatus(let statusCode) = error else {
+        return false
+    }
+    return shouldRetryRecoveryResponse(statusCode: statusCode)
+}
+
 struct ChatRecoveryAttempt: Sendable {
     let chatId: String
     let turnId: String
@@ -825,6 +836,13 @@ actor ChatRecoveryCoordinator {
                         return
                     }
                     if !(200..<300).contains(recovered.statusCode) {
+                        if shouldRetryRecoveryResponse(statusCode: recovered.statusCode) {
+                            guard attempt < Constants.ChatRecovery.maxResponseRetryAttempts else {
+                                return
+                            }
+                            try await waitForRecoveryRetry(attempt: attempt)
+                            continue
+                        }
                         for try await _ in recovered.stream {}
                         guard scanIsCurrent(
                             accountGeneration: accountGeneration,
@@ -940,10 +958,20 @@ actor ChatRecoveryCoordinator {
                         userId: userId
                     ),
                           !cancelledTurns.contains(key),
-                          !(await isChatStreaming(chatId)),
-                          let retryStatus = try? await ChatRecoveryClient.shared.status(
-                              sessionId: payload.sessionId
-                          )
+                          !(await isChatStreaming(chatId))
+                    else {
+                        return
+                    }
+                    if shouldRetryRecoveryError(error) {
+                        guard attempt < Constants.ChatRecovery.maxResponseRetryAttempts else {
+                            return
+                        }
+                        try await waitForRecoveryRetry(attempt: attempt)
+                        continue
+                    }
+                    guard let retryStatus = try? await ChatRecoveryClient.shared.status(
+                        sessionId: payload.sessionId
+                    )
                     else {
                         return
                     }

--- a/TinfoilChat/Services/ChatRecoveryCoordinator.swift
+++ b/TinfoilChat/Services/ChatRecoveryCoordinator.swift
@@ -837,11 +837,11 @@ actor ChatRecoveryCoordinator {
                     }
                     if !(200..<300).contains(recovered.statusCode) {
                         if shouldRetryRecoveryResponse(statusCode: recovered.statusCode) {
-                            guard attempt < Constants.ChatRecovery.maxResponseRetryAttempts else {
-                                return
+                            if attempt < Constants.ChatRecovery.maxResponseRetryAttempts {
+                                try await waitForRecoveryRetry(attempt: attempt)
+                                continue
                             }
-                            try await waitForRecoveryRetry(attempt: attempt)
-                            continue
+                            throw ChatRecoveryClientError.httpStatus(recovered.statusCode)
                         }
                         for try await _ in recovered.stream {}
                         guard scanIsCurrent(
@@ -963,11 +963,10 @@ actor ChatRecoveryCoordinator {
                         return
                     }
                     if shouldRetryRecoveryError(error) {
-                        guard attempt < Constants.ChatRecovery.maxResponseRetryAttempts else {
-                            return
+                        if attempt < Constants.ChatRecovery.maxResponseRetryAttempts {
+                            try await waitForRecoveryRetry(attempt: attempt)
+                            continue
                         }
-                        try await waitForRecoveryRetry(attempt: attempt)
-                        continue
                     }
                     guard let retryStatus = try? await ChatRecoveryClient.shared.status(
                         sessionId: payload.sessionId

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -178,7 +178,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Configure Sentry
         SentrySDK.start { options in
             options.dsn = "https://6f1fb6f77a16359e4d05acd52bbb2b93@o4509288836694016.ingest.us.sentry.io/4509290148069376"
-            options.tracesSampleRate = 1.0
+            options.tracesSampleRate = NSNumber(value: Constants.Observability.traceSampleRate)
             options.enableAutoSessionTracking = true
             // Disable PII collection for privacy
             // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
@@ -186,7 +186,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
             // Configure profiling. Visit https://docs.sentry.io/platforms/apple/profiling/ to learn more.
             options.configureProfiling = { profileOptions in
-                profileOptions.sessionSampleRate = 1.0
+                profileOptions.sessionSampleRate = Constants.Observability.profileSessionSampleRate
                 profileOptions.lifecycle = .trace
             }
 

--- a/TinfoilChat/Views/ChatListView.swift
+++ b/TinfoilChat/Views/ChatListView.swift
@@ -170,13 +170,21 @@ struct ChatListView: View {
             }
         }
         .onAppear {
-            setupKeyboardObservers()
             refreshArchivedMessagesStartIndex()
             pruneRecoveryDrafts()
         }
         .onDisappear {
-            removeKeyboardObservers()
             viewModel.isScrollInteractionActive = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                isKeyboardVisible = true
+                keyboardHeight = keyboardFrame.height
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            isKeyboardVisible = false
+            keyboardHeight = 0
         }
         .onChange(of: viewModel.currentModel.id) { _, _ in
             refreshArchivedMessagesStartIndex()
@@ -235,25 +243,6 @@ struct ChatListView: View {
             viewModel.isScrollInteractionActive = false
             scrollToUserTrigger = UUID()
         }
-    }
-
-    private func setupKeyboardObservers() {
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
-            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
-                isKeyboardVisible = true
-                self.keyboardHeight = keyboardFrame.height
-            }
-        }
-
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
-            isKeyboardVisible = false
-            keyboardHeight = 0
-        }
-    }
-
-    private func removeKeyboardObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     private func pruneRecoveryDrafts() {

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -610,7 +610,8 @@ struct LaTeXMarkdownView: View, Equatable {
     /// measurement pass. Fenced code blocks never have a fence split
     /// open; oversized ones are re-fenced per chunk.
     private nonisolated static func splitLargeContent(_ content: String) -> [ContentSegment] {
-        splitFencePreservingSegment(content, baseId: "md")
+        guard !Task.isCancelled else { return [] }
+        return splitFencePreservingSegment(content, baseId: "md")
     }
 
     /// Splits oversized markdown without ever leaving an opening and
@@ -636,9 +637,11 @@ struct LaTeXMarkdownView: View, Equatable {
         let nsContent = content as NSString
         let fullRange = NSRange(location: 0, length: nsContent.length)
         let codeMatches = Self.codeBlockRegex?.matches(in: content, options: [], range: fullRange) ?? []
+        guard !Task.isCancelled else { return [] }
 
         var lastIndex = content.startIndex
         for match in codeMatches {
+            guard !Task.isCancelled else { return [] }
             guard let swiftRange = Range(match.range, in: content) else { continue }
             if lastIndex < swiftRange.lowerBound {
                 appendMarkdown(String(content[lastIndex..<swiftRange.lowerBound]), at: match.range.location)
@@ -682,6 +685,7 @@ struct LaTeXMarkdownView: View, Equatable {
         while let capIndex = remainder.index(
             remainder.startIndex, offsetBy: cap, limitedBy: remainder.endIndex
         ), capIndex != remainder.endIndex {
+            guard !Task.isCancelled else { return [] }
             // Prefer splitting after the last newline inside the window so
             // chunks break between lines instead of mid-line.
             let window = remainder[..<capIndex]
@@ -709,6 +713,7 @@ struct LaTeXMarkdownView: View, Equatable {
         var subIndex = 0
 
         for (_, paragraph) in paragraphs.enumerated() {
+            guard !Task.isCancelled else { return [] }
             let candidate = current.isEmpty ? paragraph : current + "\n\n" + paragraph
             if candidate.count > Constants.Rendering.maxMarkdownSegmentCharacters && !current.isEmpty {
                 result.append(ContentSegment(
@@ -728,6 +733,7 @@ struct LaTeXMarkdownView: View, Equatable {
                 kind: .markdown(current)
             ))
         }
+        guard !Task.isCancelled else { return [] }
 
         // A single paragraph with no blank lines can still exceed the cap;
         // hard-split it so no segment stays unbounded.
@@ -749,6 +755,7 @@ struct LaTeXMarkdownView: View, Equatable {
         var subIndex = 0
 
         while remainder.count > cap {
+            guard !Task.isCancelled else { return [] }
             let capIndex = remainder.index(remainder.startIndex, offsetBy: cap)
             let window = remainder[..<capIndex]
             let splitIndex = window.lastIndex(of: "\n").map { remainder.index(after: $0) } ?? capIndex

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -92,10 +92,19 @@ private struct SegmentView: View {
 private class MarkdownRenderCache: @unchecked Sendable {
     static let shared = MarkdownRenderCache()
 
-    private var cache: [String: [ContentSegment]] = [:]
-    private let queue = DispatchQueue(label: "com.tinfoil.markdown-cache", attributes: .concurrent)
+    private final class Entry: NSObject {
+        let segments: [ContentSegment]
+
+        init(segments: [ContentSegment]) {
+            self.segments = segments
+        }
+    }
+
+    private let cache = NSCache<NSString, Entry>()
 
     init() {
+        cache.countLimit = Constants.Rendering.markdownCacheEntryLimit
+        cache.totalCostLimit = Constants.Rendering.markdownCacheCostLimitBytes
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleMemoryWarning),
@@ -112,22 +121,16 @@ private class MarkdownRenderCache: @unchecked Sendable {
         clear()
     }
 
-    func get(for key: String) -> [ContentSegment]? {
-        queue.sync {
-            cache[key]
-        }
+    func get(for content: String) -> [ContentSegment]? {
+        cache.object(forKey: content as NSString)?.segments
     }
 
-    func set(_ segments: [ContentSegment], for key: String) {
-        queue.async(flags: .barrier) {
-            self.cache[key] = segments
-        }
+    func set(_ segments: [ContentSegment], for content: String, cost: Int) {
+        cache.setObject(Entry(segments: segments), forKey: content as NSString, cost: cost)
     }
 
     func clear() {
-        queue.async(flags: .barrier) {
-            self.cache.removeAll()
-        }
+        cache.removeAllObjects()
     }
 }
 
@@ -176,8 +179,7 @@ struct LaTeXMarkdownView: View, Equatable {
         // the fallback view and then never recalculating after the async
         // .task swaps in the parsed segments.
         if !isStreaming {
-            let cacheKey = "\(content.hashValue)"
-            if let cached = MarkdownRenderCache.shared.get(for: cacheKey) {
+            if let cached = MarkdownRenderCache.shared.get(for: content) {
                 _segments = State(initialValue: cached)
             }
         }
@@ -209,14 +211,25 @@ struct LaTeXMarkdownView: View, Equatable {
         }
         .task(id: content) {
             guard !isStreaming else { return }
-            let cacheKey = "\(content.hashValue)"
-            if let cached = MarkdownRenderCache.shared.get(for: cacheKey) {
+            if let cached = MarkdownRenderCache.shared.get(for: content) {
                 segments = cached
                 return
             }
             let contentToProcess = content
-            let parsed = Self.parseContent(contentToProcess)
-            MarkdownRenderCache.shared.set(parsed, for: cacheKey)
+            let parsingTask = Task.detached(priority: .userInitiated) {
+                Self.parseContent(contentToProcess)
+            }
+            let parsed = await withTaskCancellationHandler {
+                await parsingTask.value
+            } onCancel: {
+                parsingTask.cancel()
+            }
+            guard !Task.isCancelled else { return }
+            MarkdownRenderCache.shared.set(
+                parsed,
+                for: contentToProcess,
+                cost: contentToProcess.utf8.count
+            )
             segments = parsed
         }
     }
@@ -447,6 +460,7 @@ struct LaTeXMarkdownView: View, Equatable {
 
     /// Parse content into segments of markdown and LaTeX
     private nonisolated static func parseContent(_ content: String) -> [ContentSegment] {
+        guard !Task.isCancelled else { return [] }
         if content.count > Constants.Rendering.maxFullParsingCharacters {
             return splitLargeContent(content)
         }
@@ -467,6 +481,8 @@ struct LaTeXMarkdownView: View, Equatable {
                 excludedRanges.append(match.range)
             }
         }
+
+        guard !Task.isCancelled else { return [] }
 
         let tableSegments = Self.findMarkdownTables(in: content)
         excludedRanges.append(contentsOf: tableSegments.map(\.range))
@@ -496,6 +512,8 @@ struct LaTeXMarkdownView: View, Equatable {
                 }
             }
         }
+
+        guard !Task.isCancelled else { return [] }
 
         latexRanges.sort { $0.range.location < $1.range.location }
 
@@ -1363,4 +1381,3 @@ struct MathView: UIViewRepresentable {
         uiView.sizeToFit()
     }
 }
-

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -34,6 +34,10 @@ func shouldShowMessageStopAction(
         || (isStreaming && (!hasSubmittableContent || isMessageQueueFull))
 }
 
+func hasNonWhitespaceContent(_ text: String) -> Bool {
+    text.contains { !$0.isWhitespace }
+}
+
 /// Input area for typing messages, including attachments and send button
 struct MessageInputView: View {
     // MARK: - Constants
@@ -56,6 +60,7 @@ struct MessageInputView: View {
     @EnvironmentObject private var authManager: AuthManager
     @ObservedObject private var recoveryPhaseTracker = ChatRecoveryPhaseTracker.shared
     @State private var textHeight: CGFloat = Layout.defaultHeight
+    @State private var messageTextHasNonWhitespace = false
     /// Reflects whether the editor has grown beyond a single line, so callers
     /// can hide content that would otherwise be pushed off-screen.
     var isInputExpanded: Binding<Bool>? = nil
@@ -106,7 +111,7 @@ struct MessageInputView: View {
     /// offers a send that would be rejected.
     private var hasSubmittableContent: Bool {
         guard attachmentsAreReadyToSend(viewModel.pendingAttachments) else { return false }
-        return !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return messageTextHasNonWhitespace
             || !viewModel.pendingAttachments.isEmpty
     }
 
@@ -146,7 +151,7 @@ struct MessageInputView: View {
             return .voice
         }
         if showAudioButton,
-           messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !messageTextHasNonWhitespace,
            viewModel.pendingAttachments.isEmpty {
             return .voice
         }
@@ -234,6 +239,12 @@ struct MessageInputView: View {
     @ViewBuilder
     var body: some View {
         inputContent
+            .onAppear {
+                messageTextHasNonWhitespace = hasNonWhitespaceContent(messageText)
+            }
+            .onChange(of: messageText) { _, newValue in
+                messageTextHasNonWhitespace = hasNonWhitespaceContent(newValue)
+            }
             .onChange(of: textHeight) { _, newHeight in
                 guard let isInputExpanded else { return }
                 let expanded = newHeight > Layout.minimumHeight + 1
@@ -804,7 +815,7 @@ struct MessageInputView: View {
 
     private func stopRecordingAndInsertTranscription() async {
         if let transcription = await viewModel.stopAudioRecordingAndTranscribe() {
-            if messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if !hasNonWhitespaceContent(messageText) {
                 messageText = transcription
             } else {
                 messageText += " " + transcription
@@ -1414,6 +1425,7 @@ struct CustomTextEditor: UIViewRepresentable {
         textView.accessibilityLabel = "Message"
 
         context.coordinator.textView = textView
+        context.coordinator.currentTextSnapshot = text
         handle?.coordinator = context.coordinator
 
         // Initialize with placeholder or actual text
@@ -1471,22 +1483,28 @@ struct CustomTextEditor: UIViewRepresentable {
         if text.isEmpty && !isCurrentlyEditing && uiView.textColor != .lightGray {
             uiView.text = placeholderText
             uiView.textColor = .lightGray
+            context.coordinator.currentTextSnapshot = ""
         } else if text.isEmpty && isCurrentlyEditing {
             if uiView.text.isEmpty && uiView.textColor == .lightGray {
                 uiView.text = ""
+                context.coordinator.currentTextSnapshot = ""
                 uiView.textColor = UIColor { traitCollection in
                     return traitCollection.userInterfaceStyle == .dark ? .white : .black
                 }
             } else if !uiView.text.isEmpty && uiView.textColor != .lightGray {
-                self.text = uiView.text
+                let snapshot = context.coordinator.immutableTextSnapshot(from: uiView)
+                context.coordinator.currentTextSnapshot = snapshot
+                self.text = snapshot
             }
         } else if !text.isEmpty && uiView.textColor == .lightGray {
             uiView.text = text
+            context.coordinator.currentTextSnapshot = text
             uiView.textColor = UIColor { traitCollection in
                 return traitCollection.userInterfaceStyle == .dark ? .white : .black
             }
-        } else if !text.isEmpty && uiView.text != text && uiView.textColor != .lightGray {
+        } else if !text.isEmpty && context.coordinator.currentTextSnapshot != text && uiView.textColor != .lightGray {
             uiView.text = text
+            context.coordinator.currentTextSnapshot = text
         }
 
         uiView.isEditable = true
@@ -1510,6 +1528,7 @@ struct CustomTextEditor: UIViewRepresentable {
         var isEditing = false
         var hasFocusedFromFlag = false
         weak var textView: UITextView?
+        var currentTextSnapshot = ""
         /// The draft text at the moment `clearDraft` ran. While streaming, the
         /// view model publishes on every token, so a render transaction whose
         /// state snapshot predates the send can reach `updateUIView` after the
@@ -1531,7 +1550,7 @@ struct CustomTextEditor: UIViewRepresentable {
         /// text gets resynced right back into it.
         func clearDraft() {
             guard let textView else { return }
-            clearedDraft = textView.text
+            clearedDraft = immutableTextSnapshot(from: textView)
             if isEditing {
                 textView.text = ""
                 textView.textColor = UIColor { traitCollection in
@@ -1542,6 +1561,7 @@ struct CustomTextEditor: UIViewRepresentable {
                 textView.textColor = .lightGray
             }
             parent.text = ""
+            currentTextSnapshot = ""
             parent.textHeight = MessageInputView.Layout.defaultHeight
             refreshAccessibility(textView)
         }
@@ -1552,7 +1572,7 @@ struct CustomTextEditor: UIViewRepresentable {
         /// draft, and drafts that trivially exceed the height cap skip
         /// measurement entirely.
         func measuredHeight(for textView: UITextView) -> CGFloat {
-            let text = textView.text ?? ""
+            let text = currentTextSnapshot
             let width = textView.frame.width
             let pointSize = textView.font?.pointSize ?? 0
 
@@ -1589,10 +1609,21 @@ struct CustomTextEditor: UIViewRepresentable {
         func refreshAccessibility(_ textView: UITextView) {
             textView.accessibilityLabel = "Message"
             let isShowingPlaceholder = textView.textColor == .lightGray
-            textView.accessibilityValue = isShowingPlaceholder ? "" : textView.text
+            if isShowingPlaceholder {
+                textView.accessibilityValue = ""
+            } else if UIAccessibility.isVoiceOverRunning {
+                textView.accessibilityValue = immutableTextSnapshot(from: textView)
+            } else {
+                textView.accessibilityValue = nil
+            }
         }
 
-        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        func immutableTextSnapshot(from textView: UITextView) -> String {
+            let copiedText = (textView.text as NSString).copy() as! NSString
+            return copiedText as String
+        }
+
+        func textView(_ textView: UITextView, shouldChangeTextIn _: NSRange, replacementText text: String) -> Bool {
             // Check if Enter key was pressed (without Shift)
             if text == "\n" {
                 // Check if this is running on Mac (iOS app on Mac)
@@ -1614,24 +1645,15 @@ struct CustomTextEditor: UIViewRepresentable {
                 }
             }
             
-            // Check if the text will be empty after this change
-            let currentText = textView.text as NSString
-            let newText = currentText.replacingCharacters(in: range, with: text)
-            
-            // If text is becoming empty but we're still editing, don't show placeholder
-            if newText.isEmpty && isEditing {
-                // Let the deletion happen, but don't show placeholder yet
-                // The placeholder will be shown in textViewDidEndEditing when focus is lost
-                return true
-            }
-            
             return true
         }
         
         func textViewDidChange(_ textView: UITextView) {
             // Only update if the text is not the placeholder
             if textView.textColor != .lightGray {
-                parent.text = textView.text
+                let snapshot = immutableTextSnapshot(from: textView)
+                currentTextSnapshot = snapshot
+                parent.text = snapshot
                 
                 // Calculate and update the height
                 let newHeight = measuredHeight(for: textView)
@@ -1648,6 +1670,7 @@ struct CustomTextEditor: UIViewRepresentable {
             // Clear placeholder when editing begins
             if textView.textColor == .lightGray {
                 textView.text = ""
+                currentTextSnapshot = ""
                 textView.textColor = UIColor { traitCollection in
                     return traitCollection.userInterfaceStyle == .dark ? .white : .black
                 }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1619,8 +1619,7 @@ struct CustomTextEditor: UIViewRepresentable {
         }
 
         func immutableTextSnapshot(from textView: UITextView) -> String {
-            let copiedText = (textView.text as NSString).copy() as! NSString
-            return copiedText as String
+            NSString(string: textView.text ?? "") as String
         }
 
         func textView(_ textView: UITextView, shouldChangeTextIn _: NSRange, replacementText text: String) -> Bool {

--- a/TinfoilChat/Views/MessageTableView.swift
+++ b/TinfoilChat/Views/MessageTableView.swift
@@ -130,6 +130,9 @@ struct MessageTableView: UIViewRepresentable {
                 context.coordinator.lastUsesStreamingLayout = usesStreamingLayout
                 context.coordinator.messageWrappers.removeAll()
                 context.coordinator.shownMessageIds.removeAll()
+                context.coordinator.heightCache.removeAll()
+                context.coordinator.messageHeightCache.removeAll()
+                context.coordinator.contentEstimateCache.removeAll()
 
                 // Drop any streaming inset left behind by the previous chat,
                 // and reset a blank chat to the top since no scroll trigger
@@ -1149,4 +1152,3 @@ extension UITableViewCell {
         }
     }
 }
-

--- a/TinfoilChatTests/ChatRecoveryClientTests.swift
+++ b/TinfoilChatTests/ChatRecoveryClientTests.swift
@@ -5,6 +5,33 @@ import Testing
 
 @Suite("Chat recovery client")
 struct ChatRecoveryClientTests {
+    @Test("transient server responses remain recoverable", arguments: [500, 502, 503, 504, 599])
+    func transientServerResponse(statusCode: Int) {
+        #expect(shouldRetryRecoveryResponse(statusCode: statusCode))
+    }
+
+    @Test("terminal client responses do not retry", arguments: [400, 401, 404, 409, 429])
+    func terminalClientResponse(statusCode: Int) {
+        #expect(!shouldRetryRecoveryResponse(statusCode: statusCode))
+    }
+
+    @Test("plain gateway failures retain their retryable status")
+    func plainGatewayFailure() throws {
+        let response = try #require(HTTPURLResponse(
+            url: URL(string: "https://example.com/recovery/session")!,
+            statusCode: 502,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        do {
+            _ = try recoveryResponseNonce(from: response)
+            Issue.record("Expected a plain gateway failure to fail")
+        } catch {
+            #expect(shouldRetryRecoveryError(error))
+        }
+    }
+
     @Test("status decodes persisted encrypted bytes")
     func statusBytes() throws {
         let status = try JSONDecoder().decode(

--- a/TinfoilChatTests/MessageInputContentTests.swift
+++ b/TinfoilChatTests/MessageInputContentTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import TinfoilChat
+
+@Suite("Message input content")
+struct MessageInputContentTests {
+    @Test("detects visible draft content", arguments: ["hello", "  hello  ", "\nmessage"])
+    func visibleContent(text: String) {
+        #expect(hasNonWhitespaceContent(text))
+    }
+
+    @Test("rejects whitespace-only drafts", arguments: ["", " ", "\n\t"])
+    func whitespaceOnlyContent(text: String) {
+        #expect(!hasNonWhitespaceContent(text))
+    }
+}


### PR DESCRIPTION
## Summary
- stabilize long message drafts and bound markdown parsing, rendering caches, and abandoned parsing work
- remove stale keyboard subscriptions and cross-chat layout caches that accumulate during long sessions
- retry transient recovery failures without discarding pending responses after direct retry exhaustion
- reduce production tracing and profiling overhead from 100% to 10%
- use the released Textual and Tinfoil Swift versions containing the underlying library fixes

## Dependencies
- Textual 0.0.11: https://github.com/tinfoilsh/textual/releases/tag/v0.0.11
- Tinfoil Swift 0.7.1: https://github.com/tinfoilsh/tinfoil-swift/releases/tag/v0.7.1

## Testing
- not run per repository instructions; verify build, tests, long-message rendering, selection, chat switching, and recovery flows in Xcode