### PR TITLE
Fix cross-device chat favorite sync

### DIFF
--- a/TinfoilChat/Models/CloudSyncModels.swift
+++ b/TinfoilChat/Models/CloudSyncModels.swift
@@ -541,6 +541,42 @@ struct ProfileData: Codable {
     var clockVersion: Int?
 }
 
+enum ProfileDefaults {
+    static let isDarkMode = true
+    static let language = "English"
+    static let nickname = ""
+    static let profession = ""
+    static let traits: [String] = []
+    static let additionalContext = ""
+    static let isUsingPersonalization = false
+    static let isUsingCustomPrompt = false
+    static let customSystemPrompt = ""
+    static let customPromptPresets: [SyncedPromptPreset] = []
+    static let favoritePromptPresetIds: [String] = []
+    static let reasoningEffort = ReasoningEffort.medium.rawValue
+    static let thinkingEnabled = true
+    static let webSearchAvailable = true
+    static let genUIEnabled = true
+
+    static let profile = ProfileData(
+        isDarkMode: isDarkMode,
+        language: language,
+        nickname: nickname,
+        profession: profession,
+        traits: traits,
+        additionalContext: additionalContext,
+        isUsingPersonalization: isUsingPersonalization,
+        isUsingCustomPrompt: isUsingCustomPrompt,
+        customSystemPrompt: customSystemPrompt,
+        customPromptPresets: customPromptPresets,
+        favoritePromptPresetIds: favoritePromptPresetIds,
+        reasoningEffort: reasoningEffort,
+        thinkingEnabled: thinkingEnabled,
+        webSearchAvailable: webSearchAvailable,
+        genUIEnabled: genUIEnabled
+    )
+}
+
 /// Profile sync status from server (for efficient sync checking)
 struct ProfileSyncStatus: Codable {
     let exists: Bool

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -18,25 +18,25 @@ class ProfileManager: ObservableObject {
     static let shared = ProfileManager()
     
     // Published properties for UI binding
-    @Published var isDarkMode: Bool = true
-    @Published var language: String = "English"
+    @Published var isDarkMode: Bool = ProfileDefaults.isDarkMode
+    @Published var language: String = ProfileDefaults.language
     
     // Personalization settings
-    @Published var nickname: String = ""
-    @Published var profession: String = ""
-    @Published var traits: [String] = []
-    @Published var additionalContext: String = ""
-    @Published var isUsingPersonalization: Bool = false
+    @Published var nickname: String = ProfileDefaults.nickname
+    @Published var profession: String = ProfileDefaults.profession
+    @Published var traits: [String] = ProfileDefaults.traits
+    @Published var additionalContext: String = ProfileDefaults.additionalContext
+    @Published var isUsingPersonalization: Bool = ProfileDefaults.isUsingPersonalization
     
     // Custom system prompt
-    @Published var isUsingCustomPrompt: Bool = false
-    @Published var customSystemPrompt: String = ""
+    @Published var isUsingCustomPrompt: Bool = ProfileDefaults.isUsingCustomPrompt
+    @Published var customSystemPrompt: String = ProfileDefaults.customSystemPrompt
 
     // User-created prompt presets (synced through the shared profile row)
-    @Published var customPromptPresets: [SyncedPromptPreset] = []
+    @Published var customPromptPresets: [SyncedPromptPreset] = ProfileDefaults.customPromptPresets
 
     // Preset ids pinned as homescreen favorites (built-in or custom)
-    @Published var favoritePromptPresetIds: [String] = []
+    @Published var favoritePromptPresetIds: [String] = ProfileDefaults.favoritePromptPresetIds
 
     @Published private(set) var pinnedChatIds: [String]? = nil
     
@@ -205,12 +205,12 @@ class ProfileManager: ObservableObject {
     private func createProfileData() -> ProfileData {
         let reasoningEffort = UserDefaults.standard.string(
             forKey: Constants.StorageKeys.Settings.reasoningEffort
-        ) ?? ReasoningEffort.medium.rawValue
+        ) ?? ProfileDefaults.reasoningEffort
         let thinkingEnabled: Bool
         if UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.thinkingEnabled) != nil {
             thinkingEnabled = UserDefaults.standard.bool(forKey: Constants.StorageKeys.Settings.thinkingEnabled)
         } else {
-            thinkingEnabled = true
+            thinkingEnabled = ProfileDefaults.thinkingEnabled
         }
 
         return ProfileData(
@@ -962,18 +962,18 @@ class ProfileManager: ObservableObject {
     
     private func applyDefaultProfile(pinnedChatIds: [String]? = nil) {
         isApplyingProfile = true
-        isDarkMode = true
+        isDarkMode = ProfileDefaults.isDarkMode
         themeMode = nil
-        language = "English"
-        nickname = ""
-        profession = ""
-        traits = []
-        additionalContext = ""
-        isUsingPersonalization = false
-        isUsingCustomPrompt = false
-        customSystemPrompt = ""
-        customPromptPresets = []
-        favoritePromptPresetIds = []
+        language = ProfileDefaults.language
+        nickname = ProfileDefaults.nickname
+        profession = ProfileDefaults.profession
+        traits = ProfileDefaults.traits
+        additionalContext = ProfileDefaults.additionalContext
+        isUsingPersonalization = ProfileDefaults.isUsingPersonalization
+        isUsingCustomPrompt = ProfileDefaults.isUsingCustomPrompt
+        customSystemPrompt = ProfileDefaults.customSystemPrompt
+        customPromptPresets = ProfileDefaults.customPromptPresets
+        favoritePromptPresetIds = ProfileDefaults.favoritePromptPresetIds
         self.pinnedChatIds = pinnedChatIds
         isApplyingProfile = false
     }

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -517,7 +517,8 @@ class ProfileManager: ObservableObject {
     }
 
     func isChatPinned(_ id: String) -> Bool {
-        pinnedChatIds?.contains(id) == true
+        guard let normalizedID = ChatFavorites.normalizedID(id) else { return false }
+        return pinnedChatIds?.contains(normalizedID) == true
     }
 
     private func updatePinnedChatIds(_ ids: [String]) {
@@ -531,8 +532,10 @@ class ProfileManager: ObservableObject {
     }
 
     func unpinChat(_ id: String) {
-        guard let pinnedChatIds, pinnedChatIds.contains(id) else { return }
-        updatePinnedChatIds(pinnedChatIds.filter { $0 != id })
+        guard let normalizedID = ChatFavorites.normalizedID(id),
+              let pinnedChatIds,
+              pinnedChatIds.contains(normalizedID) else { return }
+        updatePinnedChatIds(pinnedChatIds.filter { $0 != normalizedID })
     }
 
     func removePinnedChats(_ ids: Set<String>) {

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -425,14 +425,6 @@ class ProfileManager: ObservableObject {
                 self?.saveToKeychain()
             }
             .store(in: &cancellables)
-
-        $pinnedChatIds
-            .dropFirst()
-            .sink { [weak self] _ in
-                guard !(self?.isApplyingProfile ?? false) else { return }
-                self?.saveToKeychain()
-            }
-            .store(in: &cancellables)
     }
 
     // MARK: - Prompt Presets
@@ -528,24 +520,29 @@ class ProfileManager: ObservableObject {
         pinnedChatIds?.contains(id) == true
     }
 
+    private func updatePinnedChatIds(_ ids: [String]) {
+        pinnedChatIds = ids
+        saveToKeychain()
+    }
+
     func pinChat(_ id: String) {
         guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        pinnedChatIds = ChatFavorites.normalize([id] + (pinnedChatIds ?? []))
+        updatePinnedChatIds(ChatFavorites.normalize([id] + (pinnedChatIds ?? [])))
     }
 
     func unpinChat(_ id: String) {
-        guard pinnedChatIds?.contains(id) == true else { return }
-        pinnedChatIds = pinnedChatIds?.filter { $0 != id }
+        guard let pinnedChatIds, pinnedChatIds.contains(id) else { return }
+        updatePinnedChatIds(pinnedChatIds.filter { $0 != id })
     }
 
     func removePinnedChats(_ ids: Set<String>) {
         guard let pinnedChatIds,
               pinnedChatIds.contains(where: { ids.contains($0) }) else { return }
-        self.pinnedChatIds = ChatFavorites.removing(pinnedChatIds, confirmedMissing: ids)
+        updatePinnedChatIds(ChatFavorites.removing(pinnedChatIds, confirmedMissing: ids))
     }
 
     func clearPinnedChats() {
-        pinnedChatIds = []
+        updatePinnedChatIds([])
     }
 
     /// Duplicate a built-in or user preset into a new editable user preset.
@@ -672,9 +669,18 @@ class ProfileManager: ObservableObject {
                         clearLocalProfileChanged()
                     }
                 } else if hasPendingLocalProfileChanges {
-                    throw ProfileSyncError.unresolvedConflicts(
-                        ProfileMerge.changedProfileFields(local: localProfile, baseline: nil)
-                    )
+                    guard let reconciled = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+                        local: localProfile,
+                        remote: cloudProfile
+                    ) else {
+                        throw ProfileSyncError.unresolvedConflicts(
+                            ProfileMerge.changedProfileFields(local: localProfile, baseline: nil)
+                        )
+                    }
+                    applyProfile(reconciled)
+                    persistProfileToKeychain(createProfileData())
+                    commitSyncedBaseline(cloudProfile, version: cloudVersion)
+                    markLocalProfileChanged()
                 } else {
                     applyProfile(cloudProfile)
                     persistProfileToKeychain(createProfileData())

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -32,24 +32,6 @@ enum ProfileMerge {
         "projectUploadPreference", "pinnedChatIds",
     ]
 
-    private static let bootstrapDefaults = ProfileData(
-        isDarkMode: true,
-        language: "English",
-        nickname: "",
-        profession: "",
-        traits: [],
-        additionalContext: "",
-        isUsingPersonalization: false,
-        isUsingCustomPrompt: false,
-        customSystemPrompt: "",
-        customPromptPresets: [],
-        favoritePromptPresetIds: [],
-        reasoningEffort: ReasoningEffort.medium.rawValue,
-        thinkingEnabled: true,
-        webSearchAvailable: true,
-        genUIEnabled: true
-    )
-
     private static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -123,7 +105,7 @@ enum ProfileMerge {
         guard
             let localDict = try? dictionary(from: local),
             var mergedDict = try? dictionary(from: remote),
-            let defaultDict = try? dictionary(from: bootstrapDefaults),
+            let defaultDict = try? dictionary(from: ProfileDefaults.profile),
             localDict["pinnedChatIds"] != nil
         else {
             return nil

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -32,6 +32,24 @@ enum ProfileMerge {
         "projectUploadPreference", "pinnedChatIds",
     ]
 
+    private static let bootstrapDefaults = ProfileData(
+        isDarkMode: true,
+        language: "English",
+        nickname: "",
+        profession: "",
+        traits: [],
+        additionalContext: "",
+        isUsingPersonalization: false,
+        isUsingCustomPrompt: false,
+        customSystemPrompt: "",
+        customPromptPresets: [],
+        favoritePromptPresetIds: [],
+        reasoningEffort: ReasoningEffort.medium.rawValue,
+        thinkingEnabled: true,
+        webSearchAvailable: true,
+        genUIEnabled: true
+    )
+
     private static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -105,6 +123,7 @@ enum ProfileMerge {
         guard
             let localDict = try? dictionary(from: local),
             var mergedDict = try? dictionary(from: remote),
+            let defaultDict = try? dictionary(from: bootstrapDefaults),
             localDict["pinnedChatIds"] != nil
         else {
             return nil
@@ -112,16 +131,24 @@ enum ProfileMerge {
 
         for field in mergeFields {
             guard let localValue = localDict[field] else { continue }
-            if let remoteValue = mergedDict[field] {
-                guard valuesEqual(localValue, remoteValue) else { return nil }
-            } else {
-                guard field == "pinnedChatIds" else { return nil }
-                mergedDict[field] = localValue
+            if field == "pinnedChatIds" {
+                if let remoteValue = mergedDict[field] {
+                    guard valuesEqual(localValue, remoteValue) else { return nil }
+                } else {
+                    mergedDict[field] = localValue
+                }
+                continue
             }
+
+            if let remoteValue = mergedDict[field] {
+                if valuesEqual(localValue, remoteValue) { continue }
+            }
+            guard let defaultValue = defaultDict[field],
+                  valuesEqual(localValue, defaultValue) else { return nil }
         }
 
-        // Only the migration-safe favorites field may be missing remotely. Any
-        // other difference remains blocked until a baseline exists.
+        // Local defaults carry no unsynced user intent, so remote values or
+        // omissions can safely win while the favorites field is recovered.
         return try? profile(from: mergedDict)
     }
 

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -98,6 +98,33 @@ enum ProfileMerge {
         return changed
     }
 
+    static func reconcileDirtyProfileWithoutBaseline(
+        local: ProfileData,
+        remote: ProfileData
+    ) -> ProfileData? {
+        guard
+            let localDict = try? dictionary(from: local),
+            var mergedDict = try? dictionary(from: remote),
+            localDict["pinnedChatIds"] != nil
+        else {
+            return nil
+        }
+
+        for field in mergeFields {
+            guard let localValue = localDict[field] else { continue }
+            if let remoteValue = mergedDict[field] {
+                guard valuesEqual(localValue, remoteValue) else { return nil }
+            } else {
+                guard field == "pinnedChatIds" else { return nil }
+                mergedDict[field] = localValue
+            }
+        }
+
+        // Only the migration-safe favorites field may be missing remotely. Any
+        // other difference remains blocked until a baseline exists.
+        return try? profile(from: mergedDict)
+    }
+
     static func mergeProfiles(
         baseline: ProfileData,
         local: ProfileData,

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -270,11 +270,11 @@ class SettingsManager: ObservableObject {
     
     // Reset all personalization settings
     func resetPersonalization() {
-        nickname = ""
-        profession = ""
-        selectedTraits = []
-        additionalContext = ""
-        isPersonalizationEnabled = false
+        nickname = ProfileDefaults.nickname
+        profession = ProfileDefaults.profession
+        selectedTraits = ProfileDefaults.traits
+        additionalContext = ProfileDefaults.additionalContext
+        isPersonalizationEnabled = ProfileDefaults.isUsingPersonalization
     }
 }
 

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -125,20 +125,20 @@ class SettingsManager: ObservableObject {
         self.selectedLanguage = UserDefaults.standard.string(forKey: Constants.StorageKeys.Settings.selectedLanguage) ?? "System"
         
         // Initialize personalization settings
-        self.isPersonalizationEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.personalizationEnabled) as? Bool ?? false
-        self.nickname = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.nickname) ?? ""
-        self.profession = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.profession) ?? ""
-        self.additionalContext = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.additionalContext) ?? ""
+        self.isPersonalizationEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.personalizationEnabled) as? Bool ?? ProfileDefaults.isUsingPersonalization
+        self.nickname = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.nickname) ?? ProfileDefaults.nickname
+        self.profession = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.profession) ?? ProfileDefaults.profession
+        self.additionalContext = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.additionalContext) ?? ProfileDefaults.additionalContext
         
         if let traitsData = UserDefaults.standard.array(forKey: Constants.StorageKeys.UserPrefs.traits) as? [String] {
             self.selectedTraits = traitsData
         } else {
-            self.selectedTraits = []
+            self.selectedTraits = ProfileDefaults.traits
         }
         
         // Initialize custom system prompt settings
-        self.isUsingCustomPrompt = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled) as? Bool ?? false
-        self.customSystemPrompt = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt) ?? ""
+        self.isUsingCustomPrompt = UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.customPromptEnabled) as? Bool ?? ProfileDefaults.isUsingCustomPrompt
+        self.customSystemPrompt = UserDefaults.standard.string(forKey: Constants.StorageKeys.UserPrefs.customSystemPrompt) ?? ProfileDefaults.customSystemPrompt
 
         if let storedValue = UserDefaults.standard.object(
             forKey: Constants.StorageKeys.Settings.webSearchAvailable
@@ -153,14 +153,14 @@ class SettingsManager: ObservableObject {
                 forKey: Constants.StorageKeys.Settings.webSearchAvailable
             )
         } else {
-            self.webSearchAvailable = true
+            self.webSearchAvailable = ProfileDefaults.webSearchAvailable
         }
         UserDefaults.standard.removeObject(
             forKey: Constants.StorageKeys.Settings.webSearchEnabled
         )
 
         // Initialize Generative UI setting (defaults to on)
