### PR TITLE
Recover stalled cross-device profile sync

### DIFF
--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -357,20 +357,26 @@ class ProfileManager: ObservableObject {
         $nickname
             .dropFirst()
             .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
+            .compactMap { [weak self] _ in self?.accountGeneration }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
-            .sink { [weak self] _ in
-                guard !(self?.isApplyingProfile ?? false) else { return }
-                self?.saveToKeychain()
+            .sink { [weak self] generation in
+                guard let self,
+                      generation == self.accountGeneration,
+                      !self.isApplyingProfile else { return }
+                self.saveToKeychain()
             }
             .store(in: &cancellables)
         
         $profession
             .dropFirst()
             .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
+            .compactMap { [weak self] _ in self?.accountGeneration }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
-            .sink { [weak self] _ in
-                guard !(self?.isApplyingProfile ?? false) else { return }
-                self?.saveToKeychain()
+            .sink { [weak self] generation in
+                guard let self,
+                      generation == self.accountGeneration,
+                      !self.isApplyingProfile else { return }
+                self.saveToKeychain()
             }
             .store(in: &cancellables)
         
@@ -385,10 +391,13 @@ class ProfileManager: ObservableObject {
         $additionalContext
             .dropFirst()
             .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
+            .compactMap { [weak self] _ in self?.accountGeneration }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
-            .sink { [weak self] _ in
-                guard !(self?.isApplyingProfile ?? false) else { return }
-                self?.saveToKeychain()
+            .sink { [weak self] generation in
+                guard let self,
+                      generation == self.accountGeneration,
+                      !self.isApplyingProfile else { return }
+                self.saveToKeychain()
             }
             .store(in: &cancellables)
         
@@ -411,10 +420,13 @@ class ProfileManager: ObservableObject {
         $customSystemPrompt
             .dropFirst()
             .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
+            .compactMap { [weak self] _ in self?.accountGeneration }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
-            .sink { [weak self] _ in
-                guard !(self?.isApplyingProfile ?? false) else { return }
-                self?.saveToKeychain()
+            .sink { [weak self] generation in
+                guard let self,
+                      generation == self.accountGeneration,
+                      !self.isApplyingProfile else { return }
+                self.saveToKeychain()
             }
             .store(in: &cancellables)
 

--- a/TinfoilChat/Services/ProfileManager.swift
+++ b/TinfoilChat/Services/ProfileManager.swift
@@ -92,25 +92,29 @@ class ProfileManager: ObservableObject {
     
     /// Load profile from Keychain
     private func loadFromKeychain() {
-        guard let data = keychainHelper.load(for: keychainKey, service: keychainService),
-              let profile = try? JSONDecoder().decode(ProfileData.self, from: data) else {
-            // No profile in keychain, use defaults
-            return
+        var loadedProfile: ProfileData?
+        if let data = keychainHelper.load(for: keychainKey, service: keychainService),
+           let profile = try? JSONDecoder().decode(ProfileData.self, from: data) {
+            loadedProfile = profile
+            applyProfile(profile)
+
+            // Also update last synced version if profile has one
+            if let version = profile.version {
+                lastSyncedVersion = version
+            }
         }
-        
-        applyProfile(profile)
-        
-        // Also update last synced version if profile has one
-        if let version = profile.version {
-            lastSyncedVersion = version
-        }
+
         if let baselineData = keychainHelper.load(
             for: profileBaselineKey,
             service: keychainService
         ), let baseline = try? JSONDecoder().decode(ProfileData.self, from: baselineData) {
             lastSyncedProfile = baseline
             lastSyncedVersion = baseline.version ?? lastSyncedVersion
-        } else if !hasPendingLocalProfileChanges {
+            if loadedProfile == nil {
+                applyProfile(baseline)
+                persistProfileToKeychain(baseline)
+            }
+        } else if let profile = loadedProfile, !hasPendingLocalProfileChanges {
             lastSyncedProfile = profile
             persistBaselineToKeychain(profile)
         }
@@ -352,6 +356,7 @@ class ProfileManager: ObservableObject {
         
         $nickname
             .dropFirst()
+            .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard !(self?.isApplyingProfile ?? false) else { return }
@@ -361,6 +366,7 @@ class ProfileManager: ObservableObject {
         
         $profession
             .dropFirst()
+            .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard !(self?.isApplyingProfile ?? false) else { return }
@@ -378,6 +384,7 @@ class ProfileManager: ObservableObject {
         
         $additionalContext
             .dropFirst()
+            .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard !(self?.isApplyingProfile ?? false) else { return }
@@ -403,6 +410,7 @@ class ProfileManager: ObservableObject {
         
         $customSystemPrompt
             .dropFirst()
+            .filter { [weak self] _ in !(self?.isApplyingProfile ?? false) }
             .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard !(self?.isApplyingProfile ?? false) else { return }

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -114,6 +114,12 @@ enum ProfileMerge {
         for field in mergeFields {
             guard let localValue = localDict[field] else { continue }
             if field == "pinnedChatIds" {
+                if local.pinnedChatIds?.isEmpty == true {
+                    mergedDict[field] = [String]()
+                    continue
+                }
+                // Without an ancestor, keep both sides rather than silently
+                // dropping favorites; an explicit empty list still clears all.
                 let pinCandidates = (local.pinnedChatIds ?? []) + (remote.pinnedChatIds ?? [])
                 let uniquePinCount = Set(pinCandidates.compactMap(ChatFavorites.normalizedID)).count
                 guard uniquePinCount <= Constants.ChatFavorites.maxPinnedChats else { return nil }

--- a/TinfoilChat/Services/ProfileMerge.swift
+++ b/TinfoilChat/Services/ProfileMerge.swift
@@ -114,11 +114,11 @@ enum ProfileMerge {
         for field in mergeFields {
             guard let localValue = localDict[field] else { continue }
             if field == "pinnedChatIds" {
-                if let remoteValue = mergedDict[field] {
-                    guard valuesEqual(localValue, remoteValue) else { return nil }
-                } else {
-                    mergedDict[field] = localValue
-                }
+                let pinCandidates = (local.pinnedChatIds ?? []) + (remote.pinnedChatIds ?? [])
+                let uniquePinCount = Set(pinCandidates.compactMap(ChatFavorites.normalizedID)).count
+                guard uniquePinCount <= Constants.ChatFavorites.maxPinnedChats else { return nil }
+                let combinedPinnedChatIds = ChatFavorites.normalize(pinCandidates)
+                mergedDict[field] = combinedPinnedChatIds
                 continue
             }
 

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -272,6 +272,10 @@ class AuthManager: ObservableObject {
         // keys, or personalization bleed into the next account on a shared
         // device. This runs before isAuthenticated is cleared below so the
         // view model can still resolve the signing-out user's id for the wipe.
+        chatViewModel?.resetSharedProfileSettingsForAccountTeardown()
+        // Reset shared settings before the profile wipe so observer-triggered
+        // profile writes are deleted by the final teardown operation.
+        SettingsManager.shared.clearAllSettings()
         await ProfileManager.shared.clearLocalProfileForAccountRemoval()
         if let chatViewModel {
             await chatViewModel.wipeLocalChatsForSignOut()
@@ -287,8 +291,6 @@ class AuthManager: ObservableObject {
         }
         EncryptionService.shared.clearKey()
         await DeviceEncryptionService.shared.clearKey()
-        SettingsManager.shared.clearAllSettings()
-
         localUserData = nil
         isAuthenticated = false
         hasActiveSubscription = false

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -5396,6 +5396,11 @@ class ChatViewModel: ObservableObject {
         accountOperationTracker.reopen()
     }
 
+    func resetSharedProfileSettingsForAccountTeardown() {
+        reasoningEffort = ReasoningEffort(rawValue: ProfileDefaults.reasoningEffort) ?? .medium
+        thinkingEnabled = ProfileDefaults.thinkingEnabled
+    }
+
     private func finishSignIn(
         _ token: AccountOperationFence.Token,
         userId: String

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -206,6 +206,8 @@ class SettingsManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.webSearchEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.webSearchAvailable)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.genUIEnabled)
+        UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.reasoningEffort)
+        UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.thinkingEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.cloudSyncEnabled)
         UserDefaults.standard.removeObject(forKey: Constants.StorageKeys.Settings.localOnlyModeEnabled)
 

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -308,15 +308,32 @@ struct ProfileMergeTests {
             ),
             remote: ProfileData(nickname: "Remote")
         )
-        let conflictingPins = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
-            local: ProfileData(pinnedChatIds: ["local-chat"]),
-            remote: ProfileData(pinnedChatIds: ["remote-chat"])
-        )
-
         #expect(missingLocal == nil)
         #expect(conflictingSetting == nil)
         #expect(localOnlySetting == nil)
-        #expect(conflictingPins == nil)
+    }
+
+    @Test("dirty profile without baseline combines divergent pins")
+    func combinesDivergentPinsWithoutBaseline() throws {
+        let reconciled = try #require(
+            ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+                local: ProfileData(pinnedChatIds: ["local-chat", "shared-chat"]),
+                remote: ProfileData(pinnedChatIds: ["remote-chat", "shared-chat"])
+            )
+        )
+
+        #expect(reconciled.pinnedChatIds == ["local-chat", "shared-chat", "remote-chat"])
+    }
+
+    @Test("dirty profile without baseline rejects pin overflow")
+    func rejectsPinOverflowWithoutBaseline() {
+        let localPins = (0..<Constants.ChatFavorites.maxPinnedChats).map { "local-\($0)" }
+        let reconciled = ProfileMerge.reconcileDirtyProfileWithoutBaseline(
+            local: ProfileData(pinnedChatIds: localPins),
+            remote: ProfileData(pinnedChatIds: ["remote-chat"])
+        )
+
+        #expect(reconciled == nil)
     }
 
     @Test("adopts populated remote fields when local stayed empty")

--- a/TinfoilChatTests/ProfileMergeTests.swift
+++ b/TinfoilChatTests/ProfileMergeTests.swift
@@ -240,7 +240,10 @@ struct ProfileMergeTests {
         let reconciled = try #require(
             ProfileMerge.reconcileDirtyProfileWithoutBaseline(
                 local: ProfileData(pinnedChatIds: []),
-                remote: ProfileData(nickname: "Remote")
+                remote: ProfileData(
+                    nickname: "Remote",
+                    pinnedChatIds: ["remote-chat"]
+                )
             )
         )
 


### PR DESCRIPTION
## Summary
- merge divergent favorites safely when a device has lost its profile baseline
- restore working profile state independently from the saved sync baseline
- prevent account teardown callbacks from recreating a dirty profile for the next account

## Testing
- Added profile merge coverage for divergent favorites and overflow
- Not run per repository instructions; build and tests require Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers stalled cross‑device profile sync by bootstrapping from the saved baseline and merging divergent favorites instead of aborting. Fences teardown-triggered writes so sign‑out no longer recreates a dirty profile for the next account.

- Old: Conflicting `pinnedChatIds` without a baseline aborted merge. New: combine normalized, unique pins up to `Constants.ChatFavorites.maxPinnedChats`; explicit empty local pins clear all; reject on overflow.
- Old: When only a baseline existed, the app loaded defaults and left sync state inconsistent. New: apply the baseline as the active profile and persist it; if no baseline but a clean profile exists, persist that as the baseline.
- Old: Applying a profile could trigger debounced saves and cross‑account writes. New: suppress saves during `applyProfile` and require matching `accountGeneration` before saving.
- Old: Settings cleared after the profile wipe could trigger observer writes. New: reset `reasoningEffort`/`thinkingEnabled` and clear settings before wiping the profile; remove both keys in `clearAllSettings()`.

**Reviewer notes**
- `ProfileManager.loadFromKeychain`: verify baseline→profile bootstrap when `loadedProfile == nil`, and baseline promotion when a clean profile exists.
- Profile change streams: confirm `accountGeneration` fencing for nickname, profession, additionalContext, and customSystemPrompt saves.
- `ProfileMerge.reconcileDirtyProfileWithoutBaseline`: check pin merge (explicit empty local clears), normalization, and overflow guard.
- Sign‑out flow: ordering in `AuthManager.resetSharedProfileSettingsForAccountTeardown()`, `SettingsManager.clearAllSettings()`, then `clearLocalProfileForAccountRemoval()`. Tests cover combined pins, explicit empty pins, and overflow.

<sup>Written for commit d52bd791c27430eaef2f13448ad0c97a67e64046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

