### PR TITLE
Polish iOS chat layout and interactions

### DIFF
--- a/TinfoilChat.xcodeproj/project.pbxproj
+++ b/TinfoilChat.xcodeproj/project.pbxproj
@@ -640,7 +640,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TinfoilChat/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Tinfoil Chat";
+				INFOPLIST_KEY_CFBundleDisplayName = Tinfoil;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Tinfoil needs access to your microphone to support speech-to-text.";
@@ -685,7 +685,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TinfoilChat/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Tinfoil Chat";
+				INFOPLIST_KEY_CFBundleDisplayName = Tinfoil;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Tinfoil needs access to your microphone to support speech-to-text.";

--- a/TinfoilChat/Config/Constants.swift
+++ b/TinfoilChat/Config/Constants.swift
@@ -49,9 +49,10 @@ enum Constants {
     enum UI {
         static let scrollToBottomButtonSize: CGFloat = 27
         static let scrollToBottomIconSize: CGFloat = 16
-        static let tableMaxColumnWidth: CGFloat = 300
+        static let tableMaximumColumnWidthRatio: CGFloat = 0.5
         static let tableFontSize: CGFloat = 16
         static let tableCellHorizontalPadding: CGFloat = 12
+        static let tableColumnDividerWidth: CGFloat = 1
         static let streamingIndicatorSize: CGFloat = 10
         static let streamingIndicatorCornerRadius: CGFloat = 3
         static let streamingIndicatorIconColumnWidth: CGFloat = 16

--- a/TinfoilChat/ContentView.swift
+++ b/TinfoilChat/ContentView.swift
@@ -179,15 +179,6 @@ struct ContentView: View {
                 hasActiveSubscription: hasSubscription
             )
         }
-        .overlay {
-            if scenePhase != .active {
-                ZStack {
-                    splashBackground
-                    splashLogo
-                }
-                .transition(.opacity)
-            }
-        }
     }
 
     private var splashBackground: some View {

--- a/TinfoilChat/Views/LaTeXMarkdownView.swift
+++ b/TinfoilChat/Views/LaTeXMarkdownView.swift
@@ -1056,17 +1056,33 @@ private enum TableAlignment: Sendable {
     }
 }
 
