### PR TITLE
feat: show project folder colors

### DIFF
--- a/TinfoilChat/Extensions/Color+Hex.swift
+++ b/TinfoilChat/Extensions/Color+Hex.swift
@@ -7,7 +7,49 @@
 
 import SwiftUI
 
+struct ProjectColorRGB: Equatable {
+    let red: Int
+    let green: Int
+    let blue: Int
+
+    init?(identifier: String?) {
+        let components: (red: Int, green: Int, blue: Int)
+        switch identifier {
+        case "maya-blue":
+            components = (133, 198, 255)
+        case "electric-aqua":
+            components = (98, 220, 233)
+        case "sandy-brown":
+            components = (255, 181, 122)
+        case "mauve":
+            components = (233, 171, 255)
+        case "tuscan-sun":
+            components = (245, 203, 88)
+        case "light-green":
+            components = (138, 223, 141)
+        case "baby-pink":
+            components = (255, 158, 195)
+        default:
+            return nil
+        }
+        red = components.red
+        green = components.green
+        blue = components.blue
+    }
+}
+
 extension Color {
+    static func projectColor(_ identifier: String?) -> Color {
+        guard let rgb = ProjectColorRGB(identifier: identifier) else {
+            return .accentColor
+        }
+        return Color(
+            red: Double(rgb.red) / 255,
+            green: Double(rgb.green) / 255,
+            blue: Double(rgb.blue) / 255
+        )
+    }
+
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0

--- a/TinfoilChat/Models/ProjectModels.swift
+++ b/TinfoilChat/Models/ProjectModels.swift
@@ -18,6 +18,7 @@ struct MemoryFact: Codable, Identifiable, Equatable {
 struct Project: Codable, Identifiable, Equatable {
     let id: String
     var name: String
+    var color: String? = nil
     var description: String
     var systemInstructions: String
     var memory: [MemoryFact]
@@ -29,6 +30,7 @@ struct Project: Codable, Identifiable, Equatable {
 
 struct ProjectData: Codable, Equatable {
     var name: String
+    var color: String? = nil
     var description: String
     var systemInstructions: String
     var memory: [MemoryFact]
@@ -36,15 +38,17 @@ struct ProjectData: Codable, Equatable {
 
 struct CreateProjectData: Codable, Equatable {
     var name: String
+    var color: String? = nil
     var description: String = ""
     var systemInstructions: String = ""
 }
 
 struct UpdateProjectData: Codable, Equatable {
-    var name: String?
-    var description: String?
-    var systemInstructions: String?
-    var memory: [MemoryFact]?
+    var name: String? = nil
+    var color: String? = nil
+    var description: String? = nil
+    var systemInstructions: String? = nil
+    var memory: [MemoryFact]? = nil
 }
 
 struct ProjectDocument: Codable, Identifiable, Equatable {
@@ -64,6 +68,33 @@ struct ProjectDocumentPayload: Codable, Equatable {
     var content: String
     var filename: String
     var contentType: String
+    var sizeBytes: Int? = nil
+
+    var resolvedSizeBytes: Int {
+        sizeBytes ?? content.utf8.count
+    }
+}
+
+extension ProjectData {
+    init(createData: CreateProjectData) {
+        self.init(
+            name: createData.name,
+            color: createData.color,
+            description: createData.description,
+            systemInstructions: createData.systemInstructions,
+            memory: []
+        )
+    }
+
+    init(updateData: UpdateProjectData, existing: Project) {
+        self.init(
+            name: updateData.name ?? existing.name,
+            color: updateData.color ?? existing.color,
+            description: updateData.description ?? existing.description,
+            systemInstructions: updateData.systemInstructions ?? existing.systemInstructions,
+            memory: updateData.memory ?? existing.memory
+        )
+    }
 }
 
 struct ProjectChat: Codable, Identifiable, Equatable {
@@ -133,5 +164,4 @@ struct ProjectSyncStatus: Codable, Equatable {
 
 typealias ProjectChatSyncStatus = ProjectSyncStatus
 typealias ProjectDocumentSyncStatus = ProjectSyncStatus
-
 

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -125,7 +125,7 @@ final class ProjectStorageService: ObservableObject {
             description: payload.description,
             systemInstructions: payload.systemInstructions,
             memory: payload.memory,
-            createdAt: existing.createdAt,
+            createdAt: createdAtFromReverseId(projectId),
             updatedAt: isoNow(),
             syncVersion: syncVersion
         )

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -99,6 +99,7 @@ final class ProjectStorageService: ObservableObject {
         return Project(
             id: idResponse.projectId,
             name: payload.name,
+            color: payload.color,
             description: payload.description,
             systemInstructions: payload.systemInstructions,
             memory: payload.memory,
@@ -121,6 +122,7 @@ final class ProjectStorageService: ObservableObject {
         return Project(
             id: projectId,
             name: decoded.name,
+            color: decoded.color,
             description: decoded.description,
             systemInstructions: decoded.systemInstructions,
             memory: decoded.memory,
@@ -139,6 +141,7 @@ final class ProjectStorageService: ObservableObject {
             out[id] = Project(
                 id: id,
                 name: decoded.0.name,
+                color: decoded.0.color,
                 description: decoded.0.description,
                 systemInstructions: decoded.0.systemInstructions,
                 memory: decoded.0.memory,
@@ -301,7 +304,8 @@ final class ProjectStorageService: ObservableObject {
         projectId: String,
         filename: String,
         contentType: String,
-        content: String
+        content: String,
+        sizeBytes: Int
     ) async throws -> ProjectDocument {
         let idResponse = try await generateDocumentId(projectId: projectId)
         let wireId = projectDocumentId(projectId: projectId, documentId: idResponse.documentId)
@@ -310,17 +314,17 @@ final class ProjectStorageService: ObservableObject {
             projectId: projectId,
             filename: filename,
             contentType: contentType,
-            content: content
+            content: content,
+            sizeBytes: sizeBytes
         )
 
         let now = isoNow()
-        let size = payload.content.data(using: .utf8)?.count ?? payload.content.count
         return ProjectDocument(
             id: idResponse.documentId,
             projectId: projectId,
             filename: payload.filename,
             contentType: payload.contentType,
-            sizeBytes: size,
+            sizeBytes: payload.resolvedSizeBytes,
             syncVersion: syncVersion,
             createdAt: now,
             updatedAt: now,
@@ -337,7 +341,7 @@ final class ProjectStorageService: ObservableObject {
             projectId: projectId,
             filename: decoded.filename,
             contentType: decoded.contentType,
-            sizeBytes: decoded.content.data(using: .utf8)?.count ?? decoded.content.count,
+            sizeBytes: decoded.resolvedSizeBytes,
             syncVersion: syncVersion,
             createdAt: now,
             updatedAt: now,
@@ -393,7 +397,7 @@ final class ProjectStorageService: ObservableObject {
                     projectId: projectId,
                     filename: decoded.0.filename,
                     contentType: decoded.0.contentType,
-                    sizeBytes: decoded.0.content.data(using: .utf8)?.count ?? decoded.0.content.count,
+                    sizeBytes: decoded.0.resolvedSizeBytes,
                     syncVersion: decoded.1,
                     createdAt: createdAtFromReverseId(docId),
                     updatedAt: update.updatedAt,

--- a/TinfoilChat/Services/ProjectStorageService.swift
+++ b/TinfoilChat/Services/ProjectStorageService.swift
@@ -109,11 +109,26 @@ final class ProjectStorageService: ObservableObject {
         )
     }
 
-    func updateProject(_ projectId: String, data: UpdateProjectData) async throws {
+    func updateProject(_ projectId: String, data: UpdateProjectData) async throws -> Project {
         guard let existing = try await getProject(projectId) else {
             throw CloudStorageError.invalidResponse
         }
-        try await enclaveStore.updateProject(id: projectId, data: data, existing: existing)
+        let (payload, syncVersion) = try await enclaveStore.updateProject(
+            id: projectId,
+            data: data,
+            existing: existing
+        )
+        return Project(
+            id: projectId,
+            name: payload.name,
+            color: payload.color,
+            description: payload.description,
+            systemInstructions: payload.systemInstructions,
+            memory: payload.memory,
+            createdAt: existing.createdAt,
+            updatedAt: isoNow(),
+            syncVersion: syncVersion
+        )
     }
 
     func getProject(_ projectId: String) async throws -> Project? {

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -12,9 +12,10 @@ struct SyncEnclaveProjectStore {
         return (payload, etagToSyncVersion(response.etag))
     }
 
-    func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws {
+    func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws -> (ProjectData, Int) {
         let payload = ProjectData(updateData: data, existing: existing)
-        _ = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
+        let response = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
+        return (payload, etagToSyncVersion(response.etag))
     }
 
     func getProject(id: String) async throws -> (ProjectData, Int)? {

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -7,23 +7,13 @@ import Foundation
 
 struct SyncEnclaveProjectStore {
     func createProject(id: String, data: CreateProjectData) async throws -> (ProjectData, Int) {
-        let payload = ProjectData(
-            name: data.name,
-            description: data.description,
-            systemInstructions: data.systemInstructions,
-            memory: []
-        )
+        let payload = ProjectData(createData: data)
         let response = try await pushProject(id: id, payload: payload, ifMatch: nil)
         return (payload, etagToSyncVersion(response.etag))
     }
 
     func updateProject(id: String, data: UpdateProjectData, existing: Project) async throws {
-        let payload = ProjectData(
-            name: data.name ?? existing.name,
-            description: data.description ?? existing.description,
-            systemInstructions: data.systemInstructions ?? existing.systemInstructions,
-            memory: data.memory ?? existing.memory
-        )
+        let payload = ProjectData(updateData: data, existing: existing)
         _ = try await pushProject(id: id, payload: payload, ifMatch: String(existing.syncVersion))
     }
 
@@ -91,9 +81,15 @@ struct SyncEnclaveProjectStore {
         projectId: String,
         filename: String,
         contentType: String,
-        content: String
+        content: String,
+        sizeBytes: Int
     ) async throws -> (ProjectDocumentPayload, Int) {
-        let payload = ProjectDocumentPayload(content: content, filename: filename, contentType: contentType)
+        let payload = ProjectDocumentPayload(
+            content: content,
+            filename: filename,
+            contentType: contentType,
+            sizeBytes: sizeBytes
+        )
         let metadata: [String: AnyCodable] = [
             "filename": AnyCodable(filename),
             "contentType": AnyCodable(contentType),

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1960,15 +1960,8 @@ class ChatViewModel: ObservableObject {
                 systemInstructions: systemInstructions,
                 memory: memory
             )
-            try await projectStorage.updateProject(project.id, data: update)
+            let updated = try await projectStorage.updateProject(project.id, data: update)
             guard isCurrentProjectAccount(accountGeneration) else { return }
-            var updated = project
-            updated.name = name ?? updated.name
-            updated.color = color ?? updated.color
-            updated.description = description ?? updated.description
-            updated.systemInstructions = systemInstructions ?? updated.systemInstructions
-            updated.memory = memory ?? updated.memory
-            updated.updatedAt = ISO8601DateFormatter().string(from: Date())
             activeProject = updated
             if let index = projects.firstIndex(where: { $0.id == updated.id }) {
                 projects[index] = updated
@@ -2022,7 +2015,10 @@ class ChatViewModel: ObservableObject {
             }
         }
         do {
-            let sizeBytes = try Data(contentsOf: url, options: .mappedIfSafe).count
+            let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
+            guard let sizeBytes = resourceValues.fileSize else {
+                throw CocoaError(.fileReadUnknown)
+            }
             let markdown = try await DocumentConversionService.shared.convertToMarkdown(
                 url: url,
                 filename: filename

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -1673,7 +1673,7 @@ class ChatViewModel: ObservableObject {
     }
 
     @discardableResult
-    func createProject(name: String? = nil) async -> Project? {
+    func createProject(name: String? = nil, color: String? = nil) async -> Project? {
         guard hasChatAccess, isProjectAccountActive else { return nil }
         let accountGeneration = projectListAccountGeneration
 
@@ -1687,7 +1687,7 @@ class ChatViewModel: ObservableObject {
         do {
             let resolvedName = name ?? "My Project #\(projects.count + 1)"
             let project = try await projectStorage.createProject(
-                CreateProjectData(name: resolvedName)
+                CreateProjectData(name: resolvedName, color: color)
             )
             guard isCurrentProjectAccount(accountGeneration) else { return nil }
             projects.insert(project, at: 0)
@@ -1947,7 +1947,7 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func updateActiveProject(name: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
+    func updateActiveProject(name: String? = nil, color: String? = nil, description: String? = nil, systemInstructions: String? = nil, memory: [MemoryFact]? = nil) async {
         guard let project = activeProject else { return }
         let accountGeneration = projectListAccountGeneration
 
@@ -1955,6 +1955,7 @@ class ChatViewModel: ObservableObject {
         do {
             let update = UpdateProjectData(
                 name: name,
+                color: color,
                 description: description,
                 systemInstructions: systemInstructions,
                 memory: memory
@@ -1963,6 +1964,7 @@ class ChatViewModel: ObservableObject {
             guard isCurrentProjectAccount(accountGeneration) else { return }
             var updated = project
             updated.name = name ?? updated.name
+            updated.color = color ?? updated.color
             updated.description = description ?? updated.description
             updated.systemInstructions = systemInstructions ?? updated.systemInstructions
             updated.memory = memory ?? updated.memory
@@ -2020,6 +2022,7 @@ class ChatViewModel: ObservableObject {
             }
         }
         do {
+            let sizeBytes = try Data(contentsOf: url, options: .mappedIfSafe).count
             let markdown = try await DocumentConversionService.shared.convertToMarkdown(
                 url: url,
                 filename: filename
@@ -2030,7 +2033,8 @@ class ChatViewModel: ObservableObject {
                 projectId: project.id,
                 filename: filename,
                 contentType: contentType,
-                content: markdown
+                content: markdown,
+                sizeBytes: sizeBytes
             )
             guard isCurrentProjectAccount(accountGeneration) else { return }
             projectDocuments.append(document)

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -284,13 +284,16 @@ struct ChatSidebar: View {
     }
 
     private var sidebarContent: some View {
+        let projectColors = viewModel.projects.reduce(into: [String: String]()) {
+            $0[$1.id] = $1.color
+        }
         VStack(spacing: 0) {
             recoveryBanner
             ScrollViewReader { scrollProxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         if authManager.isAuthenticated && settings.isCloudSyncEnabled {
-                            favoritesSection
+                            favoritesSection(projectColors: projectColors)
                                 .padding(.horizontal, 16)
                                 .padding(.top, 16)
                                 .id(ChatNavigationDestination.favorites)
@@ -327,7 +330,7 @@ struct ChatSidebar: View {
                                     .padding(.top, 8)
                             }
 
-                            chatList
+                            chatList(projectColors: projectColors)
                                 .padding(.horizontal, 16)
                                 .padding(.top, 8)
                                 .padding(.bottom, 8)
@@ -425,7 +428,7 @@ struct ChatSidebar: View {
         }
     }
 
-    private var chatList: some View {
+    private func chatList(projectColors: [String: String]) -> some View {
         VStack(spacing: 12) {
             ForEach(Array(displayedChats.enumerated()), id: \.element.id) { _, chat in
                 ChatListItem(
@@ -439,7 +442,7 @@ struct ChatSidebar: View {
                     syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
                     isGenerating: viewModel.isChatStreaming(chat.id),
                     isPinned: profileManager.isChatPinned(chat.id),
-                    projectColor: viewModel.projects.first { $0.id == chat.projectId }?.color,
+                    projectColor: chat.projectId.flatMap { projectColors[$0] },
                     onSelect: {
                         if isChatSearchActive {
                             if !chatSearch.available {
@@ -527,7 +530,7 @@ struct ChatSidebar: View {
         }
     }
 
-    private var favoritesSection: some View {
+    private func favoritesSection(projectColors: [String: String]) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -561,14 +564,14 @@ struct ChatSidebar: View {
                         .padding(.horizontal, 14)
                 } else {
                     ForEach(viewModel.favoriteChats) { chat in
-                        favoriteChatRow(chat)
+                        favoriteChatRow(chat, projectColors: projectColors)
                     }
                 }
             }
         }
     }
 
-    private func favoriteChatRow(_ chat: Chat) -> some View {
+    private func favoriteChatRow(_ chat: Chat, projectColors: [String: String]) -> some View {
         let summary = ChatListSummary(from: chat)
         return ChatListItem(
             chat: summary,
@@ -582,7 +585,7 @@ struct ChatSidebar: View {
             isGenerating: viewModel.isChatStreaming(chat.id),
             isPinned: true,
             showPinnedIndicator: false,
-            projectColor: viewModel.projects.first { $0.id == chat.projectId }?.color,
+            projectColor: chat.projectId.flatMap { projectColors[$0] },
             onSelect: { viewModel.openSearchResult(chat) },
             onEdit: {
                 if editingChatId == chat.id {

--- a/TinfoilChat/Views/ChatSidebar.swift
+++ b/TinfoilChat/Views/ChatSidebar.swift
@@ -439,6 +439,7 @@ struct ChatSidebar: View {
                     syncFailed: !chat.isBlankChat && syncHealth.failedChats[chat.id] != nil,
                     isGenerating: viewModel.isChatStreaming(chat.id),
                     isPinned: profileManager.isChatPinned(chat.id),
+                    projectColor: viewModel.projects.first { $0.id == chat.projectId }?.color,
                     onSelect: {
                         if isChatSearchActive {
                             if !chatSearch.available {
@@ -494,7 +495,11 @@ struct ChatSidebar: View {
                                     await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
                                 }
                             } label: {
-                                Label("Add to \(project.name)", systemImage: "folder")
+                                Label {
+                                    Text("Add to \(project.name)")
+                                } icon: {
+                                    ProjectFolderIcon(color: project.color, size: 22)
+                                }
                             }
                         }
                     }
@@ -577,6 +582,7 @@ struct ChatSidebar: View {
             isGenerating: viewModel.isChatStreaming(chat.id),
             isPinned: true,
             showPinnedIndicator: false,
+            projectColor: viewModel.projects.first { $0.id == chat.projectId }?.color,
             onSelect: { viewModel.openSearchResult(chat) },
             onEdit: {
                 if editingChatId == chat.id {
@@ -620,10 +626,11 @@ struct ChatSidebar: View {
                         await viewModel.moveChatToProject(chatId: chat.id, projectId: project.id)
                     }
                 } label: {
-                    Label(
-                        chat.projectId == nil ? "Add to \(project.name)" : "Move to \(project.name)",
-                        systemImage: "folder"
-                    )
+                    Label {
+                        Text(chat.projectId == nil ? "Add to \(project.name)" : "Move to \(project.name)")
+                    } icon: {
+                        ProjectFolderIcon(color: project.color, size: 22)
+                    }
                 }
             }
         }
@@ -771,8 +778,12 @@ struct ChatSidebar: View {
                         }
                     } label: {
                         HStack(spacing: 12) {
-                            Image(systemName: project.decryptionFailed == true ? "lock.fill" : "folder")
-                                .foregroundColor(project.decryptionFailed == true ? .orange : .accentColor)
+                            if project.decryptionFailed == true {
+                                Image(systemName: "lock.fill")
+                                    .foregroundColor(.orange)
+                            } else {
+                                ProjectFolderIcon(color: project.color)
+                            }
                             Text(project.name)
                                 .lineLimit(1)
                             Spacer()
@@ -940,6 +951,7 @@ struct ChatListItem: View {
     var isGenerating: Bool = false
     var isPinned: Bool = false
     var showPinnedIndicator: Bool = true
+    var projectColor: String? = nil
     let onSelect: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -974,9 +986,7 @@ struct ChatListItem: View {
                     } else {
                         HStack(spacing: 4) {
                             if chat.projectId != nil {
-                                Image(systemName: "folder")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                                ProjectFolderIcon(color: projectColor, size: 18)
                                     .accessibilityHidden(true)
                             }
                             if isPinned && showPinnedIndicator {

--- a/TinfoilChat/Views/ChatView.swift
+++ b/TinfoilChat/Views/ChatView.swift
@@ -307,9 +307,7 @@ struct ChatContainer: View {
 
                     if let activeProject = viewModel.activeProject {
                         HStack(spacing: 6) {
-                            Image(systemName: "folder")
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(toolbarContentColor)
+                            ProjectFolderIcon(color: activeProject.color, size: 20)
                             Text(activeProject.name)
                                 .font(.caption)
                                 .fontWeight(.semibold)

--- a/TinfoilChat/Views/ProjectFolderIcon.swift
+++ b/TinfoilChat/Views/ProjectFolderIcon.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ProjectFolderIcon: View {
+    let color: String?
+    var size: CGFloat = 28
+
+    private var tint: Color {
+        Color.projectColor(color)
+    }
+
+    var body: some View {
+        Image(systemName: "folder.fill")
+            .font(.system(size: size * 0.5, weight: .medium))
+            .foregroundColor(tint)
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: size * 0.25)
+                    .fill(tint.opacity(0.12))
+            )
+    }
+}

--- a/TinfoilChat/Views/ProjectPage.swift
+++ b/TinfoilChat/Views/ProjectPage.swift
@@ -27,9 +27,7 @@ struct ProjectPage: View {
                 if let project {
                     Section {
                         HStack(spacing: 12) {
-                            Image(systemName: "folder.fill")
-                                .font(.title3)
-                                .foregroundColor(.accentColor)
+                            ProjectFolderIcon(color: project.color, size: 32)
                             VStack(alignment: .leading, spacing: 2) {
                                 TextField("Project name", text: $editingName)
                                     .font(.headline)
@@ -224,7 +222,11 @@ struct ProjectPage: View {
                         await viewModel.moveChatToProject(chatId: chat.id, projectId: destination.id)
                     }
                 } label: {
-                    Label("Move to \(destination.name)", systemImage: "folder")
+                    Label {
+                        Text("Move to \(destination.name)")
+                    } icon: {
+                        ProjectFolderIcon(color: destination.color, size: 22)
+                    }
                 }
             }
         }

--- a/TinfoilChatTests/ProjectColorTests.swift
+++ b/TinfoilChatTests/ProjectColorTests.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import Testing
+import UIKit
+@testable import TinfoilChat
+
+@Suite("Project Color Tests")
+struct ProjectColorTests {
+    @Test("Exact web project color identifiers parse", arguments: [
+        ("maya-blue", 133, 198, 255),
+        ("electric-aqua", 98, 220, 233),
+        ("sandy-brown", 255, 181, 122),
+        ("mauve", 233, 171, 255),
+        ("tuscan-sun", 245, 203, 88),
+        ("light-green", 138, 223, 141),
+        ("baby-pink", 255, 158, 195),
+    ])
+    func exactWebProjectColorIdentifiersParse(id: String, red: Int, green: Int, blue: Int) {
+        let parsed = ProjectColorRGB(identifier: id)
+
+        #expect(parsed?.red == red)
+        #expect(parsed?.green == green)
+        #expect(parsed?.blue == blue)
+    }
+
+    @Test("Non-web project color identifiers do not parse")
+    func nonWebProjectColorIdentifiersDoNotParse() {
+        #expect(ProjectColorRGB(identifier: nil) == nil)
+        #expect(ProjectColorRGB(identifier: "Maya-Blue") == nil)
+        #expect(ProjectColorRGB(identifier: " maya-blue") == nil)
+        #expect(ProjectColorRGB(identifier: "#85C6FF") == nil)
+        #expect(ProjectColorRGB(identifier: "unknown") == nil)
+    }
+
+    @Test("Web project colors render with web RGB values", arguments: [
+        ("maya-blue", 133, 198, 255),
+        ("electric-aqua", 98, 220, 233),
+        ("sandy-brown", 255, 181, 122),
+        ("mauve", 233, 171, 255),
+        ("tuscan-sun", 245, 203, 88),
+        ("light-green", 138, 223, 141),
+        ("baby-pink", 255, 158, 195),
+    ])
+    func webProjectColorsRender(id: String, red: Int, green: Int, blue: Int) {
+        let components = rgbaComponents(of: Color.projectColor(id))
+
+        #expect(abs(components.red - Double(red) / 255) < 0.0001)
+        #expect(abs(components.green - Double(green) / 255) < 0.0001)
+        #expect(abs(components.blue - Double(blue) / 255) < 0.0001)
+        #expect(abs(components.alpha - 1) < 0.0001)
+    }
+
+    @Test("Missing and invalid project colors use the accent")
+    func missingAndInvalidProjectColorsUseAccent() {
+        #expect(Color.projectColor(nil) == Color.accentColor)
+        #expect(Color.projectColor("unknown") == Color.accentColor)
+    }
+
+    private func rgbaComponents(of color: Color) -> (red: Double, green: Double, blue: Double, alpha: Double) {
+        var red = CGFloat.zero
+        var green = CGFloat.zero
+        var blue = CGFloat.zero
+        var alpha = CGFloat.zero
+        UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (Double(red), Double(green), Double(blue), Double(alpha))
+    }
+}

--- a/TinfoilChatTests/ProjectSchemaFidelityTests.swift
+++ b/TinfoilChatTests/ProjectSchemaFidelityTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct ProjectSchemaFidelityTests {
+    @Test func projectSchemasRoundTripColor() throws {
+        let project = Project(
+            id: "project-1",
+            name: "Project",
+            color: "#1A2B3C",
+            description: "Description",
+            systemInstructions: "Instructions",
+            memory: [],
+            createdAt: "2026-08-20T00:00:00.000Z",
+            updatedAt: "2026-08-20T00:00:00.000Z",
+            syncVersion: 1
+        )
+        let projectData = ProjectData(
+            name: project.name,
+            color: project.color,
+            description: project.description,
+            systemInstructions: project.systemInstructions,
+            memory: project.memory
+        )
+        let createData = CreateProjectData(name: project.name, color: project.color)
+        let updateData = UpdateProjectData(color: project.color)
+
+        #expect(try roundTrip(project).color == "#1A2B3C")
+        #expect(try roundTrip(projectData).color == "#1A2B3C")
+        #expect(try roundTrip(createData).color == "#1A2B3C")
+        #expect(try roundTrip(updateData).color == "#1A2B3C")
+        #expect(ProjectData(createData: createData).color == "#1A2B3C")
+    }
+
+    @Test func unrelatedProjectUpdatePreservesColor() {
+        let existing = Project(
+            id: "project-1",
+            name: "Project",
+            color: "blue",
+            description: "Old description",
+            systemInstructions: "Instructions",
+            memory: [],
+            createdAt: "2026-08-20T00:00:00.000Z",
+            updatedAt: "2026-08-20T00:00:00.000Z",
+            syncVersion: 1
+        )
+
+        let merged = ProjectData(
+            updateData: UpdateProjectData(description: "New description"),
+            existing: existing
+        )
+
+        #expect(merged.color == "blue")
+        #expect(merged.description == "New description")
+    }
+
+    @Test func documentPayloadRoundTripsOriginalSize() throws {
+        let payload = ProjectDocumentPayload(
+            content: "converted markdown",
+            filename: "source.pdf",
+            contentType: "application/pdf",
+            sizeBytes: 42_000
+        )
+
+        let decoded = try roundTrip(payload)
+
+        #expect(decoded.sizeBytes == 42_000)
+        #expect(decoded.resolvedSizeBytes == 42_000)
+    }
+
+    @Test func legacyDocumentPayloadFallsBackToUTF8Size() throws {
+        let data = Data(
+            #"{"content":"café","filename":"legacy.txt","contentType":"text/plain"}"#.utf8
+        )
+
+        let payload = try JSONDecoder().decode(ProjectDocumentPayload.self, from: data)
+
+        #expect(payload.sizeBytes == nil)
+        #expect(payload.resolvedSizeBytes == "café".utf8.count)
+    }
+
+    private func roundTrip<Value: Codable>(_ value: Value) throws -> Value {
+        try JSONDecoder().decode(Value.self, from: JSONEncoder().encode(value))
+    }
+}


### PR DESCRIPTION
## Summary
- render the existing web project palette on iOS folder icons
- share one icon component across project-specific rows
- preserve lock styling and accent fallback

## Testing
- added palette and fallback tests
- `git diff --check`

## Dependency
- stacked on the project schema fidelity PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows project folder colors from the existing web palette to improve project recognition. Previously folders used a generic accent/system icon; now `ProjectFolderIcon` tints folders by project color and falls back to accent when unknown, while locked projects still show an orange lock.

- Adds `Color.projectColor(_:)` with strict identifier→RGB mapping and uses `ProjectFolderIcon` in chat list items, move/add context menus, the ChatView toolbar, the Project page header, and ChatSidebar project rows.
- Passes project colors into `ChatListItem`; caches a project id→color map in `ChatSidebar` to avoid repeated lookups.
- Tests cover slug parsing, exact RGB rendering, and accent fallback.
- No migrations. Project models must supply exact web color identifiers (e.g., "maya-blue"); invalid/missing identifiers render the accent color.
- Stacked on the project schema fidelity PR; merge that first.

<sup>Written for commit 1060737735197b8ba215df214ef4fe332121e587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

