### PR TITLE
Add Home Screen quick actions

### DIFF
--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -541,6 +541,12 @@ enum Constants {
         static let minimumLaunchCount = 5
     }
 
+    enum HomeScreenQuickActions {
+        static let newChat = "sh.tinfoil.TinfoilChat.new-chat"
+        static let projects = "sh.tinfoil.TinfoilChat.projects"
+        static let favorites = "sh.tinfoil.TinfoilChat.favorites"
+    }
+
     enum RateLimit {
         static let warningThreshold = 3
     }

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -237,7 +237,7 @@ struct ContentView: View {
             // their single chat must finish streaming before the next prompt,
             // otherwise sendMessage's isLoading guard would drop it.
             return chatViewModel.hasChatAccess || !chatViewModel.isLoading
-        case .newChat, .startDictation:
+        case .newChat, .startDictation, .showProjects, .showFavorites:
             return true
         }
     }
@@ -251,7 +251,8 @@ struct ContentView: View {
             guard chatViewModel.currentChat != nil else { return }
             chatViewModel.sendMessage(text: prompt)
         case .newChat:
-            chatViewModel.createNewChat()
+            chatViewModel.createNewRootChat()
+            chatViewModel.requestNavigation(to: .chat)
         case .startDictation:
             if chatViewModel.canUseAudioInput {
                 chatViewModel.createNewChat(focusInput: false)
@@ -264,6 +265,10 @@ struct ContentView: View {
                 chatViewModel.createNewChat()
                 chatViewModel.shouldFocusInput = true
             }
+        case .showProjects:
+            chatViewModel.requestNavigation(to: .projects)
+        case .showFavorites:
+            chatViewModel.requestNavigation(to: .favorites)
         }
     }
 }

--- a/TinfoilChat/HomeScreenQuickActionSceneDelegate.swift
+++ b/TinfoilChat/HomeScreenQuickActionSceneDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  HomeScreenQuickActionSceneDelegate.swift
+//  TinfoilChat
+//
+//  Copyright © 2026 Tinfoil. All rights reserved.
+//
+
+import UIKit
+
+@MainActor
+final class HomeScreenQuickActionSceneDelegate: NSObject, UIWindowSceneDelegate {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let shortcutItem = connectionOptions.shortcutItem else { return }
+        _ = handle(shortcutItem)
+    }
+
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        completionHandler(handle(shortcutItem))
+    }
+
+    private func handle(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        let action: AppIntentCoordinator.Action
+
+        switch shortcutItem.type {
+        case Constants.HomeScreenQuickActions.newChat:
+            action = .newChat
+        case Constants.HomeScreenQuickActions.projects:
+            action = .showProjects
+        case Constants.HomeScreenQuickActions.favorites:
+            action = .showFavorites
+        default:
+            return false
+        }
+
+        AppIntentCoordinator.shared.enqueue(action)
+        return true
+    }
+}

--- a/TinfoilChat/Info.plist
+++ b/TinfoilChat/Info.plist
@@ -6,6 +6,33 @@
 	<string>Tinfoil needs access to your camera to take photos and scan QR codes.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tinfoil needs access to your microphone for voice dictation.</string>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>square.and.pencil</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>New Chat</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>sh.tinfoil.TinfoilChat.new-chat</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>folder</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Projects</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>sh.tinfoil.TinfoilChat.projects</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>pin</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Favorites</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>sh.tinfoil.TinfoilChat.favorites</string>
+		</dict>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UILaunchScreen</key>

--- a/TinfoilChat/Intents/AppIntentCoordinator.swift
+++ b/TinfoilChat/Intents/AppIntentCoordinator.swift
@@ -18,6 +18,8 @@ final class AppIntentCoordinator: ObservableObject {
         case askQuestion(String)
         case newChat
         case startDictation
+        case showProjects
+        case showFavorites
     }
 
     @Published private(set) var pendingActions: [Action] = []

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -185,7 +185,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     // MARK: UISceneSession Lifecycle
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        let configuration = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        if connectingSceneSession.role == .windowApplication {
+            configuration.delegateClass = HomeScreenQuickActionSceneDelegate.self
+        }
+        return configuration
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1532,11 +1532,15 @@ class ChatViewModel: ObservableObject {
     }
 
     func createNewRootChat() {
+        leaveProjectContext()
+        createNewChat()
+    }
+
+    private func leaveProjectContext() {
         activeProject = nil
         projectDocuments = []
         projectError = nil
         isViewingProjectChat = false
-        createNewChat()
     }
 
     /// Creates a new chat and sets it as the current chat