+enum MarkdownTableLayout {
+    static func columnWidth(
+        intrinsicWidth: CGFloat,
+        availableWidth: CGFloat?,
+        columnCount: Int
+    ) -> CGFloat {
+        guard let availableWidth, availableWidth.isFinite, availableWidth > 0 else {
+            return intrinsicWidth
+        }
+        let dividerWidth = CGFloat(max(columnCount - 1, 0)) * Constants.UI.tableColumnDividerWidth
+        let availableContentWidth = max(availableWidth - dividerWidth, 0)
+        return min(intrinsicWidth, availableContentWidth * Constants.UI.tableMaximumColumnWidthRatio)
+    }
+}
+
 private struct MarkdownTableView: View {
     let table: ParsedTable
     let isDarkMode: Bool
     let textSelectionEnabled: Bool
-    let columnWidths: [Int: CGFloat]
+    let intrinsicColumnWidths: [Int: CGFloat]
+    @State private var availableWidth: CGFloat?
 
     init(table: ParsedTable, isDarkMode: Bool, textSelectionEnabled: Bool = true) {
         self.table = table
         self.isDarkMode = isDarkMode
         self.textSelectionEnabled = textSelectionEnabled
-        self.columnWidths = Self.measureColumnWidths(for: table)
+        self.intrinsicColumnWidths = Self.measureColumnWidths(for: table)
     }
 
     private var borderColor: SwiftUI.Color {
@@ -1082,11 +1098,26 @@ private struct MarkdownTableView: View {
     }
 
     var body: some View {
+        let columnCount = intrinsicColumnWidths.count
+        let columnWidths = intrinsicColumnWidths.mapValues {
+            MarkdownTableLayout.columnWidth(
+                intrinsicWidth: $0,
+                availableWidth: availableWidth,
+                columnCount: columnCount
+            )
+        }
+
         ViewThatFits(in: .horizontal) {
-            tableContainer
+            tableContainer(columnWidths: columnWidths)
             ScrollView(.horizontal, showsIndicators: true) {
-                tableContainer
+                tableContainer(columnWidths: columnWidths)
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            availableWidth = width > 0 && width.isFinite ? width : nil
         }
         .padding(.vertical, 8)
     }
@@ -1100,13 +1131,13 @@ private struct MarkdownTableView: View {
 
         for (index, header) in table.headers.enumerated() {
             let size = (header as NSString).size(withAttributes: [.font: boldFont])
-            widths[index] = min(size.width + horizontalPadding, Constants.UI.tableMaxColumnWidth)
+            widths[index] = size.width + horizontalPadding
         }
 
         for row in table.rows {
             for (index, cell) in row.enumerated() {
                 let size = (cell as NSString).size(withAttributes: [.font: font])
-                let width = min(size.width + horizontalPadding, Constants.UI.tableMaxColumnWidth)
+                let width = size.width + horizontalPadding
                 widths[index] = max(widths[index] ?? 0, width)
             }
         }
@@ -1114,7 +1145,7 @@ private struct MarkdownTableView: View {
         return widths
     }
 
-    private var tableContainer: some View {
+    private func tableContainer(columnWidths: [Int: CGFloat]) -> some View {
         VStack(spacing: 0) {
             if !table.headers.isEmpty {
                 MarkdownTableRowView(
@@ -1185,7 +1216,7 @@ private struct MarkdownTableRowView: View {
                 if index < cells.count - 1 {
                     Rectangle()
                         .fill(borderColor)
-                        .frame(width: 1)
+                        .frame(width: Constants.UI.tableColumnDividerWidth)
                 }
             }
         }

--- a/TinfoilChat/Views/MessageView.swift
+++ b/TinfoilChat/Views/MessageView.swift
@@ -1491,6 +1491,7 @@ struct AdaptiveMarkdownText: View {
         StructuredText(markdown: content)
             .textual.highlighterTheme(.default)
             .textual.paragraphStyle(UserBubbleParagraphStyle())
+            .textual.textSelection(.enabled)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, horizontalPadding)
     }

--- a/TinfoilChatTests/MarkdownTableLayoutTests.swift
+++ b/TinfoilChatTests/MarkdownTableLayoutTests.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+import Testing
+@testable import TinfoilChat
+
+@Suite("Markdown Table Layout Tests")
+struct MarkdownTableLayoutTests {
+    @Test("Caps a wide column at half the available table width")
+    func capsWideColumnRelativeToAvailableWidth() {
+        let width = MarkdownTableLayout.columnWidth(
+            intrinsicWidth: 500,
+            availableWidth: 320,
+            columnCount: 1
+        )
+
+        #expect(width == 160)
+    }
+
+    @Test("Preserves intrinsic width below the responsive cap")
+    func preservesNarrowColumnWidth() {
+        let width = MarkdownTableLayout.columnWidth(
+            intrinsicWidth: 120,
+            availableWidth: 600,
+            columnCount: 3
+        )
+
+        #expect(width == 120)
+    }
+
+    @Test("Preserves intrinsic width before container measurement")
+    func preservesIntrinsicWidthWithoutAvailableWidth() {
+        let width = MarkdownTableLayout.columnWidth(
+            intrinsicWidth: 420,
+            availableWidth: nil,
+            columnCount: 2
+        )
+
+        #expect(width == 420)
+    }
+
+    @Test("Leaves room for column dividers at the width cap")
+    func accountsForColumnDividers() {
+        let width = MarkdownTableLayout.columnWidth(
+            intrinsicWidth: 500,
+            availableWidth: 320,
+            columnCount: 2
+        )
+
+        #expect(width == 159.5)
+    }
+}


### PR DESCRIPTION
## Summary
- cap Markdown table columns relative to the available chat width and add layout coverage
- keep conversations visible during system interruptions and enable native user-message text selection
- rename the app display name from Tinfoil Chat to Tinfoil

## Testing
- not run per repository instructions; requires verification in Xcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the iOS chat UI: Markdown tables now cap column widths relative to the container (was a fixed 300pt cap), chats remain visible during brief system interruptions (previously covered by a splash overlay), user messages allow text selection, and the app display name is now “Tinfoil”. Improves readability on narrow screens, reduces jarring overlays, and enables copy.

- Tables: compute column widths from intrinsic size and available content width (accounts for divider widths, falls back before measurement); horizontal scrolling remains when needed; adds focused tests for the layout function.
- Interactions: remove the inactive-scene splash overlay so conversations stay visible during interruptions; enable text selection in user messages only.
- Branding: update `CFBundleDisplayName` to “Tinfoil”. Verify the new name on the Home Screen and App Switcher.

<sup>Written for commit 2e7a132af351a4752648c4629c0a1def3a1a0881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

