### PR TITLE
fix: bound document staging

### DIFF
--- a/TinfoilChat/Services/DocumentConversionService.swift
+++ b/TinfoilChat/Services/DocumentConversionService.swift
@@ -49,7 +49,10 @@ actor DocumentConversionService {
     }
 
     func convertToMarkdown(url: URL, filename: String, contentType: String? = nil, mode: String = Constants.DocumentProcessing.defaultMode) async throws -> String {
-        let fileData = try Data(contentsOf: url)
+        let fileData = try BoundedFileIO.read(
+            from: url,
+            maximumBytes: Constants.Attachments.maxFileSizeBytes
+        )
         let boundary = "Boundary-\(UUID().uuidString)"
         let mimeType = contentType ?? Self.mimeType(for: filename)
         let body = Self.multipartBody(

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -39,11 +39,6 @@ final class DocumentProcessingService {
             throw ProcessingError.unsupportedFormat(fileExtension)
         }
 
-        let fileSize = try fileSize(at: url)
-        guard fileSize <= Constants.Attachments.maxFileSizeBytes else {
-            throw ProcessingError.fileTooLarge(fileSize)
-        }
-
         switch fileExtension {
         case "pdf":
             return try await Task.detached(priority: .userInitiated) {
@@ -59,7 +54,8 @@ final class DocumentProcessingService {
     }
 
     private func extractTextFromPDF(at url: URL) throws -> String {
-        guard let document = PDFDocument(url: url) else {
+        let data = try boundedData(from: url)
+        guard let document = PDFDocument(data: data) else {
             throw ProcessingError.textExtractionFailed
         }
 
@@ -82,8 +78,8 @@ final class DocumentProcessingService {
     }
 
     private func readPlainText(at url: URL) throws -> String {
-        guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else {
+        let data = try boundedData(from: url)
+        guard let text = String(data: data, encoding: .utf8) else {
             throw ProcessingError.fileReadFailed
         }
 
@@ -94,8 +90,14 @@ final class DocumentProcessingService {
         return text
     }
 
-    private func fileSize(at url: URL) throws -> Int64 {
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        return attributes[.size] as? Int64 ?? 0
+    private func boundedData(from url: URL) throws -> Data {
+        do {
+            return try BoundedFileIO.read(
+                from: url,
+                maximumBytes: Constants.Attachments.maxFileSizeBytes
+            )
+        } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
+            throw ProcessingError.fileTooLarge(size)
+        }
     }
 }

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -3,16 +3,14 @@ import Foundation
 final class ManagedFileHandle: @unchecked Sendable {
     let url: URL
     let fileName: String
-    let size: Int64
 
     private let store: ManagedFileStore
     private let lock = NSLock()
     private var isReleased = false
 
-    fileprivate init(url: URL, fileName: String, size: Int64, store: ManagedFileStore) {
+    fileprivate init(url: URL, fileName: String, store: ManagedFileStore) {
         self.url = url
         self.fileName = fileName
-        self.size = size
         self.store = store
     }
 
@@ -45,7 +43,7 @@ final class ManagedFileStore: @unchecked Sendable {
     func stage(sourceURL: URL, fileName: String) throws -> ManagedFileHandle {
         try prepareDirectory()
         let destinationURL = directoryURL.appendingPathComponent(destinationName(for: sourceURL))
-        let size = try BoundedFileIO.copy(
+        try BoundedFileIO.copy(
             from: sourceURL,
             to: destinationURL,
             maximumBytes: Constants.Attachments.maxFileSizeBytes,
@@ -56,7 +54,7 @@ final class ManagedFileStore: @unchecked Sendable {
 
         do {
             try excludeFromBackup(destinationURL)
-            return ManagedFileHandle(url: destinationURL, fileName: fileName, size: size, store: self)
+            return ManagedFileHandle(url: destinationURL, fileName: fileName, store: self)
         } catch {
             try? fileManager.removeItem(at: destinationURL)
             throw error

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -55,10 +55,6 @@ final class ManagedFileStore: @unchecked Sendable {
         )
 
         do {
-            try fileManager.setAttributes(
-                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
-                ofItemAtPath: destinationURL.path
-            )
             try excludeFromBackup(destinationURL)
             return ManagedFileHandle(url: destinationURL, fileName: fileName, size: size, store: self)
         } catch {

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+final class ManagedFileHandle: @unchecked Sendable {
+    let url: URL
+    let fileName: String
+    let size: Int64
+
+    private let store: ManagedFileStore
+    private let lock = NSLock()
+    private var isReleased = false
+
+    fileprivate init(url: URL, fileName: String, size: Int64, store: ManagedFileStore) {
+        self.url = url
+        self.fileName = fileName
+        self.size = size
+        self.store = store
+    }
+
+    deinit {
+        try? release()
+    }
+
+    func release() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isReleased else { return }
+        try store.removeFile(at: url)
+        isReleased = true
+    }
+}
+
+final class ManagedFileStore: @unchecked Sendable {
+    static let shared = ManagedFileStore()
+
+    private let fileManager: FileManager
+    private let directoryURL: URL
+
+    init(fileManager: FileManager = .default, directoryURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.directoryURL = directoryURL ?? fileManager
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("ManagedFileStaging", isDirectory: true)
+    }
+
+    func stage(sourceURL: URL, fileName: String) throws -> ManagedFileHandle {
+        try prepareDirectory()
+        let destinationURL = directoryURL.appendingPathComponent(destinationName(for: sourceURL))
+        let size = try BoundedFileIO.copy(
+            from: sourceURL,
+            to: destinationURL,
+            maximumBytes: Constants.Attachments.maxFileSizeBytes,
+            destinationAttributes: [
+                .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+            ]
+        )
+
+        do {
+            try fileManager.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                ofItemAtPath: destinationURL.path
+            )
+            try excludeFromBackup(destinationURL)
+            return ManagedFileHandle(url: destinationURL, fileName: fileName, size: size, store: self)
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        }
+    }
+
+    fileprivate func removeFile(at url: URL) throws {
+        try fileManager.removeItem(at: url)
+    }
+
+    private func prepareDirectory() throws {
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+        try fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: directoryURL.path
+        )
+        try excludeFromBackup(directoryURL)
+    }
+
+    private func excludeFromBackup(_ url: URL) throws {
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try url.setResourceValues(values)
+    }
+
+    private func destinationName(for sourceURL: URL) -> String {
+        let fileExtension = sourceURL.pathExtension
+        let safeExtension = fileExtension.count <= 16 && fileExtension.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0)
+        } ? fileExtension : ""
+        return UUID().uuidString + (safeExtension.isEmpty ? "" : ".\(safeExtension)")
+    }
+}

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -85,6 +85,7 @@ final class ManagedFileStore: @unchecked Sendable {
     }
 
     private func excludeFromBackup(_ url: URL) throws {
+        var url = url
         var values = URLResourceValues()
         values.isExcludedFromBackup = true
         try url.setResourceValues(values)

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2008,7 +2008,8 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func uploadProjectDocument(url: URL, filename: String) async {
+    func uploadProjectDocument(handle: ManagedFileHandle) async {
+        defer { try? handle.release() }
         guard let project = activeProject else { return }
         let accountGeneration = projectListAccountGeneration
 
@@ -2021,14 +2022,14 @@ class ChatViewModel: ObservableObject {
         }
         do {
             let markdown = try await DocumentConversionService.shared.convertToMarkdown(
-                url: url,
-                filename: filename
+                url: handle.url,
+                filename: handle.fileName
             )
             guard isCurrentProjectAccount(accountGeneration) else { return }
-            let contentType = DocumentConversionService.mimeType(for: filename)
+            let contentType = DocumentConversionService.mimeType(for: handle.fileName)
             let document = try await projectStorage.uploadDocument(
                 projectId: project.id,
-                filename: filename,
+                filename: handle.fileName,
                 contentType: contentType,
                 content: markdown
             )
@@ -3150,7 +3151,8 @@ class ChatViewModel: ObservableObject {
     func addDocumentAttachment(
         url: URL,
         fileName: String,
-        sharedImportRequestID: UUID? = nil
+        sharedImportRequestID: UUID? = nil,
+        managedFile: ManagedFileHandle? = nil
     ) {
         attachmentError = nil
 
@@ -3165,9 +3167,13 @@ class ChatViewModel: ObservableObject {
         pendingAttachments.append(attachment)
 
         Task {
+            defer { try? managedFile?.release() }
             do {
                 let text = try await DocumentProcessingService.shared.extractText(from: url)
-                let fileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64) ?? 0
+                let fileSize = try BoundedFileIO.size(
+                    of: url,
+                    maximumBytes: Constants.Attachments.maxFileSizeBytes
+                )
 
                 attachment.textContent = text
                 attachment.fileSize = fileSize
@@ -3184,6 +3190,14 @@ class ChatViewModel: ObservableObject {
                 attachmentError = error.localizedDescription
             }
         }
+    }
+
+    func addDocumentAttachment(handle: ManagedFileHandle) {
+        addDocumentAttachment(
+            url: handle.url,
+            fileName: handle.fileName,
+            managedFile: handle
+        )
     }
 
     func addImageAttachment(

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -8,7 +8,16 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct DocumentPickerView: UIViewControllerRepresentable {
-    var onDocumentPicked: (URL, String) -> Void
+    var onDocumentPicked: (ManagedFileHandle) -> Void
+    var onError: (Error) -> Void
+
+    init(
+        onDocumentPicked: @escaping (ManagedFileHandle) -> Void,
+        onError: @escaping (Error) -> Void
+    ) {
+        self.onDocumentPicked = onDocumentPicked
+        self.onError = onError
+    }
 
     private static let supportedTypes: [UTType] = [
         .pdf,
@@ -34,14 +43,19 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onDocumentPicked: onDocumentPicked)
+        Coordinator(onDocumentPicked: onDocumentPicked, onError: onError)
     }
 
     class Coordinator: NSObject, UIDocumentPickerDelegate {
-        let onDocumentPicked: (URL, String) -> Void
+        let onDocumentPicked: (ManagedFileHandle) -> Void
+        let onError: (Error) -> Void
 
-        init(onDocumentPicked: @escaping (URL, String) -> Void) {
+        init(
+            onDocumentPicked: @escaping (ManagedFileHandle) -> Void,
+            onError: @escaping (Error) -> Void
+        ) {
             self.onDocumentPicked = onDocumentPicked
+            self.onError = onError
         }
 
         func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
@@ -50,23 +64,16 @@ struct DocumentPickerView: UIViewControllerRepresentable {
             let fileName = sourceURL.lastPathComponent
 
             guard sourceURL.startAccessingSecurityScopedResource() else {
+                onError(BoundedFileIO.Error.readFailed)
                 return
             }
             defer { sourceURL.stopAccessingSecurityScopedResource() }
 
-            let tempDir = FileManager.default.temporaryDirectory
-            let tempURL = tempDir.appendingPathComponent(UUID().uuidString + "_" + fileName)
-
             do {
-                if FileManager.default.fileExists(atPath: tempURL.path) {
-                    try FileManager.default.removeItem(at: tempURL)
-                }
-                try FileManager.default.copyItem(at: sourceURL, to: tempURL)
-                onDocumentPicked(tempURL, fileName)
+                let handle = try ManagedFileStore.shared.stage(sourceURL: sourceURL, fileName: fileName)
+                onDocumentPicked(handle)
             } catch {
-                #if DEBUG
-                print("Failed to copy document to temp directory: \(error)")
-                #endif
+                onError(error)
             }
         }
     }

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -283,9 +283,14 @@ struct MessageInputView: View {
                 Text(viewModel.attachmentError ?? "An error occurred")
             }
             .sheet(isPresented: $viewModel.showDocumentPicker) {
-                DocumentPickerView { url, fileName in
-                    viewModel.addDocumentAttachment(url: url, fileName: fileName)
-                }
+                DocumentPickerView(
+                    onDocumentPicked: { handle in
+                        viewModel.addDocumentAttachment(handle: handle)
+                    },
+                    onError: { error in
+                        viewModel.attachmentError = error.localizedDescription
+                    }
+                )
             }
             .sheet(isPresented: $viewModel.showPhotoPicker, onDismiss: processSelectedPhotos) {
                 NavigationStack {
@@ -512,7 +517,7 @@ struct MessageInputView: View {
                          onFocusHandled: { viewModel.shouldFocusInput = false },
                          onSendMessage: { text in viewModel.sendMessage(text: text) },
                          onPasteImage: { data, fileName in viewModel.addImageAttachment(data: data, fileName: fileName) },
-                         onPasteFile: { url, fileName in viewModel.addDocumentAttachment(url: url, fileName: fileName) },
+                         onPasteFile: { handle in viewModel.addDocumentAttachment(handle: handle) },
                          onPasteFileError: { message in viewModel.attachmentError = message })
             .frame(height: textHeight)
             .padding(.horizontal)
@@ -1403,7 +1408,7 @@ struct CustomTextEditor: UIViewRepresentable {
     /// itself when the draft was actually sent or queued.
     var onSendMessage: (String) -> Bool
     var onPasteImage: ((Data, String) -> Void)? = nil
-    var onPasteFile: ((URL, String) -> Void)? = nil
+    var onPasteFile: ((ManagedFileHandle) -> Void)? = nil
     var onPasteFileError: ((String) -> Void)? = nil
 
     func makeUIView(context: Context) -> UITextView {
@@ -1696,7 +1701,7 @@ struct CustomTextEditor: UIViewRepresentable {
 final class PastingTextView: UITextView {
     var allowsImagePaste = false
     var onPasteImage: ((Data, String) -> Void)?
-    var onPasteFile: ((URL, String) -> Void)?
+    var onPasteFile: ((ManagedFileHandle) -> Void)?
     var onPasteFileError: ((String) -> Void)?
 
     /// File URLs win over any string representation on the pasteboard:
@@ -1766,30 +1771,20 @@ final class PastingTextView: UITextView {
         super.paste(sender)
     }
 
-    /// Copies a pasted file into the app's temp directory so the attachment
+    /// Copies a pasted file into the app's managed staging directory so the attachment
     /// pipeline can read it after the pasteboard's access window closes.
     /// Oversized files are rejected up front: the pipeline would refuse them
     /// anyway, and copying or reading them first would waste disk and memory.
-    private func importPastedFile(url: URL, onPasteFile: (URL, String) -> Void) {
+    private func importPastedFile(url: URL, onPasteFile: (ManagedFileHandle) -> Void) {
         let fileName = url.lastPathComponent
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + "_" + fileName)
         let didAccess = url.startAccessingSecurityScopedResource()
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
 
-        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-           Int64(fileSize) > Constants.Attachments.maxFileSizeBytes {
-            let message = DocumentProcessingService.ProcessingError
-                .fileTooLarge(Int64(fileSize)).errorDescription
-            onPasteFileError?(message ?? "File is too large.")
-            return
-        }
-
         do {
-            try FileManager.default.copyItem(at: url, to: tempURL)
-            onPasteFile(tempURL, fileName)
+            let handle = try ManagedFileStore.shared.stage(sourceURL: url, fileName: fileName)
+            onPasteFile(handle)
         } catch {
-            onPasteFileError?("Couldn't read the pasted file. Try attaching it with the + button instead.")
+            onPasteFileError?(error.localizedDescription)
         }
     }
 } 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -386,11 +386,24 @@ struct ProjectDocumentsView: View {
             }
         }
         .sheet(isPresented: $showDocumentPicker) {
-            DocumentPickerView { url, fileName in
-                Task {
-                    await viewModel.uploadProjectDocument(url: url, filename: fileName)
+            DocumentPickerView(
+                onDocumentPicked: { handle in
+                    Task {
+                        await viewModel.uploadProjectDocument(handle: handle)
+                    }
+                },
+                onError: { error in
+                    viewModel.projectError = error.localizedDescription
                 }
-            }
+            )
+        }
+        .alert("Document Error", isPresented: Binding(
+            get: { viewModel.projectError != nil },
+            set: { if !$0 { viewModel.projectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.projectError ?? "An error occurred")
         }
     }
 

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -374,6 +374,9 @@ struct ProjectDocumentsView: View {
         .background(Color.settingsBackground(for: colorScheme))
         .navigationTitle("Documents")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            viewModel.projectError = nil
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {

--- a/TinfoilChatTests/BoundedDocumentStagingTests.swift
+++ b/TinfoilChatTests/BoundedDocumentStagingTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@Suite("Bounded Document Staging Tests")
+struct BoundedDocumentStagingTests {
+    @Test("Bounded file I/O copies and reads regular files")
+    func copiesAndReadsRegularFiles() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source.txt")
+        let destination = directory.appendingPathComponent("destination.txt")
+        let data = Data(repeating: 0x41, count: BoundedFileIO.chunkSize * 2 + 17)
+        try data.write(to: source)
+
+        let copiedSize = try BoundedFileIO.copy(
+            from: source,
+            to: destination,
+            maximumBytes: Int64(data.count)
+        )
+
+        #expect(copiedSize == Int64(data.count))
+        #expect(try BoundedFileIO.read(from: destination, maximumBytes: Int64(data.count)) == data)
+    }
+
+    @Test("Bounded file I/O rejects non-regular and oversized files")
+    func rejectsUnsafeSources() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source.txt")
+        let symlink = directory.appendingPathComponent("source-link.txt")
+        try Data("too large".utf8).write(to: source)
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: source)
+
+        #expect(throws: BoundedFileIO.Error.notRegularFile) {
+            _ = try BoundedFileIO.read(from: symlink, maximumBytes: 100)
+        }
+        #expect(throws: BoundedFileIO.Error.notRegularFile) {
+            _ = try BoundedFileIO.read(from: directory, maximumBytes: 100)
+        }
+        #expect(throws: BoundedFileIO.Error.fileTooLarge(size: 9, maximum: 8)) {
+            _ = try BoundedFileIO.read(from: source, maximumBytes: 8)
+        }
+    }
+
+    @Test("Bounded file I/O preserves an existing destination")
+    func preservesExistingDestination() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source.txt")
+        let destination = directory.appendingPathComponent("destination.txt")
+        try Data("source".utf8).write(to: source)
+        try Data("existing".utf8).write(to: destination)
+
+        #expect(throws: BoundedFileIO.Error.destinationExists) {
+            _ = try BoundedFileIO.copy(from: source, to: destination, maximumBytes: 100)
+        }
+        #expect(try String(contentsOf: destination, encoding: .utf8) == "existing")
+    }
+
+    @Test("Managed files are protected, excluded from backup, and explicitly released")
+    func managesStagedFileLifecycle() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("provider-owned.txt")
+        let stagingDirectory = directory.appendingPathComponent("ManagedFileStaging", isDirectory: true)
+        try Data("managed content".utf8).write(to: source)
+        let store = ManagedFileStore(directoryURL: stagingDirectory)
+
+        let handle = try store.stage(sourceURL: source, fileName: "document.txt")
+
+        #expect(handle.fileName == "document.txt")
+        #expect(handle.size == 15)
+        #expect(FileManager.default.fileExists(atPath: handle.url.path))
+        #expect(try handle.url.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+        let attributes = try FileManager.default.attributesOfItem(atPath: handle.url.path)
+        #expect(attributes[.protectionKey] as? FileProtectionType == .completeUntilFirstUserAuthentication)
+
+        try handle.release()
+        #expect(!FileManager.default.fileExists(atPath: handle.url.path))
+        #expect(FileManager.default.fileExists(atPath: source.path))
+        try handle.release()
+    }
+
+    @Test("Document processing uses bounded regular-file reads")
+    func processingRejectsUnsafeAndOversizedFiles() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let textFile = directory.appendingPathComponent("document.txt")
+        try Data("bounded text".utf8).write(to: textFile)
+
+        let text = try await DocumentProcessingService.shared.extractText(from: textFile)
+        #expect(text == "bounded text")
+
+        let symlink = directory.appendingPathComponent("document-link.txt")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: textFile)
+        await #expect(throws: BoundedFileIO.Error.notRegularFile) {
+            _ = try await DocumentProcessingService.shared.extractText(from: symlink)
+        }
+
+        let oversized = directory.appendingPathComponent("oversized.txt")
+        try createSparseFile(at: oversized, size: UInt64(Constants.Attachments.maxFileSizeBytes + 1))
+        await #expect(throws: DocumentProcessingService.ProcessingError.self) {
+            _ = try await DocumentProcessingService.shared.extractText(from: oversized)
+        }
+    }
+
+    @Test("Project conversion rejects oversized input before client setup")
+    func conversionRejectsOversizedInput() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let oversized = directory.appendingPathComponent("oversized.docx")
+        let size = Constants.Attachments.maxFileSizeBytes + 1
+        try createSparseFile(at: oversized, size: UInt64(size))
+
+        await #expect(throws: BoundedFileIO.Error.fileTooLarge(
+            size: size,
+            maximum: Constants.Attachments.maxFileSizeBytes
+        )) {
+            _ = try await DocumentConversionService.shared.convertToMarkdown(
+                url: oversized,
+                filename: "oversized.docx"
+            )
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        return url
+    }
+
+    private func createSparseFile(at url: URL, size: UInt64) throws {
+        #expect(FileManager.default.createFile(atPath: url.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: url)
+        handle.truncateFile(atOffset: size)
+        handle.closeFile()
+    }
+}

--- a/TinfoilChatTests/BoundedDocumentStagingTests.swift
+++ b/TinfoilChatTests/BoundedDocumentStagingTests.swift
@@ -58,6 +58,40 @@ struct BoundedDocumentStagingTests {
         #expect(try String(contentsOf: destination, encoding: .utf8) == "existing")
     }
 
+    @Test("Bounded copy rejects same-size in-place source changes")
+    func rejectsSameSizeSourceChanges() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source.txt")
+        let destination = directory.appendingPathComponent("destination.txt")
+        let sourceData = Data(repeating: 0x41, count: BoundedFileIO.chunkSize * 2)
+        try sourceData.write(to: source)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_000_000)],
+            ofItemAtPath: source.path
+        )
+        var didModifySource = false
+
+        #expect(throws: BoundedFileIO.Error.fileChanged) {
+            _ = try BoundedFileIO.copy(
+                from: source,
+                to: destination,
+                maximumBytes: Int64(sourceData.count),
+                onReadChunk: {
+                    guard !didModifySource else { return }
+                    didModifySource = true
+                    let handle = try FileHandle(forWritingTo: source)
+                    try handle.write(contentsOf: Data([0x42]))
+                    try handle.close()
+                }
+            )
+        }
+
+        #expect(didModifySource)
+        #expect(try BoundedFileIO.size(of: source, maximumBytes: Int64(sourceData.count)) == Int64(sourceData.count))
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+    }
+
     @Test("Managed files are protected, excluded from backup, and explicitly released")
     func managesStagedFileLifecycle() throws {
         let directory = try makeTemporaryDirectory()

--- a/TinfoilChatTests/BoundedDocumentStagingTests.swift
+++ b/TinfoilChatTests/BoundedDocumentStagingTests.swift
@@ -98,17 +98,19 @@ struct BoundedDocumentStagingTests {
         defer { try? FileManager.default.removeItem(at: directory) }
         let source = directory.appendingPathComponent("provider-owned.txt")
         let stagingDirectory = directory.appendingPathComponent("ManagedFileStaging", isDirectory: true)
-        try Data("managed content".utf8).write(to: source)
+        let sourceData = Data("managed content".utf8)
+        try sourceData.write(to: source)
         let store = ManagedFileStore(directoryURL: stagingDirectory)
 
         let handle = try store.stage(sourceURL: source, fileName: "document.txt")
 
         #expect(handle.fileName == "document.txt")
-        #expect(handle.size == 15)
         #expect(FileManager.default.fileExists(atPath: handle.url.path))
         #expect(try handle.url.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
         let attributes = try FileManager.default.attributesOfItem(atPath: handle.url.path)
+        #expect((attributes[.size] as? NSNumber)?.int64Value == Int64(sourceData.count))
         #expect(attributes[.protectionKey] as? FileProtectionType == .completeUntilFirstUserAuthentication)
+        #expect(try Data(contentsOf: handle.url) == sourceData)
 
         try handle.release()
         #expect(!FileManager.default.fileExists(atPath: handle.url.path))

--- a/TinfoilShared/BoundedFileIO.swift
+++ b/TinfoilShared/BoundedFileIO.swift
@@ -36,9 +36,17 @@ enum BoundedFileIO {
         let device: dev_t
         let inode: ino_t
         let size: Int64
+        let modificationSeconds: Int64
+        let modificationNanoseconds: Int64
+        let statusChangeSeconds: Int64
+        let statusChangeNanoseconds: Int64
     }
 
-    static func read(from sourceURL: URL, maximumBytes: Int64) throws -> Data {
+    static func read(
+        from sourceURL: URL,
+        maximumBytes: Int64,
+        onReadChunk: (() throws -> Void)? = nil
+    ) throws -> Data {
         let descriptor = try openSource(sourceURL)
         defer { Darwin.close(descriptor) }
 
@@ -55,6 +63,7 @@ enum BoundedFileIO {
             guard bytesRead > 0 else { break }
             totalBytes += Int64(bytesRead)
             try enforceLimit(totalBytes, maximumBytes: maximumBytes)
+            try onReadChunk?()
             buffer.withUnsafeBytes { bytes in
                 data.append(bytes.bindMemory(to: UInt8.self).baseAddress!, count: bytesRead)
             }
@@ -69,7 +78,8 @@ enum BoundedFileIO {
         from sourceURL: URL,
         to destinationURL: URL,
         maximumBytes: Int64,
-        destinationAttributes: [FileAttributeKey: Any] = [:]
+        destinationAttributes: [FileAttributeKey: Any] = [:],
+        onReadChunk: (() throws -> Void)? = nil
     ) throws -> Int64 {
         let sourceDescriptor = try openSource(sourceURL)
         defer { Darwin.close(sourceDescriptor) }
@@ -116,6 +126,7 @@ enum BoundedFileIO {
             guard bytesRead > 0 else { break }
             totalBytes += Int64(bytesRead)
             try enforceLimit(totalBytes, maximumBytes: maximumBytes)
+            try onReadChunk?()
             try writeChunk(buffer, count: bytesRead, to: destinationDescriptor)
         }
 
@@ -167,7 +178,15 @@ enum BoundedFileIO {
     private static func fileInfo(from status: stat) throws -> FileInfo {
         guard status.st_mode & S_IFMT == S_IFREG else { throw Error.notRegularFile }
         guard status.st_size >= 0 else { throw Error.readFailed }
-        return FileInfo(device: status.st_dev, inode: status.st_ino, size: Int64(status.st_size))
+        return FileInfo(
+            device: status.st_dev,
+            inode: status.st_ino,
+            size: Int64(status.st_size),
+            modificationSeconds: Int64(status.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int64(status.st_mtimespec.tv_nsec),
+            statusChangeSeconds: Int64(status.st_ctimespec.tv_sec),
+            statusChangeNanoseconds: Int64(status.st_ctimespec.tv_nsec)
+        )
     }
 
     private static func verifyUnchanged(

--- a/TinfoilShared/BoundedFileIO.swift
+++ b/TinfoilShared/BoundedFileIO.swift
@@ -1,0 +1,225 @@
+import Darwin
+import Foundation
+
+enum BoundedFileIO {
+    static let chunkSize = 64 * 1024
+
+    enum Error: Swift.Error, LocalizedError, Equatable {
+        case notRegularFile
+        case fileTooLarge(size: Int64, maximum: Int64)
+        case fileChanged
+        case destinationExists
+        case readFailed
+        case writeFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .notRegularFile:
+                return "Only regular files can be attached."
+            case .fileTooLarge(let size, let maximum):
+                let sizeMB = Double(size) / 1_048_576
+                let maximumMB = maximum / 1_048_576
+                return String(format: "File is too large (%.1f MB). Maximum is %d MB.", sizeMB, maximumMB)
+            case .fileChanged:
+                return "The file changed while it was being read. Try again."
+            case .destinationExists:
+                return "Could not create a secure staging file."
+            case .readFailed:
+                return "Could not read the file."
+            case .writeFailed:
+                return "Could not stage the file."
+            }
+        }
+    }
+
+    struct FileInfo: Equatable {
+        let device: dev_t
+        let inode: ino_t
+        let size: Int64
+    }
+
+    static func read(from sourceURL: URL, maximumBytes: Int64) throws -> Data {
+        let descriptor = try openSource(sourceURL)
+        defer { Darwin.close(descriptor) }
+
+        let initial = try verifiedInfo(for: descriptor, at: sourceURL)
+        try enforceLimit(initial.size, maximumBytes: maximumBytes)
+
+        var data = Data()
+        data.reserveCapacity(Int(initial.size))
+        var totalBytes: Int64 = 0
+        var buffer = [UInt8](repeating: 0, count: chunkSize)
+
+        while true {
+            let bytesRead = try readChunk(from: descriptor, into: &buffer)
+            guard bytesRead > 0 else { break }
+            totalBytes += Int64(bytesRead)
+            try enforceLimit(totalBytes, maximumBytes: maximumBytes)
+            buffer.withUnsafeBytes { bytes in
+                data.append(bytes.bindMemory(to: UInt8.self).baseAddress!, count: bytesRead)
+            }
+        }
+
+        try verifyUnchanged(descriptor: descriptor, url: sourceURL, initial: initial, bytesRead: totalBytes)
+        return data
+    }
+
+    @discardableResult
+    static func copy(
+        from sourceURL: URL,
+        to destinationURL: URL,
+        maximumBytes: Int64,
+        destinationAttributes: [FileAttributeKey: Any] = [:]
+    ) throws -> Int64 {
+        let sourceDescriptor = try openSource(sourceURL)
+        defer { Darwin.close(sourceDescriptor) }
+
+        let initial = try verifiedInfo(for: sourceDescriptor, at: sourceURL)
+        try enforceLimit(initial.size, maximumBytes: maximumBytes)
+
+        let destinationDescriptor = Darwin.open(
+            destinationURL.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            S_IRUSR | S_IWUSR
+        )
+        guard destinationDescriptor >= 0 else {
+            if errno == EEXIST { throw Error.destinationExists }
+            throw Error.writeFailed
+        }
+        let destinationIdentity: FileInfo
+        do {
+            destinationIdentity = try descriptorInfo(destinationDescriptor)
+            if !destinationAttributes.isEmpty {
+                try FileManager.default.setAttributes(
+                    destinationAttributes,
+                    ofItemAtPath: destinationURL.path
+                )
+            }
+        } catch {
+            Darwin.close(destinationDescriptor)
+            try? FileManager.default.removeItem(at: destinationURL)
+            throw error
+        }
+
+        var completed = false
+        defer {
+            Darwin.close(destinationDescriptor)
+            if !completed {
+                removeFileIfMatching(destinationURL, identity: destinationIdentity)
+            }
+        }
+
+        var totalBytes: Int64 = 0
+        var buffer = [UInt8](repeating: 0, count: chunkSize)
+        while true {
+            let bytesRead = try readChunk(from: sourceDescriptor, into: &buffer)
+            guard bytesRead > 0 else { break }
+            totalBytes += Int64(bytesRead)
+            try enforceLimit(totalBytes, maximumBytes: maximumBytes)
+            try writeChunk(buffer, count: bytesRead, to: destinationDescriptor)
+        }
+
+        try verifyUnchanged(descriptor: sourceDescriptor, url: sourceURL, initial: initial, bytesRead: totalBytes)
+        let destinationInfo = try verifiedInfo(for: destinationDescriptor, at: destinationURL)
+        guard destinationInfo.device == destinationIdentity.device,
+              destinationInfo.inode == destinationIdentity.inode,
+              destinationInfo.size == totalBytes else {
+            throw Error.writeFailed
+        }
+        completed = true
+        return totalBytes
+    }
+
+    static func size(of url: URL, maximumBytes: Int64) throws -> Int64 {
+        let descriptor = try openSource(url)
+        defer { Darwin.close(descriptor) }
+        let info = try verifiedInfo(for: descriptor, at: url)
+        try enforceLimit(info.size, maximumBytes: maximumBytes)
+        return info.size
+    }
+
+    private static func openSource(_ url: URL) throws -> Int32 {
+        let descriptor = Darwin.open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK)
+        guard descriptor >= 0 else {
+            if errno == ELOOP { throw Error.notRegularFile }
+            throw Error.readFailed
+        }
+        return descriptor
+    }
+
+    private static func verifiedInfo(for descriptor: Int32, at url: URL) throws -> FileInfo {
+        let descriptorInfo = try descriptorInfo(descriptor)
+        var pathStatus = stat()
+        guard lstat(url.path, &pathStatus) == 0 else { throw Error.fileChanged }
+        let pathInfo = try fileInfo(from: pathStatus)
+        guard descriptorInfo.device == pathInfo.device, descriptorInfo.inode == pathInfo.inode else {
+            throw Error.fileChanged
+        }
+        return descriptorInfo
+    }
+
+    private static func descriptorInfo(_ descriptor: Int32) throws -> FileInfo {
+        var status = stat()
+        guard fstat(descriptor, &status) == 0 else { throw Error.readFailed }
+        return try fileInfo(from: status)
+    }
+
+    private static func fileInfo(from status: stat) throws -> FileInfo {
+        guard status.st_mode & S_IFMT == S_IFREG else { throw Error.notRegularFile }
+        guard status.st_size >= 0 else { throw Error.readFailed }
+        return FileInfo(device: status.st_dev, inode: status.st_ino, size: Int64(status.st_size))
+    }
+
+    private static func verifyUnchanged(
+        descriptor: Int32,
+        url: URL,
+        initial: FileInfo,
+        bytesRead: Int64
+    ) throws {
+        let final = try verifiedInfo(for: descriptor, at: url)
+        guard final == initial, final.size == bytesRead else { throw Error.fileChanged }
+    }
+
+    private static func enforceLimit(_ size: Int64, maximumBytes: Int64) throws {
+        guard size <= maximumBytes else {
+            throw Error.fileTooLarge(size: size, maximum: maximumBytes)
+        }
+    }
+
+    private static func removeFileIfMatching(_ url: URL, identity: FileInfo) {
+        var status = stat()
+        guard lstat(url.path, &status) == 0,
+              let current = try? fileInfo(from: status),
+              current.device == identity.device,
+              current.inode == identity.inode else {
+            return
+        }
+        _ = unlink(url.path)
+    }
+
+    private static func readChunk(from descriptor: Int32, into buffer: inout [UInt8]) throws -> Int {
+        while true {
+            let result = buffer.withUnsafeMutableBytes {
+                Darwin.read(descriptor, $0.baseAddress, $0.count)
+            }
+            if result >= 0 { return result }
+            if errno != EINTR { throw Error.readFailed }
+        }
+    }
+
+    private static func writeChunk(_ buffer: [UInt8], count: Int, to descriptor: Int32) throws {
+        var written = 0
+        while written < count {
+            let result = buffer.withUnsafeBytes { bytes in
+                Darwin.write(descriptor, bytes.baseAddress!.advanced(by: written), count - written)
+            }
+            if result > 0 {
+                written += result
+            } else if result < 0, errno == EINTR {
+                continue
+            } else {
+                throw Error.writeFailed
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate and stream selected documents into app-owned staging
- reject oversized, replaced, symlinked, and non-regular sources
- enforce the same bound before attachment and project conversion

## Testing
- added bounded I/O, staging, picker, and processing tests
- `git diff --check`
- Xcode build/tests required by repository policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded document staging and reads in app-owned storage with a single enforced size limit. Previously we copied to tmp and read files unbounded; now we accept only regular files, reject oversized/symlinked sources up front, verify the source didn’t change during staging, and surface localized errors per operation.

- Introduces `BoundedFileIO` for streamed read/copy/size with a byte limit; rejects non‑regular files, symlinks, in‑place source changes, and pre‑existing destinations; used by attachment parsing and project conversion. `DocumentProcessingService` maps oversize to `ProcessingError.fileTooLarge`.
- Adds `ManagedFileStore`/`ManagedFileHandle` to stage provider files under Application Support with file protection and excluded-from-backup; callers release handles. Centralizes protection settings and removes redundant staged file size metadata; compute size via `BoundedFileIO.size` when needed.
- Replaces temp-file flows in picker and paste: `DocumentPickerView` now returns a `ManagedFileHandle` and takes `onError`; `MessageInputView`/`CustomTextEditor` route handles; errors are shown via existing view-model error strings. `ProjectDocumentsView` clears prior errors on appear and alerts current document errors.
- Bounded reads in conversion/processing: `DocumentConversionService` and `DocumentProcessingService` now use `BoundedFileIO.read`; PDF/text extraction operate on bounded `Data`; legacy attribute-based pre-size checks were removed.

- Migration
  - Update `DocumentPickerView` call sites to use `DocumentPickerView(onDocumentPicked:onError:)` and handle a `ManagedFileHandle`.
  - Update paste/file handlers and callers to accept `(ManagedFileHandle) -> Void`; use `ChatViewModel.addDocumentAttachment(handle:)` and `uploadProjectDocument(handle:)`.

<sup>Written for commit 036931fc779349fa29992313389bb5c1f6595109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