-        self.genUIEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.genUIEnabled) as? Bool ?? true
+        self.genUIEnabled = UserDefaults.standard.object(forKey: Constants.StorageKeys.Settings.genUIEnabled) as? Bool ?? ProfileDefaults.genUIEnabled
 
         // Initialize cloud sync setting
         // If no explicit value has been stored, auto-enable for existing users who already have an encryption key
@@ -184,7 +184,10 @@ class SettingsManager: ObservableObject {
             UserDefaults.standard.set("System", forKey: Constants.StorageKeys.Settings.selectedLanguage)
         }
         if UserDefaults.standard.object(forKey: Constants.StorageKeys.UserPrefs.personalizationEnabled) == nil {
-            UserDefaults.standard.set(false, forKey: Constants.StorageKeys.UserPrefs.personalizationEnabled)
+            UserDefaults.standard.set(
+                ProfileDefaults.isUsingPersonalization,
+                forKey: Constants.StorageKeys.UserPrefs.personalizationEnabled
+            )
         }
     }
 
@@ -209,15 +212,15 @@ class SettingsManager: ObservableObject {
         // Reset in-memory state to defaults
         hapticFeedbackEnabled = true
         selectedLanguage = "System"
-        isPersonalizationEnabled = false
-        nickname = ""
-        profession = ""
-        selectedTraits = []
-        additionalContext = ""
-        isUsingCustomPrompt = false
-        customSystemPrompt = ""
-        webSearchAvailable = true
-        genUIEnabled = true
+        isPersonalizationEnabled = ProfileDefaults.isUsingPersonalization
+        nickname = ProfileDefaults.nickname
+        profession = ProfileDefaults.profession
+        selectedTraits = ProfileDefaults.traits
+        additionalContext = ProfileDefaults.additionalContext
+        isUsingCustomPrompt = ProfileDefaults.isUsingCustomPrompt
+        customSystemPrompt = ProfileDefaults.customSystemPrompt
+        webSearchAvailable = ProfileDefaults.webSearchAvailable
+        genUIEnabled = ProfileDefaults.genUIEnabled
         isCloudSyncEnabled = false
         isLocalOnlyModeEnabled = false
     }

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -260,6 +260,27 @@ struct ProfileMergeTests {
         #expect(reconciled.pinnedChatIds == ["chat-a"])
     }
 
