### PR TITLE
feat: secure document and project data lifecycle

### DIFF
--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -74,6 +74,16 @@ struct ContentView: View {
                 }
             }
         }
+        .alert("Account Cleanup Required", isPresented: Binding(
+            get: { authManager.accountTeardownError != nil },
+            set: { if !$0 { authManager.accountTeardownError = nil } }
+        )) {
+            Button("Retry") {
+                Task { await authManager.retryAccountTeardown() }
+            }
+        } message: {
+            Text(authManager.accountTeardownError ?? "")
+        }
         .sheet(isPresented: $passkeyManager.showPasskeyRecoveryChoice) {
             PasskeyRecoveryChoiceView(
                 onTryAgain: {

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -251,10 +251,10 @@ struct ContentView: View {
             guard chatViewModel.currentChat != nil else { return }
             chatViewModel.sendMessage(text: prompt)
         case .newChat:
-            let navigationRequestID = chatViewModel.navigationRequest?.id
+            let navigationGeneration = chatViewModel.beginNavigationOperation()
             Task {
                 guard await chatViewModel.createNewRootChat(),
-                      chatViewModel.navigationRequest?.id == navigationRequestID else { return }
+                      chatViewModel.navigationGeneration == navigationGeneration else { return }
                 chatViewModel.requestNavigation(to: .chat)
             }
         case .startDictation:

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -253,7 +253,8 @@ struct ContentView: View {
         case .newChat:
             let navigationGeneration = chatViewModel.beginNavigationOperation()
             Task {
-                guard await chatViewModel.createNewRootChat(),
+                let createdRootChat = await chatViewModel.createNewRootChat()
+                guard (createdRootChat || !chatViewModel.hasChatAccess),
                       chatViewModel.navigationGeneration == navigationGeneration else { return }
                 chatViewModel.requestNavigation(to: .chat)
             }

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -251,8 +251,10 @@ struct ContentView: View {
             guard chatViewModel.currentChat != nil else { return }
             chatViewModel.sendMessage(text: prompt)
         case .newChat:
+            let navigationRequestID = chatViewModel.navigationRequest?.id
             Task {
-                await chatViewModel.createNewRootChat()
+                guard await chatViewModel.createNewRootChat(),
+                      chatViewModel.navigationRequest?.id == navigationRequestID else { return }
                 chatViewModel.requestNavigation(to: .chat)
             }
         case .startDictation:

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -251,8 +251,10 @@ struct ContentView: View {
             guard chatViewModel.currentChat != nil else { return }
             chatViewModel.sendMessage(text: prompt)
         case .newChat:
-            chatViewModel.createNewRootChat()
-            chatViewModel.requestNavigation(to: .chat)
+            Task {
+                await chatViewModel.createNewRootChat()
+                chatViewModel.requestNavigation(to: .chat)
+            }
         case .startDictation:
             if chatViewModel.canUseAudioInput {
                 chatViewModel.createNewChat(focusInput: false)

--- a/TinfoilChat/Extensions/Color+Hex.swift
+++ b/TinfoilChat/Extensions/Color+Hex.swift
@@ -8,6 +8,27 @@
 import SwiftUI
 
 extension Color {
+    static func projectColor(_ value: String?) -> Color {
+        switch value {
+        case "maya-blue":
+            return Color(red: 133/255, green: 198/255, blue: 255/255)
+        case "electric-aqua":
+            return Color(red: 98/255, green: 220/255, blue: 233/255)
+        case "sandy-brown":
+            return Color(red: 255/255, green: 181/255, blue: 122/255)
+        case "mauve":
+            return Color(red: 233/255, green: 171/255, blue: 255/255)
+        case "tuscan-sun":
+            return Color(red: 245/255, green: 203/255, blue: 88/255)
+        case "light-green":
+            return Color(red: 138/255, green: 223/255, blue: 141/255)
+        case "baby-pink":
+            return Color(red: 255/255, green: 158/255, blue: 195/255)
+        default:
+            return .accentColor
+        }
+    }
+
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0

--- a/TinfoilChat/Models/ProjectModels.swift
+++ b/TinfoilChat/Models/ProjectModels.swift
@@ -71,7 +71,7 @@ struct ProjectDocumentPayload: Codable, Equatable {
     var sizeBytes: Int? = nil
 
     var resolvedSizeBytes: Int {
-        sizeBytes ?? content.data(using: .utf8)?.count ?? content.count
+        sizeBytes ?? content.utf8.count
     }
 }
 
@@ -142,4 +142,3 @@ struct ProjectSyncStatus: Codable, Equatable {
 
 typealias ProjectChatSyncStatus = ProjectSyncStatus
 typealias ProjectDocumentSyncStatus = ProjectSyncStatus
-

--- a/TinfoilChat/Models/ProjectModels.swift
+++ b/TinfoilChat/Models/ProjectModels.swift
@@ -21,6 +21,7 @@ struct Project: Codable, Identifiable, Equatable {
     var description: String
     var systemInstructions: String
     var memory: [MemoryFact]
+    var color: String? = nil
     var createdAt: String
     var updatedAt: String
     var syncVersion: Int
@@ -32,12 +33,14 @@ struct ProjectData: Codable, Equatable {
     var description: String
     var systemInstructions: String
     var memory: [MemoryFact]
+    var color: String? = nil
 }
 
 struct CreateProjectData: Codable, Equatable {
     var name: String
     var description: String = ""
     var systemInstructions: String = ""
+    var color: String? = nil
 }
 
 struct UpdateProjectData: Codable, Equatable {
@@ -45,6 +48,7 @@ struct UpdateProjectData: Codable, Equatable {
     var description: String?
     var systemInstructions: String?
     var memory: [MemoryFact]?
+    var color: String? = nil
 }
 
 struct ProjectDocument: Codable, Identifiable, Equatable {
@@ -64,6 +68,11 @@ struct ProjectDocumentPayload: Codable, Equatable {
     var content: String
     var filename: String
     var contentType: String
+    var sizeBytes: Int? = nil
+
+    var resolvedSizeBytes: Int {
+        sizeBytes ?? content.data(using: .utf8)?.count ?? content.count
+    }
 }
 
 struct ProjectChat: Codable, Identifiable, Equatable {
@@ -133,5 +142,4 @@ struct ProjectSyncStatus: Codable, Equatable {
 
 typealias ProjectChatSyncStatus = ProjectSyncStatus
 typealias ProjectDocumentSyncStatus = ProjectSyncStatus
-
 

--- a/TinfoilChat/Services/CloudStorageService.swift
+++ b/TinfoilChat/Services/CloudStorageService.swift
@@ -482,7 +482,7 @@ class CloudStorageService: ObservableObject {
     /// Delete every chat for the current user. Paginates a stable v2 snapshot
     /// and issues one delete per row.
     @discardableResult
-    func deleteAllChats() async throws -> Int {
+    func deleteAllChats(requestProgress: SyncEnclaveRequestProgress? = nil) async throws -> Int {
         let key = try CEKEncoding.requirePrimaryKeyB64()
         var chatIds: [String] = []
         var cursor: String? = nil
@@ -513,7 +513,8 @@ class CloudStorageService: ObservableObject {
                     ifMatch: nil,
                     idempotencyKey: newSyncEnclaveIdempotencyKey(),
                     key: key
-                )
+                ),
+                requestProgress: requestProgress
             )
         }
         return chatIds.count

--- a/TinfoilChat/Services/CloudSyncService.swift
+++ b/TinfoilChat/Services/CloudSyncService.swift
@@ -2280,7 +2280,10 @@ class CloudSyncService: ObservableObject {
     /// number of rows deleted. Callers are responsible for tombstoning local
     /// IDs only after this succeeds, mirroring the webapp's ordering.
     @discardableResult
-    func deleteAllFromCloud(userId: String) async throws -> Int {
+    func deleteAllFromCloud(
+        userId: String,
+        requestProgress: SyncEnclaveRequestProgress? = nil
+    ) async throws -> Int {
         guard let account = bulkDeleteAccount,
               account.userId == userId,
               account.generation == accountGeneration,
@@ -2288,7 +2291,7 @@ class CloudSyncService: ObservableObject {
               await cloudStorage.isAuthenticated() else {
             throw CloudStorageError.authenticationRequired
         }
-        let deleted = try await cloudStorage.deleteAllChats()
+        let deleted = try await cloudStorage.deleteAllChats(requestProgress: requestProgress)
         guard bulkDeleteAccount == account,
               account.generation == accountGeneration,
               await getCurrentUserId() == userId else {

--- a/TinfoilChat/Services/DocumentConversionService.swift
+++ b/TinfoilChat/Services/DocumentConversionService.swift
@@ -49,7 +49,10 @@ actor DocumentConversionService {
     }
 
     func convertToMarkdown(url: URL, filename: String, contentType: String? = nil, mode: String = Constants.DocumentProcessing.defaultMode) async throws -> String {
-        let fileData = try Data(contentsOf: url)
+        let fileData = try BoundedFileIO.read(
+            from: url,
+            maximumSize: Constants.Attachments.maxFileSizeBytes
+        )
         let boundary = "Boundary-\(UUID().uuidString)"
         let mimeType = contentType ?? Self.mimeType(for: filename)
         let body = Self.multipartBody(

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -51,7 +51,7 @@ final class DocumentProcessingService {
         case "pdf":
             let extractionTask = Task.detached(priority: .userInitiated) {
                 try Task.checkCancellation()
-                try self.extractTextFromPDF(at: url)
+                return try self.extractTextFromPDF(at: url)
             }
             return try await withTaskCancellationHandler {
                 try await extractionTask.value
@@ -61,7 +61,7 @@ final class DocumentProcessingService {
         case "txt", "md", "csv", "html", "json", "xml":
             let extractionTask = Task.detached(priority: .userInitiated) {
                 try Task.checkCancellation()
-                try self.readPlainText(at: url)
+                return try self.readPlainText(at: url)
             }
             return try await withTaskCancellationHandler {
                 try await extractionTask.value

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -76,10 +76,19 @@ final class DocumentProcessingService {
 
     private func extractTextFromPDF(at url: URL) throws -> String {
         try Task.checkCancellation()
-        let data = try BoundedFileIO.read(
-            from: url,
-            maximumSize: Constants.Attachments.maxFileSizeBytes
-        )
+        let data: Data
+        do {
+            data = try BoundedFileIO.read(
+                from: url,
+                maximumSize: Constants.Attachments.maxFileSizeBytes
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch BoundedFileIOError.fileTooLarge(let size, _) {
+            throw ProcessingError.fileTooLarge(size)
+        } catch {
+            throw ProcessingError.fileReadFailed
+        }
         guard let document = PDFDocument(data: data) else {
             throw ProcessingError.textExtractionFailed
         }

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -39,7 +39,10 @@ final class DocumentProcessingService {
             throw ProcessingError.unsupportedFormat(fileExtension)
         }
 
-        let fileSize = try fileSize(at: url)
+        let fileSize = try BoundedFileIO.validatedSize(
+            of: url,
+            maximumSize: Constants.Attachments.maxFileSizeBytes
+        )
         guard fileSize <= Constants.Attachments.maxFileSizeBytes else {
             throw ProcessingError.fileTooLarge(fileSize)
         }
@@ -59,7 +62,11 @@ final class DocumentProcessingService {
     }
 
     private func extractTextFromPDF(at url: URL) throws -> String {
-        guard let document = PDFDocument(url: url) else {
+        let data = try BoundedFileIO.read(
+            from: url,
+            maximumSize: Constants.Attachments.maxFileSizeBytes
+        )
+        guard let document = PDFDocument(data: data) else {
             throw ProcessingError.textExtractionFailed
         }
 
@@ -82,7 +89,10 @@ final class DocumentProcessingService {
     }
 
     private func readPlainText(at url: URL) throws -> String {
-        guard let data = try? Data(contentsOf: url),
+        guard let data = try? BoundedFileIO.read(
+                from: url,
+                maximumSize: Constants.Attachments.maxFileSizeBytes
+              ),
               let text = String(data: data, encoding: .utf8) else {
             throw ProcessingError.fileReadFailed
         }
@@ -92,10 +102,5 @@ final class DocumentProcessingService {
         }
 
         return text
-    }
-
-    private func fileSize(at url: URL) throws -> Int64 {
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        return attributes[.size] as? Int64 ?? 0
     }
 }

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -49,19 +49,32 @@ final class DocumentProcessingService {
 
         switch fileExtension {
         case "pdf":
-            return try await Task.detached(priority: .userInitiated) {
+            let extractionTask = Task.detached(priority: .userInitiated) {
+                try Task.checkCancellation()
                 try self.extractTextFromPDF(at: url)
-            }.value
+            }
+            return try await withTaskCancellationHandler {
+                try await extractionTask.value
+            } onCancel: {
+                extractionTask.cancel()
+            }
         case "txt", "md", "csv", "html", "json", "xml":
-            return try await Task.detached(priority: .userInitiated) {
+            let extractionTask = Task.detached(priority: .userInitiated) {
+                try Task.checkCancellation()
                 try self.readPlainText(at: url)
-            }.value
+            }
+            return try await withTaskCancellationHandler {
+                try await extractionTask.value
+            } onCancel: {
+                extractionTask.cancel()
+            }
         default:
             return try await DocumentConversionService.shared.convertToMarkdown(url: url, filename: url.lastPathComponent)
         }
     }
 
     private func extractTextFromPDF(at url: URL) throws -> String {
+        try Task.checkCancellation()
         let data = try BoundedFileIO.read(
             from: url,
             maximumSize: Constants.Attachments.maxFileSizeBytes
@@ -72,6 +85,7 @@ final class DocumentProcessingService {
 
         var fullText = ""
         for pageIndex in 0..<document.pageCount {
+            try Task.checkCancellation()
             guard let page = document.page(at: pageIndex) else { continue }
             if let pageText = page.string {
                 if !fullText.isEmpty {
@@ -89,6 +103,7 @@ final class DocumentProcessingService {
     }
 
     private func readPlainText(at url: URL) throws -> String {
+        try Task.checkCancellation()
         guard let data = try? BoundedFileIO.read(
                 from: url,
                 maximumSize: Constants.Attachments.maxFileSizeBytes
@@ -96,6 +111,7 @@ final class DocumentProcessingService {
               let text = String(data: data, encoding: .utf8) else {
             throw ProcessingError.fileReadFailed
         }
+        try Task.checkCancellation()
 
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw ProcessingError.textExtractionFailed

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -39,12 +39,13 @@ final class DocumentProcessingService {
             throw ProcessingError.unsupportedFormat(fileExtension)
         }
 
-        let fileSize = try BoundedFileIO.validatedSize(
-            of: url,
-            maximumSize: Constants.Attachments.maxFileSizeBytes
-        )
-        guard fileSize <= Constants.Attachments.maxFileSizeBytes else {
-            throw ProcessingError.fileTooLarge(fileSize)
+        do {
+            _ = try BoundedFileIO.validatedSize(
+                of: url,
+                maximumSize: Constants.Attachments.maxFileSizeBytes
+            )
+        } catch BoundedFileIOError.fileTooLarge(let size, _) {
+            throw ProcessingError.fileTooLarge(size)
         }
 
         switch fileExtension {
@@ -104,11 +105,18 @@ final class DocumentProcessingService {
 
     private func readPlainText(at url: URL) throws -> String {
         try Task.checkCancellation()
-        guard let data = try? BoundedFileIO.read(
+        let data: Data
+        do {
+            data = try BoundedFileIO.read(
                 from: url,
                 maximumSize: Constants.Attachments.maxFileSizeBytes
-              ),
-              let text = String(data: data, encoding: .utf8) else {
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw ProcessingError.fileReadFailed
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
             throw ProcessingError.fileReadFailed
         }
         try Task.checkCancellation()

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -113,6 +113,8 @@ final class DocumentProcessingService {
             )
         } catch is CancellationError {
             throw CancellationError()
+        } catch BoundedFileIOError.fileTooLarge(let size, _) {
+            throw ProcessingError.fileTooLarge(size)
         } catch {
             throw ProcessingError.fileReadFailed
         }

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+final class ManagedStagedFile: @unchecked Sendable {
+    let id: UUID
+    let url: URL
+    let originalSize: Int
+
+    private let store: ManagedFileStore
+    private let lock = NSLock()
+    private var isDiscarded = false
+
+    fileprivate init(id: UUID, url: URL, originalSize: Int, store: ManagedFileStore) {
+        self.id = id
+        self.url = url
+        self.originalSize = originalSize
+        self.store = store
+    }
+
+    func discard() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isDiscarded else { return }
+        isDiscarded = true
+        store.discard(id: id, url: url)
+    }
+}
+
+final class ManagedFileStore: @unchecked Sendable {
+    static let shared = ManagedFileStore()
+    static let stagingDirectoryName = "ManagedFileStaging"
+
+    let rootURL: URL
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default, rootURL: URL? = nil) {
+        self.fileManager = fileManager
+        if let rootURL {
+            self.rootURL = rootURL
+        } else {
+            let applicationSupport = fileManager.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first!
+            self.rootURL = applicationSupport.appendingPathComponent(
+                Self.stagingDirectoryName,
+                isDirectory: true
+            )
+        }
+        try? prepareRoot()
+    }
+
+    func stage(sourceURL: URL, maximumSize: Int64) throws -> ManagedStagedFile {
+        try prepareRoot()
+        let id = UUID()
+        let destinationURL = fileURL(id: id, fileExtension: sourceURL.pathExtension)
+        do {
+            let size = try BoundedFileIO.copy(
+                from: sourceURL,
+                to: destinationURL,
+                maximumSize: maximumSize
+            )
+            try protectAndExcludeFromBackup(destinationURL)
+            return ManagedStagedFile(id: id, url: destinationURL, originalSize: Int(size), store: self)
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        }
+    }
+
+    func stage(data: Data, fileExtension: String?, maximumSize: Int64) throws -> ManagedStagedFile {
+        guard Int64(data.count) <= maximumSize else {
+            throw BoundedFileIOError.fileTooLarge(
+                size: Int64(data.count),
+                maximum: maximumSize
+            )
+        }
+        try prepareRoot()
+        let id = UUID()
+        let destinationURL = fileURL(id: id, fileExtension: fileExtension)
+        do {
+            try data.write(to: destinationURL, options: [.atomic])
+            guard try BoundedFileIO.validatedSize(
+                of: destinationURL,
+                maximumSize: maximumSize
+            ) == Int64(data.count) else {
+                throw BoundedFileIOError.invalidFile
+            }
+            try protectAndExcludeFromBackup(destinationURL)
+            return ManagedStagedFile(
+                id: id,
+                url: destinationURL,
+                originalSize: data.count,
+                store: self
+            )
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        }
+    }
+
+    func sweepOnStartup() {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for entry in entries where owns(entry) {
+            try? fileManager.removeItem(at: entry)
+        }
+    }
+
+    func owns(_ url: URL) -> Bool {
+        let parent = url.standardizedFileURL.deletingLastPathComponent()
+        guard parent == rootURL.standardizedFileURL else { return false }
+        let stem = url.deletingPathExtension().lastPathComponent
+        return UUID(uuidString: stem) != nil
+    }
+
+    fileprivate func discard(id: UUID, url: URL) {
+        guard owns(url), url.deletingPathExtension().lastPathComponent == id.uuidString.lowercased() else {
+            return
+        }
+        try? fileManager.removeItem(at: url)
+    }
+
+    private func fileURL(id: UUID, fileExtension: String?) -> URL {
+        let suffix = fileExtension.flatMap { $0.isEmpty ? nil : $0.lowercased() }
+        let fileName = suffix.map { "\(id.uuidString.lowercased()).\($0)" }
+            ?? id.uuidString.lowercased()
+        return rootURL.appendingPathComponent(fileName)
+    }
+
+    private func prepareRoot() throws {
+        try fileManager.createDirectory(
+            at: rootURL,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+        try protectAndExcludeFromBackup(rootURL)
+    }
+
+    private func protectAndExcludeFromBackup(_ url: URL) throws {
+        try fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: url.path
+        )
+        var protectedURL = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try protectedURL.setResourceValues(values)
+    }
+}

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -57,7 +57,10 @@ final class ManagedFileStore: @unchecked Sendable {
             let size = try BoundedFileIO.copy(
                 from: sourceURL,
                 to: destinationURL,
-                maximumSize: maximumSize
+                maximumSize: maximumSize,
+                destinationAttributes: [
+                    .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+                ]
             )
             try protectAndExcludeFromBackup(destinationURL)
             return ManagedStagedFile(id: id, url: destinationURL, originalSize: Int(size), store: self)

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -16,12 +16,18 @@ final class ManagedStagedFile: @unchecked Sendable {
         self.store = store
     }
 
-    func discard() {
+    deinit {
+        discard()
+    }
+
+    @discardableResult
+    func discard() -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        guard !isDiscarded else { return }
+        guard !isDiscarded else { return true }
+        guard store.discard(id: id, url: url) else { return false }
         isDiscarded = true
-        store.discard(id: id, url: url)
+        return true
     }
 }
 
@@ -46,7 +52,6 @@ final class ManagedFileStore: @unchecked Sendable {
                 isDirectory: true
             )
         }
-        try? prepareRoot()
     }
 
     func stage(sourceURL: URL, maximumSize: Int64) throws -> ManagedStagedFile {
@@ -101,13 +106,22 @@ final class ManagedFileStore: @unchecked Sendable {
         }
     }
 
-    func sweepOnStartup() {
-        guard let entries = try? fileManager.contentsOfDirectory(
+    func sweepOnStartup() throws {
+        guard fileManager.fileExists(atPath: rootURL.path) else { return }
+        let entries = try fileManager.contentsOfDirectory(
             at: rootURL,
             includingPropertiesForKeys: nil
-        ) else { return }
-        for entry in entries where owns(entry) {
-            try? fileManager.removeItem(at: entry)
+        )
+        var firstError: Error?
+        for entry in entries {
+            do {
+                try fileManager.removeItem(at: entry)
+            } catch {
+                firstError = firstError ?? error
+            }
+        }
+        if let firstError {
+            throw firstError
         }
     }
 
@@ -118,11 +132,18 @@ final class ManagedFileStore: @unchecked Sendable {
         return UUID(uuidString: stem) != nil
     }
 
-    fileprivate func discard(id: UUID, url: URL) {
+    fileprivate func discard(id: UUID, url: URL) -> Bool {
         guard owns(url), url.deletingPathExtension().lastPathComponent == id.uuidString.lowercased() else {
-            return
+            return false
         }
-        try? fileManager.removeItem(at: url)
+        do {
+            try fileManager.removeItem(at: url)
+            return true
+        } catch CocoaError.fileNoSuchFile {
+            return true
+        } catch {
+            return false
+        }
     }
 
     private func fileURL(id: UUID, fileExtension: String?) -> URL {

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -102,6 +102,7 @@ final class ProjectStorageService: ObservableObject {
             description: payload.description,
             systemInstructions: payload.systemInstructions,
             memory: payload.memory,
+            color: payload.color,
             createdAt: now,
             updatedAt: now,
             syncVersion: syncVersion
@@ -124,6 +125,7 @@ final class ProjectStorageService: ObservableObject {
             description: decoded.description,
             systemInstructions: decoded.systemInstructions,
             memory: decoded.memory,
+            color: decoded.color,
             createdAt: now,
             updatedAt: now,
             syncVersion: syncVersion
@@ -142,6 +144,7 @@ final class ProjectStorageService: ObservableObject {
                 description: decoded.0.description,
                 systemInstructions: decoded.0.systemInstructions,
                 memory: decoded.0.memory,
+                color: decoded.0.color,
                 createdAt: now,
                 updatedAt: now,
                 syncVersion: decoded.1
@@ -223,6 +226,7 @@ final class ProjectStorageService: ObservableObject {
                 description: "",
                 systemInstructions: "",
                 memory: [],
+                color: nil,
                 createdAt: item.createdAt,
                 updatedAt: item.updatedAt,
                 syncVersion: item.syncVersion,
@@ -301,7 +305,8 @@ final class ProjectStorageService: ObservableObject {
         projectId: String,
         filename: String,
         contentType: String,
-        content: String
+        content: String,
+        sizeBytes: Int
     ) async throws -> ProjectDocument {
         let idResponse = try await generateDocumentId(projectId: projectId)
         let wireId = projectDocumentId(projectId: projectId, documentId: idResponse.documentId)
@@ -310,11 +315,12 @@ final class ProjectStorageService: ObservableObject {
             projectId: projectId,
             filename: filename,
             contentType: contentType,
-            content: content
+            content: content,
+            sizeBytes: sizeBytes
         )
 
         let now = isoNow()
-        let size = payload.content.data(using: .utf8)?.count ?? payload.content.count
+        let size = payload.resolvedSizeBytes
         return ProjectDocument(
             id: idResponse.documentId,
             projectId: projectId,
@@ -337,7 +343,7 @@ final class ProjectStorageService: ObservableObject {
             projectId: projectId,
             filename: decoded.filename,
             contentType: decoded.contentType,
-            sizeBytes: decoded.content.data(using: .utf8)?.count ?? decoded.content.count,
+            sizeBytes: decoded.resolvedSizeBytes,
             syncVersion: syncVersion,
             createdAt: now,
             updatedAt: now,
@@ -393,7 +399,7 @@ final class ProjectStorageService: ObservableObject {
                     projectId: projectId,
                     filename: decoded.0.filename,
                     contentType: decoded.0.contentType,
-                    sizeBytes: decoded.0.content.data(using: .utf8)?.count ?? decoded.0.content.count,
+                    sizeBytes: decoded.0.resolvedSizeBytes,
                     syncVersion: decoded.1,
                     createdAt: createdAtFromReverseId(docId),
                     updatedAt: update.updatedAt,

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -158,8 +158,8 @@ final class ProjectStorageService: ObservableObject {
     }
 
     @discardableResult
-    func deleteAllProjects() async throws -> Int {
-        try await enclaveStore.deleteAllProjects()
+    func deleteAllProjects(requestProgress: SyncEnclaveRequestProgress? = nil) async throws -> Int {
+        try await enclaveStore.deleteAllProjects(requestProgress: requestProgress)
     }
 
     func listProjects(

--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -4,44 +4,95 @@ import Foundation
 final class SharedImportCoordinator {
     static let shared = SharedImportCoordinator()
 
+    private enum PendingImport: @unchecked Sendable {
+        case image(Data, String, UUID)
+        case document(ManagedStagedFile, String, UUID)
+        case failure(String)
+    }
+
+    private var importTask: Task<Void, Never>?
+
     private init() {}
 
     func importPendingAttachments(into viewModel: ChatViewModel) {
-        guard let store = try? SharedImportStore() else { return }
+        guard importTask == nil else { return }
 
         let importedRequestIDs = Set(
             viewModel.pendingAttachments.compactMap(\.sharedImportRequestID)
         )
-        for request in store.pendingRequests() where !importedRequestIDs.contains(request.id) {
-            do {
-                let data = try store.payloadData(for: request)
-                switch request.item.kind {
-                case .image:
+        importTask = Task { [weak self, weak viewModel] in
+            let imports = await Task.detached(priority: .userInitiated) {
+                guard let store = try? SharedImportStore() else { return [PendingImport]() }
+                return store.pendingRequests()
+                    .filter { !importedRequestIDs.contains($0.id) }
+                    .map { request in
+                        do {
+                            switch request.item.kind {
+                            case .image:
+                                return .image(
+                                    try store.payloadData(for: request),
+                                    request.item.originalFileName,
+                                    request.id
+                                )
+                            case .document:
+                                let file = try ManagedFileStore.shared.stage(
+                                    sourceURL: store.payloadURL(for: request),
+                                    maximumSize: request.item.kind.maximumSizeBytes
+                                )
+                                return .document(file, request.item.originalFileName, request.id)
+                            }
+                        } catch {
+                            return .failure(error.localizedDescription)
+                        }
+                    }
+            }.value
+
+            defer { self?.importTask = nil }
+            guard let viewModel else {
+                for case .document(let file, _, _) in imports {
+                    file.discard()
+                }
+                return
+            }
+            for pendingImport in imports {
+                switch pendingImport {
+                case .image(let data, let fileName, let requestID):
                     viewModel.addImageAttachment(
                         data: data,
-                        fileName: request.item.originalFileName,
-                        sharedImportRequestID: request.id
+                        fileName: fileName,
+                        sharedImportRequestID: requestID
                     )
-                case .document:
+                case .document(let file, let fileName, let requestID):
                     viewModel.addDocumentAttachment(
-                        data: data,
-                        fileName: request.item.originalFileName,
-                        sharedImportRequestID: request.id
+                        file: file,
+                        fileName: fileName,
+                        sharedImportRequestID: requestID
                     )
+                case .failure(let message):
+                    viewModel.attachmentError = message
                 }
-            } catch {
-                viewModel.attachmentError = error.localizedDescription
             }
         }
     }
 
     func acknowledge(requestID: UUID) {
-        guard let store = try? SharedImportStore() else { return }
-        store.removeRequest(id: requestID)
+        Task.detached(priority: .utility) {
+            guard let store = try? SharedImportStore() else { return }
+            try? store.removeRequest(id: requestID)
+        }
     }
 
-    func discardAllPending() {
-        guard let store = try? SharedImportStore() else { return }
-        store.purgeAllRequests()
+    func discardAllPending() async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let store = try SharedImportStore()
+            try store.purgeAllRequests()
+        }.value
+    }
+
+    func allowPublications() async throws {
+        try await Task.detached(priority: .utility) {
+            let store = try SharedImportStore()
+            try store.allowPublications()
+        }.value
     }
 }

--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -42,8 +42,6 @@ final class SharedImportCoordinator {
 
     func discardAllPending() {
         guard let store = try? SharedImportStore() else { return }
-        for request in store.pendingRequests() {
-            store.removeRequest(id: request.id)
-        }
+        store.purgeAllRequests()
     }
 }

--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -11,6 +11,8 @@ final class SharedImportCoordinator {
     }
 
     private var importTask: Task<Void, Never>?
+    private var acknowledgementTasks: [UUID: Task<Void, Never>] = [:]
+    private var acknowledgementTokens: [UUID: UUID] = [:]
 
     private init() {}
 
@@ -19,7 +21,7 @@ final class SharedImportCoordinator {
 
         let importedRequestIDs = Set(
             viewModel.pendingAttachments.compactMap(\.sharedImportRequestID)
-        )
+        ).union(acknowledgementTasks.keys)
         importTask = Task { [weak self, weak viewModel] in
             let imports = await Task.detached(priority: .userInitiated) {
                 guard let store = try? SharedImportStore() else { return [PendingImport]() }
@@ -48,6 +50,12 @@ final class SharedImportCoordinator {
             }.value
 
             defer { self?.importTask = nil }
+            guard !Task.isCancelled else {
+                for case .document(let file, _, _) in imports {
+                    file.discard()
+                }
+                return
+            }
             guard let viewModel else {
                 for case .document(let file, _, _) in imports {
                     file.discard()
@@ -75,14 +83,42 @@ final class SharedImportCoordinator {
         }
     }
 
-    func acknowledge(requestID: UUID) {
-        Task.detached(priority: .utility) {
-            guard let store = try? SharedImportStore() else { return }
-            try? store.removeRequest(id: requestID)
+    func acknowledge(requestID: UUID, onFailure: @escaping (String) -> Void) {
+        guard acknowledgementTasks[requestID] == nil else { return }
+        let token = UUID()
+        acknowledgementTokens[requestID] = token
+        let task = Task { [weak self] in
+            let failureMessage = await Task.detached(priority: .utility) {
+                do {
+                    let store = try SharedImportStore()
+                    do {
+                        try store.removeRequest(id: requestID)
+                    } catch {
+                        try store.removeRequest(id: requestID)
+                    }
+                    return nil as String?
+                } catch {
+                    return error.localizedDescription
+                }
+            }.value
+            guard let self, acknowledgementTokens[requestID] == token else { return }
+            acknowledgementTokens.removeValue(forKey: requestID)
+            acknowledgementTasks.removeValue(forKey: requestID)
+            if let failureMessage {
+                onFailure(failureMessage)
+            }
         }
+        acknowledgementTasks[requestID] = task
     }
 
     func discardAllPending() async throws {
+        if let importTask {
+            importTask.cancel()
+            await importTask.value
+            self.importTask = nil
+        }
+        let acknowledgements = Array(acknowledgementTasks.values)
+        for task in acknowledgements { await task.value }
         try await Task.detached(priority: .userInitiated) {
             let store = try SharedImportStore()
             try store.purgeAllRequests()

--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -14,10 +14,9 @@ final class SharedImportCoordinator {
         )
         for request in store.pendingRequests() where !importedRequestIDs.contains(request.id) {
             do {
-                let payloadURL = try store.payloadURL(for: request)
+                let data = try store.payloadData(for: request)
                 switch request.item.kind {
                 case .image:
-                    let data = try Data(contentsOf: payloadURL, options: .mappedIfSafe)
                     viewModel.addImageAttachment(
                         data: data,
                         fileName: request.item.originalFileName,
@@ -25,7 +24,7 @@ final class SharedImportCoordinator {
                     )
                 case .document:
                     viewModel.addDocumentAttachment(
-                        url: payloadURL,
+                        data: data,
                         fileName: request.item.originalFileName,
                         sharedImportRequestID: request.id
                     )
@@ -39,5 +38,12 @@ final class SharedImportCoordinator {
     func acknowledge(requestID: UUID) {
         guard let store = try? SharedImportStore() else { return }
         store.removeRequest(id: requestID)
+    }
+
+    func discardAllPending() {
+        guard let store = try? SharedImportStore() else { return }
+        for request in store.pendingRequests() {
+            store.removeRequest(id: request.id)
+        }
     }
 }

--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -12,7 +12,6 @@ final class SharedImportCoordinator {
 
     private var importTask: Task<Void, Never>?
     private var acknowledgementTasks: [UUID: Task<Void, Never>] = [:]
-    private var acknowledgementTokens: [UUID: UUID] = [:]
 
     private init() {}
 
@@ -23,59 +22,83 @@ final class SharedImportCoordinator {
             viewModel.pendingAttachments.compactMap(\.sharedImportRequestID)
         ).union(acknowledgementTasks.keys)
         importTask = Task { [weak self, weak viewModel] in
-            let imports = await Task.detached(priority: .userInitiated) {
-                guard let store = try? SharedImportStore() else { return [PendingImport]() }
+            defer { self?.importTask = nil }
+            let requestTask = Task.detached(priority: .userInitiated) {
+                guard let store = try? SharedImportStore() else { return [SharedImportRequest]() }
                 return store.pendingRequests()
                     .filter { !importedRequestIDs.contains($0.id) }
-                    .map { request in
-                        do {
-                            switch request.item.kind {
-                            case .image:
-                                return .image(
-                                    try store.payloadData(for: request),
-                                    request.item.originalFileName,
-                                    request.id
-                                )
-                            case .document:
-                                let file = try ManagedFileStore.shared.stage(
-                                    sourceURL: store.payloadURL(for: request),
-                                    maximumSize: request.item.kind.maximumSizeBytes
-                                )
-                                return .document(file, request.item.originalFileName, request.id)
+            }
+            let requests = await withTaskCancellationHandler {
+                await requestTask.value
+            } onCancel: {
+                requestTask.cancel()
+            }
+            for request in requests {
+                guard !Task.isCancelled else { return }
+                let worker = Task.detached(priority: .userInitiated) { () -> PendingImport? in
+                    do {
+                        try Task.checkCancellation()
+                        let store = try SharedImportStore()
+                        switch request.item.kind {
+                        case .image:
+                            let data = try store.payloadData(for: request)
+                            try Task.checkCancellation()
+                            return .image(data, request.item.originalFileName, request.id)
+                        case .document:
+                            let file = try ManagedFileStore.shared.stage(
+                                sourceURL: store.payloadURL(for: request),
+                                maximumSize: request.item.kind.maximumSizeBytes
+                            )
+                            guard !Task.isCancelled else {
+                                file.discard()
+                                return nil
                             }
-                        } catch {
-                            return .failure(error.localizedDescription)
+                            return .document(file, request.item.originalFileName, request.id)
                         }
+                    } catch is CancellationError {
+                        return nil
+                    } catch {
+                        return .failure(error.localizedDescription)
                     }
-            }.value
-
-            defer { self?.importTask = nil }
-            guard !Task.isCancelled else {
-                for case .document(let file, _, _) in imports {
-                    file.discard()
                 }
-                return
-            }
-            guard let viewModel else {
-                for case .document(let file, _, _) in imports {
-                    file.discard()
+                guard let pendingImport = await withTaskCancellationHandler(
+                    operation: { await worker.value },
+                    onCancel: { worker.cancel() }
+                ) else {
+                    guard !Task.isCancelled else { return }
+                    continue
                 }
-                return
-            }
-            for pendingImport in imports {
+                guard !Task.isCancelled, let viewModel else {
+                    if case .document(let file, _, _) = pendingImport {
+                        file.discard()
+                    }
+                    return
+                }
                 switch pendingImport {
                 case .image(let data, let fileName, let requestID):
-                    viewModel.addImageAttachment(
+                    if let processingTask = viewModel.addImageAttachment(
                         data: data,
                         fileName: fileName,
                         sharedImportRequestID: requestID
-                    )
+                    ) {
+                        await withTaskCancellationHandler {
+                            await processingTask.value
+                        } onCancel: {
+                            processingTask.cancel()
+                        }
+                    }
                 case .document(let file, let fileName, let requestID):
-                    viewModel.addDocumentAttachment(
+                    if let processingTask = viewModel.addDocumentAttachment(
                         file: file,
                         fileName: fileName,
                         sharedImportRequestID: requestID
-                    )
+                    ) {
+                        await withTaskCancellationHandler {
+                            await processingTask.value
+                        } onCancel: {
+                            processingTask.cancel()
+                        }
+                    }
                 case .failure(let message):
                     viewModel.attachmentError = message
                 }
@@ -85,24 +108,17 @@ final class SharedImportCoordinator {
 
     func acknowledge(requestID: UUID, onFailure: @escaping (String) -> Void) {
         guard acknowledgementTasks[requestID] == nil else { return }
-        let token = UUID()
-        acknowledgementTokens[requestID] = token
         let task = Task { [weak self] in
             let failureMessage = await Task.detached(priority: .utility) {
                 do {
                     let store = try SharedImportStore()
-                    do {
-                        try store.removeRequest(id: requestID)
-                    } catch {
-                        try store.removeRequest(id: requestID)
-                    }
+                    try store.removeRequest(id: requestID)
                     return nil as String?
                 } catch {
                     return error.localizedDescription
                 }
             }.value
-            guard let self, acknowledgementTokens[requestID] == token else { return }
-            acknowledgementTokens.removeValue(forKey: requestID)
+            guard let self else { return }
             acknowledgementTasks.removeValue(forKey: requestID)
             if let failureMessage {
                 onFailure(failureMessage)

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
@@ -392,6 +392,21 @@ struct EnclaveDeleteRequest: Encodable {
     }
 }
 
+struct EnclaveDeleteAllProjectsRequest: Encodable, Equatable {
+    let key: String
+    let idempotencyKey: String
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case idempotencyKey = "idempotency_key"
+    }
+}
+
+struct EnclaveDeleteAllProjectsResponse: Decodable, Equatable {
+    let ok: Bool
+    let deleted: Int
+}
+
 struct EnclaveOKResponse: Decodable {
     let ok: Bool
 }
@@ -849,6 +864,12 @@ enum SyncEnclaveAPI {
     @discardableResult
     static func deleteRow(_ request: EnclaveDeleteRequest) async throws -> EnclaveOKResponse {
         try await SyncEnclaveClient.shared.post(path: "/v1/sync/delete", body: request)
+    }
+
+    static func deleteAllProjects(
+        _ request: EnclaveDeleteAllProjectsRequest
+    ) async throws -> EnclaveDeleteAllProjectsResponse {
+        try await SyncEnclaveClient.shared.post(path: "/v1/sync/delete-all-projects", body: request)
     }
 
     // MARK: Key registry

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
@@ -862,14 +862,26 @@ enum SyncEnclaveAPI {
     }
 
     @discardableResult
-    static func deleteRow(_ request: EnclaveDeleteRequest) async throws -> EnclaveOKResponse {
-        try await SyncEnclaveClient.shared.post(path: "/v1/sync/delete", body: request)
+    static func deleteRow(
+        _ request: EnclaveDeleteRequest,
+        requestProgress: SyncEnclaveRequestProgress? = nil
+    ) async throws -> EnclaveOKResponse {
+        try await SyncEnclaveClient.shared.post(
+            path: "/v1/sync/delete",
+            body: request,
+            requestProgress: requestProgress
+        )
     }
 
     static func deleteAllProjects(
-        _ request: EnclaveDeleteAllProjectsRequest
+        _ request: EnclaveDeleteAllProjectsRequest,
+        requestProgress: SyncEnclaveRequestProgress? = nil
     ) async throws -> EnclaveDeleteAllProjectsResponse {
-        try await SyncEnclaveClient.shared.post(path: "/v1/sync/delete-all-projects", body: request)
+        try await SyncEnclaveClient.shared.post(
+            path: "/v1/sync/delete-all-projects",
+            body: request,
+            requestProgress: requestProgress
+        )
     }
 
     // MARK: Key registry

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift
@@ -23,6 +23,14 @@ extension Notification.Name {
     )
 }
 
+actor SyncEnclaveRequestProgress {
+    private(set) var requestStarted = false
+
+    func markRequestStarted() {
+        requestStarted = true
+    }
+}
+
 /// Error envelope returned by the sync enclave, parsed from `{error, code, ...details}`.
 struct SyncEnclaveError: LocalizedError, Equatable {
     let message: String
@@ -140,7 +148,8 @@ actor SyncEnclaveClient {
     func post<Response: Decodable>(
         path: String,
         body: Encodable? = nil,
-        skipAuth: Bool = false
+        skipAuth: Bool = false,
+        requestProgress: SyncEnclaveRequestProgress? = nil
     ) async throws -> Response {
         try Self.assertRelativePath(path)
         let requestGeneration = tokenGeneration
@@ -160,6 +169,7 @@ actor SyncEnclaveClient {
         }
 
         if skipAuth {
+            await requestProgress?.markRequestStarted()
             return try Self.decode(
                 response: try await performPost(client: client, url: url, headers: headers, body: bodyData),
                 path: path
@@ -171,6 +181,7 @@ actor SyncEnclaveClient {
             generation: requestGeneration
         )
         headers["Authorization"] = "Bearer \(token)"
+        await requestProgress?.markRequestStarted()
         var response = try await performPost(client: client, url: url, headers: headers, body: bodyData)
         if response.statusCode == 401 {
             guard requestGeneration == tokenGeneration else { throw CancellationError() }
@@ -179,6 +190,7 @@ actor SyncEnclaveClient {
                 generation: requestGeneration
             )
             headers["Authorization"] = "Bearer \(refreshedToken)"
+            await requestProgress?.markRequestStarted()
             response = try await performPost(client: client, url: url, headers: headers, body: bodyData)
             if response.statusCode == 401 {
                 let error = try await persistentAuthenticationError(generation: requestGeneration)

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -11,20 +11,26 @@ struct SyncEnclaveProjectStore {
             name: data.name,
             description: data.description,
             systemInstructions: data.systemInstructions,
-            memory: []
+            memory: [],
+            color: data.color
         )
         let response = try await pushProject(id: id, payload: payload, ifMatch: nil)
         return (payload, etagToSyncVersion(response.etag))
     }
 
     func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws {
-        let payload = ProjectData(
+        let payload = Self.mergedProjectData(data, existing: existing)
+        _ = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
+    }
+
+    static func mergedProjectData(_ data: UpdateProjectData, existing: Project) -> ProjectData {
+        ProjectData(
             name: data.name ?? existing.name,
             description: data.description ?? existing.description,
             systemInstructions: data.systemInstructions ?? existing.systemInstructions,
-            memory: data.memory ?? existing.memory
+            memory: data.memory ?? existing.memory,
+            color: data.color ?? existing.color
         )
-        _ = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
     }
 
     func getProject(id: String) async throws -> (ProjectData, Int)? {
@@ -62,28 +68,14 @@ struct SyncEnclaveProjectStore {
     }
 
     func deleteAllProjects() async throws -> Int {
-        let keyB64 = try CEKEncoding.requirePrimaryKeyB64()
-        var deleted = 0
-        var cursor: String? = nil
-        repeat {
-            let status = try await SyncEnclaveAPI.listStatus(
-                EnclaveListStatusRequest(scope: .project, cursor: cursor, limit: Constants.SyncEnclave.listStatusPageLimit, projectId: nil)
+        let response = try await SyncEnclaveAPI.deleteAllProjects(
+            EnclaveDeleteAllProjectsRequest(
+                key: try CEKEncoding.requirePrimaryKeyB64(),
+                idempotencyKey: newSyncEnclaveIdempotencyKey()
             )
-            for update in status.updates {
-                _ = try await SyncEnclaveAPI.deleteRow(
-                    EnclaveDeleteRequest(
-                        scope: .project,
-                        id: update.id,
-                        ifMatch: nil,
-                        idempotencyKey: newSyncEnclaveIdempotencyKey(),
-                        key: keyB64
-                    )
-                )
-                deleted += 1
-            }
-            cursor = status.nextCursor
-        } while hasNextCursor(cursor)
-        return deleted
+        )
+        guard response.ok else { throw CloudStorageError.invalidResponse }
+        return response.deleted
     }
 
     func uploadDocument(
@@ -91,9 +83,15 @@ struct SyncEnclaveProjectStore {
         projectId: String,
         filename: String,
         contentType: String,
-        content: String
+        content: String,
+        sizeBytes: Int
     ) async throws -> (ProjectDocumentPayload, Int) {
-        let payload = ProjectDocumentPayload(content: content, filename: filename, contentType: contentType)
+        let payload = ProjectDocumentPayload(
+            content: content,
+            filename: filename,
+            contentType: contentType,
+            sizeBytes: sizeBytes
+        )
         let metadata: [String: AnyCodable] = [
             "filename": AnyCodable(filename),
             "contentType": AnyCodable(contentType),

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -67,12 +67,13 @@ struct SyncEnclaveProjectStore {
         )
     }
 
-    func deleteAllProjects() async throws -> Int {
+    func deleteAllProjects(requestProgress: SyncEnclaveRequestProgress? = nil) async throws -> Int {
         let response = try await SyncEnclaveAPI.deleteAllProjects(
             EnclaveDeleteAllProjectsRequest(
                 key: try CEKEncoding.requirePrimaryKeyB64(),
                 idempotencyKey: newSyncEnclaveIdempotencyKey()
-            )
+            ),
+            requestProgress: requestProgress
         )
         guard response.ok else { throw CloudStorageError.invalidResponse }
         return response.deleted

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -202,9 +202,4 @@ struct SyncEnclaveProjectStore {
         guard let etag, let value = Int(etag), value > 0 else { return 1 }
         return value
     }
-
-    private func hasNextCursor(_ cursor: String?) -> Bool {
-        guard let cursor else { return false }
-        return !cursor.isEmpty
-    }
 }

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -23,11 +23,6 @@ struct TinfoilChatApp: App {
 
     init() {
         StorageKeysMigration.migrateIfNeeded()
-        do {
-            try ManagedFileStore.shared.sweepOnStartup()
-        } catch {
-            SentrySDK.capture(error: error)
-        }
         Clerk.configure(
             publishableKey: AppConfig.shared.clerkPublishableKey,
             options: Clerk.Options(telemetryEnabled: false)
@@ -179,6 +174,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             // Uncomment the following lines to add more data to your events
             // options.attachScreenshot = true // This adds a screenshot to the error events
             // options.attachViewHierarchy = true // This adds the view hierarchy to the error events
+        }
+
+        do {
+            try ManagedFileStore.shared.sweepOnStartup()
+        } catch {
+            SentrySDK.capture(error: error)
         }
 
         // Ignore SIGPIPE so broken streaming connections surface as errors instead of crashes.

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -23,7 +23,13 @@ struct TinfoilChatApp: App {
 
     init() {
         StorageKeysMigration.migrateIfNeeded()
-        ManagedFileStore.shared.sweepOnStartup()
+        Task.detached(priority: .utility) {
+            do {
+                try ManagedFileStore.shared.sweepOnStartup()
+            } catch {
+                SentrySDK.capture(error: error)
+            }
+        }
         Clerk.configure(
             publishableKey: AppConfig.shared.clerkPublishableKey,
             options: Clerk.Options(telemetryEnabled: false)

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -23,6 +23,7 @@ struct TinfoilChatApp: App {
 
     init() {
         StorageKeysMigration.migrateIfNeeded()
+        ManagedFileStore.shared.sweepOnStartup()
         Clerk.configure(
             publishableKey: AppConfig.shared.clerkPublishableKey,
             options: Clerk.Options(telemetryEnabled: false)

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -23,12 +23,10 @@ struct TinfoilChatApp: App {
 
     init() {
         StorageKeysMigration.migrateIfNeeded()
-        Task.detached(priority: .utility) {
-            do {
-                try ManagedFileStore.shared.sweepOnStartup()
-            } catch {
-                SentrySDK.capture(error: error)
-            }
+        do {
+            try ManagedFileStore.shared.sweepOnStartup()
+        } catch {
+            SentrySDK.capture(error: error)
         }
         Clerk.configure(
             publishableKey: AppConfig.shared.clerkPublishableKey,

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import ClerkKit
 import Combine
+import Sentry
 
 @MainActor
 class AuthManager: ObservableObject {
@@ -251,8 +252,13 @@ class AuthManager: ObservableObject {
         let teardownId = UUID()
         let teardownTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performAccountTeardown()
-            self.chatViewModel?.completeAccountTeardown()
+            do {
+                try await self.performAccountTeardown()
+                self.chatViewModel?.completeAccountTeardown()
+            } catch {
+                SentrySDK.capture(error: error)
+                self.isLoading = false
+            }
         }
         accountTeardownId = teardownId
         accountTeardownTask = teardownTask
@@ -262,10 +268,14 @@ class AuthManager: ObservableObject {
         accountTeardownId = nil
     }
 
-    private func performAccountTeardown() async {
+    private func performAccountTeardown() async throws {
         // Handle chat state BEFORE clearing auth so the view model can still
         // save the current chat (hasChatAccess depends on isAuthenticated).
-        await chatViewModel?.handleSignOut()
+        if let chatViewModel {
+            try await chatViewModel.handleSignOut()
+        } else {
+            try await SharedImportCoordinator.shared.discardAllPending()
+        }
         await ChatRecoveryCoordinator.shared.reset(accountId: nil)
 
         // Sign-out performs a full local wipe so that no content, encryption

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -144,7 +144,7 @@ class AuthManager: ObservableObject {
         }
     }
     
-    private func updateUserData(from user: User) {
+    private func updateUserData(from user: ClerkKit.User) {
         let wasAuthenticated = isAuthenticated
         
         // Store relevant user data

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -18,6 +18,7 @@ class AuthManager: ObservableObject {
     @Published var isLoading = true
     @Published var localUserData: [String: Any]? = nil
     @Published var hasActiveSubscription = false
+    @Published var accountTeardownError: String?
 
     var localUserId: String? {
         localUserData?[Self.userIdKey] as? String
@@ -235,7 +236,10 @@ class AuthManager: ObservableObject {
                 // User was authenticated but Clerk confirms they're no longer signed in.
                 // clearAuthState calls handleSignOut first (while auth is still true)
                 // so that local chats can be saved to disk before clearing.
-                await clearAuthState()
+                guard await clearAuthState() else {
+                    isLoading = false
+                    return
+                }
                 await RevenueCatManager.shared.logoutUser()
             } else {
                 isAuthenticated = false
@@ -255,18 +259,22 @@ class AuthManager: ObservableObject {
         let teardownId = UUID()
         let teardownTask = Task { @MainActor [weak self] in
             guard let self else { return false }
-            defer { self.chatViewModel?.completeAccountTeardown() }
             do {
                 try await self.performAccountTeardown()
+                self.chatViewModel?.completeAccountTeardown()
+                self.accountTeardownError = nil
                 return true
             } catch {
                 SentrySDK.capture(error: error)
                 do {
                     try await self.performAccountTeardown()
+                    self.chatViewModel?.completeAccountTeardown()
+                    self.accountTeardownError = nil
                     return true
                 } catch {
                     SentrySDK.capture(error: error)
                     self.isLoading = false
+                    self.accountTeardownError = "Tinfoil couldn't finish clearing local account data. Account actions remain paused to protect your data. Retry cleanup before continuing."
                     return false
                 }
             }
@@ -278,6 +286,12 @@ class AuthManager: ObservableObject {
         accountTeardownTask = nil
         accountTeardownId = nil
         return didCompleteTeardown
+    }
+
+    func retryAccountTeardown() async {
+        accountTeardownError = nil
+        isLoading = true
+        await initializeAuthState()
     }
 
     private func performAccountTeardown() async throws {

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -257,7 +257,13 @@ class AuthManager: ObservableObject {
                 self.chatViewModel?.completeAccountTeardown()
             } catch {
                 SentrySDK.capture(error: error)
-                self.isLoading = false
+                do {
+                    try await self.performAccountTeardown()
+                    self.chatViewModel?.completeAccountTeardown()
+                } catch {
+                    SentrySDK.capture(error: error)
+                    self.isLoading = false
+                }
             }
         }
         accountTeardownId = teardownId

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -28,7 +28,7 @@ class AuthManager: ObservableObject {
     private var clerk: Clerk?
     private var hasTriggeredSignIn = false
     private var accountSwitchTask: Task<Void, Never>?
-    private var accountTeardownTask: Task<Void, Never>?
+    private var accountTeardownTask: Task<Bool, Never>?
     private var accountTeardownId: UUID?
     
     // UserDefaults keys
@@ -111,7 +111,7 @@ class AuthManager: ObservableObject {
                 hasTriggeredSignIn = true
                 accountSwitchTask = Task { @MainActor [weak self] in
                     guard let self else { return }
-                    await self.clearAuthState()
+                    guard await self.clearAuthState() else { return }
                     await RevenueCatManager.shared.logoutUser()
                     // A sign-out may have completed while the cleanup
                     // above was suspended; only restore auth state when
@@ -221,7 +221,10 @@ class AuthManager: ObservableObject {
         if let user = clerk.user {
             if let cachedUserId = localUserId,
                cachedUserId != user.id {
-                await clearAuthState()
+                guard await clearAuthState() else {
+                    isLoading = false
+                    return
+                }
                 await RevenueCatManager.shared.logoutUser()
             }
             isAuthenticated = true
@@ -243,35 +246,38 @@ class AuthManager: ObservableObject {
         isLoading = false
     }
     
-    private func clearAuthState() async {
+    @discardableResult
+    private func clearAuthState() async -> Bool {
         if let accountTeardownTask {
-            await accountTeardownTask.value
-            return
+            return await accountTeardownTask.value
         }
 
         let teardownId = UUID()
         let teardownTask = Task { @MainActor [weak self] in
-            guard let self else { return }
+            guard let self else { return false }
+            defer { self.chatViewModel?.completeAccountTeardown() }
             do {
                 try await self.performAccountTeardown()
-                self.chatViewModel?.completeAccountTeardown()
+                return true
             } catch {
                 SentrySDK.capture(error: error)
                 do {
                     try await self.performAccountTeardown()
-                    self.chatViewModel?.completeAccountTeardown()
+                    return true
                 } catch {
                     SentrySDK.capture(error: error)
                     self.isLoading = false
+                    return false
                 }
             }
         }
         accountTeardownId = teardownId
         accountTeardownTask = teardownTask
-        await teardownTask.value
-        guard accountTeardownId == teardownId else { return }
+        let didCompleteTeardown = await teardownTask.value
+        guard accountTeardownId == teardownId else { return didCompleteTeardown }
         accountTeardownTask = nil
         accountTeardownId = nil
+        return didCompleteTeardown
     }
 
     private func performAccountTeardown() async throws {
@@ -412,7 +418,13 @@ class AuthManager: ObservableObject {
             try await user.delete()
             
             // Clear local state
-            await clearAuthState()
+            guard await clearAuthState() else {
+                throw NSError(
+                    domain: "AuthError",
+                    code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "The account was deleted, but local data cleanup did not finish."]
+                )
+            }
             
         } catch {
             throw error

--- a/TinfoilChat/ViewModels/AuthManager.swift
+++ b/TinfoilChat/ViewModels/AuthManager.swift
@@ -289,8 +289,9 @@ class AuthManager: ObservableObject {
     }
 
     func retryAccountTeardown() async {
-        accountTeardownError = nil
         isLoading = true
+        guard await clearAuthState() else { return }
+        await RevenueCatManager.shared.logoutUser()
         await initializeAuthState()
     }
 

--- a/TinfoilChat/ViewModels/AuthenticatorMFAViewModel.swift
+++ b/TinfoilChat/ViewModels/AuthenticatorMFAViewModel.swift
@@ -48,7 +48,7 @@ struct ClerkAuthenticatorMFAService: AuthenticatorMFAService {
         try ensureCurrentUser(userId)
     }
 
-    private func currentUser() throws -> (User, String) {
+    private func currentUser() throws -> (ClerkKit.User, String) {
         guard let user = Clerk.shared.user else {
             throw AuthenticatorMFAError.missingSession
         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -300,6 +300,7 @@ class ChatViewModel: ObservableObject {
     private let accountOperationTracker = AccountOperationTracker()
     private var activeSignInToken: AccountOperationFence.Token?
     private var isAccountTeardownInProgress = false
+    private(set) var accountLifecycleGeneration = 0
     private var acceptsChatSaves = true
     private var hasPerformedInitialSync: Bool = false  // Track if initial sync has been done
     private var hasAnonymousChatsToSync: Bool = false  // Track if we have anonymous chats to sync
@@ -3400,14 +3401,15 @@ class ChatViewModel: ObservableObject {
         }
     }
 
+    @discardableResult
     func addDocumentAttachment(
         file: ManagedStagedFile,
         fileName: String,
         sharedImportRequestID: UUID? = nil
-    ) {
+    ) -> Task<Void, Never>? {
         guard !isAccountTeardownInProgress else {
             file.discard()
-            return
+            return nil
         }
         attachmentError = nil
         let attachmentId = UUID().uuidString.lowercased()
@@ -3419,7 +3421,7 @@ class ChatViewModel: ObservableObject {
             processingState: .processing
         )
         pendingAttachments.append(attachment)
-        startDocumentProcessing(
+        return startDocumentProcessing(
             file: file,
             fileName: fileName,
             attachmentId: attachmentId,
@@ -3428,13 +3430,14 @@ class ChatViewModel: ObservableObject {
         )
     }
 
+    @discardableResult
     private func startDocumentProcessing(
         file: ManagedStagedFile,
         fileName: String,
         attachmentId: String,
         sharedImportRequestID: UUID? = nil,
         processingGeneration: Int
-    ) {
+    ) -> Task<Void, Never> {
         var attachment = Attachment(
             id: attachmentId,
             type: .document,
@@ -3488,6 +3491,7 @@ class ChatViewModel: ObservableObject {
         } else {
             task.cancel()
         }
+        return task
     }
 
     func addDocumentAttachment(
@@ -3511,12 +3515,13 @@ class ChatViewModel: ObservableObject {
         }
     }
 
+    @discardableResult
     func addImageAttachment(
         data: Data,
         fileName: String,
         sharedImportRequestID: UUID? = nil
-    ) {
-        guard !isAccountTeardownInProgress else { return }
+    ) -> Task<Void, Never>? {
+        guard !isAccountTeardownInProgress else { return nil }
         attachmentError = nil
         let processingGeneration = attachmentProcessingGeneration
 
@@ -3577,6 +3582,7 @@ class ChatViewModel: ObservableObject {
         } else {
             task.cancel()
         }
+        return task
     }
 
     func removePendingAttachment(id: String) {
@@ -5765,6 +5771,10 @@ class ChatViewModel: ObservableObject {
         accountOperationTracker.reopen()
     }
 
+    func isCurrentAccountLifecycle(_ generation: Int) -> Bool {
+        !isAccountTeardownInProgress && generation == accountLifecycleGeneration
+    }
+
     func resetSharedProfileSettingsForAccountTeardown() {
         reasoningEffort = ReasoningEffort(rawValue: ProfileDefaults.reasoningEffort) ?? .medium
         thinkingEnabled = ProfileDefaults.thinkingEnabled
@@ -5832,6 +5842,7 @@ class ChatViewModel: ObservableObject {
         chatHydrationError = nil
 
         isAccountTeardownInProgress = true
+        accountLifecycleGeneration += 1
         let canceledAttachmentTasks = Array(attachmentProcessingTasks.values)
         let canceledPasteStagingTasks = Array(pasteStagingTasks.values)
         clearPendingAttachments()

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -206,6 +206,7 @@ class ChatViewModel: ObservableObject {
     @Published var shouldOpenCloudSync: Bool = false
     @Published var shouldExpandProjectsInSidebar: Bool = false
     @Published private(set) var navigationRequest: ChatNavigationRequest?
+    private(set) var navigationGeneration = 0
     @Published var isViewingProjectChat: Bool = false
     @Published var scrollTargetMessageId: String? = nil 
     @Published var scrollTargetOffset: CGFloat = 0 
@@ -382,8 +383,22 @@ class ChatViewModel: ObservableObject {
     @Published var pendingImageThumbnails: [String: String] = [:]
     private var attachmentProcessingTasks: [String: Task<Void, Never>] = [:]
     private var attachmentProcessingTokens: [String: UUID] = [:]
+    private var pasteStagingTasks: [UUID: Task<Void, Never>] = [:]
+    private var pasteStagingTokens: [UUID: UUID] = [:]
     private var managedAttachmentFiles: [String: ManagedStagedFile] = [:]
     private var attachmentProcessingGeneration = 0
+
+    private struct PastedDocumentSource: @unchecked Sendable {
+        let url: URL
+        let fileName: String
+        let attachmentId: String
+        let didAccessSecurityScope: Bool
+    }
+
+    private enum PastedDocumentStageResult: @unchecked Sendable {
+        case success(ManagedStagedFile, String, String)
+        case failure(String, String)
+    }
     var isProcessingAttachment: Bool {
         pendingAttachments.contains { $0.processingState == .processing }
     }
@@ -415,6 +430,7 @@ class ChatViewModel: ObservableObject {
     @Published var isLoadingProject: Bool = false
     @Published var isUploadingProjectDocument: Bool = false
     @Published var projectError: String?
+    @Published var projectDocumentError: String?
     private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
     private var projectUploadTokens: [UUID: UUID] = [:]
     private var projectUploadBarrierCount = 0
@@ -1530,7 +1546,13 @@ class ChatViewModel: ObservableObject {
     }
 
     func requestNavigation(to destination: ChatNavigationDestination) {
+        navigationGeneration += 1
         navigationRequest = ChatNavigationRequest(destination: destination)
+    }
+
+    func beginNavigationOperation() -> Int {
+        navigationGeneration += 1
+        return navigationGeneration
     }
 
     func consumeNavigationRequest(id: UUID) {
@@ -1540,7 +1562,10 @@ class ChatViewModel: ObservableObject {
 
     @discardableResult
     func createNewRootChat() async -> Bool {
-        guard hasChatAccess, await leaveProjectContext() else { return false }
+        guard hasChatAccess,
+              isProjectAccountActive,
+              !isAccountTeardownInProgress,
+              await leaveProjectContext() else { return false }
         createNewChat()
         return activeProject == nil && currentChat != nil
     }
@@ -1555,6 +1580,7 @@ class ChatViewModel: ObservableObject {
         activeProject = nil
         projectDocuments = []
         projectError = nil
+        projectDocumentError = nil
         isViewingProjectChat = false
         return true
     }
@@ -1678,6 +1704,7 @@ class ChatViewModel: ObservableObject {
         activeProject = nil
         projectDocuments = []
         projectError = nil
+        projectDocumentError = nil
         isLoadingProjects = false
         isLoadingProject = false
         isUploadingProjectDocument = false
@@ -1762,6 +1789,7 @@ class ChatViewModel: ObservableObject {
 
         isLoadingProject = true
         projectError = nil
+        projectDocumentError = nil
         var loaded = false
         defer {
             if generation == projectLoadGeneration {
@@ -2095,7 +2123,7 @@ class ChatViewModel: ObservableObject {
 
         projectUploadTokens[operationID] = operationToken
         isUploadingProjectDocument = true
-        projectError = nil
+        projectDocumentError = nil
         let task = Task { [weak self] in
             guard let self else {
                 file.discard()
@@ -2139,7 +2167,7 @@ class ChatViewModel: ObservableObject {
             } catch {
                 guard isCurrentProjectAccount(accountGeneration),
                       activeProject?.id == projectId else { return }
-                projectError = error.localizedDescription
+                projectDocumentError = error.localizedDescription
             }
         }
         if projectUploadTokens[operationID] == operationToken {
@@ -2164,6 +2192,7 @@ class ChatViewModel: ObservableObject {
         guard let project = activeProject else { return }
         let accountGeneration = projectListAccountGeneration
 
+        projectDocumentError = nil
         let existing = projectDocuments
         projectDocuments.removeAll { $0.id == documentId }
         do {
@@ -2171,7 +2200,7 @@ class ChatViewModel: ObservableObject {
         } catch {
             guard isCurrentProjectAccount(accountGeneration) else { return }
             projectDocuments = existing
-            projectError = error.localizedDescription
+            projectDocumentError = error.localizedDescription
         }
     }
 
@@ -3263,7 +3292,111 @@ class ChatViewModel: ObservableObject {
     /// so acknowledgment behavior can't drift between them.
     private func acknowledgeSharedImports(in attachments: [Attachment]) {
         for requestID in attachments.compactMap(\.sharedImportRequestID) {
-            SharedImportCoordinator.shared.acknowledge(requestID: requestID)
+            SharedImportCoordinator.shared.acknowledge(requestID: requestID) { [weak self] message in
+                guard let self, !self.isAccountTeardownInProgress else { return }
+                self.attachmentError = message
+            }
+        }
+    }
+
+    func stagePastedDocuments(urls: [URL]) {
+        guard !isAccountTeardownInProgress, !urls.isEmpty else { return }
+        attachmentError = nil
+        let processingGeneration = attachmentProcessingGeneration
+        let sources = urls.map { url in
+            let attachmentId = UUID().uuidString.lowercased()
+            pendingAttachments.append(Attachment(
+                id: attachmentId,
+                type: .document,
+                fileName: url.lastPathComponent,
+                processingState: .processing
+            ))
+            return PastedDocumentSource(
+                url: url,
+                fileName: url.lastPathComponent,
+                attachmentId: attachmentId,
+                didAccessSecurityScope: url.startAccessingSecurityScopedResource()
+            )
+        }
+        let operationID = UUID()
+        let operationToken = UUID()
+        pasteStagingTokens[operationID] = operationToken
+        let task = Task { [weak self] in
+            let stagingTask = Task.detached(priority: .userInitiated) {
+                defer {
+                    for source in sources where source.didAccessSecurityScope {
+                        source.url.stopAccessingSecurityScopedResource()
+                    }
+                }
+                var results: [PastedDocumentStageResult] = []
+                for source in sources {
+                    guard !Task.isCancelled else { break }
+                    do {
+                        let file = try ManagedFileStore.shared.stage(
+                            sourceURL: source.url,
+                            maximumSize: Constants.Attachments.maxFileSizeBytes
+                        )
+                        results.append(.success(file, source.fileName, source.attachmentId))
+                    } catch BoundedFileIOError.fileTooLarge(let size, _) {
+                        results.append(.failure(
+                            DocumentProcessingService.ProcessingError.fileTooLarge(size).localizedDescription,
+                            source.attachmentId
+                        ))
+                    } catch {
+                        results.append(.failure(
+                            "Couldn't read the pasted file. Try attaching it with the + button instead.",
+                            source.attachmentId
+                        ))
+                    }
+                }
+                return results
+            }
+            let results = await withTaskCancellationHandler {
+                await stagingTask.value
+            } onCancel: {
+                stagingTask.cancel()
+            }
+            guard let self else {
+                for case .success(let file, _, _) in results { file.discard() }
+                return
+            }
+            defer {
+                if pasteStagingTokens[operationID] == operationToken {
+                    pasteStagingTokens.removeValue(forKey: operationID)
+                    pasteStagingTasks.removeValue(forKey: operationID)
+                }
+            }
+            guard !Task.isCancelled,
+                  processingGeneration == attachmentProcessingGeneration else {
+                for case .success(let file, _, _) in results { file.discard() }
+                return
+            }
+            for result in results {
+                switch result {
+                case .success(let file, let fileName, let attachmentId):
+                    guard pendingAttachments.contains(where: { $0.id == attachmentId }) else {
+                        file.discard()
+                        continue
+                    }
+                    startDocumentProcessing(
+                        file: file,
+                        fileName: fileName,
+                        attachmentId: attachmentId,
+                        processingGeneration: processingGeneration
+                    )
+                case .failure(let message, let attachmentId):
+                    guard let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) else {
+                        continue
+                    }
+                    pendingAttachments[index].processingState = .failed
+                    attachmentError = message
+                }
+            }
+        }
+        if pasteStagingTokens[operationID] == operationToken {
+            pasteStagingTasks[operationID] = task
+        } else {
+            task.cancel()
         }
     }
 
@@ -3277,10 +3410,8 @@ class ChatViewModel: ObservableObject {
             return
         }
         attachmentError = nil
-        let processingGeneration = attachmentProcessingGeneration
-
         let attachmentId = UUID().uuidString.lowercased()
-        var attachment = Attachment(
+        let attachment = Attachment(
             id: attachmentId,
             type: .document,
             fileName: fileName,
@@ -3288,6 +3419,29 @@ class ChatViewModel: ObservableObject {
             processingState: .processing
         )
         pendingAttachments.append(attachment)
+        startDocumentProcessing(
+            file: file,
+            fileName: fileName,
+            attachmentId: attachmentId,
+            sharedImportRequestID: sharedImportRequestID,
+            processingGeneration: attachmentProcessingGeneration
+        )
+    }
+
+    private func startDocumentProcessing(
+        file: ManagedStagedFile,
+        fileName: String,
+        attachmentId: String,
+        sharedImportRequestID: UUID? = nil,
+        processingGeneration: Int
+    ) {
+        var attachment = Attachment(
+            id: attachmentId,
+            type: .document,
+            fileName: fileName,
+            sharedImportRequestID: sharedImportRequestID,
+            processingState: .processing
+        )
         managedAttachmentFiles[attachmentId] = file
         let operationToken = UUID()
         attachmentProcessingTokens[attachmentId] = operationToken
@@ -3444,10 +3598,14 @@ class ChatViewModel: ObservableObject {
     func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
         attachmentProcessingGeneration += 1
         let tasks = Array(attachmentProcessingTasks.values)
+        let stagingTasks = Array(pasteStagingTasks.values)
         let processingAttachmentIds = Set(attachmentProcessingTokens.keys)
         attachmentProcessingTokens.removeAll()
         attachmentProcessingTasks.removeAll()
+        pasteStagingTokens.removeAll()
+        pasteStagingTasks.removeAll()
         for task in tasks { task.cancel() }
+        for task in stagingTasks { task.cancel() }
         let unownedAttachmentIds = managedAttachmentFiles.keys.filter {
             !processingAttachmentIds.contains($0)
         }
@@ -5675,11 +5833,11 @@ class ChatViewModel: ObservableObject {
 
         isAccountTeardownInProgress = true
         let canceledAttachmentTasks = Array(attachmentProcessingTasks.values)
+        let canceledPasteStagingTasks = Array(pasteStagingTasks.values)
         clearPendingAttachments()
         for chatId in Array(messageQueues.keys) {
             discardMessageQueue(chatId: chatId)
         }
-        try await SharedImportCoordinator.shared.discardAllPending()
         let canceledProjectUploadTasks = Array(projectUploadTasks.values)
         clearHydratedFavorites()
         clearProjectState()
@@ -5694,7 +5852,9 @@ class ChatViewModel: ObservableObject {
         await canceledLegacyMigrationTask?.value
         await drainStreamTasks(canceledStreamTasks)
         for task in canceledAttachmentTasks { await task.value }
+        for task in canceledPasteStagingTasks { await task.value }
         for task in canceledProjectUploadTasks { await task.value }
+        try await SharedImportCoordinator.shared.discardAllPending()
 
         // Stop sync timers when signing out
         autoSyncTimer?.invalidate()
@@ -5753,6 +5913,7 @@ class ChatViewModel: ObservableObject {
         activeProject = nil
         projectDocuments = []
         projectError = nil
+        projectDocumentError = nil
         isViewingProjectChat = false
         pendingSearchResultChatId = nil
         activeStorageTab = .cloud
@@ -6045,6 +6206,7 @@ class ChatViewModel: ObservableObject {
         } catch {
             guard isCurrentSignIn(token, userId: userId) else { return }
             attachmentError = error.localizedDescription
+            finishSignIn(token, userId: userId)
             return
         }
         guard isCurrentSignIn(token, userId: userId) else { return }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -6519,8 +6519,8 @@ class ChatViewModel: ObservableObject {
                     try await self.cloudSync.quiesceUploadsForBulkDelete(userId: userId)
                 },
                 deleteCloud: {
-                    try Task.checkCancellation()
                     guard shouldDeleteCloud else { return }
+                    try Task.checkCancellation()
                     try await self.cloudSync.deleteAllFromCloud(
                         userId: userId,
                         requestProgress: requestProgress

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -432,6 +432,10 @@ class ChatViewModel: ObservableObject {
     @Published var isUploadingProjectDocument: Bool = false
     @Published var projectError: String?
     @Published var projectDocumentError: String?
+    struct ProjectDocumentUploadDestination: Equatable {
+        let projectId: String
+        let accountGeneration: Int
+    }
     private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
     private var projectUploadTokens: [UUID: UUID] = [:]
     private var projectUploadBarrierCount = 0
@@ -2068,14 +2072,14 @@ class ChatViewModel: ObservableObject {
     /// leave local state untouched for a retry.
     @MainActor
     func deleteAllProjects() async throws {
-        guard isProjectAccountActive else { return }
+        guard isProjectAccountActive else { throw CancellationError() }
         let accountGeneration = projectListAccountGeneration
         projectUploadBarrierCount += 1
         defer { projectUploadBarrierCount -= 1 }
         await cancelAndAwaitProjectUploads()
-        guard isCurrentProjectAccount(accountGeneration) else { return }
+        guard isCurrentProjectAccount(accountGeneration) else { throw CancellationError() }
         _ = try await projectStorage.deleteAllProjects()
-        guard isCurrentProjectAccount(accountGeneration) else { return }
+        guard isCurrentProjectAccount(accountGeneration) else { throw CancellationError() }
         projectListLoadGeneration += 1
         latestAppliedProjectListLoadGeneration = projectListLoadGeneration
         projectLoadGeneration += 1
@@ -2110,15 +2114,28 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func uploadProjectDocument(file: ManagedStagedFile, filename: String) {
+    var projectDocumentUploadDestination: ProjectDocumentUploadDestination? {
+        guard isProjectAccountActive, let projectId = activeProject?.id else { return nil }
+        return ProjectDocumentUploadDestination(
+            projectId: projectId,
+            accountGeneration: projectListAccountGeneration
+        )
+    }
+
+    func uploadProjectDocument(
+        file: ManagedStagedFile,
+        filename: String,
+        destination: ProjectDocumentUploadDestination
+    ) {
         guard projectUploadBarrierCount == 0,
               !isAccountTeardownInProgress,
-              let project = activeProject else {
+              isCurrentProjectAccount(destination.accountGeneration),
+              activeProject?.id == destination.projectId else {
             file.discard()
             return
         }
-        let accountGeneration = projectListAccountGeneration
-        let projectId = project.id
+        let accountGeneration = destination.accountGeneration
+        let projectId = destination.projectId
         let operationID = UUID()
         let operationToken = UUID()
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -380,6 +380,8 @@ class ChatViewModel: ObservableObject {
     @Published var pendingAttachments: [Attachment] = []
     @Published var attachmentError: String? = nil
     @Published var pendingImageThumbnails: [String: String] = [:]
+    private var attachmentProcessingTasks: [String: Task<Void, Never>] = [:]
+    private var managedAttachmentFiles: [String: ManagedStagedFile] = [:]
     var isProcessingAttachment: Bool {
         pendingAttachments.contains { $0.processingState == .processing }
     }
@@ -411,6 +413,7 @@ class ChatViewModel: ObservableObject {
     @Published var isLoadingProject: Bool = false
     @Published var isUploadingProjectDocument: Bool = false
     @Published var projectError: String?
+    private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
     private var projectListLoadGeneration = 0
     private var latestAppliedProjectListLoadGeneration = 0
     private var projectListAccountGeneration = 0
@@ -1653,6 +1656,7 @@ class ChatViewModel: ObservableObject {
     }
 
     private func clearProjectState() {
+        cancelProjectUploads()
         isProjectAccountActive = false
         projectListLoadGeneration += 1
         projectListAccountGeneration += 1
@@ -1947,7 +1951,7 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
+    func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil, color: String? = nil) async {
         guard let project = activeProject else { return }
         let accountGeneration = projectListAccountGeneration
 
@@ -1957,7 +1961,8 @@ class ChatViewModel: ObservableObject {
                 name: name,
                 description: description,
                 systemInstructions: systemInstructions,
-                memory: memory
+                memory: memory,
+                color: color
             )
             try await projectStorage.updateProject(project.id, data: update)
             guard isCurrentProjectAccount(accountGeneration) else { return }
@@ -1966,6 +1971,7 @@ class ChatViewModel: ObservableObject {
             updated.description = description ?? updated.description
             updated.systemInstructions = systemInstructions ?? updated.systemInstructions
             updated.memory = memory ?? updated.memory
+            updated.color = color ?? updated.color
             updated.updatedAt = ISO8601DateFormatter().string(from: Date())
             activeProject = updated
             if let index = projects.firstIndex(where: { $0.id == updated.id }) {
@@ -1986,10 +1992,16 @@ class ChatViewModel: ObservableObject {
         let accountGeneration = projectListAccountGeneration
         _ = try await projectStorage.deleteAllProjects()
         guard isCurrentProjectAccount(accountGeneration) else { return }
+        projectListLoadGeneration += 1
+        latestAppliedProjectListLoadGeneration = projectListLoadGeneration
+        projectLoadGeneration += 1
         projects = []
-        if activeProject != nil {
-            exitProject()
-        }
+        activeProject = nil
+        projectDocuments = []
+        isViewingProjectChat = false
+        pendingSearchResultChatId = nil
+        activeStorageTab = .cloud
+        createNewChat(isLocalOnly: false, focusInput: false)
     }
 
     func deleteActiveProject() async {
@@ -2008,36 +2020,64 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func uploadProjectDocument(url: URL, filename: String) async {
-        guard let project = activeProject else { return }
+    func uploadProjectDocument(file: ManagedStagedFile, filename: String) {
+        guard let project = activeProject else {
+            file.discard()
+            return
+        }
         let accountGeneration = projectListAccountGeneration
+        let operationID = UUID()
 
         isUploadingProjectDocument = true
         projectError = nil
-        defer {
-            if isCurrentProjectAccount(accountGeneration) {
-                isUploadingProjectDocument = false
+        let task = Task { [weak self] in
+            guard let self else {
+                file.discard()
+                return
+            }
+            defer {
+                file.discard()
+                projectUploadTasks.removeValue(forKey: operationID)
+                if isCurrentProjectAccount(accountGeneration) {
+                    isUploadingProjectDocument = !projectUploadTasks.isEmpty
+                }
+            }
+            do {
+                _ = try BoundedFileIO.validatedSize(
+                    of: file.url,
+                    maximumSize: Constants.Attachments.maxFileSizeBytes
+                )
+                let markdown = try await DocumentConversionService.shared.convertToMarkdown(
+                    url: file.url,
+                    filename: filename
+                )
+                try Task.checkCancellation()
+                guard isCurrentProjectAccount(accountGeneration) else { return }
+                let contentType = DocumentConversionService.mimeType(for: filename)
+                let document = try await projectStorage.uploadDocument(
+                    projectId: project.id,
+                    filename: filename,
+                    contentType: contentType,
+                    content: markdown,
+                    sizeBytes: file.originalSize
+                )
+                try Task.checkCancellation()
+                guard isCurrentProjectAccount(accountGeneration) else { return }
+                projectDocuments.append(document)
+            } catch is CancellationError {
+            } catch {
+                guard isCurrentProjectAccount(accountGeneration) else { return }
+                projectError = error.localizedDescription
             }
         }
-        do {
-            let markdown = try await DocumentConversionService.shared.convertToMarkdown(
-                url: url,
-                filename: filename
-            )
-            guard isCurrentProjectAccount(accountGeneration) else { return }
-            let contentType = DocumentConversionService.mimeType(for: filename)
-            let document = try await projectStorage.uploadDocument(
-                projectId: project.id,
-                filename: filename,
-                contentType: contentType,
-                content: markdown
-            )
-            guard isCurrentProjectAccount(accountGeneration) else { return }
-            projectDocuments.append(document)
-        } catch {
-            guard isCurrentProjectAccount(accountGeneration) else { return }
-            projectError = error.localizedDescription
-        }
+        projectUploadTasks[operationID] = task
+    }
+
+    private func cancelProjectUploads() {
+        let tasks = Array(projectUploadTasks.values)
+        projectUploadTasks.removeAll()
+        for task in tasks { task.cancel() }
+        isUploadingProjectDocument = false
     }
 
     func deleteProjectDocument(_ documentId: String) async {
@@ -3148,7 +3188,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func addDocumentAttachment(
-        url: URL,
+        file: ManagedStagedFile,
         fileName: String,
         sharedImportRequestID: UUID? = nil
     ) {
@@ -3163,19 +3203,30 @@ class ChatViewModel: ObservableObject {
             processingState: .processing
         )
         pendingAttachments.append(attachment)
+        managedAttachmentFiles[attachmentId] = file
 
-        Task {
+        let task = Task { [weak self] in
+            guard let self else {
+                file.discard()
+                return
+            }
+            defer {
+                file.discard()
+                managedAttachmentFiles.removeValue(forKey: attachmentId)
+                attachmentProcessingTasks.removeValue(forKey: attachmentId)
+            }
             do {
-                let text = try await DocumentProcessingService.shared.extractText(from: url)
-                let fileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64) ?? 0
+                let text = try await DocumentProcessingService.shared.extractText(from: file.url)
+                try Task.checkCancellation()
 
                 attachment.textContent = text
-                attachment.fileSize = fileSize
+                attachment.fileSize = Int64(file.originalSize)
                 attachment.processingState = .completed
 
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
                     pendingAttachments[index] = attachment
                 }
+            } catch is CancellationError {
             } catch {
                 attachment.processingState = .failed
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
@@ -3183,6 +3234,28 @@ class ChatViewModel: ObservableObject {
                 }
                 attachmentError = error.localizedDescription
             }
+        }
+        attachmentProcessingTasks[attachmentId] = task
+    }
+
+    func addDocumentAttachment(
+        data: Data,
+        fileName: String,
+        sharedImportRequestID: UUID? = nil
+    ) {
+        do {
+            let file = try ManagedFileStore.shared.stage(
+                data: data,
+                fileExtension: URL(fileURLWithPath: fileName).pathExtension,
+                maximumSize: Constants.Attachments.maxFileSizeBytes
+            )
+            addDocumentAttachment(
+                file: file,
+                fileName: fileName,
+                sharedImportRequestID: sharedImportRequestID
+            )
+        } catch {
+            attachmentError = error.localizedDescription
         }
     }
 
@@ -3204,9 +3277,12 @@ class ChatViewModel: ObservableObject {
         )
         pendingAttachments.append(attachment)
 
-        Task {
+        let task = Task { [weak self] in
+            guard let self else { return }
+            defer { attachmentProcessingTasks.removeValue(forKey: attachmentId) }
             do {
                 let processed = try await ImageProcessingService.shared.processImage(data: data)
+                try Task.checkCancellation()
 
                 attachment.mimeType = Constants.Attachments.defaultImageMimeType
                 attachment.base64 = processed.base64
@@ -3222,6 +3298,7 @@ class ChatViewModel: ObservableObject {
                     pendingAttachments[index] = attachment
                 }
                 pendingImageThumbnails[attachmentId] = processed.thumbnailBase64
+            } catch is CancellationError {
             } catch {
                 attachment.processingState = .failed
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
@@ -3230,9 +3307,12 @@ class ChatViewModel: ObservableObject {
                 attachmentError = error.localizedDescription
             }
         }
+        attachmentProcessingTasks[attachmentId] = task
     }
 
     func removePendingAttachment(id: String) {
+        attachmentProcessingTasks.removeValue(forKey: id)?.cancel()
+        managedAttachmentFiles.removeValue(forKey: id)?.discard()
         let removed = pendingAttachments.filter { $0.id == id }
         pendingAttachments.removeAll { $0.id == id }
         pendingImageThumbnails.removeValue(forKey: id)
@@ -3243,6 +3323,12 @@ class ChatViewModel: ObservableObject {
     }
 
     func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
+        let tasks = Array(attachmentProcessingTasks.values)
+        attachmentProcessingTasks.removeAll()
+        for task in tasks { task.cancel() }
+        let files = Array(managedAttachmentFiles.values)
+        managedAttachmentFiles.removeAll()
+        for file in files { file.discard() }
         let removed = pendingAttachments
         pendingAttachments.removeAll()
         pendingImageThumbnails.removeAll()
@@ -5462,6 +5548,13 @@ class ChatViewModel: ObservableObject {
         hydratingChatId = nil
         chatHydrationError = nil
 
+        let canceledAttachmentTasks = Array(attachmentProcessingTasks.values)
+        clearPendingAttachments()
+        for chatId in Array(messageQueues.keys) {
+            discardMessageQueue(chatId: chatId)
+        }
+        SharedImportCoordinator.shared.discardAllPending()
+        let canceledProjectUploadTasks = Array(projectUploadTasks.values)
         clearHydratedFavorites()
         isAccountTeardownInProgress = true
         clearProjectState()
@@ -5475,6 +5568,8 @@ class ChatViewModel: ObservableObject {
         await canceledSignInTask?.value
         await canceledLegacyMigrationTask?.value
         await drainStreamTasks(canceledStreamTasks)
+        for task in canceledAttachmentTasks { await task.value }
+        for task in canceledProjectUploadTasks { await task.value }
 
         // Stop sync timers when signing out
         autoSyncTimer?.invalidate()

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -301,6 +301,7 @@ class ChatViewModel: ObservableObject {
     private var activeSignInToken: AccountOperationFence.Token?
     private var isAccountTeardownInProgress = false
     private(set) var accountLifecycleGeneration = 0
+    private var accountLifecycleUserId: String?
     private var acceptsChatSaves = true
     private var hasPerformedInitialSync: Bool = false  // Track if initial sync has been done
     private var hasAnonymousChatsToSync: Bool = false  // Track if we have anonymous chats to sync
@@ -2085,7 +2086,9 @@ class ChatViewModel: ObservableObject {
         projectUploadBarrierCount += 1
         defer { projectUploadBarrierCount -= 1 }
         await cancelAndAwaitProjectUploads()
-        guard isCurrentProjectAccount(accountGeneration), currentUserId == accountUserId else {
+        guard !Task.isCancelled,
+              isCurrentProjectAccount(accountGeneration),
+              currentUserId == accountUserId else {
             throw CancellationError()
         }
         do {
@@ -5880,6 +5883,7 @@ class ChatViewModel: ObservableObject {
         chatHydrationError = nil
 
         isAccountTeardownInProgress = true
+        accountLifecycleUserId = nil
         accountLifecycleGeneration += 1
         let canceledAttachmentTasks = Array(attachmentProcessingTasks.values)
         let canceledPasteStagingTasks = Array(pasteStagingTasks.values)
@@ -6199,6 +6203,11 @@ class ChatViewModel: ObservableObject {
             return
         }
 
+        if accountLifecycleUserId != userId {
+            accountLifecycleUserId = userId
+            accountLifecycleGeneration += 1
+        }
+
         passkeyManager.resumeAccountOperations()
 
         // Wire up passkey recovery callback
@@ -6510,6 +6519,7 @@ class ChatViewModel: ObservableObject {
                     try await self.cloudSync.quiesceUploadsForBulkDelete(userId: userId)
                 },
                 deleteCloud: {
+                    try Task.checkCancellation()
                     guard shouldDeleteCloud else { return }
                     try await self.cloudSync.deleteAllFromCloud(
                         userId: userId,

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -436,6 +436,10 @@ class ChatViewModel: ObservableObject {
         let projectId: String
         let accountGeneration: Int
     }
+    enum DeleteAllProjectsOutcome: Equatable {
+        case deleted
+        case accountChangedAfterCommit
+    }
     private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
     private var projectUploadTokens: [UUID: UUID] = [:]
     private var projectUploadBarrierCount = 0
@@ -2068,18 +2072,24 @@ class ChatViewModel: ObservableObject {
     }
 
     /// Permanently deletes every project the user owns, mirroring the
-    /// webapp's bulk action. Throws so callers can surface the failure and
-    /// leave local state untouched for a retry.
+    /// webapp's bulk action. Throws before the request when account context
+    /// is lost, and reports account changes after a successful commit.
     @MainActor
-    func deleteAllProjects() async throws {
-        guard isProjectAccountActive else { throw CancellationError() }
+    func deleteAllProjects() async throws -> DeleteAllProjectsOutcome {
+        guard isProjectAccountActive, let accountUserId = currentUserId else {
+            throw CancellationError()
+        }
         let accountGeneration = projectListAccountGeneration
         projectUploadBarrierCount += 1
         defer { projectUploadBarrierCount -= 1 }
         await cancelAndAwaitProjectUploads()
-        guard isCurrentProjectAccount(accountGeneration) else { throw CancellationError() }
+        guard isCurrentProjectAccount(accountGeneration), currentUserId == accountUserId else {
+            throw CancellationError()
+        }
         _ = try await projectStorage.deleteAllProjects()
-        guard isCurrentProjectAccount(accountGeneration) else { throw CancellationError() }
+        guard isCurrentProjectAccount(accountGeneration), currentUserId == accountUserId else {
+            return .accountChangedAfterCommit
+        }
         projectListLoadGeneration += 1
         latestAppliedProjectListLoadGeneration = projectListLoadGeneration
         projectLoadGeneration += 1
@@ -2090,6 +2100,7 @@ class ChatViewModel: ObservableObject {
         pendingSearchResultChatId = nil
         activeStorageTab = .cloud
         createNewChat(isLocalOnly: false, focusInput: false)
+        return .deleted
     }
 
     func deleteActiveProject() async {
@@ -6436,7 +6447,7 @@ class ChatViewModel: ObservableObject {
     /// the user can retry without partial-deletion side effects.
     @MainActor
     func deleteAllChats() async throws {
-        guard let userId = currentUserId else { return }
+        guard let userId = currentUserId else { throw CancellationError() }
         let allChatIds = Set(
             cloudSidebarSummaries.map(\.id)
                 + localSidebarSummaries.map(\.id)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -381,6 +381,7 @@ class ChatViewModel: ObservableObject {
     @Published var attachmentError: String? = nil
     @Published var pendingImageThumbnails: [String: String] = [:]
     private var attachmentProcessingTasks: [String: Task<Void, Never>] = [:]
+    private var attachmentProcessingTokens: [String: UUID] = [:]
     private var managedAttachmentFiles: [String: ManagedStagedFile] = [:]
     private var attachmentProcessingGeneration = 0
     var isProcessingAttachment: Bool {
@@ -415,6 +416,7 @@ class ChatViewModel: ObservableObject {
     @Published var isUploadingProjectDocument: Bool = false
     @Published var projectError: String?
     private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
+    private var projectUploadTokens: [UUID: UUID] = [:]
     private var projectUploadBarrierCount = 0
     private var projectListLoadGeneration = 0
     private var latestAppliedProjectListLoadGeneration = 0
@@ -1541,12 +1543,12 @@ class ChatViewModel: ObservableObject {
         createNewChat()
     }
 
-    private func leaveProjectContext() async -> Bool {
+    private func leaveProjectContext(validateOperation: () -> Bool = { true }) async -> Bool {
         let projectId = activeProject?.id
         projectUploadBarrierCount += 1
         defer { projectUploadBarrierCount -= 1 }
         await cancelAndAwaitProjectUploads()
-        guard activeProject?.id == projectId else { return false }
+        guard validateOperation(), activeProject?.id == projectId else { return false }
         activeProject = nil
         projectDocuments = []
         projectError = nil
@@ -1968,7 +1970,14 @@ class ChatViewModel: ObservableObject {
                 }
                 self.isViewingProjectChat = true
             } else if self.activeProject != nil {
-                guard await self.leaveProjectContext() else {
+                guard await self.leaveProjectContext(validateOperation: {
+                    !Task.isCancelled
+                        && self.currentUserId == userId
+                        && self.chatSelectionFence.accepts(
+                            id: chat.id,
+                            generation: selectionGeneration
+                        )
+                }) else {
                     self.failSelection(id: chat.id, generation: selectionGeneration)
                     return
                 }
@@ -2067,7 +2076,9 @@ class ChatViewModel: ObservableObject {
         let accountGeneration = projectListAccountGeneration
         let projectId = project.id
         let operationID = UUID()
+        let operationToken = UUID()
 
+        projectUploadTokens[operationID] = operationToken
         isUploadingProjectDocument = true
         projectError = nil
         let task = Task { [weak self] in
@@ -2077,9 +2088,12 @@ class ChatViewModel: ObservableObject {
             }
             defer {
                 file.discard()
-                projectUploadTasks.removeValue(forKey: operationID)
-                if isCurrentProjectAccount(accountGeneration) {
-                    isUploadingProjectDocument = !projectUploadTasks.isEmpty
+                if projectUploadTokens[operationID] == operationToken {
+                    projectUploadTokens.removeValue(forKey: operationID)
+                    projectUploadTasks.removeValue(forKey: operationID)
+                    if isCurrentProjectAccount(accountGeneration) {
+                        isUploadingProjectDocument = !projectUploadTokens.isEmpty
+                    }
                 }
             }
             do {
@@ -2113,7 +2127,11 @@ class ChatViewModel: ObservableObject {
                 projectError = error.localizedDescription
             }
         }
-        projectUploadTasks[operationID] = task
+        if projectUploadTokens[operationID] == operationToken {
+            projectUploadTasks[operationID] = task
+        } else {
+            task.cancel()
+        }
     }
 
     private func cancelProjectUploads() {
@@ -3256,6 +3274,8 @@ class ChatViewModel: ObservableObject {
         )
         pendingAttachments.append(attachment)
         managedAttachmentFiles[attachmentId] = file
+        let operationToken = UUID()
+        attachmentProcessingTokens[attachmentId] = operationToken
 
         let task = Task { [weak self] in
             guard let self else {
@@ -3265,7 +3285,10 @@ class ChatViewModel: ObservableObject {
             defer {
                 file.discard()
                 managedAttachmentFiles.removeValue(forKey: attachmentId)
-                attachmentProcessingTasks.removeValue(forKey: attachmentId)
+                if attachmentProcessingTokens[attachmentId] == operationToken {
+                    attachmentProcessingTokens.removeValue(forKey: attachmentId)
+                    attachmentProcessingTasks.removeValue(forKey: attachmentId)
+                }
             }
             do {
                 let text = try await DocumentProcessingService.shared.extractText(from: file.url)
@@ -3291,7 +3314,11 @@ class ChatViewModel: ObservableObject {
                 attachmentError = error.localizedDescription
             }
         }
-        attachmentProcessingTasks[attachmentId] = task
+        if attachmentProcessingTokens[attachmentId] == operationToken {
+            attachmentProcessingTasks[attachmentId] = task
+        } else {
+            task.cancel()
+        }
     }
 
     func addDocumentAttachment(
@@ -3334,10 +3361,17 @@ class ChatViewModel: ObservableObject {
             processingState: .processing
         )
         pendingAttachments.append(attachment)
+        let operationToken = UUID()
+        attachmentProcessingTokens[attachmentId] = operationToken
 
         let task = Task { [weak self] in
             guard let self else { return }
-            defer { attachmentProcessingTasks.removeValue(forKey: attachmentId) }
+            defer {
+                if attachmentProcessingTokens[attachmentId] == operationToken {
+                    attachmentProcessingTokens.removeValue(forKey: attachmentId)
+                    attachmentProcessingTasks.removeValue(forKey: attachmentId)
+                }
+            }
             do {
                 let processed = try await ImageProcessingService.shared.processImage(data: data)
                 try Task.checkCancellation()
@@ -3369,11 +3403,16 @@ class ChatViewModel: ObservableObject {
                 attachmentError = error.localizedDescription
             }
         }
-        attachmentProcessingTasks[attachmentId] = task
+        if attachmentProcessingTokens[attachmentId] == operationToken {
+            attachmentProcessingTasks[attachmentId] = task
+        } else {
+            task.cancel()
+        }
     }
 
     func removePendingAttachment(id: String) {
-        if let task = attachmentProcessingTasks[id] {
+        attachmentProcessingTokens.removeValue(forKey: id)
+        if let task = attachmentProcessingTasks.removeValue(forKey: id) {
             task.cancel()
         } else {
             managedAttachmentFiles.removeValue(forKey: id)?.discard()
@@ -3390,8 +3429,10 @@ class ChatViewModel: ObservableObject {
     func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
         attachmentProcessingGeneration += 1
         let tasks = Array(attachmentProcessingTasks.values)
+        let processingAttachmentIds = Set(attachmentProcessingTokens.keys)
+        attachmentProcessingTokens.removeAll()
+        attachmentProcessingTasks.removeAll()
         for task in tasks { task.cancel() }
-        let processingAttachmentIds = Set(attachmentProcessingTasks.keys)
         let unownedAttachmentIds = managedAttachmentFiles.keys.filter {
             !processingAttachmentIds.contains($0)
         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -382,6 +382,7 @@ class ChatViewModel: ObservableObject {
     @Published var pendingImageThumbnails: [String: String] = [:]
     private var attachmentProcessingTasks: [String: Task<Void, Never>] = [:]
     private var managedAttachmentFiles: [String: ManagedStagedFile] = [:]
+    private var attachmentProcessingGeneration = 0
     var isProcessingAttachment: Bool {
         pendingAttachments.contains { $0.processingState == .processing }
     }
@@ -414,6 +415,7 @@ class ChatViewModel: ObservableObject {
     @Published var isUploadingProjectDocument: Bool = false
     @Published var projectError: String?
     private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
+    private var projectUploadBarrierCount = 0
     private var projectListLoadGeneration = 0
     private var latestAppliedProjectListLoadGeneration = 0
     private var projectListAccountGeneration = 0
@@ -1534,16 +1536,22 @@ class ChatViewModel: ObservableObject {
         navigationRequest = nil
     }
 
-    func createNewRootChat() {
-        leaveProjectContext()
+    func createNewRootChat() async {
+        guard await leaveProjectContext() else { return }
         createNewChat()
     }
 
-    private func leaveProjectContext() {
+    private func leaveProjectContext() async -> Bool {
+        let projectId = activeProject?.id
+        projectUploadBarrierCount += 1
+        defer { projectUploadBarrierCount -= 1 }
+        await cancelAndAwaitProjectUploads()
+        guard activeProject?.id == projectId else { return false }
         activeProject = nil
         projectDocuments = []
         projectError = nil
         isViewingProjectChat = false
+        return true
     }
 
     /// Creates a new chat and sets it as the current chat
@@ -1723,6 +1731,22 @@ class ChatViewModel: ObservableObject {
     func loadActiveProject(projectId: String) async -> Bool {
         guard hasChatAccess, isProjectAccountActive, !Task.isCancelled else { return false }
         let accountGeneration = projectListAccountGeneration
+        let activeProjectId = activeProject?.id
+        let isSwitchingProjects = activeProjectId != nil && activeProjectId != projectId
+        if isSwitchingProjects {
+            projectUploadBarrierCount += 1
+        }
+        defer {
+            if isSwitchingProjects {
+                projectUploadBarrierCount -= 1
+            }
+        }
+        if isSwitchingProjects {
+            await cancelAndAwaitProjectUploads()
+            guard !Task.isCancelled,
+                  isCurrentProjectAccount(accountGeneration),
+                  activeProject?.id == activeProjectId else { return false }
+        }
 
         projectLoadGeneration += 1
         let generation = projectLoadGeneration
@@ -1797,8 +1821,8 @@ class ChatViewModel: ObservableObject {
         return loaded
     }
 
-    func exitProject() {
-        leaveProjectContext()
+    func exitProject() async {
+        guard await leaveProjectContext() else { return }
         shouldExpandProjectsInSidebar = true
         createNewChat(isLocalOnly: false, focusInput: false)
     }
@@ -1814,13 +1838,13 @@ class ChatViewModel: ObservableObject {
         isViewingProjectChat = true
     }
 
-    func openSummaryChat(id: String, projectId: String?, isLocalOnly: Bool) {
+    func openSummaryChat(id: String, projectId: String?, isLocalOnly: Bool) async {
         guard let projectId, activeProject?.id != projectId else {
             if projectId == nil {
                 beginSelection(id: id)
             }
             if projectId == nil, activeProject != nil {
-                leaveProjectContext()
+                guard await leaveProjectContext() else { return }
             }
             _ = selectChat(id: id, isLocalOnly: isLocalOnly)
             if projectId != nil { isViewingProjectChat = true }
@@ -1944,7 +1968,10 @@ class ChatViewModel: ObservableObject {
                 }
                 self.isViewingProjectChat = true
             } else if self.activeProject != nil {
-                self.leaveProjectContext()
+                guard await self.leaveProjectContext() else {
+                    self.failSelection(id: chat.id, generation: selectionGeneration)
+                    return
+                }
             }
             self.chatSelectionTask = nil
             self.installSelectedChat(persisted, generation: selectionGeneration)
@@ -1990,6 +2017,10 @@ class ChatViewModel: ObservableObject {
     func deleteAllProjects() async throws {
         guard isProjectAccountActive else { return }
         let accountGeneration = projectListAccountGeneration
+        projectUploadBarrierCount += 1
+        defer { projectUploadBarrierCount -= 1 }
+        await cancelAndAwaitProjectUploads()
+        guard isCurrentProjectAccount(accountGeneration) else { return }
         _ = try await projectStorage.deleteAllProjects()
         guard isCurrentProjectAccount(accountGeneration) else { return }
         projectListLoadGeneration += 1
@@ -2009,11 +2040,17 @@ class ChatViewModel: ObservableObject {
         let accountGeneration = projectListAccountGeneration
 
         projectError = nil
+        projectUploadBarrierCount += 1
+        defer { projectUploadBarrierCount -= 1 }
         do {
+            await cancelAndAwaitProjectUploads()
+            guard isCurrentProjectAccount(accountGeneration),
+                  activeProject?.id == project.id else { return }
             try await projectStorage.deleteProject(project.id)
-            guard isCurrentProjectAccount(accountGeneration) else { return }
+            guard isCurrentProjectAccount(accountGeneration),
+                  activeProject?.id == project.id else { return }
             projects.removeAll { $0.id == project.id }
-            exitProject()
+            await exitProject()
         } catch {
             guard isCurrentProjectAccount(accountGeneration) else { return }
             projectError = error.localizedDescription
@@ -2021,11 +2058,14 @@ class ChatViewModel: ObservableObject {
     }
 
     func uploadProjectDocument(file: ManagedStagedFile, filename: String) {
-        guard let project = activeProject else {
+        guard projectUploadBarrierCount == 0,
+              !isAccountTeardownInProgress,
+              let project = activeProject else {
             file.discard()
             return
         }
         let accountGeneration = projectListAccountGeneration
+        let projectId = project.id
         let operationID = UUID()
 
         isUploadingProjectDocument = true
@@ -2052,21 +2092,24 @@ class ChatViewModel: ObservableObject {
                     filename: filename
                 )
                 try Task.checkCancellation()
-                guard isCurrentProjectAccount(accountGeneration) else { return }
+                guard isCurrentProjectAccount(accountGeneration),
+                      activeProject?.id == projectId else { return }
                 let contentType = DocumentConversionService.mimeType(for: filename)
                 let document = try await projectStorage.uploadDocument(
-                    projectId: project.id,
+                    projectId: projectId,
                     filename: filename,
                     contentType: contentType,
                     content: markdown,
                     sizeBytes: file.originalSize
                 )
                 try Task.checkCancellation()
-                guard isCurrentProjectAccount(accountGeneration) else { return }
+                guard isCurrentProjectAccount(accountGeneration),
+                      activeProject?.id == projectId else { return }
                 projectDocuments.append(document)
             } catch is CancellationError {
             } catch {
-                guard isCurrentProjectAccount(accountGeneration) else { return }
+                guard isCurrentProjectAccount(accountGeneration),
+                      activeProject?.id == projectId else { return }
                 projectError = error.localizedDescription
             }
         }
@@ -2075,9 +2118,13 @@ class ChatViewModel: ObservableObject {
 
     private func cancelProjectUploads() {
         let tasks = Array(projectUploadTasks.values)
-        projectUploadTasks.removeAll()
         for task in tasks { task.cancel() }
-        isUploadingProjectDocument = false
+    }
+
+    private func cancelAndAwaitProjectUploads() async {
+        let tasks = Array(projectUploadTasks.values)
+        for task in tasks { task.cancel() }
+        for task in tasks { await task.value }
     }
 
     func deleteProjectDocument(_ documentId: String) async {
@@ -3192,7 +3239,12 @@ class ChatViewModel: ObservableObject {
         fileName: String,
         sharedImportRequestID: UUID? = nil
     ) {
+        guard !isAccountTeardownInProgress else {
+            file.discard()
+            return
+        }
         attachmentError = nil
+        let processingGeneration = attachmentProcessingGeneration
 
         let attachmentId = UUID().uuidString.lowercased()
         var attachment = Attachment(
@@ -3218,6 +3270,8 @@ class ChatViewModel: ObservableObject {
             do {
                 let text = try await DocumentProcessingService.shared.extractText(from: file.url)
                 try Task.checkCancellation()
+                guard processingGeneration == attachmentProcessingGeneration,
+                      pendingAttachments.contains(where: { $0.id == attachmentId }) else { return }
 
                 attachment.textContent = text
                 attachment.fileSize = Int64(file.originalSize)
@@ -3228,6 +3282,8 @@ class ChatViewModel: ObservableObject {
                 }
             } catch is CancellationError {
             } catch {
+                guard processingGeneration == attachmentProcessingGeneration,
+                      pendingAttachments.contains(where: { $0.id == attachmentId }) else { return }
                 attachment.processingState = .failed
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
                     pendingAttachments[index] = attachment
@@ -3264,7 +3320,9 @@ class ChatViewModel: ObservableObject {
         fileName: String,
         sharedImportRequestID: UUID? = nil
     ) {
+        guard !isAccountTeardownInProgress else { return }
         attachmentError = nil
+        let processingGeneration = attachmentProcessingGeneration
 
         let attachmentId = UUID().uuidString.lowercased()
         var attachment = Attachment(
@@ -3283,6 +3341,8 @@ class ChatViewModel: ObservableObject {
             do {
                 let processed = try await ImageProcessingService.shared.processImage(data: data)
                 try Task.checkCancellation()
+                guard processingGeneration == attachmentProcessingGeneration,
+                      pendingAttachments.contains(where: { $0.id == attachmentId }) else { return }
 
                 attachment.mimeType = Constants.Attachments.defaultImageMimeType
                 attachment.base64 = processed.base64
@@ -3300,6 +3360,8 @@ class ChatViewModel: ObservableObject {
                 pendingImageThumbnails[attachmentId] = processed.thumbnailBase64
             } catch is CancellationError {
             } catch {
+                guard processingGeneration == attachmentProcessingGeneration,
+                      pendingAttachments.contains(where: { $0.id == attachmentId }) else { return }
                 attachment.processingState = .failed
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
                     pendingAttachments[index] = attachment
@@ -3311,8 +3373,11 @@ class ChatViewModel: ObservableObject {
     }
 
     func removePendingAttachment(id: String) {
-        attachmentProcessingTasks.removeValue(forKey: id)?.cancel()
-        managedAttachmentFiles.removeValue(forKey: id)?.discard()
+        if let task = attachmentProcessingTasks[id] {
+            task.cancel()
+        } else {
+            managedAttachmentFiles.removeValue(forKey: id)?.discard()
+        }
         let removed = pendingAttachments.filter { $0.id == id }
         pendingAttachments.removeAll { $0.id == id }
         pendingImageThumbnails.removeValue(forKey: id)
@@ -3323,12 +3388,16 @@ class ChatViewModel: ObservableObject {
     }
 
     func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
+        attachmentProcessingGeneration += 1
         let tasks = Array(attachmentProcessingTasks.values)
-        attachmentProcessingTasks.removeAll()
         for task in tasks { task.cancel() }
-        let files = Array(managedAttachmentFiles.values)
-        managedAttachmentFiles.removeAll()
-        for file in files { file.discard() }
+        let processingAttachmentIds = Set(attachmentProcessingTasks.keys)
+        let unownedAttachmentIds = managedAttachmentFiles.keys.filter {
+            !processingAttachmentIds.contains($0)
+        }
+        for id in unownedAttachmentIds {
+            managedAttachmentFiles.removeValue(forKey: id)?.discard()
+        }
         let removed = pendingAttachments
         pendingAttachments.removeAll()
         pendingImageThumbnails.removeAll()
@@ -5548,6 +5617,7 @@ class ChatViewModel: ObservableObject {
         hydratingChatId = nil
         chatHydrationError = nil
 
+        isAccountTeardownInProgress = true
         let canceledAttachmentTasks = Array(attachmentProcessingTasks.values)
         clearPendingAttachments()
         for chatId in Array(messageQueues.keys) {
@@ -5556,7 +5626,6 @@ class ChatViewModel: ObservableObject {
         SharedImportCoordinator.shared.discardAllPending()
         let canceledProjectUploadTasks = Array(projectUploadTasks.values)
         clearHydratedFavorites()
-        isAccountTeardownInProgress = true
         clearProjectState()
         activeFullSyncId = nil
         isSyncing = false

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -436,9 +436,10 @@ class ChatViewModel: ObservableObject {
         let projectId: String
         let accountGeneration: Int
     }
-    enum DeleteAllProjectsOutcome: Equatable {
+    enum DeleteAllDataOutcome: Equatable {
         case deleted
-        case accountChangedAfterCommit
+        case accountChanged
+        case refreshRequired
     }
     private var projectUploadTasks: [UUID: Task<Void, Never>] = [:]
     private var projectUploadTokens: [UUID: UUID] = [:]
@@ -2073,22 +2074,31 @@ class ChatViewModel: ObservableObject {
 
     /// Permanently deletes every project the user owns, mirroring the
     /// webapp's bulk action. Throws before the request when account context
-    /// is lost, and reports account changes after a successful commit.
+    /// is lost, and distinguishes cancellation after request dispatch.
     @MainActor
-    func deleteAllProjects() async throws -> DeleteAllProjectsOutcome {
+    func deleteAllProjects() async throws -> DeleteAllDataOutcome {
         guard isProjectAccountActive, let accountUserId = currentUserId else {
             throw CancellationError()
         }
         let accountGeneration = projectListAccountGeneration
+        let requestProgress = SyncEnclaveRequestProgress()
         projectUploadBarrierCount += 1
         defer { projectUploadBarrierCount -= 1 }
         await cancelAndAwaitProjectUploads()
         guard isCurrentProjectAccount(accountGeneration), currentUserId == accountUserId else {
             throw CancellationError()
         }
-        _ = try await projectStorage.deleteAllProjects()
+        do {
+            _ = try await projectStorage.deleteAllProjects(requestProgress: requestProgress)
+        } catch is CancellationError {
+            guard await requestProgress.requestStarted else { throw CancellationError() }
+            guard isCurrentProjectAccount(accountGeneration), currentUserId == accountUserId else {
+                return .accountChanged
+            }
+            return .refreshRequired
+        }
         guard isCurrentProjectAccount(accountGeneration), currentUserId == accountUserId else {
-            return .accountChangedAfterCommit
+            return .accountChanged
         }
         projectListLoadGeneration += 1
         latestAppliedProjectListLoadGeneration = projectListLoadGeneration
@@ -6446,8 +6456,10 @@ class ChatViewModel: ObservableObject {
     /// bulk-delete runs first so a failure leaves local state untouched and
     /// the user can retry without partial-deletion side effects.
     @MainActor
-    func deleteAllChats() async throws {
+    func deleteAllChats() async throws -> DeleteAllDataOutcome {
         guard let userId = currentUserId else { throw CancellationError() }
+        let accountGeneration = accountLifecycleGeneration
+        let requestProgress = SyncEnclaveRequestProgress()
         let allChatIds = Set(
             cloudSidebarSummaries.map(\.id)
                 + localSidebarSummaries.map(\.id)
@@ -6465,48 +6477,62 @@ class ChatViewModel: ObservableObject {
         let hasKey = EncryptionService.shared.hasEncryptionKey()
         let shouldDeleteCloud = isAuthenticated
             && (hasKey || SettingsManager.shared.isCloudSyncEnabled)
-        try await DeleteAllChatsCoordinator.quiesceAndDeleteCloud(
-            closeSaveAdmission: {
-                self.acceptsChatSaves = false
-            },
-            stopProducers: {
-                self.autoSyncTimer?.invalidate()
-                self.autoSyncTimer = nil
-                let autoSyncTask = self.autoSyncTask
-                self.autoSyncTask = nil
-                autoSyncTask?.cancel()
-                self.recoveryScanTimer?.invalidate()
-                self.recoveryScanTimer = nil
-                let streamTasks = self.cancelAllGenerations()
-                await self.accountOperationTracker.closeAndWait()
-                await autoSyncTask?.value
-                await self.suspendRecoveryScans()
-                await self.drainStreamTasks(streamTasks)
-                let cleanupTasks = Array(self.recoverySessionCleanupTasks.values)
-                self.recoverySessionCleanupTasks.values.forEach { $0.cancel() }
-                self.recoverySessionCleanupTasks.removeAll()
-                for task in cleanupTasks {
-                    await task.value
+        do {
+            try await DeleteAllChatsCoordinator.quiesceAndDeleteCloud(
+                closeSaveAdmission: {
+                    self.acceptsChatSaves = false
+                },
+                stopProducers: {
+                    self.autoSyncTimer?.invalidate()
+                    self.autoSyncTimer = nil
+                    let autoSyncTask = self.autoSyncTask
+                    self.autoSyncTask = nil
+                    autoSyncTask?.cancel()
+                    self.recoveryScanTimer?.invalidate()
+                    self.recoveryScanTimer = nil
+                    let streamTasks = self.cancelAllGenerations()
+                    await self.accountOperationTracker.closeAndWait()
+                    await autoSyncTask?.value
+                    await self.suspendRecoveryScans()
+                    await self.drainStreamTasks(streamTasks)
+                    let cleanupTasks = Array(self.recoverySessionCleanupTasks.values)
+                    self.recoverySessionCleanupTasks.values.forEach { $0.cancel() }
+                    self.recoverySessionCleanupTasks.removeAll()
+                    for task in cleanupTasks {
+                        await task.value
+                    }
+                },
+                drainSavesAndBackups: {
+                    await self.drainPendingSaves()
+                },
+                quiesceUploads: {
+                    guard shouldDeleteCloud else { return }
+                    try await self.cloudSync.quiesceUploadsForBulkDelete(userId: userId)
+                },
+                deleteCloud: {
+                    guard shouldDeleteCloud else { return }
+                    try await self.cloudSync.deleteAllFromCloud(
+                        userId: userId,
+                        requestProgress: requestProgress
+                    )
+                },
+                recoverFromFailure: {
+                    await self.restoreDeleteAllOperationalState(
+                        userId: userId,
+                        inMemoryWasCleared: false
+                    )
                 }
-            },
-            drainSavesAndBackups: {
-                await self.drainPendingSaves()
-            },
-            quiesceUploads: {
-                guard shouldDeleteCloud else { return }
-                try await self.cloudSync.quiesceUploadsForBulkDelete(userId: userId)
-            },
-            deleteCloud: {
-                guard shouldDeleteCloud else { return }
-                try await self.cloudSync.deleteAllFromCloud(userId: userId)
-            },
-            recoverFromFailure: {
-                await self.restoreDeleteAllOperationalState(
-                    userId: userId,
-                    inMemoryWasCleared: false
-                )
+            )
+        } catch is CancellationError {
+            guard await requestProgress.requestStarted else { throw CancellationError() }
+            guard isCurrentAccountLifecycle(accountGeneration), currentUserId == userId else {
+                return .accountChanged
             }
-        )
+            return .refreshRequired
+        }
+        guard isCurrentAccountLifecycle(accountGeneration), currentUserId == userId else {
+            return .accountChanged
+        }
 
         clearHydratedFavorites()
         ProfileManager.shared.clearPinnedChats()
@@ -6534,9 +6560,16 @@ class ChatViewModel: ObservableObject {
             userId: userId,
             inMemoryWasCleared: inMemoryWasCleared
         )
+        guard isCurrentAccountLifecycle(accountGeneration), currentUserId == userId else {
+            return .accountChanged
+        }
         if let cleanupError {
+            if cleanupError is CancellationError {
+                return .refreshRequired
+            }
             throw cleanupError
         }
+        return .deleted
     }
 
     private func restoreDeleteAllOperationalState(

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1538,15 +1538,18 @@ class ChatViewModel: ObservableObject {
         navigationRequest = nil
     }
 
-    func createNewRootChat() async {
-        guard await leaveProjectContext() else { return }
+    @discardableResult
+    func createNewRootChat() async -> Bool {
+        guard hasChatAccess, await leaveProjectContext() else { return false }
         createNewChat()
+        return activeProject == nil && currentChat != nil
     }
 
     private func leaveProjectContext(validateOperation: () -> Bool = { true }) async -> Bool {
         let projectId = activeProject?.id
         projectUploadBarrierCount += 1
         defer { projectUploadBarrierCount -= 1 }
+        projectLoadGeneration += 1
         await cancelAndAwaitProjectUploads()
         guard validateOperation(), activeProject?.id == projectId else { return false }
         activeProject = nil
@@ -1731,7 +1734,10 @@ class ChatViewModel: ObservableObject {
     /// resources load.
     @discardableResult
     func loadActiveProject(projectId: String) async -> Bool {
-        guard hasChatAccess, isProjectAccountActive, !Task.isCancelled else { return false }
+        guard hasChatAccess,
+              isProjectAccountActive,
+              projectUploadBarrierCount == 0,
+              !Task.isCancelled else { return false }
         let accountGeneration = projectListAccountGeneration
         let activeProjectId = activeProject?.id
         let isSwitchingProjects = activeProjectId != nil && activeProjectId != projectId
@@ -1746,6 +1752,7 @@ class ChatViewModel: ObservableObject {
         if isSwitchingProjects {
             await cancelAndAwaitProjectUploads()
             guard !Task.isCancelled,
+                  projectUploadBarrierCount == 1,
                   isCurrentProjectAccount(accountGeneration),
                   activeProject?.id == activeProjectId else { return false }
         }
@@ -1823,10 +1830,12 @@ class ChatViewModel: ObservableObject {
         return loaded
     }
 
-    func exitProject() async {
-        guard await leaveProjectContext() else { return }
+    @discardableResult
+    func exitProject() async -> Bool {
+        guard await leaveProjectContext() else { return false }
         shouldExpandProjectsInSidebar = true
         createNewChat(isLocalOnly: false, focusInput: false)
+        return true
     }
 
     func returnToProjectLanding() {
@@ -1842,11 +1851,17 @@ class ChatViewModel: ObservableObject {
 
     func openSummaryChat(id: String, projectId: String?, isLocalOnly: Bool) async {
         guard let projectId, activeProject?.id != projectId else {
+            var selectionGeneration: Int?
             if projectId == nil {
                 beginSelection(id: id)
+                selectionGeneration = chatSelectionFence.generation
             }
             if projectId == nil, activeProject != nil {
-                guard await leaveProjectContext() else { return }
+                guard await leaveProjectContext(validateOperation: {
+                    guard let selectionGeneration else { return false }
+                    return !Task.isCancelled
+                        && chatSelectionFence.accepts(id: id, generation: selectionGeneration)
+                }) else { return }
             }
             _ = selectChat(id: id, isLocalOnly: isLocalOnly)
             if projectId != nil { isViewingProjectChat = true }
@@ -5647,7 +5662,7 @@ class ChatViewModel: ObservableObject {
     }
     
     /// Handle sign-out by clearing current chats but preserving them in storage
-    func handleSignOut() async {
+    func handleSignOut() async throws {
         // Capture the signing-out user's id up front. Later steps (and
         // the auth manager's cleanup) clear the authenticated state, after
         // which currentUserId no longer resolves this user.
@@ -5664,7 +5679,7 @@ class ChatViewModel: ObservableObject {
         for chatId in Array(messageQueues.keys) {
             discardMessageQueue(chatId: chatId)
         }
-        SharedImportCoordinator.shared.discardAllPending()
+        try await SharedImportCoordinator.shared.discardAllPending()
         let canceledProjectUploadTasks = Array(projectUploadTasks.values)
         clearHydratedFavorites()
         clearProjectState()
@@ -6023,6 +6038,15 @@ class ChatViewModel: ObservableObject {
         token: AccountOperationFence.Token,
         userId: String
     ) async {
+        guard isCurrentSignIn(token, userId: userId) else { return }
+
+        do {
+            try await SharedImportCoordinator.shared.allowPublications()
+        } catch {
+            guard isCurrentSignIn(token, userId: userId) else { return }
+            attachmentError = error.localizedDescription
+            return
+        }
         guard isCurrentSignIn(token, userId: userId) else { return }
 
         // Restore pagination state immediately for better UX on cold start

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -442,11 +442,13 @@ struct ChatSidebar: View {
                     onSelect: {
                         if isChatSearchActive {
                             if !chatSearch.available {
-                                viewModel.openSummaryChat(
-                                    id: chat.id,
-                                    projectId: chat.projectId,
-                                    isLocalOnly: chat.isLocalOnly
-                                )
+                                Task {
+                                    await viewModel.openSummaryChat(
+                                        id: chat.id,
+                                        projectId: chat.projectId,
+                                        isLocalOnly: chat.isLocalOnly
+                                    )
+                                }
                                 return
                             }
                             guard let fullChat = resolveSidebarSearchChat(

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -439,6 +439,7 @@ struct ChatSidebar: View {
                     syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
                     isGenerating: viewModel.isChatStreaming(chat.id),
                     isPinned: profileManager.isChatPinned(chat.id),
+                    projectColor: viewModel.projects.first { $0.id == chat.projectId }?.color,
                     onSelect: {
                         if isChatSearchActive {
                             if !chatSearch.available {
@@ -496,7 +497,11 @@ struct ChatSidebar: View {
                                     await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
                                 }
                             } label: {
-                                Label("Add to \(project.name)", systemImage: "folder")
+                                Label {
+                                    Text("Add to \(project.name)")
+                                } icon: {
+                                    ProjectFolderIcon(color: project.color, size: 22)
+                                }
                             }
                         }
                     }
@@ -579,6 +584,7 @@ struct ChatSidebar: View {
             isGenerating: viewModel.isChatStreaming(chat.id),
             isPinned: true,
             showPinnedIndicator: false,
+            projectColor: viewModel.projects.first { $0.id == chat.projectId }?.color,
             onSelect: { viewModel.openSearchResult(chat) },
             onEdit: {
                 if editingChatId == chat.id {
@@ -622,10 +628,11 @@ struct ChatSidebar: View {
                         await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
                     }
                 } label: {
-                    Label(
-                        chat.projectId == nil ? "Add to \(project.name)" : "Move to \(project.name)",
-                        systemImage: "folder"
-                    )
+                    Label {
+                        Text(chat.projectId == nil ? "Add to \(project.name)" : "Move to \(project.name)")
+                    } icon: {
+                        ProjectFolderIcon(color: project.color, size: 22)
+                    }
                 }
             }
         }
@@ -773,8 +780,12 @@ struct ChatSidebar: View {
                         }
                     } label: {
                         HStack(spacing: 12) {
-                            Image(systemName: project.decryptionFailed == true ? "lock.fill" : "folder")
-                                .foregroundColor(project.decryptionFailed == true ? .orange : .accentColor)
+                            if project.decryptionFailed == true {
+                                Image(systemName: "lock.fill")
+                                    .foregroundColor(.orange)
+                            } else {
+                                ProjectFolderIcon(color: project.color)
+                            }
                             Text(project.name)
                                 .lineLimit(1)
                             Spacer()
@@ -942,6 +953,7 @@ struct ChatListItem: View {
     var isGenerating: Bool = false
     var isPinned: Bool = false
     var showPinnedIndicator: Bool = true
+    var projectColor: String? = nil
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -976,9 +988,7 @@ struct ChatListItem: View {
                     } else {
                         HStack(spacing: 4) {
                             if chat.projectId != nil {
-                                Image(systemName: "folder")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                                ProjectFolderIcon(color: projectColor, size: 18)
                                     .accessibilityHidden(true)
                             }
                             if isPinned && showPinnedIndicator {

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -309,9 +309,7 @@ struct ChatContainer: View {
 
                     if let activeProject = viewModel.activeProject {
                         HStack(spacing: 6) {
-                            Image(systemName: "folder")
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(toolbarContentColor)
+                            ProjectFolderIcon(color: activeProject.color, size: 20)
                             Text(activeProject.name)
                                 .font(.caption)
                                 .fontWeight(.semibold)

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -265,7 +265,7 @@ struct ChatContainer: View {
                             viewModel.returnToProjectLanding()
                         } else {
                             Task {
-                                await viewModel.exitProject()
+                                guard await viewModel.exitProject() else { return }
                                 withAnimation {
                                     isSidebarOpen = true
                                 }

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -264,9 +264,11 @@ struct ChatContainer: View {
                         if isInProjectChat {
                             viewModel.returnToProjectLanding()
                         } else {
-                            viewModel.exitProject()
-                            withAnimation {
-                                isSidebarOpen = true
+                            Task {
+                                await viewModel.exitProject()
+                                withAnimation {
+                                    isSidebarOpen = true
+                                }
                             }
                         }
                     } label: {

--- a/TinfoilChat/Views/CloudSyncOnboardingView.swift
+++ b/TinfoilChat/Views/CloudSyncOnboardingView.swift
@@ -86,6 +86,7 @@ struct CloudSyncOnboardingView: View {
     @State private var direction: Edge = .trailing
     @State private var showFeatures: Bool = false
     @State private var animateIcon: Bool = false
+    @State private var showStartFreshConfirmation: Bool = false
 
     private var currentPageIndex: Int {
         switch currentStep {
@@ -347,7 +348,13 @@ struct CloudSyncOnboardingView: View {
                             .onboardingSecondaryButton()
                     }
 
-                    Button(action: { handleGenerateKey() }) {
+                    Button(action: {
+                        if mode == .recovery {
+                            showStartFreshConfirmation = true
+                        } else {
+                            handleGenerateKey()
+                        }
+                    }) {
                         Group {
                             if isProcessing {
                                 ProgressView()
@@ -362,6 +369,12 @@ struct CloudSyncOnboardingView: View {
                 }
                 .padding(.horizontal, 24)
                 .padding(.top, 8)
+                .alert("You will lose your conversations", isPresented: $showStartFreshConfirmation) {
+                    Button("Yes, start fresh", role: .destructive, action: handleGenerateKey)
+                    Button("Go Back", role: .cancel) {}
+                } message: {
+                    Text("Starting fresh will generate a new encryption key that is not compatible with your existing one. Your existing encrypted cloud data will be deleted. All your conversations and settings encrypted with the old key will be lost.")
+                }
 
                 Spacer().frame(height: 20)
             }

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct DocumentPickerView: UIViewControllerRepresentable {
-    var onDocumentPicked: (URL, String) -> Void
+    var onDocumentPicked: (ManagedStagedFile, String) -> Void
 
     private static let supportedTypes: [UTType] = [
         .pdf,
@@ -38,9 +38,9 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     }
 
     class Coordinator: NSObject, UIDocumentPickerDelegate {
-        let onDocumentPicked: (URL, String) -> Void
+        let onDocumentPicked: (ManagedStagedFile, String) -> Void
 
-        init(onDocumentPicked: @escaping (URL, String) -> Void) {
+        init(onDocumentPicked: @escaping (ManagedStagedFile, String) -> Void) {
             self.onDocumentPicked = onDocumentPicked
         }
 
@@ -54,18 +54,15 @@ struct DocumentPickerView: UIViewControllerRepresentable {
             }
             defer { sourceURL.stopAccessingSecurityScopedResource() }
 
-            let tempDir = FileManager.default.temporaryDirectory
-            let tempURL = tempDir.appendingPathComponent(UUID().uuidString + "_" + fileName)
-
             do {
-                if FileManager.default.fileExists(atPath: tempURL.path) {
-                    try FileManager.default.removeItem(at: tempURL)
-                }
-                try FileManager.default.copyItem(at: sourceURL, to: tempURL)
-                onDocumentPicked(tempURL, fileName)
+                let stagedFile = try ManagedFileStore.shared.stage(
+                    sourceURL: sourceURL,
+                    maximumSize: Constants.Attachments.maxFileSizeBytes
+                )
+                onDocumentPicked(stagedFile, fileName)
             } catch {
                 #if DEBUG
-                print("Failed to copy document to temp directory: \(error)")
+                print("Failed to stage document: \(error)")
                 #endif
             }
         }

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -87,15 +87,18 @@ struct DocumentPickerView: UIViewControllerRepresentable {
                 onError(PickerError.accessDenied)
                 return
             }
+            let accountLifecycleGeneration = accountLifecycleGeneration()
             Task {
-                await stageDocument(at: sourceURL)
+                await stageDocument(
+                    at: sourceURL,
+                    accountLifecycleGeneration: accountLifecycleGeneration
+                )
             }
         }
 
-        func stageDocument(at sourceURL: URL) async {
+        func stageDocument(at sourceURL: URL, accountLifecycleGeneration: Int) async {
             let fileName = sourceURL.lastPathComponent
             let stageDocument = stageDocument
-            let accountLifecycleGeneration = accountLifecycleGeneration()
             let result = await Task.detached(priority: .userInitiated) {
                 defer { sourceURL.stopAccessingSecurityScopedResource() }
                 return Result { try stageDocument(sourceURL) }

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -18,6 +18,8 @@ struct DocumentPickerView: UIViewControllerRepresentable {
 
     var onDocumentPicked: (ManagedStagedFile, String) -> Void
     var onError: (Error) -> Void
+    var accountLifecycleGeneration: Int
+    var isAccountLifecycleCurrent: @MainActor (Int) -> Bool
 
     private static let supportedTypes: [UTType] = [
         .pdf,
@@ -43,17 +45,27 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onDocumentPicked: onDocumentPicked, onError: onError)
+        Coordinator(
+            onDocumentPicked: onDocumentPicked,
+            onError: onError,
+            accountLifecycleGeneration: accountLifecycleGeneration,
+            isAccountLifecycleCurrent: isAccountLifecycleCurrent
+        )
     }
 
+    @MainActor
     class Coordinator: NSObject, UIDocumentPickerDelegate {
         let onDocumentPicked: (ManagedStagedFile, String) -> Void
         let onError: (Error) -> Void
+        let accountLifecycleGeneration: Int
+        let isAccountLifecycleCurrent: (Int) -> Bool
         private let stageDocument: @Sendable (URL) throws -> ManagedStagedFile
 
         init(
             onDocumentPicked: @escaping (ManagedStagedFile, String) -> Void,
             onError: @escaping (Error) -> Void,
+            accountLifecycleGeneration: Int,
+            isAccountLifecycleCurrent: @escaping (Int) -> Bool,
             stageDocument: @escaping @Sendable (URL) throws -> ManagedStagedFile = {
                 try ManagedFileStore.shared.stage(
                     sourceURL: $0,
@@ -63,6 +75,8 @@ struct DocumentPickerView: UIViewControllerRepresentable {
         ) {
             self.onDocumentPicked = onDocumentPicked
             self.onError = onError
+            self.accountLifecycleGeneration = accountLifecycleGeneration
+            self.isAccountLifecycleCurrent = isAccountLifecycleCurrent
             self.stageDocument = stageDocument
         }
 
@@ -85,6 +99,12 @@ struct DocumentPickerView: UIViewControllerRepresentable {
                 defer { sourceURL.stopAccessingSecurityScopedResource() }
                 return Result { try stageDocument(sourceURL) }
             }.value
+            guard isAccountLifecycleCurrent(accountLifecycleGeneration) else {
+                if case .success(let stagedFile) = result {
+                    stagedFile.discard()
+                }
+                return
+            }
             switch result {
             case .success(let stagedFile):
                 onDocumentPicked(stagedFile, fileName)

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -9,6 +9,7 @@ import UniformTypeIdentifiers
 
 struct DocumentPickerView: UIViewControllerRepresentable {
     var onDocumentPicked: (ManagedStagedFile, String) -> Void
+    var onError: (Error) -> Void
 
     private static let supportedTypes: [UTType] = [
         .pdf,
@@ -34,36 +35,46 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onDocumentPicked: onDocumentPicked)
+        Coordinator(onDocumentPicked: onDocumentPicked, onError: onError)
     }
 
     class Coordinator: NSObject, UIDocumentPickerDelegate {
         let onDocumentPicked: (ManagedStagedFile, String) -> Void
+        let onError: (Error) -> Void
+        private let stageDocument: (URL) throws -> ManagedStagedFile
 
-        init(onDocumentPicked: @escaping (ManagedStagedFile, String) -> Void) {
+        init(
+            onDocumentPicked: @escaping (ManagedStagedFile, String) -> Void,
+            onError: @escaping (Error) -> Void,
+            stageDocument: @escaping (URL) throws -> ManagedStagedFile = {
+                try ManagedFileStore.shared.stage(
+                    sourceURL: $0,
+                    maximumSize: Constants.Attachments.maxFileSizeBytes
+                )
+            }
+        ) {
             self.onDocumentPicked = onDocumentPicked
+            self.onError = onError
+            self.stageDocument = stageDocument
         }
 
         func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
             guard let sourceURL = urls.first else { return }
-
-            let fileName = sourceURL.lastPathComponent
 
             guard sourceURL.startAccessingSecurityScopedResource() else {
                 return
             }
             defer { sourceURL.stopAccessingSecurityScopedResource() }
 
+            stageDocument(at: sourceURL)
+        }
+
+        func stageDocument(at sourceURL: URL) {
             do {
-                let stagedFile = try ManagedFileStore.shared.stage(
-                    sourceURL: sourceURL,
-                    maximumSize: Constants.Attachments.maxFileSizeBytes
-                )
-                onDocumentPicked(stagedFile, fileName)
+                let stagedFile = try stageDocument(sourceURL)
+                onDocumentPicked(stagedFile, sourceURL.lastPathComponent)
             } catch {
-                #if DEBUG
-                print("Failed to stage document: \(error)")
-                #endif
+                onError(error)
             }
         }
     }

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -18,7 +18,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
 
     var onDocumentPicked: (ManagedStagedFile, String) -> Void
     var onError: (Error) -> Void
-    var accountLifecycleGeneration: Int
+    var accountLifecycleGeneration: @MainActor () -> Int
     var isAccountLifecycleCurrent: @MainActor (Int) -> Bool
 
     private static let supportedTypes: [UTType] = [
@@ -57,14 +57,14 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     class Coordinator: NSObject, UIDocumentPickerDelegate {
         let onDocumentPicked: (ManagedStagedFile, String) -> Void
         let onError: (Error) -> Void
-        let accountLifecycleGeneration: Int
+        let accountLifecycleGeneration: @MainActor () -> Int
         let isAccountLifecycleCurrent: (Int) -> Bool
         private let stageDocument: @Sendable (URL) throws -> ManagedStagedFile
 
         init(
             onDocumentPicked: @escaping (ManagedStagedFile, String) -> Void,
             onError: @escaping (Error) -> Void,
-            accountLifecycleGeneration: Int,
+            accountLifecycleGeneration: @escaping @MainActor () -> Int,
             isAccountLifecycleCurrent: @escaping (Int) -> Bool,
             stageDocument: @escaping @Sendable (URL) throws -> ManagedStagedFile = {
                 try ManagedFileStore.shared.stage(
@@ -95,6 +95,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
         func stageDocument(at sourceURL: URL) async {
             let fileName = sourceURL.lastPathComponent
             let stageDocument = stageDocument
+            let accountLifecycleGeneration = accountLifecycleGeneration()
             let result = await Task.detached(priority: .userInitiated) {
                 defer { sourceURL.stopAccessingSecurityScopedResource() }
                 return Result { try stageDocument(sourceURL) }

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -8,6 +8,14 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct DocumentPickerView: UIViewControllerRepresentable {
+    enum PickerError: LocalizedError {
+        case accessDenied
+
+        var errorDescription: String? {
+            "Tinfoil could not access the selected file."
+        }
+    }
+
     var onDocumentPicked: (ManagedStagedFile, String) -> Void
     var onError: (Error) -> Void
 
@@ -41,12 +49,12 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     class Coordinator: NSObject, UIDocumentPickerDelegate {
         let onDocumentPicked: (ManagedStagedFile, String) -> Void
         let onError: (Error) -> Void
-        private let stageDocument: (URL) throws -> ManagedStagedFile
+        private let stageDocument: @Sendable (URL) throws -> ManagedStagedFile
 
         init(
             onDocumentPicked: @escaping (ManagedStagedFile, String) -> Void,
             onError: @escaping (Error) -> Void,
-            stageDocument: @escaping (URL) throws -> ManagedStagedFile = {
+            stageDocument: @escaping @Sendable (URL) throws -> ManagedStagedFile = {
                 try ManagedFileStore.shared.stage(
                     sourceURL: $0,
                     maximumSize: Constants.Attachments.maxFileSizeBytes
@@ -62,18 +70,25 @@ struct DocumentPickerView: UIViewControllerRepresentable {
             guard let sourceURL = urls.first else { return }
 
             guard sourceURL.startAccessingSecurityScopedResource() else {
+                onError(PickerError.accessDenied)
                 return
             }
-            defer { sourceURL.stopAccessingSecurityScopedResource() }
-
-            stageDocument(at: sourceURL)
+            Task {
+                await stageDocument(at: sourceURL)
+            }
         }
 
-        func stageDocument(at sourceURL: URL) {
-            do {
-                let stagedFile = try stageDocument(sourceURL)
-                onDocumentPicked(stagedFile, sourceURL.lastPathComponent)
-            } catch {
+        func stageDocument(at sourceURL: URL) async {
+            let fileName = sourceURL.lastPathComponent
+            let stageDocument = stageDocument
+            let result = await Task.detached(priority: .userInitiated) {
+                defer { sourceURL.stopAccessingSecurityScopedResource() }
+                return Result { try stageDocument(sourceURL) }
+            }.value
+            switch result {
+            case .success(let stagedFile):
+                onDocumentPicked(stagedFile, fileName)
+            case .failure(let error):
                 onError(error)
             }
         }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -283,8 +283,8 @@ struct MessageInputView: View {
                 Text(viewModel.attachmentError ?? "An error occurred")
             }
             .sheet(isPresented: $viewModel.showDocumentPicker) {
-                DocumentPickerView { url, fileName in
-                    viewModel.addDocumentAttachment(url: url, fileName: fileName)
+                DocumentPickerView { file, fileName in
+                    viewModel.addDocumentAttachment(file: file, fileName: fileName)
                 }
             }
             .sheet(isPresented: $viewModel.showPhotoPicker, onDismiss: processSelectedPhotos) {
@@ -512,7 +512,7 @@ struct MessageInputView: View {
                          onFocusHandled: { viewModel.shouldFocusInput = false },
                          onSendMessage: { text in viewModel.sendMessage(text: text) },
                          onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                         onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
+                         onPasteFile: { file, fileName in viewModel.addDocumentAttachment(file: file, fileName: fileName) },
                          onPasteFileError: { message in viewModel.attachmentError = message })
             .frame(height: textHeight)
             .padding(.horizontal)
@@ -1403,7 +1403,7 @@ struct CustomTextEditor: UIViewRepresentable {
     /// itself when the draft was actually sent or queued.
     var onSendMessage: (String) -> Bool
     var onPasteImage: ((Data, String) -> Void)? = nil
-    var onPasteFile: ((URL, String) -> Void)? = nil
+    var onPasteFile: ((ManagedStagedFile, String) -> Void)? = nil
     var onPasteFileError: ((String) -> Void)? = nil
 
     func makeUIView(context: Context) -> UITextView {
@@ -1696,7 +1696,7 @@ struct CustomTextEditor: UIViewRepresentable {
 final class PastingTextView: UITextView {
     var allowsImagePaste = false
     var onPasteImage: ((Data, String) -> Void)?
-    var onPasteFile: ((URL, String) -> Void)?
+    var onPasteFile: ((ManagedStagedFile, String) -> Void)?
     var onPasteFileError: ((String) -> Void)?
 
     /// File URLs win over any string representation on the pasteboard:
@@ -1766,28 +1766,21 @@ final class PastingTextView: UITextView {
         super.paste(sender)
     }
 
-    /// Copies a pasted file into the app's temp directory so the attachment
+    /// Copies a pasted file into app-owned staging so the attachment
     /// pipeline can read it after the pasteboard's access window closes.
     /// Oversized files are rejected up front: the pipeline would refuse them
     /// anyway, and copying or reading them first would waste disk and memory.
-    private func importPastedFile(url: URL, onPasteFile: (URL, String) -> Void) {
+    private func importPastedFile(url: URL, onPasteFile: (ManagedStagedFile, String) -> Void) {
         let fileName = url.lastPathComponent
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + "_" + fileName)
         let didAccess = url.startAccessingSecurityScopedResource()
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
 
-        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-           Int64(fileSize) > Constants.Attachments.maxFileSizeBytes {
-            let message = DocumentProcessingService.ProcessingError
-                .fileTooLarge(Int64(fileSize)).errorDescription
-            onPasteFileError?(message ?? "File is too large.")
-            return
-        }
-
         do {
-            try FileManager.default.copyItem(at: url, to: tempURL)
-            onPasteFile(tempURL, fileName)
+            let file = try ManagedFileStore.shared.stage(
+                sourceURL: url,
+                maximumSize: Constants.Attachments.maxFileSizeBytes
+            )
+            onPasteFile(file, fileName)
         } catch {
             onPasteFileError?("Couldn't read the pasted file. Try attaching it with the + button instead.")
         }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -517,8 +517,7 @@ struct MessageInputView: View {
                          onFocusHandled: { viewModel.shouldFocusInput = false },
                          onSendMessage: { text in viewModel.sendMessage(text: text) },
                          onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                         onPasteFile: { file, fileName in viewModel.addDocumentAttachment(file: file, fileName: fileName) },
-                         onPasteFileError: { message in viewModel.attachmentError = message })
+                         onPasteFiles: { urls in viewModel.stagePastedDocuments(urls: urls) })
             .frame(height: textHeight)
             .padding(.horizontal)
     }
@@ -1408,15 +1407,13 @@ struct CustomTextEditor: UIViewRepresentable {
     /// itself when the draft was actually sent or queued.
     var onSendMessage: (String) -> Bool
     var onPasteImage: ((Data, String) -> Void)? = nil
-    var onPasteFile: ((ManagedStagedFile, String) -> Void)? = nil
-    var onPasteFileError: ((String) -> Void)? = nil
+    var onPasteFiles: (([URL]) -> Void)? = nil
 
     func makeUIView(context: Context) -> UITextView {
         let textView = PastingTextView()
         textView.allowsImagePaste = allowsImagePaste
         textView.onPasteImage = onPasteImage
-        textView.onPasteFile = onPasteFile
-        textView.onPasteFileError = onPasteFileError
+        textView.onPasteFiles = onPasteFiles
         textView.delegate = context.coordinator
         textView.font = UIFont.preferredFont(forTextStyle: .body)
         textView.backgroundColor = .clear
@@ -1456,8 +1453,7 @@ struct CustomTextEditor: UIViewRepresentable {
         if let pastingView = uiView as? PastingTextView {
             pastingView.allowsImagePaste = allowsImagePaste
             pastingView.onPasteImage = onPasteImage
-            pastingView.onPasteFile = onPasteFile
-            pastingView.onPasteFileError = onPasteFileError
+            pastingView.onPasteFiles = onPasteFiles
         }
         let isCurrentlyEditing = context.coordinator.isEditing
 
@@ -1701,8 +1697,7 @@ struct CustomTextEditor: UIViewRepresentable {
 final class PastingTextView: UITextView {
     var allowsImagePaste = false
     var onPasteImage: ((Data, String) -> Void)?
-    var onPasteFile: ((ManagedStagedFile, String) -> Void)?
-    var onPasteFileError: ((String) -> Void)?
+    var onPasteFiles: (([URL]) -> Void)?
 
     /// File URLs win over any string representation on the pasteboard:
     /// copying a file (e.g. from the Files app) often includes its name as
@@ -1736,7 +1731,7 @@ final class PastingTextView: UITextView {
             if allowsImagePaste && onPasteImage != nil && pasteboardState().hasImages {
                 return true
             }
-            if onPasteFile != nil && pasteboardState().hasFileURLs {
+            if onPasteFiles != nil && pasteboardState().hasFileURLs {
                 return true
             }
         }
@@ -1758,49 +1753,14 @@ final class PastingTextView: UITextView {
             return
         }
 
-        if let onPasteFile {
+        if let onPasteFiles {
             let fileURLs = pasteboardFileURLs
             if !fileURLs.isEmpty {
-                for url in fileURLs {
-                    importPastedFile(url: url, onPasteFile: onPasteFile)
-                }
+                onPasteFiles(fileURLs)
                 return
             }
         }
 
         super.paste(sender)
     }
-
-    /// Copies a pasted file into app-owned staging so the attachment
-    /// pipeline can read it after the pasteboard's access window closes.
-    /// Oversized files are rejected up front: the pipeline would refuse them
-    /// anyway, and copying or reading them first would waste disk and memory.
-    private func importPastedFile(url: URL, onPasteFile: @escaping (ManagedStagedFile, String) -> Void) {
-        let fileName = url.lastPathComponent
-        let didAccess = url.startAccessingSecurityScopedResource()
-        Task { @MainActor [weak self] in
-            let result = await Task.detached(priority: .userInitiated) {
-                defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-                return Result {
-                    try ManagedFileStore.shared.stage(
-                        sourceURL: url,
-                        maximumSize: Constants.Attachments.maxFileSizeBytes
-                    )
-                }
-            }.value
-            switch result {
-            case .success(let file):
-                onPasteFile(file, fileName)
-            case .failure(let error):
-                if let boundedError = error as? BoundedFileIOError,
-                   case .fileTooLarge(let size, _) = boundedError {
-                    self?.onPasteFileError?(
-                        DocumentProcessingService.ProcessingError.fileTooLarge(size).localizedDescription
-                    )
-                } else {
-                    self?.onPasteFileError?("Couldn't read the pasted file. Try attaching it with the + button instead.")
-                }
-            }
-        }
-    }
-} 
+}

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -283,9 +283,14 @@ struct MessageInputView: View {
                 Text(viewModel.attachmentError ?? "An error occurred")
             }
             .sheet(isPresented: $viewModel.showDocumentPicker) {
-                DocumentPickerView { file, fileName in
-                    viewModel.addDocumentAttachment(file: file, fileName: fileName)
-                }
+                DocumentPickerView(
+                    onDocumentPicked: { file, fileName in
+                        viewModel.addDocumentAttachment(file: file, fileName: fileName)
+                    },
+                    onError: { error in
+                        viewModel.attachmentError = error.localizedDescription
+                    }
+                )
             }
             .sheet(isPresented: $viewModel.showPhotoPicker, onDismiss: processSelectedPhotos) {
                 NavigationStack {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1775,19 +1775,32 @@ final class PastingTextView: UITextView {
     /// pipeline can read it after the pasteboard's access window closes.
     /// Oversized files are rejected up front: the pipeline would refuse them
     /// anyway, and copying or reading them first would waste disk and memory.
-    private func importPastedFile(url: URL, onPasteFile: (ManagedStagedFile, String) -> Void) {
+    private func importPastedFile(url: URL, onPasteFile: @escaping (ManagedStagedFile, String) -> Void) {
         let fileName = url.lastPathComponent
         let didAccess = url.startAccessingSecurityScopedResource()
-        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-
-        do {
-            let file = try ManagedFileStore.shared.stage(
-                sourceURL: url,
-                maximumSize: Constants.Attachments.maxFileSizeBytes
-            )
-            onPasteFile(file, fileName)
-        } catch {
-            onPasteFileError?("Couldn't read the pasted file. Try attaching it with the + button instead.")
+        Task { @MainActor [weak self] in
+            let result = await Task.detached(priority: .userInitiated) {
+                defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                return Result {
+                    try ManagedFileStore.shared.stage(
+                        sourceURL: url,
+                        maximumSize: Constants.Attachments.maxFileSizeBytes
+                    )
+                }
+            }.value
+            switch result {
+            case .success(let file):
+                onPasteFile(file, fileName)
+            case .failure(let error):
+                if let boundedError = error as? BoundedFileIOError,
+                   case .fileTooLarge(let size, _) = boundedError {
+                    self?.onPasteFileError?(
+                        DocumentProcessingService.ProcessingError.fileTooLarge(size).localizedDescription
+                    )
+                } else {
+                    self?.onPasteFileError?("Couldn't read the pasted file. Try attaching it with the + button instead.")
+                }
+            }
         }
     }
 } 

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -291,7 +291,7 @@ struct MessageInputView: View {
                     onError: { error in
                         viewModel.attachmentError = error.localizedDescription
                     },
-                    accountLifecycleGeneration: viewModel.accountLifecycleGeneration,
+                    accountLifecycleGeneration: { viewModel.accountLifecycleGeneration },
                     isAccountLifecycleCurrent: viewModel.isCurrentAccountLifecycle
                 )
             }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -289,7 +289,9 @@ struct MessageInputView: View {
                     },
                     onError: { error in
                         viewModel.attachmentError = error.localizedDescription
-                    }
+                    },
+                    accountLifecycleGeneration: viewModel.accountLifecycleGeneration,
+                    isAccountLifecycleCurrent: viewModel.isCurrentAccountLifecycle
                 )
             }
             .sheet(isPresented: $viewModel.showPhotoPicker, onDismiss: processSelectedPhotos) {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -215,6 +215,7 @@ struct MessageInputView: View {
 
 
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    @State private var photoPickerAccountGeneration: Int?
     @State private var pendingPickerAction: PickerAction?
     @State private var showCameraPermissionAlert = false
 
@@ -325,7 +326,7 @@ struct MessageInputView: View {
                 pendingPickerAction = nil
                 switch action {
                 case .camera: requestCameraAccess()
-                case .photos: viewModel.showPhotoPicker = true
+                case .photos: presentPhotoPicker()
                 case .files: viewModel.showDocumentPicker = true
                 }
             }) {
@@ -798,8 +799,10 @@ struct MessageInputView: View {
 
     private func processSelectedPhotos() {
         let items = selectedPhotoItems
-        let accountGeneration = viewModel.accountLifecycleGeneration
+        let accountGeneration = photoPickerAccountGeneration
         selectedPhotoItems = []
+        photoPickerAccountGeneration = nil
+        guard let accountGeneration else { return }
         for (index, item) in items.enumerated() {
             Task {
                 if let data = try? await item.loadTransferable(type: Data.self) {
@@ -809,6 +812,12 @@ struct MessageInputView: View {
                 }
             }
         }
+    }
+
+    private func presentPhotoPicker() {
+        selectedPhotoItems = []
+        photoPickerAccountGeneration = viewModel.accountLifecycleGeneration
+        viewModel.showPhotoPicker = true
     }
 
     private func handleAudioButtonTap() {

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -798,10 +798,12 @@ struct MessageInputView: View {
 
     private func processSelectedPhotos() {
         let items = selectedPhotoItems
+        let accountGeneration = viewModel.accountLifecycleGeneration
         selectedPhotoItems = []
         for (index, item) in items.enumerated() {
             Task {
                 if let data = try? await item.loadTransferable(type: Data.self) {
+                    guard viewModel.isCurrentAccountLifecycle(accountGeneration) else { return }
                     let fileName = items.count > 1 ? "Photo \(index + 1).jpg" : "Photo.jpg"
                     viewModel.addImageAttachment(data: data, fileName: fileName)
                 }

--- a/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
+++ b/TinfoilChat/Views/PasskeyRecoveryChoiceView.swift
@@ -22,6 +22,7 @@ struct PasskeyRecoveryChoiceView: View {
 
     @State private var isLoading = false
     @State private var loadingAction: LoadingAction?
+    @State private var showStartFreshConfirmation = false
 
     private enum LoadingAction {
         case tryAgain
@@ -80,7 +81,7 @@ struct PasskeyRecoveryChoiceView: View {
                 .disabled(isLoading)
 
                 // Start Fresh — new key + new passkey
-                Button(action: handleStartFresh) {
+                Button(action: { showStartFreshConfirmation = true }) {
                     Group {
                         if loadingAction == .startFresh {
                             ProgressView()
@@ -132,6 +133,12 @@ struct PasskeyRecoveryChoiceView: View {
         .presentationDetents([.height(520)])
         .presentationDragIndicator(.visible)
         .interactiveDismissDisabled(isLoading)
+        .alert("You will lose your conversations", isPresented: $showStartFreshConfirmation) {
+            Button("Yes, start fresh", role: .destructive, action: handleStartFresh)
+            Button("Go Back", role: .cancel) {}
+        } message: {
+            Text("Starting fresh will generate a new encryption key that is not compatible with your existing one. Your existing encrypted cloud data will be deleted. All your conversations and settings encrypted with the old key will be lost.")
+        }
     }
 
     // MARK: - Actions

--- a/TinfoilChat/Views/ProjectFolderIcon.swift
+++ b/TinfoilChat/Views/ProjectFolderIcon.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ProjectFolderIcon: View {
+    let color: String?
+    var size: CGFloat = 28
+
+    private var tint: Color {
+        Color.projectColor(color)
+    }
+
+    var body: some View {
+        Image(systemName: "folder.fill")
+            .font(.system(size: size * 0.5, weight: .medium))
+            .foregroundColor(tint)
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: size * 0.25)
+                    .fill(tint.opacity(0.12))
+            )
+    }
+}

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -395,6 +395,14 @@ struct ProjectDocumentsView: View {
                 }
             )
         }
+        .alert("Project Error", isPresented: Binding(
+            get: { viewModel.projectError != nil },
+            set: { if !$0 { viewModel.projectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.projectError ?? "An error occurred")
+        }
     }
 
     private func documentRow(_ document: ProjectDocument) -> some View {

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -386,10 +386,8 @@ struct ProjectDocumentsView: View {
             }
         }
         .sheet(isPresented: $showDocumentPicker) {
-            DocumentPickerView { url, fileName in
-                Task {
-                    await viewModel.uploadProjectDocument(url: url, filename: fileName)
-                }
+            DocumentPickerView { file, fileName in
+                viewModel.uploadProjectDocument(file: file, filename: fileName)
             }
         }
     }

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -357,6 +357,7 @@ struct ProjectDocumentsView: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var viewModel: TinfoilChat.ChatViewModel
     @State private var showDocumentPicker = false
+    @State private var uploadDestination: ChatViewModel.ProjectDocumentUploadDestination?
 
     var body: some View {
         Form {
@@ -393,7 +394,8 @@ struct ProjectDocumentsView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
-                    showDocumentPicker = true
+                    uploadDestination = viewModel.projectDocumentUploadDestination
+                    showDocumentPicker = uploadDestination != nil
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -401,17 +403,23 @@ struct ProjectDocumentsView: View {
                 .accessibilityLabel("Add document")
             }
         }
-        .sheet(isPresented: $showDocumentPicker) {
-            DocumentPickerView(
-                onDocumentPicked: { file, fileName in
-                    viewModel.uploadProjectDocument(file: file, filename: fileName)
-                },
+        .sheet(isPresented: $showDocumentPicker, onDismiss: { uploadDestination = nil }) {
+            if let uploadDestination {
+                DocumentPickerView(
+                    onDocumentPicked: { file, fileName in
+                        viewModel.uploadProjectDocument(
+                            file: file,
+                            filename: fileName,
+                            destination: uploadDestination
+                        )
+                    },
                     onError: { error in
                         viewModel.projectDocumentError = error.localizedDescription
                     },
                     accountLifecycleGeneration: viewModel.accountLifecycleGeneration,
                     isAccountLifecycleCurrent: viewModel.isCurrentAccountLifecycle
                 )
+            }
         }
         .alert("Project Error", isPresented: Binding(
             get: { viewModel.projectDocumentError != nil },

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -406,10 +406,12 @@ struct ProjectDocumentsView: View {
                 onDocumentPicked: { file, fileName in
                     viewModel.uploadProjectDocument(file: file, filename: fileName)
                 },
-                onError: { error in
-                    viewModel.projectDocumentError = error.localizedDescription
-                }
-            )
+                    onError: { error in
+                        viewModel.projectDocumentError = error.localizedDescription
+                    },
+                    accountLifecycleGeneration: viewModel.accountLifecycleGeneration,
+                    isAccountLifecycleCurrent: viewModel.isCurrentAccountLifecycle
+                )
         }
         .alert("Project Error", isPresented: Binding(
             get: { viewModel.projectDocumentError != nil },

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -386,9 +386,14 @@ struct ProjectDocumentsView: View {
             }
         }
         .sheet(isPresented: $showDocumentPicker) {
-            DocumentPickerView { file, fileName in
-                viewModel.uploadProjectDocument(file: file, filename: fileName)
-            }
+            DocumentPickerView(
+                onDocumentPicked: { file, fileName in
+                    viewModel.uploadProjectDocument(file: file, filename: fileName)
+                },
+                onError: { error in
+                    viewModel.projectError = error.localizedDescription
+                }
+            )
         }
     }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -418,7 +418,7 @@ struct ProjectDocumentsView: View {
                     onError: { error in
                         viewModel.projectDocumentError = error.localizedDescription
                     },
-                    accountLifecycleGeneration: viewModel.accountLifecycleGeneration,
+                    accountLifecycleGeneration: { viewModel.accountLifecycleGeneration },
                     isAccountLifecycleCurrent: viewModel.isCurrentAccountLifecycle
                 )
             }

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -122,6 +122,14 @@ struct ProjectPage: View {
                 deletingChatId = nil
             }
         }
+        .alert("Project Error", isPresented: Binding(
+            get: { viewModel.projectError != nil },
+            set: { if !$0 { viewModel.projectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.projectError ?? "An error occurred")
+        }
     }
 
     private func syncEditingName() {
@@ -310,6 +318,14 @@ struct ProjectDetailsView: View {
         }
         .onAppear(perform: syncEditingState)
         .onChange(of: project?.id) { _, _ in syncEditingState() }
+        .alert("Project Error", isPresented: Binding(
+            get: { viewModel.projectError != nil },
+            set: { if !$0 { viewModel.projectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.projectError ?? "An error occurred")
+        }
     }
 
     private func saveChanges() {
@@ -391,17 +407,17 @@ struct ProjectDocumentsView: View {
                     viewModel.uploadProjectDocument(file: file, filename: fileName)
                 },
                 onError: { error in
-                    viewModel.projectError = error.localizedDescription
+                    viewModel.projectDocumentError = error.localizedDescription
                 }
             )
         }
         .alert("Project Error", isPresented: Binding(
-            get: { viewModel.projectError != nil },
-            set: { if !$0 { viewModel.projectError = nil } }
+            get: { viewModel.projectDocumentError != nil },
+            set: { if !$0 { viewModel.projectDocumentError = nil } }
         )) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text(viewModel.projectError ?? "An error occurred")
+            Text(viewModel.projectDocumentError ?? "An error occurred")
         }
     }
 
@@ -489,6 +505,14 @@ struct ProjectSettingsView: View {
             }
         } message: {
             Text("This deletes the project and its project context documents.")
+        }
+        .alert("Project Error", isPresented: Binding(
+            get: { viewModel.projectError != nil },
+            set: { if !$0 { viewModel.projectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.projectError ?? "An error occurred")
         }
     }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -27,9 +27,7 @@ struct ProjectPage: View {
                 if let project {
                     Section {
                         HStack(spacing: 12) {
-                            Image(systemName: "folder.fill")
-                                .font(.title3)
-                                .foregroundColor(.accentColor)
+                            ProjectFolderIcon(color: project.color, size: 32)
                             VStack(alignment: .leading, spacing: 2) {
                                 TextField("Project name", text: $editingName)
                                     .font(.headline)
@@ -232,7 +230,11 @@ struct ProjectPage: View {
                         await viewModel.moveChatToProject(chatId: chat.id, projectId: destination.id)
                     }
                 } label: {
-                    Label("Move to \(destination.name)", systemImage: "folder")
+                    Label {
+                        Text("Move to \(destination.name)")
+                    } icon: {
+                        ProjectFolderIcon(color: destination.color, size: 22)
+                    }
                 }
             }
         }

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -816,6 +816,7 @@ struct SettingsView: View {
             setDeleting: { isDeletingAllChats = $0 }
         ) {
             try await chatViewModel.deleteAllChats()
+            return .deleted
         }
     }
 
@@ -839,7 +840,7 @@ struct SettingsView: View {
         phrase: String,
         itemsName: String,
         setDeleting: @escaping (Bool) -> Void,
-        delete: @escaping () async throws -> Void
+        delete: @escaping () async throws -> ChatViewModel.DeleteAllProjectsOutcome
     ) {
         guard typed.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == phrase else {
             dataActionMessage = "Deletion cancelled: the confirmation phrase didn't match."
@@ -848,8 +849,10 @@ struct SettingsView: View {
         setDeleting(true)
         Task {
             do {
-                try await delete()
-                dataActionMessage = "All \(itemsName) have been deleted."
+                let outcome = try await delete()
+                if outcome == .deleted {
+                    dataActionMessage = "All \(itemsName) have been deleted."
+                }
             } catch is CancellationError {
                 dataActionMessage = "Deletion cancelled before a request could be completed."
             } catch {

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -816,7 +816,6 @@ struct SettingsView: View {
             setDeleting: { isDeletingAllChats = $0 }
         ) {
             try await chatViewModel.deleteAllChats()
-            return .deleted
         }
     }
 
@@ -840,7 +839,7 @@ struct SettingsView: View {
         phrase: String,
         itemsName: String,
         setDeleting: @escaping (Bool) -> Void,
-        delete: @escaping () async throws -> ChatViewModel.DeleteAllProjectsOutcome
+        delete: @escaping () async throws -> ChatViewModel.DeleteAllDataOutcome
     ) {
         guard typed.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == phrase else {
             dataActionMessage = "Deletion cancelled: the confirmation phrase didn't match."
@@ -850,8 +849,13 @@ struct SettingsView: View {
         Task {
             do {
                 let outcome = try await delete()
-                if outcome == .deleted {
+                switch outcome {
+                case .deleted:
                     dataActionMessage = "All \(itemsName) have been deleted."
+                case .accountChanged:
+                    break
+                case .refreshRequired:
+                    dataActionMessage = "Deletion may have completed. Refresh to confirm."
                 }
             } catch is CancellationError {
                 dataActionMessage = "Deletion cancelled before a request could be completed."

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -850,6 +850,8 @@ struct SettingsView: View {
             do {
                 try await delete()
                 dataActionMessage = "All \(itemsName) have been deleted."
+            } catch is CancellationError {
+                dataActionMessage = "Deletion cancelled before a request could be completed."
             } catch {
                 dataActionMessage = "Failed to delete all \(itemsName). Please try again."
             }
@@ -1073,7 +1075,7 @@ struct SettingsView: View {
         profileUpdateError = nil
         
         do {
-            var updateParams = User.UpdateParams()
+            var updateParams = ClerkKit.User.UpdateParams()
             updateParams.firstName = editingFirstName
             updateParams.lastName = editingLastName
             try await clerk.user?.update(updateParams)

--- a/TinfoilChatTests/AttachmentProcessingTests.swift
+++ b/TinfoilChatTests/AttachmentProcessingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import TinfoilChat
 
@@ -24,5 +25,25 @@ struct AttachmentProcessingTests {
         #expect(attachmentsAreReadyToSend([completed]))
         #expect(!attachmentsAreReadyToSend([completed, processing]))
         #expect(!attachmentsAreReadyToSend([failed]))
+    }
+
+    @Test("Oversized PDFs use the document size error")
+    func oversizedPDFUsesDocumentSizeError() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString.lowercased()).pdf")
+        FileManager.default.createFile(atPath: url.path, contents: Data())
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: UInt64(Constants.Attachments.maxFileSizeBytes + 1))
+        try handle.close()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            _ = try await DocumentProcessingService.shared.extractText(from: url)
+            Issue.record("Expected an oversized document error")
+        } catch DocumentProcessingService.ProcessingError.fileTooLarge(let size) {
+            #expect(size == Constants.Attachments.maxFileSizeBytes + 1)
+        } catch {
+            Issue.record("Expected ProcessingError.fileTooLarge, got \(error)")
+        }
     }
 }

--- a/TinfoilChatTests/AttachmentProcessingTests.swift
+++ b/TinfoilChatTests/AttachmentProcessingTests.swift
@@ -32,10 +32,10 @@ struct AttachmentProcessingTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString.lowercased()).pdf")
         FileManager.default.createFile(atPath: url.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: url) }
         let handle = try FileHandle(forWritingTo: url)
         try handle.truncate(atOffset: UInt64(Constants.Attachments.maxFileSizeBytes + 1))
         try handle.close()
-        defer { try? FileManager.default.removeItem(at: url) }
 
         do {
             _ = try await DocumentProcessingService.shared.extractText(from: url)

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -43,14 +43,51 @@ struct DataLifecycleSourceTests {
     func attachmentRemovalAndSignOutCancelProcessing() throws {
         let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let removal = try functionBody(named: "func removePendingAttachment", in: source)
+        let clearing = try functionBody(named: "func clearPendingAttachments", in: source)
         let signOut = try functionBody(named: "func handleSignOut()", in: source)
 
-        #expect(removal.contains("attachmentProcessingTasks.removeValue(forKey: id)?.cancel()"))
-        #expect(removal.contains("managedAttachmentFiles.removeValue(forKey: id)?.discard()"))
+        #expect(removal.contains("attachmentProcessingTasks[id]"))
+        #expect(removal.contains("task.cancel()"))
+        #expect(clearing.contains("attachmentProcessingGeneration += 1"))
+        #expect(clearing.contains("for task in tasks { task.cancel() }"))
         #expect(signOut.contains("clearPendingAttachments()"))
         #expect(signOut.contains("discardMessageQueue(chatId: chatId)"))
         #expect(signOut.contains("SharedImportCoordinator.shared.discardAllPending()"))
         #expect(signOut.contains("await task.value"))
+    }
+
+    @Test("Project uploads are canceled before context changes")
+    func projectUploadsAreCanceledBeforeContextChanges() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let bulkDelete = try functionBody(named: "func deleteAllProjects()", in: source)
+        let singleDelete = try functionBody(named: "func deleteActiveProject()", in: source)
+        let leaveProject = try functionBody(named: "func leaveProjectContext()", in: source)
+        let upload = try functionBody(named: "func uploadProjectDocument", in: source)
+
+        #expect(bulkDelete.contains("await cancelAndAwaitProjectUploads()"))
+        #expect(singleDelete.contains("await cancelAndAwaitProjectUploads()"))
+        #expect(leaveProject.contains("await cancelAndAwaitProjectUploads()"))
+        #expect(upload.contains("projectUploadBarrierCount == 0"))
+        #expect(upload.contains("activeProject?.id == projectId"))
+        #expect(upload.contains("isCurrentProjectAccount(accountGeneration)"))
+        #expect(upload.contains("file.discard()"))
+    }
+
+    @Test("Document cancellation waits for extraction before discard")
+    func documentCancellationWaitsForExtractionBeforeDiscard() throws {
+        let processingSource = try sourceFile("TinfoilChat/Services/DocumentProcessingService.swift")
+        let viewModelSource = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let extraction = try functionBody(named: "func extractText(from url", in: processingSource)
+        let attachment = try functionBody(named: "func addDocumentAttachment", in: viewModelSource)
+
+        #expect(extraction.contains("withTaskCancellationHandler"))
+        #expect(extraction.contains("extractionTask.cancel()"))
+        #expect(extraction.contains("try await extractionTask.value"))
+        let extractionCall = try #require(attachment.range(of: "extractText(from: file.url)"))
+        let deferredCleanup = try #require(attachment.range(of: "defer {"))
+        let cleanup = attachment[deferredCleanup.lowerBound..<extractionCall.lowerBound]
+        #expect(cleanup.contains("file.discard()"))
+        #expect(attachment.contains("processingGeneration == attachmentProcessingGeneration"))
     }
 
     private func sourceFile(_ relativePath: String) throws -> String {

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -73,6 +73,20 @@ struct DataLifecycleSourceTests {
         #expect(upload.contains("file.discard()"))
     }
 
+    @Test("Root selection is revalidated after project upload cancellation")
+    func rootSelectionIsRevalidatedAfterProjectUploadCancellation() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let leaveProject = try functionBody(named: "func leaveProjectContext", in: source)
+        let openSearchResult = try functionBody(named: "func openSearchResult", in: source)
+
+        let cancellation = try #require(leaveProject.range(of: "await cancelAndAwaitProjectUploads()"))
+        let validation = try #require(leaveProject.range(of: "guard validateOperation()"))
+        #expect(cancellation.lowerBound < validation.lowerBound)
+        #expect(openSearchResult.contains("leaveProjectContext(validateOperation:"))
+        #expect(openSearchResult.contains("self.currentUserId == userId"))
+        #expect(openSearchResult.contains("self.chatSelectionFence.accepts("))
+    }
+
     @Test("Document cancellation waits for extraction before discard")
     func documentCancellationWaitsForExtractionBeforeDiscard() throws {
         let processingSource = try sourceFile("TinfoilChat/Services/DocumentProcessingService.swift")
@@ -83,11 +97,38 @@ struct DataLifecycleSourceTests {
         #expect(extraction.contains("withTaskCancellationHandler"))
         #expect(extraction.contains("extractionTask.cancel()"))
         #expect(extraction.contains("try await extractionTask.value"))
+        #expect(extraction.contains("return try self.extractTextFromPDF(at: url)"))
+        #expect(extraction.contains("return try self.readPlainText(at: url)"))
         let extractionCall = try #require(attachment.range(of: "extractText(from: file.url)"))
         let deferredCleanup = try #require(attachment.range(of: "defer {"))
         let cleanup = attachment[deferredCleanup.lowerBound..<extractionCall.lowerBound]
         #expect(cleanup.contains("file.discard()"))
         #expect(attachment.contains("processingGeneration == attachmentProcessingGeneration"))
+    }
+
+    @Test("Async attachment and upload tasks use token-aware registration")
+    func asyncTasksUseTokenAwareRegistration() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let projectUpload = try functionBody(named: "func uploadProjectDocument", in: source)
+        let documentAttachment = try functionBody(named: "func addDocumentAttachment", in: source)
+        let imageAttachment = try functionBody(named: "func addImageAttachment", in: source)
+
+        assertTokenRegistration(
+            in: projectUpload,
+            registration: "projectUploadTokens[operationID] = operationToken",
+            taskCreation: "let task = Task",
+            pendingCheck: "if projectUploadTokens[operationID] == operationToken",
+            taskStorage: "projectUploadTasks[operationID] = task"
+        )
+        for attachment in [documentAttachment, imageAttachment] {
+            assertTokenRegistration(
+                in: attachment,
+                registration: "attachmentProcessingTokens[attachmentId] = operationToken",
+                taskCreation: "let task = Task",
+                pendingCheck: "if attachmentProcessingTokens[attachmentId] == operationToken",
+                taskStorage: "attachmentProcessingTasks[attachmentId] = task"
+            )
+        }
     }
 
     private func sourceFile(_ relativePath: String) throws -> String {
@@ -118,6 +159,25 @@ struct DataLifecycleSourceTests {
             index = source.index(after: index)
         }
         throw SourceTestError.functionNotFound
+    }
+
+    private func assertTokenRegistration(
+        in function: Substring,
+        registration: String,
+        taskCreation: String,
+        pendingCheck: String,
+        taskStorage: String
+    ) {
+        guard let registrationRange = function.range(of: registration),
+              let creationRange = function.range(of: taskCreation),
+              let pendingRange = function.range(of: pendingCheck, options: .backwards),
+              let storageRange = function.range(of: taskStorage, options: .backwards) else {
+            Issue.record("Expected token-aware task registration")
+            return
+        }
+        #expect(registrationRange.lowerBound < creationRange.lowerBound)
+        #expect(creationRange.lowerBound < pendingRange.lowerBound)
+        #expect(pendingRange.lowerBound < storageRange.lowerBound)
     }
 }
 

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -69,6 +69,35 @@ struct DataLifecycleSourceTests {
         #expect(deletion.contains("guard await requestProgress.requestStarted else { throw CancellationError() }"))
         #expect(deletion.contains("return .accountChanged"))
         #expect(deletion.contains("return .refreshRequired"))
+        let cloudGuard = try #require(deletion.range(of: "guard shouldDeleteCloud else { return }", options: .backwards))
+        let cancellation = try #require(deletion.range(of: "try Task.checkCancellation()", range: cloudGuard.upperBound..<deletion.endIndex))
+        #expect(cloudGuard.lowerBound < cancellation.lowerBound)
+    }
+
+    @Test("Document picker captures account state before staging")
+    func documentPickerCapturesAccountStateBeforeStaging() throws {
+        let source = try sourceFile("TinfoilChat/Views/DocumentPickerView.swift")
+        let callback = try functionBody(named: "func documentPicker(", in: source)
+        let staging = try functionBody(named: "func stageDocument(at sourceURL", in: source)
+
+        let capture = try #require(callback.range(of: "let accountLifecycleGeneration = accountLifecycleGeneration()"))
+        let task = try #require(callback.range(of: "Task {"))
+        #expect(capture.lowerBound < task.lowerBound)
+        #expect(callback.contains("accountLifecycleGeneration: accountLifecycleGeneration"))
+        #expect(!staging.contains("accountLifecycleGeneration()"))
+    }
+
+    @Test("Account teardown retry preserves failure until cleanup succeeds")
+    func accountTeardownRetryPreservesFailureUntilCleanupSucceeds() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/AuthManager.swift")
+        let retry = try functionBody(named: "func retryAccountTeardown()", in: source)
+
+        let cleanup = try #require(retry.range(of: "guard await clearAuthState() else { return }"))
+        let revenueCat = try #require(retry.range(of: "await RevenueCatManager.shared.logoutUser()"))
+        let clerk = try #require(retry.range(of: "await initializeAuthState()"))
+        #expect(cleanup.lowerBound < revenueCat.lowerBound)
+        #expect(revenueCat.lowerBound < clerk.lowerBound)
+        #expect(!retry.contains("accountTeardownError = nil"))
     }
 
     @Test("Bulk delete progress starts at network dispatch")

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -41,7 +41,7 @@ struct DataLifecycleSourceTests {
         let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let function = try functionBody(named: "func deleteAllProjects()", in: source)
 
-        let request = try #require(function.range(of: "try await projectStorage.deleteAllProjects()"))
+        let request = try #require(function.range(of: "try await projectStorage.deleteAllProjects(requestProgress: requestProgress)"))
         let clearProjects = try #require(function.range(of: "projects = []"))
         #expect(request.lowerBound < clearProjects.lowerBound)
         #expect(function.contains("projectListLoadGeneration += 1"))
@@ -51,32 +51,48 @@ struct DataLifecycleSourceTests {
         #expect(function.contains("createNewChat(isLocalOnly: false"))
     }
 
-    @Test("Bulk project deletion distinguishes account changes around commit")
-    func bulkProjectDeletionDistinguishesAccountChanges() throws {
+    @Test("Bulk project deletion distinguishes cancellation around dispatch")
+    func bulkProjectDeletionDistinguishesCancellationAroundDispatch() throws {
         let viewModelSource = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let settingsSource = try sourceFile("TinfoilChat/Views/SettingsView.swift")
         let deletion = try functionBody(named: "func deleteAllProjects()", in: viewModelSource)
         let confirmation = try functionBody(named: "private func confirmBulkDelete", in: settingsSource)
 
         let cancellation = try #require(deletion.range(of: "await cancelAndAwaitProjectUploads()"))
-        let request = try #require(deletion.range(of: "try await projectStorage.deleteAllProjects()"))
-        let committedChange = try #require(deletion.range(of: "return .accountChangedAfterCommit"))
+        let request = try #require(deletion.range(of: "try await projectStorage.deleteAllProjects(requestProgress: requestProgress)"))
         let beforeRequest = deletion[cancellation.upperBound..<request.lowerBound]
-        let afterRequest = deletion[request.upperBound..<deletion.endIndex]
         #expect(beforeRequest.contains("throw CancellationError()"))
-        #expect(!afterRequest.contains("throw CancellationError()"))
-        #expect(request.lowerBound < committedChange.lowerBound)
+        #expect(deletion.contains("guard await requestProgress.requestStarted else { throw CancellationError() }"))
+        #expect(deletion.contains("return .accountChanged"))
+        #expect(deletion.contains("return .refreshRequired"))
         #expect(deletion.contains("currentUserId == accountUserId"))
         #expect(confirmation.contains("catch is CancellationError"))
-        #expect(confirmation.contains("if outcome == .deleted"))
+        #expect(confirmation.contains("Deletion may have completed. Refresh to confirm."))
+        #expect(confirmation.contains("case .accountChanged:"))
     }
 
-    @Test("Bulk chat deletion cancels without a current account")
-    func bulkChatDeletionRequiresCurrentAccount() throws {
+    @Test("Bulk chat deletion uses the same request outcome distinction")
+    func bulkChatDeletionDistinguishesCancellationAroundDispatch() throws {
         let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let deletion = try functionBody(named: "func deleteAllChats()", in: source)
 
         #expect(deletion.contains("guard let userId = currentUserId else { throw CancellationError() }"))
+        #expect(deletion.contains("requestProgress: requestProgress"))
+        #expect(deletion.contains("guard await requestProgress.requestStarted else { throw CancellationError() }"))
+        #expect(deletion.contains("return .accountChanged"))
+        #expect(deletion.contains("return .refreshRequired"))
+    }
+
+    @Test("Bulk delete progress starts at network dispatch")
+    func bulkDeleteProgressStartsAtNetworkDispatch() throws {
+        let clientSource = try sourceFile("TinfoilChat/Services/SyncEnclave/SyncEnclaveClient.swift")
+        let post = try functionBody(named: "func post<Response: Decodable>", in: clientSource)
+
+        let token = try #require(post.range(of: "let token = try await requireToken"))
+        let started = try #require(post.range(of: "await requestProgress?.markRequestStarted()", options: [], range: token.upperBound..<post.endIndex))
+        let dispatch = try #require(post.range(of: "var response = try await performPost"))
+        #expect(token.lowerBound < started.lowerBound)
+        #expect(started.lowerBound < dispatch.lowerBound)
     }
 
     @Test("Attachment removal and sign-out cancel processing")

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@Suite("Data Lifecycle Source Tests")
+struct DataLifecycleSourceTests {
+    @Test("Both recovery flows confirm before starting fresh")
+    func recoveryFlowsConfirmBeforeStartingFresh() throws {
+        let onboarding = try sourceFile("TinfoilChat/Views/CloudSyncOnboardingView.swift")
+        let passkey = try sourceFile("TinfoilChat/Views/PasskeyRecoveryChoiceView.swift")
+
+        for source in [onboarding, passkey] {
+            #expect(source.contains("You will lose your conversations"))
+            #expect(source.contains("role: .destructive"))
+            #expect(source.contains("Yes, start fresh"))
+        }
+    }
+
+    @Test("Bulk project deletion uses the atomic endpoint")
+    func bulkProjectDeletionUsesAtomicEndpoint() throws {
+        let source = try sourceFile("TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift")
+
+        #expect(source.contains("/v1/sync/delete-all-projects"))
+        #expect(source.contains("EnclaveDeleteAllProjectsRequest"))
+        #expect(source.contains("EnclaveDeleteAllProjectsResponse"))
+    }
+
+    @Test("Bulk deletion resets project state after the request")
+    func bulkDeletionResetsProjectStateAfterRequest() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let function = try functionBody(named: "func deleteAllProjects()", in: source)
+
+        let request = try #require(function.range(of: "try await projectStorage.deleteAllProjects()"))
+        let clearProjects = try #require(function.range(of: "projects = []"))
+        #expect(request.lowerBound < clearProjects.lowerBound)
+        #expect(function.contains("projectListLoadGeneration += 1"))
+        #expect(function.contains("projectLoadGeneration += 1"))
+        #expect(function.contains("projectDocuments = []"))
+        #expect(function.contains("activeStorageTab = .cloud"))
+        #expect(function.contains("createNewChat(isLocalOnly: false"))
+    }
+
+    @Test("Attachment removal and sign-out cancel processing")
+    func attachmentRemovalAndSignOutCancelProcessing() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let removal = try functionBody(named: "func removePendingAttachment", in: source)
+        let signOut = try functionBody(named: "func handleSignOut()", in: source)
+
+        #expect(removal.contains("attachmentProcessingTasks.removeValue(forKey: id)?.cancel()"))
+        #expect(removal.contains("managedAttachmentFiles.removeValue(forKey: id)?.discard()"))
+        #expect(signOut.contains("clearPendingAttachments()"))
+        #expect(signOut.contains("discardMessageQueue(chatId: chatId)"))
+        #expect(signOut.contains("SharedImportCoordinator.shared.discardAllPending()"))
+        #expect(signOut.contains("await task.value"))
+    }
+
+    private func sourceFile(_ relativePath: String) throws -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let repositoryRoot = testsDirectory.deletingLastPathComponent()
+        return try String(
+            contentsOf: repositoryRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func functionBody(named signature: String, in source: String) throws -> Substring {
+        let start = try #require(source.range(of: signature)?.lowerBound)
+        var depth = 0
+        var foundOpeningBrace = false
+        var index = start
+        while index < source.endIndex {
+            let character = source[index]
+            if character == "{" {
+                foundOpeningBrace = true
+                depth += 1
+            } else if character == "}" && foundOpeningBrace {
+                depth -= 1
+                if depth == 0 {
+                    return source[start...index]
+                }
+            }
+            index = source.index(after: index)
+        }
+        throw SourceTestError.functionNotFound
+    }
+}
+
+private enum SourceTestError: Error {
+    case functionNotFound
+}

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -3,18 +3,6 @@ import Testing
 
 @Suite("Data Lifecycle Source Tests")
 struct DataLifecycleSourceTests {
-    @Test("Sentry imports keep Clerk user types explicit")
-    func sentryImportsKeepClerkUserTypesExplicit() throws {
-        let authSource = try sourceFile("TinfoilChat/ViewModels/AuthManager.swift")
-        let mfaSource = try sourceFile("TinfoilChat/ViewModels/AuthenticatorMFAViewModel.swift")
-        let settingsSource = try sourceFile("TinfoilChat/Views/SettingsView.swift")
-
-        #expect(authSource.contains("import Sentry"))
-        #expect(authSource.contains("from user: ClerkKit.User"))
-        #expect(mfaSource.contains("-> (ClerkKit.User, String)"))
-        #expect(settingsSource.contains("ClerkKit.User.UpdateParams()"))
-    }
-
     @Test("Both recovery flows confirm before starting fresh")
     func recoveryFlowsConfirmBeforeStartingFresh() throws {
         let onboarding = try sourceFile("TinfoilChat/Views/CloudSyncOnboardingView.swift")

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -92,7 +92,7 @@ struct DataLifecycleSourceTests {
         let processingSource = try sourceFile("TinfoilChat/Services/DocumentProcessingService.swift")
         let viewModelSource = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let extraction = try functionBody(named: "func extractText(from url", in: processingSource)
-        let attachment = try functionBody(named: "func addDocumentAttachment", in: viewModelSource)
+        let attachment = try functionBody(named: "func startDocumentProcessing", in: viewModelSource)
 
         #expect(extraction.contains("withTaskCancellationHandler"))
         #expect(extraction.contains("extractionTask.cancel()"))
@@ -110,7 +110,7 @@ struct DataLifecycleSourceTests {
     func asyncTasksUseTokenAwareRegistration() throws {
         let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let projectUpload = try functionBody(named: "func uploadProjectDocument", in: source)
-        let documentAttachment = try functionBody(named: "func addDocumentAttachment", in: source)
+        let documentAttachment = try functionBody(named: "func startDocumentProcessing", in: source)
         let imageAttachment = try functionBody(named: "func addImageAttachment", in: source)
 
         assertTokenRegistration(

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -5,10 +5,14 @@ import Testing
 struct DataLifecycleSourceTests {
     @Test("Sentry imports keep Clerk user types explicit")
     func sentryImportsKeepClerkUserTypesExplicit() throws {
-        let source = try sourceFile("TinfoilChat/ViewModels/AuthManager.swift")
+        let authSource = try sourceFile("TinfoilChat/ViewModels/AuthManager.swift")
+        let mfaSource = try sourceFile("TinfoilChat/ViewModels/AuthenticatorMFAViewModel.swift")
+        let settingsSource = try sourceFile("TinfoilChat/Views/SettingsView.swift")
 
-        #expect(source.contains("import Sentry"))
-        #expect(source.contains("from user: ClerkKit.User"))
+        #expect(authSource.contains("import Sentry"))
+        #expect(authSource.contains("from user: ClerkKit.User"))
+        #expect(mfaSource.contains("-> (ClerkKit.User, String)"))
+        #expect(settingsSource.contains("ClerkKit.User.UpdateParams()"))
     }
 
     @Test("Both recovery flows confirm before starting fresh")
@@ -47,19 +51,32 @@ struct DataLifecycleSourceTests {
         #expect(function.contains("createNewChat(isLocalOnly: false"))
     }
 
-    @Test("Bulk project deletion cancels instead of reporting a skipped request")
-    func bulkProjectDeletionCancelsWhenAccountChanges() throws {
+    @Test("Bulk project deletion distinguishes account changes around commit")
+    func bulkProjectDeletionDistinguishesAccountChanges() throws {
         let viewModelSource = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
         let settingsSource = try sourceFile("TinfoilChat/Views/SettingsView.swift")
         let deletion = try functionBody(named: "func deleteAllProjects()", in: viewModelSource)
         let confirmation = try functionBody(named: "private func confirmBulkDelete", in: settingsSource)
 
         let cancellation = try #require(deletion.range(of: "await cancelAndAwaitProjectUploads()"))
-        let validation = try #require(deletion.range(of: "guard isCurrentProjectAccount(accountGeneration) else { throw CancellationError() }"))
         let request = try #require(deletion.range(of: "try await projectStorage.deleteAllProjects()"))
-        #expect(cancellation.lowerBound < validation.lowerBound)
-        #expect(validation.lowerBound < request.lowerBound)
+        let committedChange = try #require(deletion.range(of: "return .accountChangedAfterCommit"))
+        let beforeRequest = deletion[cancellation.upperBound..<request.lowerBound]
+        let afterRequest = deletion[request.upperBound..<deletion.endIndex]
+        #expect(beforeRequest.contains("throw CancellationError()"))
+        #expect(!afterRequest.contains("throw CancellationError()"))
+        #expect(request.lowerBound < committedChange.lowerBound)
+        #expect(deletion.contains("currentUserId == accountUserId"))
         #expect(confirmation.contains("catch is CancellationError"))
+        #expect(confirmation.contains("if outcome == .deleted"))
+    }
+
+    @Test("Bulk chat deletion cancels without a current account")
+    func bulkChatDeletionRequiresCurrentAccount() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let deletion = try functionBody(named: "func deleteAllChats()", in: source)
+
+        #expect(deletion.contains("guard let userId = currentUserId else { throw CancellationError() }"))
     }
 
     @Test("Attachment removal and sign-out cancel processing")
@@ -96,18 +113,23 @@ struct DataLifecycleSourceTests {
         #expect(upload.contains("file.discard()"))
     }
 
-    @Test("Photo loading validates the captured account before publishing")
-    func photoLoadingValidatesCapturedAccount() throws {
+    @Test("Photo loading validates the presentation account before publishing")
+    func photoLoadingValidatesPresentationAccount() throws {
         let source = try sourceFile("TinfoilChat/Views/MessageInputView.swift")
+        let presentation = try functionBody(named: "private func presentPhotoPicker()", in: source)
         let function = try functionBody(named: "private func processSelectedPhotos()", in: source)
 
-        let capture = try #require(function.range(of: "let accountGeneration = viewModel.accountLifecycleGeneration"))
+        let capture = try #require(presentation.range(of: "photoPickerAccountGeneration = viewModel.accountLifecycleGeneration"))
+        let present = try #require(presentation.range(of: "viewModel.showPhotoPicker = true"))
+        let useCapture = try #require(function.range(of: "let accountGeneration = photoPickerAccountGeneration"))
         let load = try #require(function.range(of: "await item.loadTransferable(type: Data.self)"))
         let validation = try #require(function.range(of: "viewModel.isCurrentAccountLifecycle(accountGeneration)"))
         let publish = try #require(function.range(of: "viewModel.addImageAttachment"))
-        #expect(capture.lowerBound < load.lowerBound)
+        #expect(capture.lowerBound < present.lowerBound)
+        #expect(useCapture.lowerBound < load.lowerBound)
         #expect(load.lowerBound < validation.lowerBound)
         #expect(validation.lowerBound < publish.lowerBound)
+        #expect(!function.contains("viewModel.accountLifecycleGeneration"))
     }
 
     @Test("Project document staging preserves its upload destination")

--- a/TinfoilChatTests/DataLifecycleSourceTests.swift
+++ b/TinfoilChatTests/DataLifecycleSourceTests.swift
@@ -3,6 +3,14 @@ import Testing
 
 @Suite("Data Lifecycle Source Tests")
 struct DataLifecycleSourceTests {
+    @Test("Sentry imports keep Clerk user types explicit")
+    func sentryImportsKeepClerkUserTypesExplicit() throws {
+        let source = try sourceFile("TinfoilChat/ViewModels/AuthManager.swift")
+
+        #expect(source.contains("import Sentry"))
+        #expect(source.contains("from user: ClerkKit.User"))
+    }
+
     @Test("Both recovery flows confirm before starting fresh")
     func recoveryFlowsConfirmBeforeStartingFresh() throws {
         let onboarding = try sourceFile("TinfoilChat/Views/CloudSyncOnboardingView.swift")
@@ -39,6 +47,21 @@ struct DataLifecycleSourceTests {
         #expect(function.contains("createNewChat(isLocalOnly: false"))
     }
 
+    @Test("Bulk project deletion cancels instead of reporting a skipped request")
+    func bulkProjectDeletionCancelsWhenAccountChanges() throws {
+        let viewModelSource = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let settingsSource = try sourceFile("TinfoilChat/Views/SettingsView.swift")
+        let deletion = try functionBody(named: "func deleteAllProjects()", in: viewModelSource)
+        let confirmation = try functionBody(named: "private func confirmBulkDelete", in: settingsSource)
+
+        let cancellation = try #require(deletion.range(of: "await cancelAndAwaitProjectUploads()"))
+        let validation = try #require(deletion.range(of: "guard isCurrentProjectAccount(accountGeneration) else { throw CancellationError() }"))
+        let request = try #require(deletion.range(of: "try await projectStorage.deleteAllProjects()"))
+        #expect(cancellation.lowerBound < validation.lowerBound)
+        #expect(validation.lowerBound < request.lowerBound)
+        #expect(confirmation.contains("catch is CancellationError"))
+    }
+
     @Test("Attachment removal and sign-out cancel processing")
     func attachmentRemovalAndSignOutCancelProcessing() throws {
         let source = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
@@ -71,6 +94,44 @@ struct DataLifecycleSourceTests {
         #expect(upload.contains("activeProject?.id == projectId"))
         #expect(upload.contains("isCurrentProjectAccount(accountGeneration)"))
         #expect(upload.contains("file.discard()"))
+    }
+
+    @Test("Photo loading validates the captured account before publishing")
+    func photoLoadingValidatesCapturedAccount() throws {
+        let source = try sourceFile("TinfoilChat/Views/MessageInputView.swift")
+        let function = try functionBody(named: "private func processSelectedPhotos()", in: source)
+
+        let capture = try #require(function.range(of: "let accountGeneration = viewModel.accountLifecycleGeneration"))
+        let load = try #require(function.range(of: "await item.loadTransferable(type: Data.self)"))
+        let validation = try #require(function.range(of: "viewModel.isCurrentAccountLifecycle(accountGeneration)"))
+        let publish = try #require(function.range(of: "viewModel.addImageAttachment"))
+        #expect(capture.lowerBound < load.lowerBound)
+        #expect(load.lowerBound < validation.lowerBound)
+        #expect(validation.lowerBound < publish.lowerBound)
+    }
+
+    @Test("Project document staging preserves its upload destination")
+    func projectDocumentStagingPreservesDestination() throws {
+        let pageSource = try sourceFile("TinfoilChat/Views/ProjectPage.swift")
+        let viewModelSource = try sourceFile("TinfoilChat/ViewModels/ChatViewModel.swift")
+        let upload = try functionBody(named: "func uploadProjectDocument", in: viewModelSource)
+
+        #expect(pageSource.contains("uploadDestination = viewModel.projectDocumentUploadDestination"))
+        #expect(pageSource.contains("destination: uploadDestination"))
+        #expect(upload.contains("isCurrentProjectAccount(destination.accountGeneration)"))
+        #expect(upload.contains("activeProject?.id == destination.projectId"))
+        #expect(upload.contains("let projectId = destination.projectId"))
+        #expect(upload.contains("file.discard()"))
+    }
+
+    @Test("Share imports prefer file representations over in-memory data")
+    func shareImportsPreferFileRepresentations() throws {
+        let source = try sourceFile("TinfoilShareExtension/ShareViewController.swift")
+        let addToTinfoil = try functionBody(named: "private func addToTinfoil()", in: source)
+
+        let fileLoad = try #require(addToTinfoil.range(of: "provider.loadFileRepresentation"))
+        let fallback = try #require(addToTinfoil.range(of: "loadDataFallback("))
+        #expect(fileLoad.lowerBound < fallback.lowerBound)
     }
 
     @Test("Root selection is revalidated after project upload cancellation")

--- a/TinfoilChatTests/DocumentPickerViewTests.swift
+++ b/TinfoilChatTests/DocumentPickerViewTests.swift
@@ -13,6 +13,8 @@ struct DocumentPickerViewTests {
         let coordinator = DocumentPickerView.Coordinator(
             onDocumentPicked: { _, _ in },
             onError: { receivedError = $0 },
+            accountLifecycleGeneration: 0,
+            isAccountLifecycleCurrent: { $0 == 0 },
             stageDocument: { _ in
                 throw BoundedFileIOError.fileTooLarge(
                     size: expectedSize,
@@ -30,5 +32,33 @@ struct DocumentPickerViewTests {
         }
         #expect(size == expectedSize)
         #expect(maximum == expectedMaximum)
+    }
+
+    @Test("Discards staging completed after an account change")
+    @MainActor
+    func discardsStaleStagingResult() async throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        let sourceURL = rootURL.appendingPathComponent("source.txt")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try Data("old account".utf8).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let store = ManagedFileStore(rootURL: rootURL.appendingPathComponent("staging"))
+        var didPublishResult = false
+        let coordinator = DocumentPickerView.Coordinator(
+            onDocumentPicked: { _, _ in didPublishResult = true },
+            onError: { _ in didPublishResult = true },
+            accountLifecycleGeneration: 1,
+            isAccountLifecycleCurrent: { _ in false },
+            stageDocument: { url in
+                try store.stage(sourceURL: url, maximumSize: 1_024)
+            }
+        )
+
+        await coordinator.stageDocument(at: sourceURL)
+
+        #expect(!didPublishResult)
+        #expect((try FileManager.default.contentsOfDirectory(atPath: store.rootURL.path)).isEmpty)
     }
 }

--- a/TinfoilChatTests/DocumentPickerViewTests.swift
+++ b/TinfoilChatTests/DocumentPickerViewTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Document Picker View Tests")
+struct DocumentPickerViewTests {
+    @Test("Propagates managed staging errors")
+    @MainActor
+    func propagatesManagedStagingErrors() {
+        let expectedSize: Int64 = 2_048
+        let expectedMaximum: Int64 = 1_024
+        var receivedError: Error?
+        let coordinator = DocumentPickerView.Coordinator(
+            onDocumentPicked: { _, _ in },
+            onError: { receivedError = $0 },
+            stageDocument: { _ in
+                throw BoundedFileIOError.fileTooLarge(
+                    size: expectedSize,
+                    maximum: expectedMaximum
+                )
+            }
+        )
+
+        coordinator.stageDocument(at: URL(fileURLWithPath: "/tmp/oversized.txt"))
+
+        guard let error = receivedError as? BoundedFileIOError,
+              case let .fileTooLarge(size, maximum) = error else {
+            Issue.record("Expected an oversized managed staging error")
+            return
+        }
+        #expect(size == expectedSize)
+        #expect(maximum == expectedMaximum)
+    }
+}

--- a/TinfoilChatTests/DocumentPickerViewTests.swift
+++ b/TinfoilChatTests/DocumentPickerViewTests.swift
@@ -13,7 +13,7 @@ struct DocumentPickerViewTests {
         let coordinator = DocumentPickerView.Coordinator(
             onDocumentPicked: { _, _ in },
             onError: { receivedError = $0 },
-            accountLifecycleGeneration: 0,
+            accountLifecycleGeneration: { 0 },
             isAccountLifecycleCurrent: { $0 == 0 },
             stageDocument: { _ in
                 throw BoundedFileIOError.fileTooLarge(
@@ -45,15 +45,15 @@ struct DocumentPickerViewTests {
         defer { try? FileManager.default.removeItem(at: rootURL) }
 
         let store = ManagedFileStore(rootURL: rootURL.appendingPathComponent("staging"))
+        let stagedFile = try store.stage(sourceURL: sourceURL, maximumSize: 1_024)
+        #expect(FileManager.default.fileExists(atPath: stagedFile.url.path))
         var didPublishResult = false
         let coordinator = DocumentPickerView.Coordinator(
             onDocumentPicked: { _, _ in didPublishResult = true },
             onError: { _ in didPublishResult = true },
-            accountLifecycleGeneration: 1,
+            accountLifecycleGeneration: { 1 },
             isAccountLifecycleCurrent: { _ in false },
-            stageDocument: { url in
-                try store.stage(sourceURL: url, maximumSize: 1_024)
-            }
+            stageDocument: { _ in stagedFile }
         )
 
         await coordinator.stageDocument(at: sourceURL)

--- a/TinfoilChatTests/DocumentPickerViewTests.swift
+++ b/TinfoilChatTests/DocumentPickerViewTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct DocumentPickerViewTests {
     @Test("Propagates managed staging errors")
     @MainActor
-    func propagatesManagedStagingErrors() {
+    func propagatesManagedStagingErrors() async {
         let expectedSize: Int64 = 2_048
         let expectedMaximum: Int64 = 1_024
         var receivedError: Error?
@@ -21,7 +21,7 @@ struct DocumentPickerViewTests {
             }
         )
 
-        coordinator.stageDocument(at: URL(fileURLWithPath: "/tmp/oversized.txt"))
+        await coordinator.stageDocument(at: URL(fileURLWithPath: "/tmp/oversized.txt"))
 
         guard let error = receivedError as? BoundedFileIOError,
               case let .fileTooLarge(size, maximum) = error else {

--- a/TinfoilChatTests/DocumentPickerViewTests.swift
+++ b/TinfoilChatTests/DocumentPickerViewTests.swift
@@ -23,7 +23,10 @@ struct DocumentPickerViewTests {
             }
         )
 
-        await coordinator.stageDocument(at: URL(fileURLWithPath: "/tmp/oversized.txt"))
+        await coordinator.stageDocument(
+            at: URL(fileURLWithPath: "/tmp/oversized.txt"),
+            accountLifecycleGeneration: 0
+        )
 
         guard let error = receivedError as? BoundedFileIOError,
               case let .fileTooLarge(size, maximum) = error else {
@@ -56,7 +59,7 @@ struct DocumentPickerViewTests {
             stageDocument: { _ in stagedFile }
         )
 
-        await coordinator.stageDocument(at: sourceURL)
+        await coordinator.stageDocument(at: sourceURL, accountLifecycleGeneration: 1)
 
         #expect(!didPublishResult)
         #expect((try FileManager.default.contentsOfDirectory(atPath: store.rootURL.path)).isEmpty)

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -183,6 +183,29 @@ struct LazyChatHydrationTests {
     }
 
     @Test
+    func resumedRootSelectionRequiresItsFenceAndAccount() {
+        var fence = ChatSelectionFence()
+        let capturedAccount = "account-a"
+        var currentAccount = capturedAccount
+        let generation = fence.begin(id: "root-chat")
+        let acceptsResume = {
+            currentAccount == capturedAccount
+                && fence.accepts(id: "root-chat", generation: generation)
+        }
+
+        #expect(acceptsResume())
+        _ = fence.begin(id: "newer-chat")
+        #expect(!acceptsResume())
+
+        let accountGeneration = fence.begin(id: "root-chat")
+        currentAccount = "account-b"
+        #expect(
+            !(currentAccount == capturedAccount
+                && fence.accepts(id: "root-chat", generation: accountGeneration))
+        )
+    }
+
+    @Test
     func newerTransientSummaryOverridesOlderIndexSummary() {
         let older = makeChat(id: "chat", updatedAt: Date(timeIntervalSince1970: 1))
         var newer = older

--- a/TinfoilChatTests/ManagedFileStoreTests.swift
+++ b/TinfoilChatTests/ManagedFileStoreTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Managed File Store Tests")
+struct ManagedFileStoreTests {
+    @Test("Stages owned files without deleting providers")
+    func stagesOwnedFilesWithoutDeletingProviders() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let providerURL = fixture.rootURL.appendingPathComponent("provider.txt")
+        try Data("provider data".utf8).write(to: providerURL)
+
+        let file = try fixture.store.stage(sourceURL: providerURL, maximumSize: 1_024)
+
+        #expect(fixture.store.owns(file.url))
+        #expect(FileManager.default.fileExists(atPath: providerURL.path))
+        file.discard()
+        file.discard()
+        #expect(!FileManager.default.fileExists(atPath: file.url.path))
+        #expect(FileManager.default.fileExists(atPath: providerURL.path))
+    }
+
+    @Test("Rejects oversized and symbolic link sources")
+    func rejectsOversizedAndSymbolicLinkSources() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let sourceURL = fixture.rootURL.appendingPathComponent("source.txt")
+        let linkURL = fixture.rootURL.appendingPathComponent("link.txt")
+        try Data(repeating: 1, count: 32).write(to: sourceURL)
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: sourceURL)
+
+        #expect(throws: BoundedFileIOError.self) {
+            try fixture.store.stage(sourceURL: sourceURL, maximumSize: 8)
+        }
+        #expect(throws: BoundedFileIOError.self) {
+            try fixture.store.stage(sourceURL: linkURL, maximumSize: 1_024)
+        }
+    }
+
+    @Test("Startup sweep removes only owned staging files")
+    func startupSweepRemovesOnlyOwnedStagingFiles() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let file = try fixture.store.stage(
+            data: Data("staged".utf8),
+            fileExtension: "txt",
+            maximumSize: 1_024
+        )
+        let unrelatedURL = fixture.stagingURL.appendingPathComponent("keep.txt")
+        try Data("keep".utf8).write(to: unrelatedURL)
+
+        fixture.store.sweepOnStartup()
+
+        #expect(!FileManager.default.fileExists(atPath: file.url.path))
+        #expect(FileManager.default.fileExists(atPath: unrelatedURL.path))
+    }
+
+    @Test("Staged files use protection and backup exclusion")
+    func stagedFilesUseProtectionAndBackupExclusion() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let file = try fixture.store.stage(
+            data: Data("protected".utf8),
+            fileExtension: "txt",
+            maximumSize: 1_024
+        )
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.url.path)
+        let values = try file.url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+
+        #expect(attributes[.protectionKey] as? FileProtectionType == .completeUntilFirstUserAuthentication)
+        #expect(values.isExcludedFromBackup == true)
+    }
+
+    private func makeFixture() throws -> (
+        store: ManagedFileStore,
+        rootURL: URL,
+        stagingURL: URL
+    ) {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        let stagingURL = rootURL.appendingPathComponent("ManagedFileStaging", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: rootURL,
+            withIntermediateDirectories: true
+        )
+        return (
+            ManagedFileStore(rootURL: stagingURL),
+            rootURL,
+            stagingURL
+        )
+    }
+}

--- a/TinfoilChatTests/ManagedFileStoreTests.swift
+++ b/TinfoilChatTests/ManagedFileStoreTests.swift
@@ -36,6 +36,25 @@ struct ManagedFileStoreTests {
         #expect(throws: BoundedFileIOError.self) {
             try fixture.store.stage(sourceURL: linkURL, maximumSize: 1_024)
         }
+        #expect(FileManager.default.fileExists(atPath: sourceURL.path))
+        #expect(FileManager.default.fileExists(atPath: linkURL.path))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: fixture.stagingURL.path).isEmpty)
+    }
+
+    @Test("Stops incremental I/O when a source grows beyond the limit")
+    func stopsIncrementalIOWhenSourceGrowsBeyondLimit() throws {
+        var chunks = [Data(repeating: 1, count: 4), Data(repeating: 2, count: 5)]
+        var consumed = Data()
+
+        #expect(throws: BoundedFileIOError.self) {
+            try BoundedFileIO.stream(maximumSize: 8) { _ in
+                chunks.isEmpty ? nil : chunks.removeFirst()
+            } consume: { chunk in
+                consumed.append(chunk)
+            }
+        }
+
+        #expect(consumed == Data(repeating: 1, count: 4))
     }
 
     @Test("Startup sweep removes only owned staging files")

--- a/TinfoilChatTests/ManagedFileStoreTests.swift
+++ b/TinfoilChatTests/ManagedFileStoreTests.swift
@@ -57,8 +57,8 @@ struct ManagedFileStoreTests {
         #expect(consumed == Data(repeating: 1, count: 4))
     }
 
-    @Test("Startup sweep removes only owned staging files")
-    func startupSweepRemovesOnlyOwnedStagingFiles() throws {
+    @Test("Startup sweep removes every file in the managed root")
+    func startupSweepRemovesEveryManagedFile() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
         let file = try fixture.store.stage(
@@ -69,10 +69,10 @@ struct ManagedFileStoreTests {
         let unrelatedURL = fixture.stagingURL.appendingPathComponent("keep.txt")
         try Data("keep".utf8).write(to: unrelatedURL)
 
-        fixture.store.sweepOnStartup()
+        try fixture.store.sweepOnStartup()
 
         #expect(!FileManager.default.fileExists(atPath: file.url.path))
-        #expect(FileManager.default.fileExists(atPath: unrelatedURL.path))
+        #expect(!FileManager.default.fileExists(atPath: unrelatedURL.path))
     }
 
     @Test("Staged files use protection and backup exclusion")

--- a/TinfoilChatTests/ProjectColorTests.swift
+++ b/TinfoilChatTests/ProjectColorTests.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import Testing
+import UIKit
+@testable import TinfoilChat
+
+@Suite("Project Color Tests")
+struct ProjectColorTests {
+    @Test("Web project colors resolve", arguments: [
+        ("maya-blue", 133, 198, 255),
+        ("electric-aqua", 98, 220, 233),
+        ("sandy-brown", 255, 181, 122),
+        ("mauve", 233, 171, 255),
+        ("tuscan-sun", 245, 203, 88),
+        ("light-green", 138, 223, 141),
+        ("baby-pink", 255, 158, 195),
+    ])
+    func webProjectColorsResolve(id: String, red: Int, green: Int, blue: Int) {
+        let components = rgbaComponents(of: Color.projectColor(id))
+
+        #expect(abs(components.red - Double(red) / 255) < 0.0001)
+        #expect(abs(components.green - Double(green) / 255) < 0.0001)
+        #expect(abs(components.blue - Double(blue) / 255) < 0.0001)
+        #expect(abs(components.alpha - 1) < 0.0001)
+    }
+
+    @Test("Missing project colors use the accent")
+    func missingProjectColorsUseAccent() {
+        #expect(Color.projectColor(nil) == Color.accentColor)
+    }
+
+    @Test("Invalid project colors use the accent")
+    func invalidProjectColorsUseAccent() {
+        #expect(Color.projectColor("#85C6FF") == Color.accentColor)
+        #expect(Color.projectColor("unknown") == Color.accentColor)
+    }
+
+    @Test("Project rows use the project folder icon")
+    func projectRowsUseProjectFolderIcon() throws {
+        let source = try sourceFile("TinfoilChat/Views/ChatSidebar.swift")
+
+        #expect(source.contains("ProjectFolderIcon(color: project.color)"))
+        #expect(source.contains("ProjectFolderIcon(color: projectColor, size: 18)"))
+        #expect(source.contains("ProjectFolderIcon(color: project.color, size: 22)"))
+    }
+
+    private func rgbaComponents(of color: Color) -> (red: Double, green: Double, blue: Double, alpha: Double) {
+        var red = CGFloat.zero
+        var green = CGFloat.zero
+        var blue = CGFloat.zero
+        var alpha = CGFloat.zero
+        UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (Double(red), Double(green), Double(blue), Double(alpha))
+    }
+
+    private func sourceFile(_ relativePath: String) throws -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let repositoryRoot = testsDirectory.deletingLastPathComponent()
+        return try String(contentsOf: repositoryRoot.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+}

--- a/TinfoilChatTests/ProjectColorTests.swift
+++ b/TinfoilChatTests/ProjectColorTests.swift
@@ -34,15 +34,6 @@ struct ProjectColorTests {
         #expect(Color.projectColor("unknown") == Color.accentColor)
     }
 
-    @Test("Project rows use the project folder icon")
-    func projectRowsUseProjectFolderIcon() throws {
-        let source = try sourceFile("TinfoilChat/Views/ChatSidebar.swift")
-
-        #expect(source.contains("ProjectFolderIcon(color: project.color)"))
-        #expect(source.contains("ProjectFolderIcon(color: projectColor, size: 18)"))
-        #expect(source.contains("ProjectFolderIcon(color: project.color, size: 22)"))
-    }
-
     private func rgbaComponents(of color: Color) -> (red: Double, green: Double, blue: Double, alpha: Double) {
         var red = CGFloat.zero
         var green = CGFloat.zero
@@ -50,11 +41,5 @@ struct ProjectColorTests {
         var alpha = CGFloat.zero
         UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         return (Double(red), Double(green), Double(blue), Double(alpha))
-    }
-
-    private func sourceFile(_ relativePath: String) throws -> String {
-        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-        let repositoryRoot = testsDirectory.deletingLastPathComponent()
-        return try String(contentsOf: repositoryRoot.appendingPathComponent(relativePath), encoding: .utf8)
     }
 }

--- a/TinfoilChatTests/ProjectSchemaFidelityTests.swift
+++ b/TinfoilChatTests/ProjectSchemaFidelityTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Project Schema Fidelity Tests")
+struct ProjectSchemaFidelityTests {
+    @Test("Project color round trips")
+    func projectColorRoundTrips() throws {
+        let payload = ProjectData(
+            name: "Research",
+            description: "",
+            systemInstructions: "",
+            memory: [],
+            color: "#0f766e"
+        )
+
+        let decoded = try JSONDecoder().decode(
+            ProjectData.self,
+            from: JSONEncoder().encode(payload)
+        )
+
+        #expect(decoded.color == "#0f766e")
+    }
+
+    @Test("Legacy project data decodes without color")
+    func legacyProjectDataDecodesWithoutColor() throws {
+        let data = Data(#"{"name":"Research","description":"","systemInstructions":"","memory":[]}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(ProjectData.self, from: data)
+
+        #expect(decoded.color == nil)
+    }
+
+    @Test("Project document preserves original size")
+    func projectDocumentPreservesOriginalSize() throws {
+        let payload = ProjectDocumentPayload(
+            content: "Converted markdown",
+            filename: "source.pdf",
+            contentType: "application/pdf",
+            sizeBytes: 4_096
+        )
+
+        let decoded = try JSONDecoder().decode(
+            ProjectDocumentPayload.self,
+            from: JSONEncoder().encode(payload)
+        )
+
+        #expect(decoded.sizeBytes == 4_096)
+    }
+
+    @Test("Legacy document size falls back to UTF-8 bytes")
+    func legacyDocumentSizeFallsBackToUTF8() throws {
+        let data = Data(#"{"content":"caf\u00e9","filename":"notes.txt","contentType":"text/plain"}"#.utf8)
+        let decoded = try JSONDecoder().decode(ProjectDocumentPayload.self, from: data)
+
+        #expect(decoded.sizeBytes == nil)
+        #expect(decoded.resolvedSizeBytes == 5)
+    }
+
+    @Test("Unrelated project updates preserve color")
+    func unrelatedProjectUpdatesPreserveColor() {
+        let existing = Project(
+            id: "project-1",
+            name: "Research",
+            description: "Existing",
+            systemInstructions: "",
+            memory: [],
+            color: "#0f766e",
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            syncVersion: 1
+        )
+
+        let merged = SyncEnclaveProjectStore.mergedProjectData(
+            UpdateProjectData(description: "Updated"),
+            existing: existing
+        )
+
+        #expect(merged.description == "Updated")
+        #expect(merged.color == "#0f766e")
+    }
+
+    @Test("Bulk delete request uses enclave wire keys")
+    func bulkDeleteRequestUsesWireKeys() throws {
+        let request = EnclaveDeleteAllProjectsRequest(
+            key: "base64-key",
+            idempotencyKey: "operation-id"
+        )
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: String]
+        )
+
+        #expect(object == [
+            "key": "base64-key",
+            "idempotency_key": "operation-id"
+        ])
+    }
+
+    @Test("Bulk delete response decodes deleted count")
+    func bulkDeleteResponseDecodesDeletedCount() throws {
+        let data = Data(#"{"ok":true,"deleted":3}"#.utf8)
+        let response = try JSONDecoder().decode(EnclaveDeleteAllProjectsResponse.self, from: data)
+
+        #expect(response == EnclaveDeleteAllProjectsResponse(ok: true, deleted: 3))
+    }
+}

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -3,6 +3,30 @@ import Testing
 import UniformTypeIdentifiers
 @testable import TinfoilChat
 
+private final class SharedImportCoordinationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var publicationReleased = false
+    private var purgeEnteredBeforeRelease = false
+
+    func releasePublication() {
+        lock.lock()
+        publicationReleased = true
+        lock.unlock()
+    }
+
+    func recordPurgeEntry() {
+        lock.lock()
+        purgeEnteredBeforeRelease = purgeEnteredBeforeRelease || !publicationReleased
+        lock.unlock()
+    }
+
+    var didSerializePurgeAfterPublication: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !purgeEnteredBeforeRelease
+    }
+}
+
 @Suite("Shared Import Store Tests")
 struct SharedImportStoreTests {
     @Test("Classifies supported images and documents")
@@ -159,14 +183,19 @@ struct SharedImportStoreTests {
         let publicationBegan = DispatchSemaphore(value: 0)
         let allowPublication = DispatchSemaphore(value: 0)
         let purgeAttempted = DispatchSemaphore(value: 0)
+        let coordinationState = SharedImportCoordinationState()
         let publicationStore = try SharedImportStore(
             inboxURL: inboxURL,
             publicationDidBegin: {
                 publicationBegan.signal()
                 allowPublication.wait()
+                coordinationState.releasePublication()
             }
         )
-        let purgeStore = try SharedImportStore(inboxURL: inboxURL)
+        let purgeStore = try SharedImportStore(
+            inboxURL: inboxURL,
+            purgeDidBegin: coordinationState.recordPurgeEntry
+        )
 
         let publication = Task.detached {
             _ = try publicationStore.enqueue(
@@ -186,6 +215,7 @@ struct SharedImportStoreTests {
         try await publication.value
         try await purge.value
 
+        #expect(coordinationState.didSerializePurgeAfterPublication)
         #expect(purgeStore.pendingRequests().isEmpty)
     }
 

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -148,6 +148,47 @@ struct SharedImportStoreTests {
         #expect(fixture.store.pendingRequests().isEmpty)
     }
 
+    @Test("Purge waits for publication and removes its request")
+    func purgeCoordinatesWithPublication() async throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        let inboxURL = rootURL.appendingPathComponent("ShareInbox", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let publicationBegan = DispatchSemaphore(value: 0)
+        let allowPublication = DispatchSemaphore(value: 0)
+        let purgeBegan = DispatchSemaphore(value: 0)
+        let publicationStore = try SharedImportStore(
+            inboxURL: inboxURL,
+            publicationDidBegin: {
+                publicationBegan.signal()
+                allowPublication.wait()
+            }
+        )
+        let purgeStore = try SharedImportStore(
+            inboxURL: inboxURL,
+            purgeDidBegin: { purgeBegan.signal() }
+        )
+
+        let publication = Task.detached {
+            _ = try publicationStore.enqueue(
+                data: Data("Shared text".utf8),
+                typeIdentifier: UTType.plainText.identifier,
+                originalFileName: "Notes.txt"
+            )
+        }
+        publicationBegan.wait()
+        let purge = Task.detached { purgeStore.purgeAllRequests() }
+
+        #expect(purgeBegan.wait(timeout: .now() + 0.1) == .timedOut)
+        allowPublication.signal()
+        try await publication.value
+        await purge.value
+
+        #expect(purgeStore.pendingRequests().isEmpty)
+    }
+
     private func makeFixture() throws -> (
         store: SharedImportStore,
         rootURL: URL,

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -80,6 +80,74 @@ struct SharedImportStoreTests {
         #expect(fixture.store.pendingRequests().isEmpty)
     }
 
+    @Test("Enqueues payload data without an intermediary file")
+    func enqueuesPayloadDataDirectly() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let payload = Data("Direct shared text".utf8)
+
+        let request = try fixture.store.enqueue(
+            data: payload,
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "Notes.txt"
+        )
+
+        #expect(try fixture.store.payloadData(for: request) == payload)
+    }
+
+    @Test("Removes stale corrupt requests after 24 hours")
+    func removesStaleCorruptRequests() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let requestDirectory = fixture.inboxURL.appendingPathComponent(
+            UUID().uuidString.lowercased(),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: requestDirectory, withIntermediateDirectories: false)
+        try Data("invalid".utf8).write(
+            to: requestDirectory.appendingPathComponent(SharedImportConfiguration.manifestFileName)
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-25 * 60 * 60)],
+            ofItemAtPath: requestDirectory.path
+        )
+
+        _ = fixture.store.pendingRequests()
+
+        #expect(!FileManager.default.fileExists(atPath: requestDirectory.path))
+    }
+
+    @Test("Retains valid requests for 30 days")
+    func retainsValidRequestsForThirtyDays() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let request = try fixture.store.enqueue(
+            data: Data("Shared text".utf8),
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "Notes.txt"
+        )
+        let manifestURL = fixture.inboxURL
+            .appendingPathComponent(request.id.uuidString.lowercased(), isDirectory: true)
+            .appendingPathComponent(SharedImportConfiguration.manifestFileName)
+        let retainedRequest = SharedImportRequest(
+            id: request.id,
+            createdAt: Date().addingTimeInterval(-29 * 24 * 60 * 60),
+            item: request.item
+        )
+        try JSONEncoder().encode(retainedRequest).write(to: manifestURL, options: .atomic)
+
+        #expect(fixture.store.pendingRequests() == [retainedRequest])
+
+        let expiredRequest = SharedImportRequest(
+            id: request.id,
+            createdAt: Date().addingTimeInterval(-31 * 24 * 60 * 60),
+            item: request.item
+        )
+        try JSONEncoder().encode(expiredRequest).write(to: manifestURL, options: .atomic)
+
+        #expect(fixture.store.pendingRequests().isEmpty)
+    }
+
     private func makeFixture() throws -> (
         store: SharedImportStore,
         rootURL: URL,

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -46,7 +46,7 @@ struct SharedImportStoreTests {
         #expect(fixture.store.pendingRequests() == [request])
         #expect(try Data(contentsOf: fixture.store.payloadURL(for: request)) == sourceData)
 
-        fixture.store.removeRequest(id: request.id)
+        try fixture.store.removeRequest(id: request.id)
         #expect(fixture.store.pendingRequests().isEmpty)
     }
 
@@ -158,7 +158,7 @@ struct SharedImportStoreTests {
 
         let publicationBegan = DispatchSemaphore(value: 0)
         let allowPublication = DispatchSemaphore(value: 0)
-        let purgeBegan = DispatchSemaphore(value: 0)
+        let purgeAttempted = DispatchSemaphore(value: 0)
         let publicationStore = try SharedImportStore(
             inboxURL: inboxURL,
             publicationDidBegin: {
@@ -166,10 +166,7 @@ struct SharedImportStoreTests {
                 allowPublication.wait()
             }
         )
-        let purgeStore = try SharedImportStore(
-            inboxURL: inboxURL,
-            purgeDidBegin: { purgeBegan.signal() }
-        )
+        let purgeStore = try SharedImportStore(inboxURL: inboxURL)
 
         let publication = Task.detached {
             _ = try publicationStore.enqueue(
@@ -179,14 +176,41 @@ struct SharedImportStoreTests {
             )
         }
         publicationBegan.wait()
-        let purge = Task.detached { purgeStore.purgeAllRequests() }
+        let purge = Task.detached {
+            purgeAttempted.signal()
+            try purgeStore.purgeAllRequests()
+        }
 
-        #expect(purgeBegan.wait(timeout: .now() + 0.1) == .timedOut)
+        purgeAttempted.wait()
         allowPublication.signal()
         try await publication.value
-        await purge.value
+        try await purge.value
 
         #expect(purgeStore.pendingRequests().isEmpty)
+    }
+
+    @Test("Purge blocks publication until the next account is ready")
+    func purgeFencesPublication() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try fixture.store.purgeAllRequests()
+
+        #expect(throws: SharedImportError.self) {
+            try fixture.store.enqueue(
+                data: Data("Shared text".utf8),
+                typeIdentifier: UTType.plainText.identifier,
+                originalFileName: "Notes.txt"
+            )
+        }
+
+        try fixture.store.allowPublications()
+        let request = try fixture.store.enqueue(
+            data: Data("Shared text".utf8),
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "Notes.txt"
+        )
+        #expect(fixture.store.pendingRequests() == [request])
     }
 
     private func makeFixture() throws -> (

--- a/TinfoilShareExtension/ShareViewController.swift
+++ b/TinfoilShareExtension/ShareViewController.swift
@@ -110,11 +110,25 @@ final class ShareViewController: UIViewController {
             guard let self else { return }
 
             if let url {
-                saveSharedItem(
-                    from: url,
-                    provider: provider,
-                    typeIdentifier: typeIdentifier
-                )
+                do {
+                    guard let kind = SharedImportClassifier.kind(
+                        typeIdentifier: typeIdentifier,
+                        fileName: provider.suggestedName
+                    ) else {
+                        throw SharedImportError.unsupportedType
+                    }
+                    let data = try BoundedFileIO.read(
+                        from: url,
+                        maximumSize: kind.maximumSizeBytes
+                    )
+                    saveSharedItem(
+                        data: data,
+                        provider: provider,
+                        typeIdentifier: typeIdentifier
+                    )
+                } catch {
+                    showError(error)
+                }
             } else {
                 loadDataFallback(
                     provider: provider,
@@ -137,31 +151,23 @@ final class ShareViewController: UIViewController {
                 return
             }
 
-            let temporaryURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent(UUID().uuidString.lowercased())
-            do {
-                try data.write(to: temporaryURL, options: .atomic)
-                saveSharedItem(
-                    from: temporaryURL,
-                    provider: provider,
-                    typeIdentifier: typeIdentifier
-                )
-                try? FileManager.default.removeItem(at: temporaryURL)
-            } catch {
-                showError(error)
-            }
+            saveSharedItem(
+                data: data,
+                provider: provider,
+                typeIdentifier: typeIdentifier
+            )
         }
     }
 
     private func saveSharedItem(
-        from sourceURL: URL,
+        data: Data,
         provider: NSItemProvider,
         typeIdentifier: String
     ) {
         do {
             let store = try SharedImportStore()
             _ = try store.enqueue(
-                sourceURL: sourceURL,
+                data: data,
                 typeIdentifier: typeIdentifier,
                 originalFileName: sharedFileName(
                     provider: provider,

--- a/TinfoilShareExtension/ShareViewController.swift
+++ b/TinfoilShareExtension/ShareViewController.swift
@@ -110,25 +110,11 @@ final class ShareViewController: UIViewController {
             guard let self else { return }
 
             if let url {
-                do {
-                    guard let kind = SharedImportClassifier.kind(
-                        typeIdentifier: typeIdentifier,
-                        fileName: provider.suggestedName
-                    ) else {
-                        throw SharedImportError.unsupportedType
-                    }
-                    let data = try BoundedFileIO.read(
-                        from: url,
-                        maximumSize: kind.maximumSizeBytes
-                    )
-                    saveSharedItem(
-                        data: data,
-                        provider: provider,
-                        typeIdentifier: typeIdentifier
-                    )
-                } catch {
-                    showError(error)
-                }
+                saveSharedItem(
+                    sourceURL: url,
+                    provider: provider,
+                    typeIdentifier: typeIdentifier
+                )
             } else {
                 loadDataFallback(
                     provider: provider,
@@ -156,6 +142,29 @@ final class ShareViewController: UIViewController {
                 provider: provider,
                 typeIdentifier: typeIdentifier
             )
+        }
+    }
+
+    private func saveSharedItem(
+        sourceURL: URL,
+        provider: NSItemProvider,
+        typeIdentifier: String
+    ) {
+        do {
+            let store = try SharedImportStore()
+            _ = try store.enqueue(
+                sourceURL: sourceURL,
+                typeIdentifier: typeIdentifier,
+                originalFileName: sharedFileName(
+                    provider: provider,
+                    typeIdentifier: typeIdentifier
+                )
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.extensionContext?.completeRequest(returningItems: nil)
+            }
+        } catch {
+            showError(error)
         }
     }
 

--- a/TinfoilShared/BoundedFileIO.swift
+++ b/TinfoilShared/BoundedFileIO.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 enum BoundedFileIOError: LocalizedError {
@@ -15,7 +16,19 @@ enum BoundedFileIOError: LocalizedError {
 }
 
 struct BoundedFileIO {
+    private static let chunkSize = 64 * 1_024
+
+    private struct OpenFile {
+        let handle: FileHandle
+        let device: dev_t
+        let inode: ino_t
+        let expectedSize: Int64
+    }
+
     static func validatedSize(of url: URL, maximumSize: Int64) throws -> Int64 {
+        guard maximumSize >= 0 else {
+            throw BoundedFileIOError.invalidFile
+        }
         let values = try url.resourceValues(forKeys: [
             .fileSizeKey,
             .isRegularFileKey,
@@ -34,26 +47,149 @@ struct BoundedFileIO {
     }
 
     static func read(from url: URL, maximumSize: Int64) throws -> Data {
-        let expectedSize = try validatedSize(of: url, maximumSize: maximumSize)
-        let data = try Data(contentsOf: url, options: .mappedIfSafe)
-        guard Int64(data.count) <= maximumSize,
-              Int64(data.count) == expectedSize,
-              try validatedSize(of: url, maximumSize: maximumSize) == expectedSize else {
-            throw BoundedFileIOError.invalidFile
+        let source = try openSource(at: url, maximumSize: maximumSize)
+        defer { try? source.handle.close() }
+
+        var data = Data()
+        let size = try stream(maximumSize: maximumSize) { requestedCount in
+            try source.handle.read(upToCount: requestedCount)
+        } consume: { chunk in
+            data.append(chunk)
         }
+        try verify(source, at: url, streamedSize: size)
         return data
     }
 
     @discardableResult
-    static func copy(from sourceURL: URL, to destinationURL: URL, maximumSize: Int64) throws -> Int64 {
-        let expectedSize = try validatedSize(of: sourceURL, maximumSize: maximumSize)
-        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
-        let copiedSize = try validatedSize(of: destinationURL, maximumSize: maximumSize)
-        guard copiedSize == expectedSize,
-              try validatedSize(of: sourceURL, maximumSize: maximumSize) == expectedSize else {
-            try? FileManager.default.removeItem(at: destinationURL)
+    static func copy(
+        from sourceURL: URL,
+        to destinationURL: URL,
+        maximumSize: Int64,
+        destinationAttributes: [FileAttributeKey: Any] = [:]
+    ) throws -> Int64 {
+        let source = try openSource(at: sourceURL, maximumSize: maximumSize)
+        defer { try? source.handle.close() }
+
+        var destinationHandle: FileHandle?
+        var ownsDestination = false
+        do {
+            let descriptor = Darwin.open(
+                destinationURL.path,
+                O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                S_IRUSR | S_IWUSR
+            )
+            guard descriptor >= 0 else {
+                throw BoundedFileIOError.invalidFile
+            }
+            ownsDestination = true
+            let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+            destinationHandle = handle
+            if !destinationAttributes.isEmpty {
+                try FileManager.default.setAttributes(
+                    destinationAttributes,
+                    ofItemAtPath: destinationURL.path
+                )
+            }
+
+            let size = try stream(maximumSize: maximumSize) { requestedCount in
+                try source.handle.read(upToCount: requestedCount)
+            } consume: { chunk in
+                try handle.write(contentsOf: chunk)
+            }
+            try verify(source, at: sourceURL, streamedSize: size)
+            try handle.synchronize()
+            try handle.close()
+            destinationHandle = nil
+
+            guard try validatedSize(of: destinationURL, maximumSize: maximumSize) == size else {
+                throw BoundedFileIOError.invalidFile
+            }
+            return size
+        } catch {
+            try? destinationHandle?.close()
+            if ownsDestination {
+                try? FileManager.default.removeItem(at: destinationURL)
+            }
+            throw error
+        }
+    }
+
+    @discardableResult
+    static func stream(
+        maximumSize: Int64,
+        readChunk: (Int) throws -> Data?,
+        consume: (Data) throws -> Void
+    ) throws -> Int64 {
+        guard maximumSize >= 0 else {
             throw BoundedFileIOError.invalidFile
         }
-        return copiedSize
+        var totalSize: Int64 = 0
+        while true {
+            try Task<Never, Never>.checkCancellation()
+            let remaining = maximumSize - totalSize
+            let requestedCount = remaining >= Int64(chunkSize)
+                ? chunkSize
+                : Int(remaining) + 1
+            guard let chunk = try readChunk(requestedCount), !chunk.isEmpty else {
+                return totalSize
+            }
+            let nextSize = totalSize + Int64(chunk.count)
+            guard nextSize <= maximumSize else {
+                throw BoundedFileIOError.fileTooLarge(size: nextSize, maximum: maximumSize)
+            }
+            try Task<Never, Never>.checkCancellation()
+            try consume(chunk)
+            totalSize = nextSize
+        }
+    }
+
+    private static func openSource(at url: URL, maximumSize: Int64) throws -> OpenFile {
+        let expectedSize = try validatedSize(of: url, maximumSize: maximumSize)
+        let descriptor = Darwin.open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK)
+        guard descriptor >= 0 else {
+            throw BoundedFileIOError.invalidFile
+        }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        do {
+            var status = stat()
+            guard fstat(descriptor, &status) == 0,
+                  status.st_mode & S_IFMT == S_IFREG,
+                  Int64(status.st_size) == expectedSize else {
+                throw BoundedFileIOError.invalidFile
+            }
+            try verifyPath(at: url, device: status.st_dev, inode: status.st_ino)
+            return OpenFile(
+                handle: handle,
+                device: status.st_dev,
+                inode: status.st_ino,
+                expectedSize: expectedSize
+            )
+        } catch {
+            try? handle.close()
+            throw error
+        }
+    }
+
+    private static func verify(_ file: OpenFile, at url: URL, streamedSize: Int64) throws {
+        var status = stat()
+        guard fstat(file.handle.fileDescriptor, &status) == 0,
+              status.st_mode & S_IFMT == S_IFREG,
+              status.st_dev == file.device,
+              status.st_ino == file.inode,
+              Int64(status.st_size) == file.expectedSize,
+              streamedSize == file.expectedSize else {
+            throw BoundedFileIOError.invalidFile
+        }
+        try verifyPath(at: url, device: file.device, inode: file.inode)
+    }
+
+    private static func verifyPath(at url: URL, device: dev_t, inode: ino_t) throws {
+        var status = stat()
+        guard lstat(url.path, &status) == 0,
+              status.st_mode & S_IFMT == S_IFREG,
+              status.st_dev == device,
+              status.st_ino == inode else {
+            throw BoundedFileIOError.invalidFile
+        }
     }
 }

--- a/TinfoilShared/BoundedFileIO.swift
+++ b/TinfoilShared/BoundedFileIO.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum BoundedFileIOError: LocalizedError {
+    case invalidFile
+    case fileTooLarge(size: Int64, maximum: Int64)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFile:
+            return "The file could not be read safely."
+        case .fileTooLarge(let size, let maximum):
+            return "The file is too large (\(size) bytes). Maximum is \(maximum) bytes."
+        }
+    }
+}
+
+struct BoundedFileIO {
+    static func validatedSize(of url: URL, maximumSize: Int64) throws -> Int64 {
+        let values = try url.resourceValues(forKeys: [
+            .fileSizeKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey
+        ])
+        guard values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              let fileSize = values.fileSize else {
+            throw BoundedFileIOError.invalidFile
+        }
+        let size = Int64(fileSize)
+        guard size <= maximumSize else {
+            throw BoundedFileIOError.fileTooLarge(size: size, maximum: maximumSize)
+        }
+        return size
+    }
+
+    static func read(from url: URL, maximumSize: Int64) throws -> Data {
+        let expectedSize = try validatedSize(of: url, maximumSize: maximumSize)
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        guard Int64(data.count) <= maximumSize,
+              Int64(data.count) == expectedSize,
+              try validatedSize(of: url, maximumSize: maximumSize) == expectedSize else {
+            throw BoundedFileIOError.invalidFile
+        }
+        return data
+    }
+
+    @discardableResult
+    static func copy(from sourceURL: URL, to destinationURL: URL, maximumSize: Int64) throws -> Int64 {
+        let expectedSize = try validatedSize(of: sourceURL, maximumSize: maximumSize)
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        let copiedSize = try validatedSize(of: destinationURL, maximumSize: maximumSize)
+        guard copiedSize == expectedSize,
+              try validatedSize(of: sourceURL, maximumSize: maximumSize) == expectedSize else {
+            try? FileManager.default.removeItem(at: destinationURL)
+            throw BoundedFileIOError.invalidFile
+        }
+        return copiedSize
+    }
+}

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -8,9 +8,11 @@ enum SharedImportConfiguration {
     static let maximumFileNameLength = 120
     static let maximumImageSizeBytes: Int64 = 10 * 1024 * 1024
     static let maximumDocumentSizeBytes: Int64 = 20 * 1024 * 1024
+    static let maximumManifestSizeBytes: Int64 = 64 * 1024
     /// Hidden staging directories older than this are treated as abandoned
     /// by an interrupted share and swept from the app-group inbox.
     static let staleStagingLifetimeSeconds: TimeInterval = 24 * 60 * 60
+    static let validRequestRetentionSeconds: TimeInterval = 30 * 24 * 60 * 60
     static let supportedDocumentExtensions: Set<String> = [
         "pdf", "docx", "pptx", "xlsx", "txt", "md", "csv", "html", "json", "xml",
     ]

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -84,6 +84,7 @@ enum SharedImportError: LocalizedError {
     case invalidFile
     case fileTooLarge(kind: SharedImportKind, size: Int64)
     case invalidRequest
+    case publicationBlocked
 
     var errorDescription: String? {
         switch self {
@@ -104,6 +105,8 @@ enum SharedImportError: LocalizedError {
             )
         case .invalidRequest:
             return "The shared file request is invalid."
+        case .publicationBlocked:
+            return "Tinfoil cannot accept shared files during account changes. Try again after signing in."
         }
     }
 }

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -18,7 +18,7 @@ enum SharedImportConfiguration {
     ]
 }
 
-enum SharedImportKind: String, Codable, Equatable {
+enum SharedImportKind: String, Codable, Equatable, Sendable {
     case image
     case document
 
@@ -32,13 +32,13 @@ enum SharedImportKind: String, Codable, Equatable {
     }
 }
 
-struct SharedImportRequest: Codable, Equatable, Identifiable {
+struct SharedImportRequest: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     let createdAt: Date
     let item: SharedImportItem
 }
 
-struct SharedImportItem: Codable, Equatable, Identifiable {
+struct SharedImportItem: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     let kind: SharedImportKind
     let typeIdentifier: String

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -2,20 +2,18 @@ import Foundation
 import UniformTypeIdentifiers
 
 struct SharedImportStore: @unchecked Sendable {
+    private static let publicationBlockFileName = ".publication-blocked"
     private let fileManager: FileManager
     private let publicationDidBegin: (@Sendable () -> Void)?
-    private let purgeDidBegin: (@Sendable () -> Void)?
     let inboxURL: URL
 
     init(
         fileManager: FileManager = .default,
         inboxURL: URL? = nil,
-        publicationDidBegin: (@Sendable () -> Void)? = nil,
-        purgeDidBegin: (@Sendable () -> Void)? = nil
+        publicationDidBegin: (@Sendable () -> Void)? = nil
     ) throws {
         self.fileManager = fileManager
         self.publicationDidBegin = publicationDidBegin
-        self.purgeDidBegin = purgeDidBegin
 
         if let inboxURL {
             self.inboxURL = inboxURL
@@ -50,22 +48,33 @@ struct SharedImportStore: @unchecked Sendable {
         ) else {
             throw SharedImportError.unsupportedType
         }
-        let data: Data
         do {
-            data = try BoundedFileIO.read(
-                from: sourceURL,
+            let byteCount = try BoundedFileIO.validatedSize(
+                of: sourceURL,
                 maximumSize: kind.maximumSizeBytes
             )
+            return try enqueue(
+                kind: kind,
+                byteCount: byteCount,
+                typeIdentifier: typeIdentifier,
+                originalFileName: originalFileName
+            ) { stagedURL in
+                let copiedSize = try BoundedFileIO.copy(
+                    from: sourceURL,
+                    to: stagedURL,
+                    maximumSize: kind.maximumSizeBytes
+                )
+                guard copiedSize == byteCount else {
+                    throw SharedImportError.invalidFile
+                }
+            }
         } catch BoundedFileIOError.fileTooLarge(let size, _) {
             throw SharedImportError.fileTooLarge(kind: kind, size: size)
+        } catch let error as SharedImportError {
+            throw error
         } catch {
             throw SharedImportError.invalidFile
         }
-        return try enqueue(
-            data: data,
-            typeIdentifier: typeIdentifier,
-            originalFileName: originalFileName
-        )
     }
 
     @discardableResult
@@ -85,6 +94,24 @@ struct SharedImportStore: @unchecked Sendable {
         guard byteCount <= kind.maximumSizeBytes else {
             throw SharedImportError.fileTooLarge(kind: kind, size: byteCount)
         }
+
+        return try enqueue(
+            kind: kind,
+            byteCount: byteCount,
+            typeIdentifier: typeIdentifier,
+            originalFileName: originalFileName
+        ) { stagedURL in
+            try data.write(to: stagedURL, options: .atomic)
+        }
+    }
+
+    private func enqueue(
+        kind: SharedImportKind,
+        byteCount: Int64,
+        typeIdentifier: String,
+        originalFileName: String,
+        writePayload: (URL) throws -> Void
+    ) throws -> SharedImportRequest {
 
         let requestID = UUID()
         let itemID = UUID()
@@ -114,6 +141,9 @@ struct SharedImportStore: @unchecked Sendable {
         let requestDirectory = directoryURL(for: requestID)
 
         return try withCoordinatedInboxWrite {
+            guard !fileManager.fileExists(atPath: publicationBlockURL.path) else {
+                throw SharedImportError.publicationBlocked
+            }
             publicationDidBegin?()
             try fileManager.createDirectory(
                 at: temporaryDirectory,
@@ -123,13 +153,11 @@ struct SharedImportStore: @unchecked Sendable {
 
             do {
                 let stagedURL = temporaryDirectory.appendingPathComponent(stagedFileName)
-                try data.write(to: stagedURL, options: .atomic)
-
-                let copiedData = try BoundedFileIO.read(
-                    from: stagedURL,
+                try writePayload(stagedURL)
+                guard try BoundedFileIO.validatedSize(
+                    of: stagedURL,
                     maximumSize: kind.maximumSizeBytes
-                )
-                guard copiedData.count == data.count else {
+                ) == byteCount else {
                     throw SharedImportError.invalidFile
                 }
 
@@ -235,27 +263,36 @@ struct SharedImportStore: @unchecked Sendable {
         )
     }
 
-    func removeRequest(id: UUID) {
-        try? withCoordinatedInboxWrite {
-            try? fileManager.removeItem(at: directoryURL(for: id))
+    func removeRequest(id: UUID) throws {
+        try withCoordinatedInboxWrite {
+            try removeIfPresent(at: directoryURL(for: id))
         }
     }
 
-    func purgeAllRequests() {
-        try? withCoordinatedInboxWrite {
-            purgeDidBegin?()
-            let entries = (try? fileManager.contentsOfDirectory(
+    func purgeAllRequests() throws {
+        try withCoordinatedInboxWrite {
+            guard fileManager.fileExists(atPath: publicationBlockURL.path)
+                || fileManager.createFile(atPath: publicationBlockURL.path, contents: Data()) else {
+                throw SharedImportError.invalidFile
+            }
+            let entries = try fileManager.contentsOfDirectory(
                 at: inboxURL,
                 includingPropertiesForKeys: nil,
                 options: []
-            )) ?? []
+            )
             for url in entries {
                 let name = url.lastPathComponent
                 if UUID(uuidString: name) != nil
                     || (name.hasPrefix(".") && name.hasSuffix(".tmp")) {
-                    try? fileManager.removeItem(at: url)
+                    try removeIfPresent(at: url)
                 }
             }
+        }
+    }
+
+    func allowPublications() throws {
+        try withCoordinatedInboxWrite {
+            try removeIfPresent(at: publicationBlockURL)
         }
     }
 
@@ -312,12 +349,23 @@ struct SharedImportStore: @unchecked Sendable {
         inboxURL.appendingPathComponent(requestID.uuidString.lowercased(), isDirectory: true)
     }
 
+    private var publicationBlockURL: URL {
+        inboxURL.appendingPathComponent(Self.publicationBlockFileName)
+    }
+
     private func fileSize(at url: URL) throws -> Int64 {
         let attributes = try fileManager.attributesOfItem(atPath: url.path)
         guard let size = attributes[.size] as? NSNumber else {
             throw SharedImportError.invalidFile
         }
         return size.int64Value
+    }
+
+    private func removeIfPresent(at url: URL) throws {
+        do {
+            try fileManager.removeItem(at: url)
+        } catch CocoaError.fileNoSuchFile {
+        }
     }
 
     private func protectAndExcludeFromBackup(_ url: URL) {

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -5,15 +5,18 @@ struct SharedImportStore: @unchecked Sendable {
     private static let publicationBlockFileName = ".publication-blocked"
     private let fileManager: FileManager
     private let publicationDidBegin: (@Sendable () -> Void)?
+    private let purgeDidBegin: (@Sendable () -> Void)?
     let inboxURL: URL
 
     init(
         fileManager: FileManager = .default,
         inboxURL: URL? = nil,
-        publicationDidBegin: (@Sendable () -> Void)? = nil
+        publicationDidBegin: (@Sendable () -> Void)? = nil,
+        purgeDidBegin: (@Sendable () -> Void)? = nil
     ) throws {
         self.fileManager = fileManager
         self.publicationDidBegin = publicationDidBegin
+        self.purgeDidBegin = purgeDidBegin
 
         if let inboxURL {
             self.inboxURL = inboxURL
@@ -271,6 +274,7 @@ struct SharedImportStore: @unchecked Sendable {
 
     func purgeAllRequests() throws {
         try withCoordinatedInboxWrite {
+            purgeDidBegin?()
             guard fileManager.fileExists(atPath: publicationBlockURL.path)
                 || fileManager.createFile(atPath: publicationBlockURL.path, contents: Data()) else {
                 throw SharedImportError.invalidFile

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -41,15 +41,38 @@ struct SharedImportStore {
         ) else {
             throw SharedImportError.unsupportedType
         }
-
-        let sourceValues = try sourceURL.resourceValues(
-            forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
-        )
-        guard sourceValues.isRegularFile == true, sourceValues.isSymbolicLink != true else {
+        let data: Data
+        do {
+            data = try BoundedFileIO.read(
+                from: sourceURL,
+                maximumSize: kind.maximumSizeBytes
+            )
+        } catch BoundedFileIOError.fileTooLarge(let size, _) {
+            throw SharedImportError.fileTooLarge(kind: kind, size: size)
+        } catch {
             throw SharedImportError.invalidFile
         }
+        return try enqueue(
+            data: data,
+            typeIdentifier: typeIdentifier,
+            originalFileName: originalFileName
+        )
+    }
 
-        let byteCount = Int64(sourceValues.fileSize ?? 0)
+    @discardableResult
+    func enqueue(
+        data: Data,
+        typeIdentifier: String,
+        originalFileName: String
+    ) throws -> SharedImportRequest {
+        guard let kind = SharedImportClassifier.kind(
+            typeIdentifier: typeIdentifier,
+            fileName: originalFileName
+        ) else {
+            throw SharedImportError.unsupportedType
+        }
+
+        let byteCount = Int64(data.count)
         guard byteCount <= kind.maximumSizeBytes else {
             throw SharedImportError.fileTooLarge(kind: kind, size: byteCount)
         }
@@ -89,10 +112,13 @@ struct SharedImportStore {
 
         do {
             let stagedURL = temporaryDirectory.appendingPathComponent(stagedFileName)
-            try fileManager.copyItem(at: sourceURL, to: stagedURL)
+            try data.write(to: stagedURL, options: .atomic)
 
-            let copiedSize = try fileSize(at: stagedURL)
-            guard copiedSize == byteCount else {
+            let copiedData = try BoundedFileIO.read(
+                from: stagedURL,
+                maximumSize: kind.maximumSizeBytes
+            )
+            guard copiedData.count == data.count else {
                 throw SharedImportError.invalidFile
             }
 
@@ -114,7 +140,7 @@ struct SharedImportStore {
     }
 
     func pendingRequests() -> [SharedImportRequest] {
-        removeStaleTemporaryDirectories()
+        removeStaleEntries()
 
         let directories = (try? fileManager.contentsOfDirectory(
             at: inboxURL,
@@ -127,25 +153,39 @@ struct SharedImportStore {
             .sorted { $0.createdAt < $1.createdAt }
     }
 
-    /// Removes staging directories abandoned by an interrupted share (the
-    /// extension was killed between copy and publish), so they don't retain
-    /// app-group storage indefinitely. Only directories older than the
-    /// staging lifetime are removed, to never race a share in progress.
-    private func removeStaleTemporaryDirectories() {
-        let cutoff = Date().addingTimeInterval(
+    /// Removes abandoned hidden staging, stale malformed requests, and valid
+    /// requests past their retention window without racing an active share.
+    private func removeStaleEntries() {
+        let staleCutoff = Date().addingTimeInterval(
             -SharedImportConfiguration.staleStagingLifetimeSeconds
+        )
+        let retentionCutoff = Date().addingTimeInterval(
+            -SharedImportConfiguration.validRequestRetentionSeconds
         )
         let entries = (try? fileManager.contentsOfDirectory(
             at: inboxURL,
-            includingPropertiesForKeys: [.creationDateKey],
+            includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
             options: []
         )) ?? []
         for url in entries {
             let name = url.lastPathComponent
-            guard name.hasPrefix("."), name.hasSuffix(".tmp") else { continue }
-            let created = (try? url.resourceValues(forKeys: [.creationDateKey]))?
-                .creationDate ?? .distantPast
-            if created < cutoff {
+            let values = try? url.resourceValues(forKeys: [
+                .creationDateKey,
+                .contentModificationDateKey
+            ])
+            let entryDate = values?.contentModificationDate ?? values?.creationDate ?? .distantPast
+            if name.hasPrefix(".") && name.hasSuffix(".tmp") {
+                if entryDate < staleCutoff {
+                    try? fileManager.removeItem(at: url)
+                }
+                continue
+            }
+            guard UUID(uuidString: name) != nil else { continue }
+            if let request = loadRequest(from: url) {
+                if request.createdAt < retentionCutoff {
+                    try? fileManager.removeItem(at: url)
+                }
+            } else if entryDate < staleCutoff {
                 try? fileManager.removeItem(at: url)
             }
         }
@@ -174,6 +214,13 @@ struct SharedImportStore {
             throw SharedImportError.invalidRequest
         }
         return payloadURL
+    }
+
+    func payloadData(for request: SharedImportRequest) throws -> Data {
+        try BoundedFileIO.read(
+            from: payloadURL(for: request),
+            maximumSize: request.item.kind.maximumSizeBytes
+        )
     }
 
     func removeRequest(id: UUID) {
@@ -217,7 +264,10 @@ struct SharedImportStore {
         )
         let decoder = JSONDecoder()
 
-        guard let data = try? Data(contentsOf: manifestURL),
+        guard let data = try? BoundedFileIO.read(
+                  from: manifestURL,
+                  maximumSize: SharedImportConfiguration.maximumManifestSizeBytes
+              ),
               let request = try? decoder.decode(SharedImportRequest.self, from: data),
               directoryURL == self.directoryURL(for: request.id),
               (try? payloadURL(for: request)) != nil else {

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -1,12 +1,21 @@
 import Foundation
 import UniformTypeIdentifiers
 
-struct SharedImportStore {
+struct SharedImportStore: @unchecked Sendable {
     private let fileManager: FileManager
+    private let publicationDidBegin: (@Sendable () -> Void)?
+    private let purgeDidBegin: (@Sendable () -> Void)?
     let inboxURL: URL
 
-    init(fileManager: FileManager = .default, inboxURL: URL? = nil) throws {
+    init(
+        fileManager: FileManager = .default,
+        inboxURL: URL? = nil,
+        publicationDidBegin: (@Sendable () -> Void)? = nil,
+        purgeDidBegin: (@Sendable () -> Void)? = nil
+    ) throws {
         self.fileManager = fileManager
+        self.publicationDidBegin = publicationDidBegin
+        self.purgeDidBegin = purgeDidBegin
 
         if let inboxURL {
             self.inboxURL = inboxURL
@@ -104,38 +113,41 @@ struct SharedImportStore {
         )
         let requestDirectory = directoryURL(for: requestID)
 
-        try fileManager.createDirectory(
-            at: temporaryDirectory,
-            withIntermediateDirectories: false,
-            attributes: nil
-        )
-
-        do {
-            let stagedURL = temporaryDirectory.appendingPathComponent(stagedFileName)
-            try data.write(to: stagedURL, options: .atomic)
-
-            let copiedData = try BoundedFileIO.read(
-                from: stagedURL,
-                maximumSize: kind.maximumSizeBytes
+        return try withCoordinatedInboxWrite {
+            publicationDidBegin?()
+            try fileManager.createDirectory(
+                at: temporaryDirectory,
+                withIntermediateDirectories: false,
+                attributes: nil
             )
-            guard copiedData.count == data.count else {
-                throw SharedImportError.invalidFile
+
+            do {
+                let stagedURL = temporaryDirectory.appendingPathComponent(stagedFileName)
+                try data.write(to: stagedURL, options: .atomic)
+
+                let copiedData = try BoundedFileIO.read(
+                    from: stagedURL,
+                    maximumSize: kind.maximumSizeBytes
+                )
+                guard copiedData.count == data.count else {
+                    throw SharedImportError.invalidFile
+                }
+
+                let manifestURL = temporaryDirectory.appendingPathComponent(
+                    SharedImportConfiguration.manifestFileName
+                )
+                let encoder = JSONEncoder()
+                try encoder.encode(request).write(to: manifestURL, options: .atomic)
+
+                protectAndExcludeFromBackup(stagedURL)
+                protectAndExcludeFromBackup(manifestURL)
+                protectAndExcludeFromBackup(temporaryDirectory)
+                try fileManager.moveItem(at: temporaryDirectory, to: requestDirectory)
+                return request
+            } catch {
+                try? fileManager.removeItem(at: temporaryDirectory)
+                throw error
             }
-
-            let manifestURL = temporaryDirectory.appendingPathComponent(
-                SharedImportConfiguration.manifestFileName
-            )
-            let encoder = JSONEncoder()
-            try encoder.encode(request).write(to: manifestURL, options: .atomic)
-
-            protectAndExcludeFromBackup(stagedURL)
-            protectAndExcludeFromBackup(manifestURL)
-            protectAndExcludeFromBackup(temporaryDirectory)
-            try fileManager.moveItem(at: temporaryDirectory, to: requestDirectory)
-            return request
-        } catch {
-            try? fileManager.removeItem(at: temporaryDirectory)
-            throw error
         }
     }
 
@@ -224,7 +236,27 @@ struct SharedImportStore {
     }
 
     func removeRequest(id: UUID) {
-        try? fileManager.removeItem(at: directoryURL(for: id))
+        try? withCoordinatedInboxWrite {
+            try? fileManager.removeItem(at: directoryURL(for: id))
+        }
+    }
+
+    func purgeAllRequests() {
+        try? withCoordinatedInboxWrite {
+            purgeDidBegin?()
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: inboxURL,
+                includingPropertiesForKeys: nil,
+                options: []
+            )) ?? []
+            for url in entries {
+                let name = url.lastPathComponent
+                if UUID(uuidString: name) != nil
+                    || (name.hasPrefix(".") && name.hasSuffix(".tmp")) {
+                    try? fileManager.removeItem(at: url)
+                }
+            }
+        }
     }
 
     static func sanitizedFileName(_ fileName: String) -> String {
@@ -297,6 +329,23 @@ struct SharedImportStore {
         var values = URLResourceValues()
         values.isExcludedFromBackup = true
         try? protectedURL.setResourceValues(values)
+    }
+
+    private func withCoordinatedInboxWrite<T>(_ operation: () throws -> T) throws -> T {
+        let coordinator = NSFileCoordinator(filePresenter: nil)
+        var coordinationError: NSError?
+        var result: Result<T, Error>?
+        coordinator.coordinate(
+            writingItemAt: inboxURL,
+            options: .forMerging,
+            error: &coordinationError
+        ) { _ in
+            result = Result { try operation() }
+        }
+        if let result {
+            return try result.get()
+        }
+        throw coordinationError ?? SharedImportError.invalidFile
     }
 
     private static func stagedFileName(


### PR DESCRIPTION
## Summary
- stage selected documents in bounded, protected app-owned storage with deterministic cleanup
- serialize ShareInbox publication and account teardown while preserving retry behavior
- preserve project color and original document sizes across platforms
- use atomic bulk project deletion and confirm destructive Start Fresh recovery

## Testing
- added managed staging, ShareInbox, cancellation, schema, and bulk-delete tests
- `git diff --check`
- command-line builds/tests not run because `AGENTS.md` requires Xcode

## Related
- Depends on tinfoilsh/controlplane#574 and tinfoilsh/confidential-sync#40.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures document and project data lifecycles and hardens account/cleanup boundaries. Old code read provider URLs directly and allowed navigation/import/delete races; new code stages files in `ManagedFileStore` with bounded I/O, gates async transitions behind navigation/account fences, serializes import/upload/ack/purge, confirms destructive recovery, and reports precise outcomes with retry.

- Adds `BoundedFileIO` and switches conversion/extraction to cancellable, size‑bounded reads with consistent errors. Introduces `ManagedFileStore`/`ManagedStagedFile` for deterministic staging and a startup sweep; the share extension writes payload data directly (no temp files).
- Document and photo pickers stage files and enforce account lifecycle fences during selection; propagate staging errors via onError. Eliminates selection/navigation races by awaiting view‑model ops and checking `navigationGeneration` and `accountLifecycleGeneration` before transitions.
- Serializes shared import publication/ack/purge and preserves account context across async operations. Surfaces account teardown errors via alert with a Retry action; deletion/cleanup actions remain fenced if the account changes mid‑flight.
- Extends the project schema with optional color across create/update/sync; merges partial updates; maps web color IDs via Color.projectColor and tints a new ProjectFolderIcon.
- Adds `/v1/sync/delete-all-projects` and threads `SyncEnclaveRequestProgress` through request APIs. “Start Fresh” flows require confirmation and delete‑all returns a `DeleteAllDataOutcome` to distinguish deleted, account‑changed, and refresh‑required states.

**Migration**
- Document picker:
  - Was: onDocumentPicked(URL, String)
  - Now: onDocumentPicked(`ManagedStagedFile`, String), onError(Error), accountLifecycleGeneration: () -> Int, isAccountLifecycleCurrent: (Int) -> Bool. Pass generation closures, forward the staged file, and call discard() when done.
- Navigation and project/chat ops are async and fenced (e.g., beginNavigationOperation(), createNewRootChat(), openSummaryChat(...), exitProject()). Await results and verify the current generation before changing UI state.
- Update delete‑all call sites to handle `DeleteAllDataOutcome` and, if calling lower‑level clients, pass `SyncEnclaveRequestProgress` to propagate “request started.” Ensure the backend exposes `/v1/sync/delete-all-projects`.

<sup>Written for commit 2ea1d812f56757d6a0f62c033c8b9044a4bb6411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

