### PR TITLE
fix: preserve cross-platform project fields

### DIFF
--- a/TinfoilChat/Models/ProjectModels.swift
+++ b/TinfoilChat/Models/ProjectModels.swift
@@ -18,6 +18,7 @@ struct MemoryFact: Codable, Identifiable, Equatable {
 struct Project: Codable, Identifiable, Equatable {
     let id: String
     var name: String
+    var color: String? = nil
     var description: String
     var systemInstructions: String
     var memory: [MemoryFact]
@@ -29,6 +30,7 @@ struct Project: Codable, Identifiable, Equatable {
 
 struct ProjectData: Codable, Equatable {
     var name: String
+    var color: String? = nil
     var description: String
     var systemInstructions: String
     var memory: [MemoryFact]
@@ -36,15 +38,17 @@ struct ProjectData: Codable, Equatable {
 
 struct CreateProjectData: Codable, Equatable {
     var name: String
+    var color: String? = nil
     var description: String = ""
     var systemInstructions: String = ""
 }
 
 struct UpdateProjectData: Codable, Equatable {
-    var name: String?
-    var description: String?
-    var systemInstructions: String?
-    var memory: [MemoryFact]?
+    var name: String? = nil
+    var color: String? = nil
+    var description: String? = nil
+    var systemInstructions: String? = nil
+    var memory: [MemoryFact]? = nil
 }
 
 struct ProjectDocument: Codable, Identifiable, Equatable {
@@ -64,6 +68,33 @@ struct ProjectDocumentPayload: Codable, Equatable {
     var content: String
     var filename: String
     var contentType: String
+    var sizeBytes: Int? = nil
+
+    var resolvedSizeBytes: Int {
+        sizeBytes ?? content.utf8.count
+    }
+}
+
+extension ProjectData {
+    init(createData: CreateProjectData) {
+        self.init(
+            name: createData.name,
+            color: createData.color,
+            description: createData.description,
+            systemInstructions: createData.systemInstructions,
+            memory: []
+        )
+    }
+
+    init(updateData: UpdateProjectData, existing: Project) {
+        self.init(
+            name: updateData.name ?? existing.name,
+            color: updateData.color ?? existing.color,
+            description: updateData.description ?? existing.description,
+            systemInstructions: updateData.systemInstructions ?? existing.systemInstructions,
+            memory: updateData.memory ?? existing.memory
+        )
+    }
 }
 
 struct ProjectChat: Codable, Identifiable, Equatable {
@@ -133,5 +164,4 @@ struct ProjectSyncStatus: Codable, Equatable {
 
 typealias ProjectChatSyncStatus = ProjectSyncStatus
 typealias ProjectDocumentSyncStatus = ProjectSyncStatus
-
 

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -125,7 +125,7 @@ final class ProjectStorageService: ObservableObject {
             description: payload.description,
             systemInstructions: payload.systemInstructions,
             memory: payload.memory,
-            createdAt: existing.createdAt,
+            createdAt: createdAtFromReverseId(projectId),
             updatedAt: isoNow(),
             syncVersion: syncVersion
         )

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -99,6 +99,7 @@ final class ProjectStorageService: ObservableObject {
         return Project(
             id: idResponse.projectId,
             name: payload.name,
+            color: payload.color,
             description: payload.description,
             systemInstructions: payload.systemInstructions,
             memory: payload.memory,
@@ -121,6 +122,7 @@ final class ProjectStorageService: ObservableObject {
         return Project(
             id: projectId,
             name: decoded.name,
+            color: decoded.color,
             description: decoded.description,
             systemInstructions: decoded.systemInstructions,
             memory: decoded.memory,
@@ -139,6 +141,7 @@ final class ProjectStorageService: ObservableObject {
             out[id] = Project(
                 id: id,
                 name: decoded.0.name,
+                color: decoded.0.color,
                 description: decoded.0.description,
                 systemInstructions: decoded.0.systemInstructions,
                 memory: decoded.0.memory,
@@ -301,7 +304,8 @@ final class ProjectStorageService: ObservableObject {
         projectId: String,
         filename: String,
         contentType: String,
-        content: String
+        content: String,
+        sizeBytes: Int
     ) async throws -> ProjectDocument {
         let idResponse = try await generateDocumentId(projectId: projectId)
         let wireId = projectDocumentId(projectId: projectId, documentId: idResponse.documentId)
@@ -310,17 +314,17 @@ final class ProjectStorageService: ObservableObject {
             projectId: projectId,
             filename: filename,
             contentType: contentType,
-            content: content
+            content: content,
+            sizeBytes: sizeBytes
         )
 
         let now = isoNow()
-        let size = payload.content.data(using: .utf8)?.count ?? payload.content.count
         return ProjectDocument(
             id: idResponse.documentId,
             projectId: projectId,
             filename: payload.filename,
             contentType: payload.contentType,
-            sizeBytes: size,
+            sizeBytes: payload.resolvedSizeBytes,
             syncVersion: syncVersion,
             createdAt: now,
             updatedAt: now,
@@ -337,7 +341,7 @@ final class ProjectStorageService: ObservableObject {
             projectId: projectId,
             filename: decoded.filename,
             contentType: decoded.contentType,
-            sizeBytes: decoded.content.data(using: .utf8)?.count ?? decoded.content.count,
+            sizeBytes: decoded.resolvedSizeBytes,
             syncVersion: syncVersion,
             createdAt: now,
             updatedAt: now,
@@ -393,7 +397,7 @@ final class ProjectStorageService: ObservableObject {
                     projectId: projectId,
                     filename: decoded.0.filename,
                     contentType: decoded.0.contentType,
-                    sizeBytes: decoded.0.content.data(using: .utf8)?.count ?? decoded.0.content.count,
+                    sizeBytes: decoded.0.resolvedSizeBytes,
                     syncVersion: decoded.1,
                     createdAt: createdAtFromReverseId(docId),
                     updatedAt: update.updatedAt,

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -109,11 +109,26 @@ final class ProjectStorageService: ObservableObject {
         )
     }
 
-    func updateProject(_ projectId: String, data: UpdateProjectData) async throws {
+    func updateProject(_ projectId: String, data: UpdateProjectData) async throws -> Project {
         guard let existing = try await getProject(projectId) else {
             throw CloudStorageError.invalidResponse
         }
-        try await enclaveStore.updateProject(id: projectId, data: data, existing: existing)
+        let (payload, syncVersion) = try await enclaveStore.updateProject(
+            id: projectId,
+            data: data,
+            existing: existing
+        )
+        return Project(
+            id: projectId,
+            name: payload.name,
+            color: payload.color,
+            description: payload.description,
+            systemInstructions: payload.systemInstructions,
+            memory: payload.memory,
+            createdAt: existing.createdAt,
+            updatedAt: isoNow(),
+            syncVersion: syncVersion
+        )
     }
 
     func getProject(_ projectId: String) async throws -> Project? {

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -12,9 +12,10 @@ struct SyncEnclaveProjectStore {
         return (payload, etagToSyncVersion(response.etag))
     }
 
-    func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws {
+    func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws -> (ProjectData, Int) {
         let payload = ProjectData(updateData: data, existing: existing)
-        _ = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
+        let response = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
+        return (payload, etagToSyncVersion(response.etag))
     }
 
     func getProject(id: String) async throws -> (ProjectData, Int)? {

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -7,23 +7,13 @@ import Foundation
 
 struct SyncEnclaveProjectStore {
     func createProject(id: String, data: CreateProjectData) async throws -> (ProjectData, Int) {
-        let payload = ProjectData(
-            name: data.name,
-            description: data.description,
-            systemInstructions: data.systemInstructions,
-            memory: []
-        )
+        let payload = ProjectData(createData: data)
         let response = try await pushProject(id: id, payload: payload, ifMatch: nil)
         return (payload, etagToSyncVersion(response.etag))
     }
 
     func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws {
-        let payload = ProjectData(
-            name: data.name ?? existing.name,
-            description: data.description ?? existing.description,
-            systemInstructions: data.systemInstructions ?? existing.systemInstructions,
-            memory: data.memory ?? existing.memory
-        )
+        let payload = ProjectData(updateData: data, existing: existing)
         _ = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
     }
 
@@ -91,9 +81,15 @@ struct SyncEnclaveProjectStore {
         projectId: String,
         filename: String,
         contentType: String,
-        content: String
+        content: String,
+        sizeBytes: Int
     ) async throws -> (ProjectDocumentPayload, Int) {
-        let payload = ProjectDocumentPayload(content: content, filename: filename, contentType: contentType)
+        let payload = ProjectDocumentPayload(
+            content: content,
+            filename: filename,
+            contentType: contentType,
+            sizeBytes: sizeBytes
+        )
         let metadata: [String: AnyCodable] = [
             "filename": AnyCodable(filename),
             "contentType": AnyCodable(contentType),

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1960,15 +1960,8 @@ class ChatViewModel: ObservableObject {
                 systemInstructions: systemInstructions,
                 memory: memory
             )
-            try await projectStorage.updateProject(project.id, data: update)
+            let updated = try await projectStorage.updateProject(project.id, data: update)
             guard isCurrentProjectAccount(accountGeneration) else { return }
-            var updated = project
-            updated.name = name ?? updated.name
-            updated.color = color ?? updated.color
-            updated.description = description ?? updated.description
-            updated.systemInstructions = systemInstructions ?? updated.systemInstructions
-            updated.memory = memory ?? updated.memory
-            updated.updatedAt = ISO8601DateFormatter().string(from: Date())
             activeProject = updated
             if let index = projects.firstIndex(where: { $0.id == updated.id }) {
                 projects[index] = updated
@@ -2022,7 +2015,10 @@ class ChatViewModel: ObservableObject {
             }
         }
         do {
-            let sizeBytes = try Data(contentsOf: url, options: .mappedIfSafe).count
+            let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
+            guard let sizeBytes = resourceValues.fileSize else {
+                throw CocoaError(.fileReadUnknown)
+            }
             let markdown = try await DocumentConversionService.shared.convertToMarkdown(
                 url: url,
                 filename: filename

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1673,7 +1673,7 @@ class ChatViewModel: ObservableObject {
     }
 
     @discardableResult
-    func createProject(name: String? = nil) async -> Project? {
+    func createProject(name: String? = nil, color: String? = nil) async -> Project? {
         guard hasChatAccess, isProjectAccountActive else { return nil }
         let accountGeneration = projectListAccountGeneration
 
@@ -1687,7 +1687,7 @@ class ChatViewModel: ObservableObject {
         do {
             let resolvedName = name ?? "My Project #\(projects.count + 1)"
             let project = try await projectStorage.createProject(
-                CreateProjectData(name: resolvedName)
+                CreateProjectData(name: resolvedName, color: color)
             )
             guard isCurrentProjectAccount(accountGeneration) else { return nil }
             projects.insert(project, at: 0)
@@ -1947,7 +1947,7 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
+    func updateActiveProject(name: String? = nil, color: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
         guard let project = activeProject else { return }
         let accountGeneration = projectListAccountGeneration
 
@@ -1955,6 +1955,7 @@ class ChatViewModel: ObservableObject {
         do {
             let update = UpdateProjectData(
                 name: name,
+                color: color,
                 description: description,
                 systemInstructions: systemInstructions,
                 memory: memory
@@ -1963,6 +1964,7 @@ class ChatViewModel: ObservableObject {
             guard isCurrentProjectAccount(accountGeneration) else { return }
             var updated = project
             updated.name = name ?? updated.name
+            updated.color = color ?? updated.color
             updated.description = description ?? updated.description
             updated.systemInstructions = systemInstructions ?? updated.systemInstructions
             updated.memory = memory ?? updated.memory
@@ -2020,6 +2022,7 @@ class ChatViewModel: ObservableObject {
             }
         }
         do {
+            let sizeBytes = try Data(contentsOf: url, options: .mappedIfSafe).count
             let markdown = try await DocumentConversionService.shared.convertToMarkdown(
                 url: url,
                 filename: filename
@@ -2030,7 +2033,8 @@ class ChatViewModel: ObservableObject {
                 projectId: project.id,
                 filename: filename,
                 contentType: contentType,
-                content: markdown
+                content: markdown,
+                sizeBytes: sizeBytes
             )
             guard isCurrentProjectAccount(accountGeneration) else { return }
             projectDocuments.append(document)

--- a/TinfoilChatTests/ProjectSchemaFidelityTests.swift
+++ b/TinfoilChatTests/ProjectSchemaFidelityTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ProjectSchemaFidelityTests {
+    @Test func projectSchemasRoundTripColor() throws {
+        let project = Project(
+            id: "project-1",
+            name: "Project",
+            color: "#1A2B3C",
+            description: "Description",
+            systemInstructions: "Instructions",
+            memory: [],
+            createdAt: "2026-08-20T00:00:00.000Z",
+            updatedAt: "2026-08-20T00:00:00.000Z",
+            syncVersion: 1
+        )
+        let projectData = ProjectData(
+            name: project.name,
+            color: project.color,
+            description: project.description,
+            systemInstructions: project.systemInstructions,
+            memory: project.memory
+        )
+        let createData = CreateProjectData(name: project.name, color: project.color)
+        let updateData = UpdateProjectData(color: project.color)
+
+        #expect(try roundTrip(project).color == "#1A2B3C")
+        #expect(try roundTrip(projectData).color == "#1A2B3C")
+        #expect(try roundTrip(createData).color == "#1A2B3C")
+        #expect(try roundTrip(updateData).color == "#1A2B3C")
+        #expect(ProjectData(createData: createData).color == "#1A2B3C")
+    }
+
+    @Test func unrelatedProjectUpdatePreservesColor() {
+        let existing = Project(
+            id: "project-1",
+            name: "Project",
+            color: "blue",
+            description: "Old description",
+            systemInstructions: "Instructions",
+            memory: [],
+            createdAt: "2026-08-20T00:00:00.000Z",
+            updatedAt: "2026-08-20T00:00:00.000Z",
+            syncVersion: 1
+        )
+
+        let merged = ProjectData(
+            updateData: UpdateProjectData(description: "New description"),
+            existing: existing
+        )
+
+        #expect(merged.color == "blue")
+        #expect(merged.description == "New description")
+    }
+
+    @Test func documentPayloadRoundTripsOriginalSize() throws {
+        let payload = ProjectDocumentPayload(
+            content: "converted markdown",
+            filename: "source.pdf",
+            contentType: "application/pdf",
+            sizeBytes: 42_000
+        )
+
+        let decoded = try roundTrip(payload)
+
+        #expect(decoded.sizeBytes == 42_000)
+        #expect(decoded.resolvedSizeBytes == 42_000)
+    }
+
+    @Test func legacyDocumentPayloadFallsBackToUTF8Size() throws {
+        let data = Data(
+            #"{"content":"café","filename":"legacy.txt","contentType":"text/plain"}"#.utf8
+        )
+
+        let payload = try JSONDecoder().decode(ProjectDocumentPayload.self, from: data)
+
+        #expect(payload.sizeBytes == nil)
+        #expect(payload.resolvedSizeBytes == "café".utf8.count)
+    }
+
+    private func roundTrip<Value: Codable>(_ value: Value) throws -> Value {
+        try JSONDecoder().decode(Value.self, from: JSONEncoder().encode(value))
+    }
+}


### PR DESCRIPTION
## Summary
- preserve optional project colors across iOS updates
- retain original project-document sizes with legacy fallback
- keep older payloads backward compatible

## Testing
- added schema round-trip and merge tests
- `git diff --check`
- Xcode build/tests required by repository policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves cross-platform project color, original document size, and project creation timestamps while making project updates authoritative. Previously iOS updates dropped color, recomputed document size from converted content, and could overwrite createdAt; now color round-trips, documents carry original sizeBytes with a legacy UTF‑8 fallback, and createdAt is preserved on updates.

- Adds optional color to Project, ProjectData, CreateProjectData, and UpdateProjectData; propagates through storage and sync. ChatViewModel.createProject and updateActiveProject accept color.
- Adds sizeBytes to ProjectDocumentPayload with resolvedSizeBytes fallback; storage uses resolvedSizeBytes for create/get/list; Sync Enclave includes sizeBytes metadata.
- Introduces ProjectData initializers to merge create/update with existing. SyncEnclave.updateProject returns (payload, version); ProjectStorageService.updateProject returns the updated Project; ChatViewModel uses this instead of local merges.
- Preserves createdAt across create/get/update using reverse-id timestamps.

**Required updates**
- Pass the original file size as sizeBytes when calling ProjectStorageService.createProjectDocument and SyncEnclaveProjectStore.createProjectDocument.
- Provide color when creating or updating projects via CreateProjectData, UpdateProjectData, or ChatViewModel methods if available.

<sup>Written for commit 4a3e0545dbd0870d588fbec64b5382ae7521ab1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