+    @Test("dirty profile without baseline ignores omitted local defaults")
+    func reconcilesPinnedChatsWithOmittedDefaults() throws {
+        let reconciled = try #require(
+            ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+                local: ProfileData(
+                    isDarkMode: true,
+                    language: "English",
+                    reasoningEffort: ReasoningEffort.medium.rawValue,
+                    thinkingEnabled: true,
+                    webSearchAvailable: true,
+                    genUIEnabled: true,
+                    pinnedChatIds: ["chat-a"]
+                ),
+                remote: ProfileData(webSearchAvailable: false)
+            )
+        )
+
+        #expect(reconciled.webSearchAvailable == false)
+        #expect(reconciled.pinnedChatIds == ["chat-a"])
+    }
+
     @Test("dirty profile without baseline rejects ambiguous changes")
     func rejectsAmbiguousChangesWithoutBaseline() {
         let missingLocal = ProfileMerge.reconcileDirtyProfileWithoutBaseline(

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -206,6 +206,89 @@ struct ProfileMergeTests {
         #expect(Set(fields) == Set(["nickname", "traits", "webSearchAvailable"]))
     }
 
+    @Test("dirty profile without baseline preserves local pins and remote settings")
+    func reconcilesPinnedChatsWithoutBaseline() throws {
+        let local = ProfileData(
+            themeMode: "light",
+            nickname: "Remote",
+            profession: "Researcher",
+            pinnedChatIds: ["chat-a"]
+        )
+        var remote = ProfileData(
+            themeMode: "light",
+            nickname: "Remote",
+            profession: "Researcher"
+        )
+        remote.version = 4
+
+        let reconciled = try #require(
+            ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+                local: local,
+                remote: remote
+            )
+        )
+
+        #expect(reconciled.themeMode == "light")
+        #expect(reconciled.nickname == "Remote")
+        #expect(reconciled.profession == "Researcher")
+        #expect(reconciled.pinnedChatIds == ["chat-a"])
+        #expect(reconciled.version == 4)
+    }
+
+    @Test("dirty profile without baseline preserves an explicit pin clear")
+    func reconcilesExplicitPinnedChatClearWithoutBaseline() throws {
+        let reconciled = try #require(
+            ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+                local: ProfileData(pinnedChatIds: []),
+                remote: ProfileData(nickname: "Remote")
+            )
+        )
+
+        #expect(reconciled.nickname == "Remote")
+        #expect(reconciled.pinnedChatIds == [])
+    }
+
+    @Test("dirty profile without baseline accepts matching remote pins")
+    func acceptsMatchingPinnedChatsWithoutBaseline() throws {
+        let reconciled = try #require(
+            ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+                local: ProfileData(nickname: "Remote", pinnedChatIds: ["chat-a"]),
+                remote: ProfileData(nickname: "Remote", pinnedChatIds: ["chat-a"])
+            )
+        )
+
+        #expect(reconciled.pinnedChatIds == ["chat-a"])
+    }
+
+    @Test("dirty profile without baseline rejects ambiguous changes")
+    func rejectsAmbiguousChangesWithoutBaseline() {
+        let missingLocal = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+            local: ProfileData(nickname: "Local"),
+            remote: ProfileData(nickname: "Remote")
+        )
+        let conflictingSetting = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+            local: ProfileData(nickname: "Local", pinnedChatIds: ["chat-a"]),
+            remote: ProfileData(nickname: "Remote")
+        )
+        let localOnlySetting = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+            local: ProfileData(
+                nickname: "Remote",
+                profession: "Researcher",
+                pinnedChatIds: ["chat-a"]
+            ),
+            remote: ProfileData(nickname: "Remote")
+        )
+        let conflictingPins = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+            local: ProfileData(pinnedChatIds: ["local-chat"]),
+            remote: ProfileData(pinnedChatIds: ["remote-chat"])
+        )
+
+        #expect(missingLocal == nil)
+        #expect(conflictingSetting == nil)
+        #expect(localOnlySetting == nil)
+        #expect(conflictingPins == nil)
+    }
+
     @Test("adopts populated remote fields when local stayed empty")
     func staleEmptyAdoptsRemote() {
         let baseline = ProfileData(nickname: "", customSystemPrompt: "")

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -265,19 +265,28 @@ struct ProfileMergeTests {
         let reconciled = try #require(
             ProfileMerge.reconcileDirtyProfileWithoutBaseline(
                 local: ProfileData(
-                    isDarkMode: true,
-                    language: "English",
-                    reasoningEffort: ReasoningEffort.medium.rawValue,
-                    thinkingEnabled: true,
-                    webSearchAvailable: true,
-                    genUIEnabled: true,
+                    isDarkMode: ProfileDefaults.isDarkMode,
+                    language: ProfileDefaults.language,
+                    isUsingPersonalization: ProfileDefaults.isUsingPersonalization,
+                    reasoningEffort: ProfileDefaults.reasoningEffort,
+                    thinkingEnabled: ProfileDefaults.thinkingEnabled,
+                    webSearchAvailable: ProfileDefaults.webSearchAvailable,
+                    genUIEnabled: ProfileDefaults.genUIEnabled,
                     pinnedChatIds: ["chat-a"]
                 ),
-                remote: ProfileData(webSearchAvailable: false)
+                remote: ProfileData(
+                    webSearchAvailable: !ProfileDefaults.webSearchAvailable
+                )
             )
         )
 
-        #expect(reconciled.webSearchAvailable == false)
+        #expect(reconciled.webSearchAvailable == !ProfileDefaults.webSearchAvailable)
+        #expect(reconciled.isDarkMode == nil)
+        #expect(reconciled.language == nil)
+        #expect(reconciled.isUsingPersonalization == nil)
+        #expect(reconciled.reasoningEffort == nil)
+        #expect(reconciled.thinkingEnabled == nil)
+        #expect(reconciled.genUIEnabled == nil)
         #expect(reconciled.pinnedChatIds == ["chat-a"])
     }
 


