### PR TITLE
fix: clean staged documents reliably

### DIFF
--- a/TinfoilChat/Services/AttachmentProcessingStore.swift
+++ b/TinfoilChat/Services/AttachmentProcessingStore.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+@MainActor
+final class AttachmentProcessingStore {
+    struct Publication {
+        fileprivate let isCurrentOperation: @MainActor () -> Bool
+
+        var isCurrent: Bool { isCurrentOperation() }
+    }
+
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var tokens: [String: UUID] = [:]
+
+    @discardableResult
+    func start(
+        id: String,
+        operation: @escaping @MainActor (Publication) async -> Void
+    ) -> Task<Void, Never> {
+        cancel(id: id)
+        let token = UUID()
+        tokens[id] = token
+        let publication = Publication { [weak self] in
+            self?.tokens[id] == token
+        }
+        let task = Task { [weak self] in
+            await operation(publication)
+            guard self?.tokens[id] == token else { return }
+            self?.tokens.removeValue(forKey: id)
+            self?.tasks.removeValue(forKey: id)
+        }
+        tasks[id] = task
+        return task
+    }
+
+    @discardableResult
+    func start(
+        id: String,
+        stagedFile: ManagedStagedFile,
+        operation: @escaping @MainActor (Publication) async -> Void
+    ) -> Task<Void, Never> {
+        start(id: id) { publication in
+            defer { stagedFile.discard() }
+            await operation(publication)
+        }
+    }
+
+    @discardableResult
+    func cancel(id: String) -> Task<Void, Never>? {
+        tokens.removeValue(forKey: id)
+        let task = tasks.removeValue(forKey: id)
+        task?.cancel()
+        return task
+    }
+
+    @discardableResult
+    func cancelAll() -> [Task<Void, Never>] {
+        tokens.removeAll()
+        let canceledTasks = Array(tasks.values)
+        tasks.removeAll()
+        for task in canceledTasks {
+            task.cancel()
+        }
+        return canceledTasks
+    }
+}

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -41,26 +41,40 @@ final class DocumentProcessingService {
 
         switch fileExtension {
         case "pdf":
-            return try await Task.detached(priority: .userInitiated) {
+            let extractionTask = Task.detached(priority: .userInitiated) {
+                try Task.checkCancellation()
                 try self.extractTextFromPDF(at: url)
-            }.value
+            }
+            return try await withTaskCancellationHandler {
+                try await extractionTask.value
+            } onCancel: {
+                extractionTask.cancel()
+            }
         case "txt", "md", "csv", "html", "json", "xml":
-            return try await Task.detached(priority: .userInitiated) {
+            let extractionTask = Task.detached(priority: .userInitiated) {
+                try Task.checkCancellation()
                 try self.readPlainText(at: url)
-            }.value
+            }
+            return try await withTaskCancellationHandler {
+                try await extractionTask.value
+            } onCancel: {
+                extractionTask.cancel()
+            }
         default:
             return try await DocumentConversionService.shared.convertToMarkdown(url: url, filename: url.lastPathComponent)
         }
     }
 
     private func extractTextFromPDF(at url: URL) throws -> String {
-        let data = try boundedData(from: url)
+        try Task.checkCancellation()
+        let data = try boundedData(from: url, checkingCancellation: true)
         guard let document = PDFDocument(data: data) else {
             throw ProcessingError.textExtractionFailed
         }
 
         var fullText = ""
         for pageIndex in 0..<document.pageCount {
+            try Task.checkCancellation()
             guard let page = document.page(at: pageIndex) else { continue }
             if let pageText = page.string {
                 if !fullText.isEmpty {
@@ -78,10 +92,12 @@ final class DocumentProcessingService {
     }
 
     private func readPlainText(at url: URL) throws -> String {
-        let data = try boundedData(from: url)
+        try Task.checkCancellation()
+        let data = try boundedData(from: url, checkingCancellation: true)
         guard let text = String(data: data, encoding: .utf8) else {
             throw ProcessingError.fileReadFailed
         }
+        try Task.checkCancellation()
 
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw ProcessingError.textExtractionFailed
@@ -90,11 +106,12 @@ final class DocumentProcessingService {
         return text
     }
 
-    private func boundedData(from url: URL) throws -> Data {
+    private func boundedData(from url: URL, checkingCancellation: Bool = false) throws -> Data {
         do {
             return try BoundedFileIO.read(
                 from: url,
-                maximumBytes: Constants.Attachments.maxFileSizeBytes
+                maximumBytes: Constants.Attachments.maxFileSizeBytes,
+                onReadChunk: checkingCancellation ? { try Task.checkCancellation() } : nil
             )
         } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
             throw ProcessingError.fileTooLarge(size)

--- a/TinfoilChat/Services/DocumentProcessingService.swift
+++ b/TinfoilChat/Services/DocumentProcessingService.swift
@@ -42,7 +42,6 @@ final class DocumentProcessingService {
         switch fileExtension {
         case "pdf":
             let extractionTask = Task.detached(priority: .userInitiated) {
-                try Task.checkCancellation()
                 try self.extractTextFromPDF(at: url)
             }
             return try await withTaskCancellationHandler {
@@ -52,7 +51,6 @@ final class DocumentProcessingService {
             }
         case "txt", "md", "csv", "html", "json", "xml":
             let extractionTask = Task.detached(priority: .userInitiated) {
-                try Task.checkCancellation()
                 try self.readPlainText(at: url)
             }
             return try await withTaskCancellationHandler {
@@ -67,7 +65,7 @@ final class DocumentProcessingService {
 
     private func extractTextFromPDF(at url: URL) throws -> String {
         try Task.checkCancellation()
-        let data = try boundedData(from: url, checkingCancellation: true)
+        let data = try boundedData(from: url)
         guard let document = PDFDocument(data: data) else {
             throw ProcessingError.textExtractionFailed
         }
@@ -93,7 +91,7 @@ final class DocumentProcessingService {
 
     private func readPlainText(at url: URL) throws -> String {
         try Task.checkCancellation()
-        let data = try boundedData(from: url, checkingCancellation: true)
+        let data = try boundedData(from: url)
         guard let text = String(data: data, encoding: .utf8) else {
             throw ProcessingError.fileReadFailed
         }
@@ -106,12 +104,12 @@ final class DocumentProcessingService {
         return text
     }
 
-    private func boundedData(from url: URL, checkingCancellation: Bool = false) throws -> Data {
+    private func boundedData(from url: URL) throws -> Data {
         do {
             return try BoundedFileIO.read(
                 from: url,
                 maximumBytes: Constants.Attachments.maxFileSizeBytes,
-                onReadChunk: checkingCancellation ? { try Task.checkCancellation() } : nil
+                onReadChunk: { try Task.checkCancellation() }
             )
         } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
             throw ProcessingError.fileTooLarge(size)

--- a/TinfoilChat/Services/ManagedFileStore.swift
+++ b/TinfoilChat/Services/ManagedFileStore.swift
@@ -1,68 +1,148 @@
 import Foundation
 
-final class ManagedFileHandle: @unchecked Sendable {
+final class ManagedStagedFile: @unchecked Sendable {
+    let id: UUID
     let url: URL
     let fileName: String
 
     private let store: ManagedFileStore
     private let lock = NSLock()
-    private var isReleased = false
+    private var isDiscarded = false
 
-    fileprivate init(url: URL, fileName: String, store: ManagedFileStore) {
+    fileprivate init(id: UUID, url: URL, fileName: String, store: ManagedFileStore) {
+        self.id = id
         self.url = url
         self.fileName = fileName
         self.store = store
     }
 
     deinit {
-        try? release()
+        discard()
     }
 
-    func release() throws {
+    @discardableResult
+    func discard() -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        guard !isReleased else { return }
-        try store.removeFile(at: url)
-        isReleased = true
+        guard !isDiscarded else { return true }
+        guard store.discard(id: id, url: url) else { return false }
+        isDiscarded = true
+        return true
     }
 }
 
 final class ManagedFileStore: @unchecked Sendable {
     static let shared = ManagedFileStore()
+    static let stagingDirectoryName = "ManagedFileStaging"
 
     private let fileManager: FileManager
     private let directoryURL: URL
+    private let removeItem: (URL) throws -> Void
+    private let lock = NSLock()
+    private var activeIDs: Set<UUID> = []
 
-    init(fileManager: FileManager = .default, directoryURL: URL? = nil) {
+    init(
+        fileManager: FileManager = .default,
+        directoryURL: URL? = nil,
+        removeItem: ((URL) throws -> Void)? = nil
+    ) {
         self.fileManager = fileManager
+        self.removeItem = removeItem ?? fileManager.removeItem(at:)
         self.directoryURL = directoryURL ?? fileManager
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("ManagedFileStaging", isDirectory: true)
+            .appendingPathComponent(Self.stagingDirectoryName, isDirectory: true)
     }
 
-    func stage(sourceURL: URL, fileName: String) throws -> ManagedFileHandle {
-        try prepareDirectory()
-        let destinationURL = directoryURL.appendingPathComponent(destinationName(for: sourceURL))
-        try BoundedFileIO.copy(
-            from: sourceURL,
-            to: destinationURL,
-            maximumBytes: Constants.Attachments.maxFileSizeBytes,
-            destinationAttributes: [
-                .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
-            ]
-        )
+    func stage(sourceURL: URL, fileName: String) throws -> ManagedStagedFile {
+        let id = UUID()
+        lock.lock()
+        activeIDs.insert(id)
+        lock.unlock()
+        let destinationURL = directoryURL.appendingPathComponent(destinationName(id: id, for: sourceURL))
 
         do {
+            try prepareDirectory()
+            try BoundedFileIO.copy(
+                from: sourceURL,
+                to: destinationURL,
+                maximumBytes: Constants.Attachments.maxFileSizeBytes,
+                destinationAttributes: [
+                    .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+                ]
+            )
             try excludeFromBackup(destinationURL)
-            return ManagedFileHandle(url: destinationURL, fileName: fileName, store: self)
+            let stagedFile = ManagedStagedFile(
+                id: id,
+                url: destinationURL,
+                fileName: fileName,
+                store: self
+            )
+            return stagedFile
         } catch {
             try? fileManager.removeItem(at: destinationURL)
+            lock.lock()
+            activeIDs.remove(id)
+            lock.unlock()
             throw error
         }
     }
 
-    fileprivate func removeFile(at url: URL) throws {
-        try fileManager.removeItem(at: url)
+    func sweepOnStartup() -> [Error] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fileManager.fileExists(atPath: directoryURL.path) else { return [] }
+
+        let children: [URL]
+        do {
+            children = try fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil
+            )
+        } catch {
+            return [error]
+        }
+
+        var failures: [Error] = []
+        for child in children {
+            let stem = child.deletingPathExtension().lastPathComponent
+            if let id = UUID(uuidString: stem), activeIDs.contains(id) {
+                continue
+            }
+            do {
+                try removeItem(child)
+            } catch CocoaError.fileNoSuchFile {
+            } catch {
+                failures.append(error)
+            }
+        }
+        return failures
+    }
+
+    func owns(_ url: URL) -> Bool {
+        let standardizedURL = url.standardizedFileURL
+        guard standardizedURL.deletingLastPathComponent() == directoryURL.standardizedFileURL else {
+            return false
+        }
+        let stem = standardizedURL.deletingPathExtension().lastPathComponent
+        guard let id = UUID(uuidString: stem) else { return false }
+        return stem == id.uuidString.lowercased()
+    }
+
+    func discard(id: UUID, url: URL) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let stem = url.deletingPathExtension().lastPathComponent
+        guard owns(url), stem == id.uuidString.lowercased() else { return false }
+        do {
+            try removeItem(url)
+            activeIDs.remove(id)
+            return true
+        } catch CocoaError.fileNoSuchFile {
+            activeIDs.remove(id)
+            return true
+        } catch {
+            return false
+        }
     }
 
     private func prepareDirectory() throws {
@@ -85,11 +165,11 @@ final class ManagedFileStore: @unchecked Sendable {
         try url.setResourceValues(values)
     }
 
-    private func destinationName(for sourceURL: URL) -> String {
+    private func destinationName(id: UUID, for sourceURL: URL) -> String {
         let fileExtension = sourceURL.pathExtension
         let safeExtension = fileExtension.count <= 16 && fileExtension.unicodeScalars.allSatisfy {
             CharacterSet.alphanumerics.contains($0)
         } ? fileExtension : ""
-        return UUID().uuidString + (safeExtension.isEmpty ? "" : ".\(safeExtension)")
+        return id.uuidString.lowercased() + (safeExtension.isEmpty ? "" : ".\(safeExtension.lowercased())")
     }
 }

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -176,6 +176,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             // options.attachViewHierarchy = true // This adds the view hierarchy to the error events
         }
 
+        Task.detached(priority: .utility) {
+            for failure in ManagedFileStore.shared.sweepOnStartup() {
+                SentrySDK.capture(error: failure.error)
+            }
+        }
+
         // Ignore SIGPIPE so broken streaming connections surface as errors instead of crashes.
         // Must be set after SentrySDK.start which installs its own signal handlers.
         signal(SIGPIPE, SIG_IGN)

--- a/TinfoilChat/TinfoilChatApp.swift
+++ b/TinfoilChat/TinfoilChatApp.swift
@@ -177,8 +177,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         }
 
         Task.detached(priority: .utility) {
-            for failure in ManagedFileStore.shared.sweepOnStartup() {
-                SentrySDK.capture(error: failure.error)
+            for error in ManagedFileStore.shared.sweepOnStartup() {
+                SentrySDK.capture(error: error)
             }
         }
 

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -380,6 +380,7 @@ class ChatViewModel: ObservableObject {
     @Published var pendingAttachments: [Attachment] = []
     @Published var attachmentError: String? = nil
     @Published var pendingImageThumbnails: [String: String] = [:]
+    private let attachmentProcessingStore = AttachmentProcessingStore()
     var isProcessingAttachment: Bool {
         pendingAttachments.contains { $0.processingState == .processing }
     }
@@ -2072,8 +2073,8 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func uploadProjectDocument(handle: ManagedFileHandle) async {
-        defer { try? handle.release() }
+    func uploadProjectDocument(handle: ManagedStagedFile) async {
+        defer { handle.discard() }
         guard let project = activeProject else { return }
         let accountGeneration = projectListAccountGeneration
 
@@ -3221,7 +3222,7 @@ class ChatViewModel: ObservableObject {
         url: URL,
         fileName: String,
         sharedImportRequestID: UUID? = nil,
-        managedFile: ManagedFileHandle? = nil
+        managedFile: ManagedStagedFile? = nil
     ) {
         attachmentError = nil
 
@@ -3235,14 +3236,16 @@ class ChatViewModel: ObservableObject {
         )
         pendingAttachments.append(attachment)
 
-        Task {
-            defer { try? managedFile?.release() }
+        let processAttachment: @MainActor (AttachmentProcessingStore.Publication) async -> Void = { [weak self] publication in
+            guard let self else { return }
             do {
                 let text = try await DocumentProcessingService.shared.extractText(from: url)
+                try Task.checkCancellation()
                 let fileSize = try BoundedFileIO.size(
                     of: url,
                     maximumBytes: Constants.Attachments.maxFileSizeBytes
                 )
+                guard publication.isCurrent else { return }
 
                 attachment.textContent = text
                 attachment.fileSize = fileSize
@@ -3251,7 +3254,9 @@ class ChatViewModel: ObservableObject {
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
                     pendingAttachments[index] = attachment
                 }
+            } catch is CancellationError {
             } catch {
+                guard publication.isCurrent else { return }
                 attachment.processingState = .failed
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
                     pendingAttachments[index] = attachment
@@ -3259,9 +3264,18 @@ class ChatViewModel: ObservableObject {
                 attachmentError = error.localizedDescription
             }
         }
+        if let managedFile {
+            attachmentProcessingStore.start(
+                id: attachmentId,
+                stagedFile: managedFile,
+                operation: processAttachment
+            )
+        } else {
+            attachmentProcessingStore.start(id: attachmentId, operation: processAttachment)
+        }
     }
 
-    func addDocumentAttachment(handle: ManagedFileHandle) {
+    func addDocumentAttachment(handle: ManagedStagedFile) {
         addDocumentAttachment(
             url: handle.url,
             fileName: handle.fileName,
@@ -3287,9 +3301,12 @@ class ChatViewModel: ObservableObject {
         )
         pendingAttachments.append(attachment)
 
-        Task {
+        attachmentProcessingStore.start(id: attachmentId) { [weak self] publication in
+            guard let self else { return }
             do {
                 let processed = try await ImageProcessingService.shared.processImage(data: data)
+                try Task.checkCancellation()
+                guard publication.isCurrent else { return }
 
                 attachment.mimeType = Constants.Attachments.defaultImageMimeType
                 attachment.base64 = processed.base64
@@ -3305,7 +3322,9 @@ class ChatViewModel: ObservableObject {
                     pendingAttachments[index] = attachment
                 }
                 pendingImageThumbnails[attachmentId] = processed.thumbnailBase64
+            } catch is CancellationError {
             } catch {
+                guard publication.isCurrent else { return }
                 attachment.processingState = .failed
                 if let index = pendingAttachments.firstIndex(where: { $0.id == attachmentId }) {
                     pendingAttachments[index] = attachment
@@ -3316,6 +3335,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func removePendingAttachment(id: String) {
+        attachmentProcessingStore.cancel(id: id)
         let removed = pendingAttachments.filter { $0.id == id }
         pendingAttachments.removeAll { $0.id == id }
         pendingImageThumbnails.removeValue(forKey: id)
@@ -3326,6 +3346,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func clearPendingAttachments(acknowledgeSharedImports: Bool = true) {
+        attachmentProcessingStore.cancelAll()
         let removed = pendingAttachments
         pendingAttachments.removeAll()
         pendingImageThumbnails.removeAll()

--- a/TinfoilChat/Views/DocumentPickerView.swift
+++ b/TinfoilChat/Views/DocumentPickerView.swift
@@ -8,11 +8,11 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct DocumentPickerView: UIViewControllerRepresentable {
-    var onDocumentPicked: (ManagedFileHandle) -> Void
+    var onDocumentPicked: (ManagedStagedFile) -> Void
     var onError: (Error) -> Void
 
     init(
-        onDocumentPicked: @escaping (ManagedFileHandle) -> Void,
+        onDocumentPicked: @escaping (ManagedStagedFile) -> Void,
         onError: @escaping (Error) -> Void
     ) {
         self.onDocumentPicked = onDocumentPicked
@@ -47,11 +47,11 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     }
 
     class Coordinator: NSObject, UIDocumentPickerDelegate {
-        let onDocumentPicked: (ManagedFileHandle) -> Void
+        let onDocumentPicked: (ManagedStagedFile) -> Void
         let onError: (Error) -> Void
 
         init(
-            onDocumentPicked: @escaping (ManagedFileHandle) -> Void,
+            onDocumentPicked: @escaping (ManagedStagedFile) -> Void,
             onError: @escaping (Error) -> Void
         ) {
             self.onDocumentPicked = onDocumentPicked

--- a/TinfoilChat/Views/MessageInputView.swift
+++ b/TinfoilChat/Views/MessageInputView.swift
@@ -1408,7 +1408,7 @@ struct CustomTextEditor: UIViewRepresentable {
     /// itself when the draft was actually sent or queued.
     var onSendMessage: (String) -> Bool
     var onPasteImage: ((Data, String) -> Void)? = nil
-    var onPasteFile: ((ManagedFileHandle) -> Void)? = nil
+    var onPasteFile: ((ManagedStagedFile) -> Void)? = nil
     var onPasteFileError: ((String) -> Void)? = nil
 
     func makeUIView(context: Context) -> UITextView {
@@ -1701,7 +1701,7 @@ struct CustomTextEditor: UIViewRepresentable {
 final class PastingTextView: UITextView {
     var allowsImagePaste = false
     var onPasteImage: ((Data, String) -> Void)?
-    var onPasteFile: ((ManagedFileHandle) -> Void)?
+    var onPasteFile: ((ManagedStagedFile) -> Void)?
     var onPasteFileError: ((String) -> Void)?
 
     /// File URLs win over any string representation on the pasteboard:
@@ -1775,7 +1775,7 @@ final class PastingTextView: UITextView {
     /// pipeline can read it after the pasteboard's access window closes.
     /// Oversized files are rejected up front: the pipeline would refuse them
     /// anyway, and copying or reading them first would waste disk and memory.
-    private func importPastedFile(url: URL, onPasteFile: (ManagedFileHandle) -> Void) {
+    private func importPastedFile(url: URL, onPasteFile: (ManagedStagedFile) -> Void) {
         let fileName = url.lastPathComponent
         let didAccess = url.startAccessingSecurityScopedResource()
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }

--- a/TinfoilChatTests/AttachmentProcessingStoreTests.swift
+++ b/TinfoilChatTests/AttachmentProcessingStoreTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+@MainActor
+@Suite("Attachment Processing Store Tests")
+struct AttachmentProcessingStoreTests {
+    @Test("Removal cancels processing and prevents late publication")
+    func removalPreventsLatePublication() async {
+        let store = AttachmentProcessingStore()
+        var observedCancellation = false
+        var didPublish = false
+
+        store.start(id: "document") { publication in
+            await Task.yield()
+            observedCancellation = Task.isCancelled
+            if publication.isCurrent {
+                didPublish = true
+            }
+        }
+        let task = store.cancel(id: "document")
+        await task?.value
+
+        #expect(observedCancellation)
+        #expect(!didPublish)
+    }
+
+    @Test("Clear cancels every operation and prevents late publication")
+    func clearPreventsLatePublication() async {
+        let store = AttachmentProcessingStore()
+        var publishedIDs: [String] = []
+
+        for id in ["document", "image"] {
+            store.start(id: id) { publication in
+                await Task.yield()
+                if publication.isCurrent {
+                    publishedIDs.append(id)
+                }
+            }
+        }
+        let tasks = store.cancelAll()
+        for task in tasks {
+            await task.value
+        }
+
+        #expect(tasks.count == 2)
+        #expect(publishedIDs.isEmpty)
+    }
+
+    @Test("Active operations can publish once processing completes")
+    func activeOperationPublishes() async {
+        let store = AttachmentProcessingStore()
+        var didPublish = false
+
+        store.start(id: "document") { publication in
+            if publication.isCurrent {
+                didPublish = true
+            }
+        }
+        await Task.yield()
+
+        #expect(didPublish)
+    }
+
+    @Test("Staged files are discarded after successful and failed operations")
+    func completedOperationsDiscardStagedFiles() async throws {
+        let fixture = try makeStagedFile(content: "document", fileName: "success.txt")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let failedFixture = try makeStagedFile(content: "", fileName: "failure.txt")
+        defer { try? FileManager.default.removeItem(at: failedFixture.rootURL) }
+        let store = AttachmentProcessingStore()
+
+        let successTask = store.start(id: "success", stagedFile: fixture.file) { _ in
+            _ = try? await DocumentProcessingService.shared.extractText(from: fixture.file.url)
+        }
+        let failureTask = store.start(id: "failure", stagedFile: failedFixture.file) { _ in
+            _ = try? await DocumentProcessingService.shared.extractText(from: failedFixture.file.url)
+        }
+        await successTask.value
+        await failureTask.value
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.file.url.path))
+        #expect(!FileManager.default.fileExists(atPath: failedFixture.file.url.path))
+    }
+
+    @Test("Cancellation waits for extraction before discarding its staged file")
+    func cancellationWaitsBeforeDiscard() async throws {
+        let fixture = try makeStagedFile(content: "document", fileName: "cancel.txt")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let store = AttachmentProcessingStore()
+        var extractionObservedFile = false
+
+        let task = store.start(id: "cancel", stagedFile: fixture.file) { _ in
+            let extractionTask = Task.detached {
+                while !Task.isCancelled {
+                    await Task.yield()
+                }
+                return FileManager.default.fileExists(atPath: fixture.file.url.path)
+            }
+            extractionObservedFile = await withTaskCancellationHandler {
+                await extractionTask.value
+            } onCancel: {
+                extractionTask.cancel()
+            }
+        }
+        await Task.yield()
+        store.cancel(id: "cancel")
+        await task.value
+
+        #expect(extractionObservedFile)
+        #expect(!FileManager.default.fileExists(atPath: fixture.file.url.path))
+    }
+
+    private func makeStagedFile(
+        content: String,
+        fileName: String
+    ) throws -> (file: ManagedStagedFile, rootURL: URL) {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: false)
+        let sourceURL = rootURL.appendingPathComponent(fileName)
+        try Data(content.utf8).write(to: sourceURL)
+        let store = ManagedFileStore(
+            directoryURL: rootURL.appendingPathComponent("ManagedFileStaging", isDirectory: true)
+        )
+        return (try store.stage(sourceURL: sourceURL, fileName: fileName), rootURL)
+    }
+}

--- a/TinfoilChatTests/BoundedDocumentStagingTests.swift
+++ b/TinfoilChatTests/BoundedDocumentStagingTests.swift
@@ -112,10 +112,67 @@ struct BoundedDocumentStagingTests {
         #expect(attributes[.protectionKey] as? FileProtectionType == .completeUntilFirstUserAuthentication)
         #expect(try Data(contentsOf: handle.url) == sourceData)
 
-        try handle.release()
+        #expect(handle.discard())
         #expect(!FileManager.default.fileExists(atPath: handle.url.path))
         #expect(FileManager.default.fileExists(atPath: source.path))
-        try handle.release()
+        #expect(handle.discard())
+    }
+
+    @Test("Managed discard never removes files outside staging")
+    func managedDiscardIsRestrictedToOwnedDirectChildren() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let stagingDirectory = directory.appendingPathComponent("ManagedFileStaging", isDirectory: true)
+        let providerFile = directory.appendingPathComponent("provider.txt")
+        try Data("provider".utf8).write(to: providerFile)
+        let store = ManagedFileStore(directoryURL: stagingDirectory)
+        let stagedFile = try store.stage(sourceURL: providerFile, fileName: "provider.txt")
+
+        #expect(store.owns(stagedFile.url))
+        #expect(!store.owns(providerFile))
+        #expect(!store.owns(stagingDirectory.appendingPathComponent("not-a-uuid.txt")))
+        #expect(!store.discard(id: stagedFile.id, url: providerFile))
+        #expect(FileManager.default.fileExists(atPath: providerFile.path))
+        #expect(stagedFile.discard())
+    }
+
+    @Test("Startup sweep removes only staging children and reports individual failures")
+    func startupSweepIsScopedAndReportsFailures() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let stagingDirectory = directory.appendingPathComponent("ManagedFileStaging", isDirectory: true)
+        let providerFile = directory.appendingPathComponent("provider.txt")
+        try Data("provider".utf8).write(to: providerFile)
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: false)
+        var blockedURL: URL?
+        let store = ManagedFileStore(
+            directoryURL: stagingDirectory,
+            removeItem: { url in
+                if url == blockedURL {
+                    throw CocoaError(.fileWriteNoPermission)
+                }
+                try FileManager.default.removeItem(at: url)
+            }
+        )
+        let removedURL = stagingDirectory.appendingPathComponent("\(UUID().uuidString.lowercased()).txt")
+        let failedURL = stagingDirectory.appendingPathComponent("\(UUID().uuidString.lowercased()).txt")
+        let unrelatedChild = stagingDirectory.appendingPathComponent("keep.txt")
+        let nestedDirectory = stagingDirectory.appendingPathComponent("nested", isDirectory: true)
+        try Data("first".utf8).write(to: removedURL)
+        try Data("second".utf8).write(to: failedURL)
+        try Data("keep".utf8).write(to: unrelatedChild)
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: false)
+        blockedURL = failedURL
+
+        let failures = store.sweepOnStartup()
+
+        #expect(!FileManager.default.fileExists(atPath: removedURL.path))
+        #expect(FileManager.default.fileExists(atPath: failedURL.path))
+        #expect(failures.count == 1)
+        #expect((failures.first as? CocoaError)?.code == .fileWriteNoPermission)
+        #expect(!FileManager.default.fileExists(atPath: unrelatedChild.path))
+        #expect(!FileManager.default.fileExists(atPath: nestedDirectory.path))
+        #expect(FileManager.default.fileExists(atPath: providerFile.path))
     }
 
     @Test("Document processing uses bounded regular-file reads")


### PR DESCRIPTION
## Summary
- clean managed files after success, failure, and cancellation
- prevent canceled processing from publishing late results
- sweep only the dedicated staging directory at launch

## Testing
- added lifecycle, cancellation, and sweep tests
- `git diff --check`

## Dependency
- stacked on bounded document staging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans staged document files reliably and prevents late UI updates from canceled processing. Previously, staged files could linger and canceled tasks could publish after removal; now staging is discarded on success, failure, or cancel, and publication applies only to the current run.

- Introduces AttachmentProcessingStore: per-attachment tasks keyed by id with cancel(id)/cancelAll, Publication.isCurrent to guard UI updates, and optional auto-discard of a ManagedStagedFile after completion.
- Refactors staging: ManagedFileHandle → ManagedStagedFile (UUID id). ManagedFileStore now restricts `discard(id:url)` to owned staging files via `owns(_:)`, names files as lowercase UUID + safe extension, tracks active ids, and `sweepOnStartup()` removes only staging children and returns per-file errors.
- Makes document extraction cancellation-safe: wraps detached work with `withTaskCancellationHandler` and checks cancellation before bounded reads, per read chunk, and per PDF page.
- App startup runs `ManagedFileStore.shared.sweepOnStartup()` on a utility task and reports each failure via `SentrySDK`.
- Routes attachment processing through AttachmentProcessingStore in ChatViewModel; cancels work on removal/clear and guards UI updates with Publication.isCurrent; updates view/callback types to ManagedStagedFile.

- Migration: replace ManagedFileHandle with ManagedStagedFile and release() with discard(); update callback signatures in DocumentPickerView, MessageInputView, and ChatViewModel.

<sup>Written for commit 71d88d82f0642af3758d5b57a6634eaa233e7f4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