@@ -1790,10 +1794,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func exitProject() {
-        activeProject = nil
-        projectDocuments = []
-        projectError = nil
-        isViewingProjectChat = false
+        leaveProjectContext()
         shouldExpandProjectsInSidebar = true
         createNewChat(isLocalOnly: false, focusInput: false)
     }
@@ -1815,10 +1816,7 @@ class ChatViewModel: ObservableObject {
                 beginSelection(id: id)
             }
             if projectId == nil, activeProject != nil {
-                activeProject = nil
-                projectDocuments = []
-                projectError = nil
-                isViewingProjectChat = false
+                leaveProjectContext()
             }
             _ = selectChat(id: id, isLocalOnly: isLocalOnly)
             if projectId != nil { isViewingProjectChat = true }
@@ -1942,10 +1940,7 @@ class ChatViewModel: ObservableObject {
                 }
                 self.isViewingProjectChat = true
             } else if self.activeProject != nil {
-                self.activeProject = nil
-                self.projectDocuments = []
-                self.projectError = nil
-                self.isViewingProjectChat = false
+                self.leaveProjectContext()
             }
             self.chatSelectionTask = nil
             self.installSelectedChat(persisted, generation: selectionGeneration)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -17,6 +17,17 @@ enum ChatStorageTab: String, Sendable, Hashable {
     case local
 }
 
+enum ChatNavigationDestination: Hashable {
+    case chat
+    case projects
+    case favorites
+}
+
+struct ChatNavigationRequest: Equatable {
+    let id = UUID()
+    let destination: ChatNavigationDestination
+}
+
 /// Graded reasoning effort exposed to the user. Maps directly onto the
 /// webapp vocabulary; per-model translation (e.g. DeepSeek's `low|medium →
 /// high`, `high → max`) is handled by `ChatQueryBuilder` via `effortMap`.
@@ -194,6 +205,7 @@ class ChatViewModel: ObservableObject {
     @Published var cloudSyncOnboardingMode: CloudSyncOnboardingMode = .setup
     @Published var shouldOpenCloudSync: Bool = false
     @Published var shouldExpandProjectsInSidebar: Bool = false
+    @Published private(set) var navigationRequest: ChatNavigationRequest?
     @Published var isViewingProjectChat: Bool = false
     @Published var scrollTargetMessageId: String? = nil 
     @Published var scrollTargetOffset: CGFloat = 0 
@@ -1508,6 +1520,23 @@ class ChatViewModel: ObservableObject {
         } else {
             createNewChat(isLocalOnly: shouldBeLocal, focusInput: false)
         }
+    }
+
+    func requestNavigation(to destination: ChatNavigationDestination) {
+        navigationRequest = ChatNavigationRequest(destination: destination)
+    }
+
+    func consumeNavigationRequest(id: UUID) {
+        guard navigationRequest?.id == id else { return }
+        navigationRequest = nil
+    }
+
+    func createNewRootChat() {
+        activeProject = nil
+        projectDocuments = []
+        projectError = nil
+        isViewingProjectChat = false
+        createNewChat()
     }
 
     /// Creates a new chat and sets it as the current chat

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -230,17 +230,18 @@ struct ChatSidebar: View {
         scrollProxy: ScrollViewProxy
     ) {
         guard let request else { return }
+        guard request.destination != .chat else {
+            navigationRequest = nil
+            return
+        }
 
         withAnimation(.easeInOut(duration: 0.2)) {
-            switch request.destination {
-            case .projects:
+            if request.destination == .projects {
                 isFavoritesExpanded = false
                 isProjectsExpanded = true
-            case .favorites:
+            } else {
                 isFavoritesExpanded = true
                 isProjectsExpanded = false
-            case .chat:
-                break
             }
             scrollProxy.scrollTo(request.destination, anchor: .top)
         }

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -41,6 +41,7 @@ struct ChatSidebar: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(Clerk.self) private var clerk
     @Binding var isOpen: Bool
+    @Binding var navigationRequest: ChatNavigationRequest?
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
     @ObservedObject var authManager: AuthManager
     @State private var editingChatId: String? = nil
@@ -223,6 +224,29 @@ struct ChatSidebar: View {
             }
         }
     }