### PR DESCRIPTION
## Summary
- persist favorite changes after the published value is assigned
- recover safe favorite updates when no profile baseline exists
- reject ambiguous profile reconciliation and add merge regression coverage

## Testing
- Not run per repository instructions; build and tests require Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-device sync of pinned chats (favorites). Previously, sync aborted when a device had local pins but no baseline; now we merge local pins into the remote profile when other local changes match remote values or app defaults, and still flag conflicts when ambiguous.

- Persist pins immediately via updatePinnedChatIds; remove the `$pinnedChatIds` save sink to avoid saves during profile application and order keychain writes after value updates.
- Recover pins without a baseline using ProfileMerge.reconcileDirtyProfileWithoutBaseline: copy `pinnedChatIds` when other changed fields equal the remote or defaults; preserve remote settings and version; otherwise raise `unresolvedConflicts`.
- Normalize chat IDs in `isChatPinned`, `pinChat`, and `unpinChat` so favorites behave consistently across devices.
- Centralize defaults in `ProfileDefaults` and use them in `ProfileManager`, `SettingsView`, and reset flows; treat omitted fields as defaults (not changes) in merge.
- Add tests for safe pin recovery, explicit clears, matching pins, ignoring omitted defaults, and rejecting ambiguous cases.

<sup>Written for commit 96073129ceba4dd83a882618d0a13b0ada25a588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