+
+    private func applyNavigationRequest(
+        _ request: ChatNavigationRequest?,
+        scrollProxy: ScrollViewProxy
+    ) {
+        guard let request else { return }
+
+        withAnimation(.easeInOut(duration: 0.2)) {
+            switch request.destination {
+            case .projects:
+                isFavoritesExpanded = false
+                isProjectsExpanded = true
+            case .favorites:
+                isFavoritesExpanded = true
+                isProjectsExpanded = false
+            case .chat:
+                break
+            }
+            scrollProxy.scrollTo(request.destination, anchor: .top)
+        }
+
+        navigationRequest = nil
+    }
     
     @ViewBuilder
     private var recoveryBanner: some View {
@@ -261,57 +285,67 @@ struct ChatSidebar: View {
     private var sidebarContent: some View {
         VStack(spacing: 0) {
             recoveryBanner
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    if authManager.isAuthenticated && settings.isCloudSyncEnabled {
-                        favoritesSection
-                            .padding(.horizontal, 16)
-                            .padding(.top, 16)
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        if authManager.isAuthenticated && settings.isCloudSyncEnabled {
+                            favoritesSection
+                                .padding(.horizontal, 16)
+                                .padding(.top, 16)
+                                .id(ChatNavigationDestination.favorites)
 
-                        projectsSection
-                            .padding(.horizontal, 16)
-                            .padding(.top, 8)
-                    }
-
-                    chatsSectionHeader
-                        .padding(.horizontal, 16)
-                        .padding(.top, 8)
-
-                    if isTabSwitching {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 24)
-                    } else if isChatsExpanded {
-                        if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
-                            cloudLocalTabSwitcher
+                            projectsSection
                                 .padding(.horizontal, 16)
                                 .padding(.top, 8)
+                                .id(ChatNavigationDestination.projects)
                         }
 
-                        chatsDescription
+                        chatsSectionHeader
                             .padding(.horizontal, 16)
                             .padding(.top, 8)
 
-                        if isChatSearchEnabled {
-                            chatSearchField
+                        if isTabSwitching {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 24)
+                        } else if isChatsExpanded {
+                            if authManager.isAuthenticated && settings.isCloudSyncEnabled && settings.isLocalOnlyModeEnabled {
+                                cloudLocalTabSwitcher
+                                    .padding(.horizontal, 16)
+                                    .padding(.top, 8)
+                            }
+
+                            chatsDescription
                                 .padding(.horizontal, 16)
                                 .padding(.top, 8)
-                        }
 
-                        chatList
-                            .padding(.horizontal, 16)
-                            .padding(.top, 8)
-                            .padding(.bottom, 8)
+                            if isChatSearchEnabled {
+                                chatSearchField
+                                    .padding(.horizontal, 16)
+                                    .padding(.top, 8)
+                            }
+
+                            chatList
+                                .padding(.horizontal, 16)
+                                .padding(.top, 8)
+                                .padding(.bottom, 8)
+                        }
                     }
                 }
+                .applyAlwaysBounceIfAvailable()
+                .refreshable {
+                    await authManager.initializeAuthState()
+                    await viewModel.performFullSync()
+                }
+                .frame(maxHeight: .infinity)
+                .onAppear {
+                    applyNavigationRequest(navigationRequest, scrollProxy: scrollProxy)
+                }
+                .onChange(of: navigationRequest) { _, request in
+                    applyNavigationRequest(request, scrollProxy: scrollProxy)
+                }
             }
-            .applyAlwaysBounceIfAvailable()
-            .refreshable {
-                await authManager.initializeAuthState()
-                await viewModel.performFullSync()
-            }
-            .frame(maxHeight: .infinity)
 
             Divider()
                 .background(Color.gray.opacity(0.3))

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -33,6 +33,7 @@ struct ChatContainer: View {
     @State private var shouldCreateNewChatAfterSubscription = false
     @State private var showPremiumModal = false
     @State private var isVerificationBadgeExpanded = false
+    @State private var sidebarNavigationRequest: ChatNavigationRequest?
 
     private var isAnySheetPresented: Bool {
         viewModel.showVerifierSheet || viewModel.showAddSheet || viewModel.showModelSelectorSheet || viewModel.showRateLimitPaywall || viewModel.showDocumentPicker || viewModel.showPhotoPicker || viewModel.showCamera || viewModel.showMessageSheet || viewModel.showImageViewer || viewModel.showSidebarSettings || showAuthView || showSettings || showPremiumModal
@@ -90,6 +91,10 @@ struct ChatContainer: View {
             setupNavigationBarAppearance()
 
             dragOffset = 0
+            handleNavigationRequest(viewModel.navigationRequest)
+        }
+        .onChange(of: viewModel.navigationRequest) { _, request in
+            handleNavigationRequest(request)
         }
         .onChange(of: colorScheme) { _, _ in
             setupNavigationBarAppearance()
@@ -491,7 +496,12 @@ struct ChatContainer: View {
 
     @ViewBuilder
     private var activeSidebar: some View {
-        ChatSidebar(isOpen: $isSidebarOpen, viewModel: viewModel, authManager: authManager)
+        ChatSidebar(
+            isOpen: $isSidebarOpen,
+            navigationRequest: $sidebarNavigationRequest,
+            viewModel: viewModel,
+            authManager: authManager
+        )
     }
 
     private var isShowingProjectLanding: Bool {
@@ -513,6 +523,29 @@ struct ChatContainer: View {
     }
     
     // MARK: - Helper Methods
+
+    private func handleNavigationRequest(_ request: ChatNavigationRequest?) {
+        guard let request else { return }
+
+        switch request.destination {
+        case .chat:
+            sidebarNavigationRequest = nil
+            messageText = ""
+            withAnimation(.easeInOut(duration: 0.3)) {
+                isSidebarOpen = false
+                dragOffset = 0
+            }
+        case .projects, .favorites:
+            sidebarNavigationRequest = request
+            dismissKeyboard()
+            withAnimation(.easeInOut(duration: 0.3)) {
+                isSidebarOpen = true
+                dragOffset = 0
+            }
+        }
+
+        viewModel.consumeNavigationRequest(id: request.id)
+    }
     
     /// Checks if enough time has passed since the app went to background and creates a new chat if needed
     private func checkAndCreateNewChatIfNeeded() {


### PR DESCRIPTION
## Summary
- add New Chat, Projects, and Favorites actions to the app icon menu
- handle actions during cold launches and when returning to the running app
- open a fresh root chat or reveal and scroll to the requested sidebar section

## Testing
- not run (project instructions require building and testing in Xcode)
- validated `Info.plist` syntax with `plutil`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Home Screen quick actions for New Chat, Projects, and Favorites to jump directly into common destinations. Previously there were no quick actions; now selecting one launches the app into the destination. New Chat now clears any active project before creating a chat.

- Handles `UIApplicationShortcutItem` in a dedicated scene delegate wired via `UISceneConfiguration` to support cold and warm launches; defines three static items in Info.plist with SF Symbols.
- Maps shortcut types to `AppIntentCoordinator` actions (`.newChat`, `.showProjects`, `.showFavorites`) and routes them through a single navigation path.
- Introduces `ChatNavigationDestination` and `ChatNavigationRequest` in `ChatViewModel` with `requestNavigation(...)`/`consumeNavigationRequest(...)`; `.newChat` uses `createNewRootChat()` and requests `.chat`.
- `ChatView` observes `navigationRequest` to open/close the sidebar and forward sidebar requests; `ChatSidebar` expands the requested section and scrolls to it via `ScrollViewReader` anchors.
- Adds `Constants.HomeScreenQuickActions` for shortcut identifiers.

- QA: Verify the three quick actions appear; test cold launch and when app is running; confirm Projects/Favorites expand and scroll into view; ensure dictation and message sending still behave as before.

<sup>Written for commit d14e672cbb88828187c7c32d5838d5dc6c3d8e6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

