### PR TITLE
fix: bound shared import files

### DIFF
--- a/TinfoilChat/Services/SharedImportCoordinator.swift
+++ b/TinfoilChat/Services/SharedImportCoordinator.swift
@@ -1,43 +1,78 @@
 import Foundation
 
 @MainActor
+protocol SharedImportAttachmentReceiving: AnyObject {
+    var pendingAttachments: [Attachment] { get }
+    var attachmentError: String? { get set }
+
+    func addImageAttachment(
+        data: Data,
+        fileName: String,
+        sharedImportRequestID: UUID?
+    )
+
+    func addDocumentAttachment(
+        url: URL,
+        fileName: String,
+        sharedImportRequestID: UUID?,
+        managedFile: ManagedStagedFile?
+    )
+}
+
+extension ChatViewModel: SharedImportAttachmentReceiving {}
+
+@MainActor
 final class SharedImportCoordinator {
     static let shared = SharedImportCoordinator()
 
-    private init() {}
+    private let storeProvider: () throws -> SharedImportStore
+    private let managedFileStore: ManagedFileStore
 
-    func importPendingAttachments(into viewModel: ChatViewModel) {
-        guard let store = try? SharedImportStore() else { return }
+    init(
+        storeProvider: @escaping () throws -> SharedImportStore = { try SharedImportStore() },
+        managedFileStore: ManagedFileStore = .shared
+    ) {
+        self.storeProvider = storeProvider
+        self.managedFileStore = managedFileStore
+    }
+
+    func importPendingAttachments(into receiver: SharedImportAttachmentReceiving) {
+        guard let store = try? storeProvider() else { return }
 
         let importedRequestIDs = Set(
-            viewModel.pendingAttachments.compactMap(\.sharedImportRequestID)
+            receiver.pendingAttachments.compactMap(\.sharedImportRequestID)
         )
         for request in store.pendingRequests() where !importedRequestIDs.contains(request.id) {
             do {
-                let payloadURL = try store.payloadURL(for: request)
                 switch request.item.kind {
                 case .image:
-                    let data = try Data(contentsOf: payloadURL, options: .mappedIfSafe)
-                    viewModel.addImageAttachment(
+                    let data = try store.payloadData(for: request)
+                    receiver.addImageAttachment(
                         data: data,
                         fileName: request.item.originalFileName,
                         sharedImportRequestID: request.id
                     )
                 case .document:
-                    viewModel.addDocumentAttachment(
-                        url: payloadURL,
+                    let payloadURL = try store.payloadURL(for: request)
+                    let managedFile = try managedFileStore.stage(
+                        sourceURL: payloadURL,
+                        fileName: request.item.originalFileName
+                    )
+                    receiver.addDocumentAttachment(
+                        url: managedFile.url,
                         fileName: request.item.originalFileName,
-                        sharedImportRequestID: request.id
+                        sharedImportRequestID: request.id,
+                        managedFile: managedFile
                     )
                 }
             } catch {
-                viewModel.attachmentError = error.localizedDescription
+                receiver.attachmentError = error.localizedDescription
             }
         }
     }
 
     func acknowledge(requestID: UUID) {
-        guard let store = try? SharedImportStore() else { return }
+        guard let store = try? storeProvider() else { return }
         store.removeRequest(id: requestID)
     }
 }

--- a/TinfoilChatTests/SharedImportCoordinatorTests.swift
+++ b/TinfoilChatTests/SharedImportCoordinatorTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+@testable import TinfoilChat
+
+@MainActor
+@Suite("Shared Import Coordinator Tests")
+struct SharedImportCoordinatorTests {
+    @Test("Stages documents while retaining their inbox request")
+    func stagesDocumentAndRetainsRequest() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let importStore = try SharedImportStore(
+            inboxURL: rootURL.appendingPathComponent("ShareInbox", isDirectory: true)
+        )
+        let managedStore = ManagedFileStore(
+            directoryURL: rootURL.appendingPathComponent("ManagedFileStaging", isDirectory: true)
+        )
+        let request = try importStore.enqueue(
+            data: Data("shared document".utf8),
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "notes.txt"
+        )
+        let coordinator = SharedImportCoordinator(
+            storeProvider: { importStore },
+            managedFileStore: managedStore
+        )
+        let receiver = RecordingSharedImportReceiver()
+
+        coordinator.importPendingAttachments(into: receiver)
+
+        #expect(receiver.documents.count == 1)
+        let document = try #require(receiver.documents.first)
+        #expect(managedStore.owns(document.url))
+        #expect(try BoundedFileIO.read(from: document.url, maximumBytes: 100) == Data("shared document".utf8))
+        #expect(importStore.pendingRequests() == [request])
+
+        coordinator.importPendingAttachments(into: receiver)
+        #expect(receiver.documents.count == 1)
+
+        coordinator.acknowledge(requestID: request.id)
+        #expect(importStore.pendingRequests().isEmpty)
+        #expect(document.managedFile.discard())
+    }
+}
+
+@MainActor
+private final class RecordingSharedImportReceiver: SharedImportAttachmentReceiving {
+    struct Document {
+        let url: URL
+        let managedFile: ManagedStagedFile
+    }
+
+    var pendingAttachments: [Attachment] = []
+    var attachmentError: String?
+    var documents: [Document] = []
+
+    func addImageAttachment(
+        data: Data,
+        fileName: String,
+        sharedImportRequestID: UUID?
+    ) {
+        pendingAttachments.append(Attachment(
+            type: .image,
+            fileName: fileName,
+            fileSize: Int64(data.count),
+            sharedImportRequestID: sharedImportRequestID,
+            processingState: .completed
+        ))
+    }
+
+    func addDocumentAttachment(
+        url: URL,
+        fileName: String,
+        sharedImportRequestID: UUID?,
+        managedFile: ManagedStagedFile?
+    ) {
+        guard let managedFile else { return }
+        documents.append(Document(url: url, managedFile: managedFile))
+        pendingAttachments.append(Attachment(
+            type: .document,
+            fileName: fileName,
+            sharedImportRequestID: sharedImportRequestID,
+            processingState: .completed
+        ))
+    }
+}

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -66,6 +66,137 @@ struct SharedImportStoreTests {
         #expect(try fixture.store.payloadData(for: request) == sourceData)
     }
 
+    @Test("Rejects new shares at the pending request limit")
+    func enforcesPendingRequestLimit() throws {
+        let fixture = try makeFixture(
+            maximumPendingRequestCount: 2,
+            maximumPendingPayloadBytes: 100
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        for name in ["first.txt", "second.txt"] {
+            _ = try fixture.store.enqueue(
+                data: Data(name.utf8),
+                typeIdentifier: UTType.plainText.identifier,
+                originalFileName: name
+            )
+        }
+
+        #expect(throws: SharedImportError.tooManyPendingRequests(maximum: 2)) {
+            _ = try fixture.store.enqueue(
+                data: Data("third".utf8),
+                typeIdentifier: UTType.plainText.identifier,
+                originalFileName: "third.txt"
+            )
+        }
+        #expect(fixture.store.pendingRequests().count == 2)
+    }
+
+    @Test("Rejects new shares above the aggregate payload quota")
+    func enforcesPendingPayloadQuota() throws {
+        let fixture = try makeFixture(
+            maximumPendingRequestCount: 10,
+            maximumPendingPayloadBytes: 5
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        _ = try fixture.store.enqueue(
+            data: Data("12345".utf8),
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "full.txt"
+        )
+
+        #expect(throws: SharedImportError.pendingPayloadQuotaExceeded(maximumBytes: 5)) {
+            _ = try fixture.store.enqueue(
+                data: Data("6".utf8),
+                typeIdentifier: UTType.plainText.identifier,
+                originalFileName: "extra.txt"
+            )
+        }
+        #expect(fixture.store.pendingRequests().count == 1)
+    }
+
+    @Test("Serializes concurrent aggregate quota checks")
+    func serializesConcurrentEnqueue() async throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        let inboxURL = rootURL.appendingPathComponent("ShareInbox", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        var results: [ConcurrentEnqueueResult] = []
+        await withTaskGroup(of: ConcurrentEnqueueResult.self) { group in
+            for name in ["first.txt", "second.txt"] {
+                group.addTask {
+                    do {
+                        let store = try SharedImportStore(
+                            inboxURL: inboxURL,
+                            maximumPendingRequestCount: 10,
+                            maximumPendingPayloadBytes: 1
+                        )
+                        _ = try store.enqueue(
+                            data: Data("1".utf8),
+                            typeIdentifier: UTType.plainText.identifier,
+                            originalFileName: name
+                        )
+                        return .success
+                    } catch SharedImportError.pendingPayloadQuotaExceeded(let maximumBytes) {
+                        return maximumBytes == 1 ? .quotaRejected : .unexpectedFailure
+                    } catch {
+                        return .unexpectedFailure
+                    }
+                }
+            }
+            for await result in group {
+                results.append(result)
+            }
+        }
+
+        #expect(results.filter { $0 == .success }.count == 1)
+        #expect(results.filter { $0 == .quotaRejected }.count == 1)
+        let store = try SharedImportStore(inboxURL: inboxURL)
+        #expect(store.pendingRequests().count == 1)
+    }
+
+    @Test("Prefers files before immediately bounding materialized fallback data")
+    func boundsMaterializedDataFallback() throws {
+        let fixture = try makeFixture(
+            maximumPendingRequestCount: 10,
+            maximumPendingPayloadBytes: 3
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        var callOrder: [String] = []
+        var observedError: SharedImportError?
+
+        SharedImportRepresentationLoader.load(
+            fileRepresentation: { completion in
+                callOrder.append("file")
+                completion(nil, CocoaError(.fileReadUnknown))
+            },
+            dataRepresentation: { completion in
+                callOrder.append("data")
+                completion(Data("1234".utf8), nil)
+            }
+        ) { result in
+            guard case .success(.data(let data)) = result else {
+                observedError = .invalidFile
+                return
+            }
+            do {
+                _ = try fixture.store.enqueue(
+                    data: data,
+                    typeIdentifier: UTType.plainText.identifier,
+                    originalFileName: "fallback.txt"
+                )
+            } catch let error as SharedImportError {
+                observedError = error
+            } catch {
+                observedError = .invalidFile
+            }
+        }
+
+        #expect(callOrder == ["file", "data"])
+        #expect(observedError == .pendingPayloadQuotaExceeded(maximumBytes: 3))
+        #expect(fixture.store.pendingRequests().isEmpty)
+    }
+
     @Test("Rejects oversized file representations before publishing")
     func rejectsOversizedFileRepresentation() throws {
         let fixture = try makeFixture()
@@ -179,7 +310,9 @@ struct SharedImportStoreTests {
     }
 
     private func makeFixture(
-        currentDate: @escaping () -> Date = Date.init
+        currentDate: @escaping () -> Date = Date.init,
+        maximumPendingRequestCount: Int = SharedImportConfiguration.maximumPendingRequestCount,
+        maximumPendingPayloadBytes: Int64 = SharedImportConfiguration.maximumPendingPayloadBytes
     ) throws -> (
         store: SharedImportStore,
         rootURL: URL,
@@ -194,9 +327,20 @@ struct SharedImportStoreTests {
             attributes: nil
         )
         return (
-            try SharedImportStore(inboxURL: inboxURL, currentDate: currentDate),
+            try SharedImportStore(
+                inboxURL: inboxURL,
+                currentDate: currentDate,
+                maximumPendingRequestCount: maximumPendingRequestCount,
+                maximumPendingPayloadBytes: maximumPendingPayloadBytes
+            ),
             rootURL,
             inboxURL
         )
     }
+}
+
+private enum ConcurrentEnqueueResult: Equatable, Sendable {
+    case success
+    case quotaRejected
+    case unexpectedFailure
 }

--- a/TinfoilChatTests/SharedImportStoreTests.swift
+++ b/TinfoilChatTests/SharedImportStoreTests.swift
@@ -50,6 +50,42 @@ struct SharedImportStoreTests {
         #expect(fixture.store.pendingRequests().isEmpty)
     }
 
+    @Test("Persists data without an intermediate source file")
+    func persistsDataRepresentation() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let sourceData = Data("direct shared data".utf8)
+
+        let request = try fixture.store.enqueue(
+            data: sourceData,
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "Notes.txt"
+        )
+
+        #expect(request.item.byteCount == Int64(sourceData.count))
+        #expect(try fixture.store.payloadData(for: request) == sourceData)
+    }
+
+    @Test("Rejects oversized file representations before publishing")
+    func rejectsOversizedFileRepresentation() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let sourceURL = fixture.rootURL.appendingPathComponent("oversized.pdf")
+        #expect(FileManager.default.createFile(atPath: sourceURL.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: sourceURL)
+        try handle.truncate(atOffset: UInt64(SharedImportConfiguration.maximumDocumentSizeBytes + 1))
+        try handle.close()
+
+        #expect(throws: SharedImportError.self) {
+            _ = try fixture.store.enqueue(
+                sourceURL: sourceURL,
+                typeIdentifier: UTType.pdf.identifier,
+                originalFileName: "oversized.pdf"
+            )
+        }
+        #expect(fixture.store.pendingRequests().isEmpty)
+    }
+
     @Test("Keeps the extension when truncating an overlong file name")
     func keepsExtensionWhenTruncating() {
         let longStem = String(repeating: "a", count: 300)
@@ -59,9 +95,10 @@ struct SharedImportStoreTests {
         #expect(sanitized.hasSuffix(".pdf"))
     }
 
-    @Test("Ignores requests with corrupted manifests")
-    func ignoresCorruptedManifest() throws {
-        let fixture = try makeFixture()
+    @Test("Removes malformed request directories only after the stale interval")
+    func removesStaleMalformedRequest() throws {
+        var now = Date()
+        let fixture = try makeFixture(currentDate: { now })
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
 
         let sourceURL = fixture.rootURL.appendingPathComponent("source.txt")
@@ -75,12 +112,75 @@ struct SharedImportStoreTests {
         let manifestURL = fixture.inboxURL
             .appendingPathComponent(request.id.uuidString.lowercased(), isDirectory: true)
             .appendingPathComponent(SharedImportConfiguration.manifestFileName)
-        try Data("invalid".utf8).write(to: manifestURL)
+        try Data(
+            repeating: 0x41,
+            count: Int(SharedImportConfiguration.maximumManifestSizeBytes + 1)
+        ).write(to: manifestURL)
 
         #expect(fixture.store.pendingRequests().isEmpty)
+        let requestDirectory = manifestURL.deletingLastPathComponent()
+        #expect(FileManager.default.fileExists(atPath: requestDirectory.path))
+
+        now.addTimeInterval(SharedImportConfiguration.staleStagingLifetimeSeconds + 1)
+        #expect(fixture.store.pendingRequests().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: requestDirectory.path))
     }
 
-    private func makeFixture() throws -> (
+    @Test("Preserves valid pending requests across the stale interval")
+    func preservesValidPendingRequest() throws {
+        var now = Date()
+        let fixture = try makeFixture(currentDate: { now })
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let request = try fixture.store.enqueue(
+            data: Data("retry me".utf8),
+            typeIdentifier: UTType.plainText.identifier,
+            originalFileName: "retry.txt"
+        )
+
+        now.addTimeInterval(SharedImportConfiguration.staleStagingLifetimeSeconds + 1)
+
+        #expect(fixture.store.pendingRequests() == [request])
+    }
+
+    @Test("Bounds payload reads by their content type limit")
+    func boundsPayloadReads() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let request = try fixture.store.enqueue(
+            data: Data("image".utf8),
+            typeIdentifier: UTType.png.identifier,
+            originalFileName: "image.png"
+        )
+        let oversizedByteCount = SharedImportConfiguration.maximumImageSizeBytes + 1
+        let payloadURL = try fixture.store.payloadURL(for: request)
+        let handle = try FileHandle(forWritingTo: payloadURL)
+        try handle.truncate(atOffset: UInt64(oversizedByteCount))
+        try handle.close()
+        let oversizedItem = SharedImportItem(
+            id: request.item.id,
+            kind: request.item.kind,
+            typeIdentifier: request.item.typeIdentifier,
+            originalFileName: request.item.originalFileName,
+            stagedFileName: request.item.stagedFileName,
+            byteCount: oversizedByteCount
+        )
+        let oversizedRequest = SharedImportRequest(
+            id: request.id,
+            createdAt: request.createdAt,
+            item: oversizedItem
+        )
+
+        #expect(throws: BoundedFileIO.Error.fileTooLarge(
+            size: oversizedByteCount,
+            maximum: SharedImportConfiguration.maximumImageSizeBytes
+        )) {
+            _ = try fixture.store.payloadData(for: oversizedRequest)
+        }
+    }
+
+    private func makeFixture(
+        currentDate: @escaping () -> Date = Date.init
+    ) throws -> (
         store: SharedImportStore,
         rootURL: URL,
         inboxURL: URL
@@ -94,7 +194,7 @@ struct SharedImportStoreTests {
             attributes: nil
         )
         return (
-            try SharedImportStore(inboxURL: inboxURL),
+            try SharedImportStore(inboxURL: inboxURL, currentDate: currentDate),
             rootURL,
             inboxURL
         )

--- a/TinfoilShareExtension/ShareViewController.swift
+++ b/TinfoilShareExtension/ShareViewController.swift
@@ -106,53 +106,60 @@ final class ShareViewController: UIViewController {
         }
 
         setSaving(true)
-        provider.loadFileRepresentation(forTypeIdentifier: typeIdentifier) { [weak self] url, error in
+        SharedImportRepresentationLoader.load(
+            fileRepresentation: { completion in
+                _ = provider.loadFileRepresentation(
+                    forTypeIdentifier: typeIdentifier,
+                    completionHandler: completion
+                )
+            },
+            dataRepresentation: { completion in
+                _ = provider.loadDataRepresentation(
+                    forTypeIdentifier: typeIdentifier,
+                    completionHandler: completion
+                )
+            }
+        ) { [weak self] result in
             guard let self else { return }
-
-            if let url {
+            switch result {
+            case .success(.file(let url)):
                 saveSharedItem(
                     from: url,
                     provider: provider,
                     typeIdentifier: typeIdentifier
                 )
-            } else {
-                loadDataFallback(
+            case .success(.data(let data)):
+                saveSharedItem(
+                    data: data,
                     provider: provider,
-                    typeIdentifier: typeIdentifier,
-                    underlyingError: error
+                    typeIdentifier: typeIdentifier
                 )
+            case .failure(let error):
+                showError(error)
             }
         }
     }
 
-    private func loadDataFallback(
+    private func saveSharedItem(
+        data: Data,
         provider: NSItemProvider,
-        typeIdentifier: String,
-        underlyingError: Error?
+        typeIdentifier: String
     ) {
-        provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { [weak self] data, error in
-            guard let self else { return }
-            guard let data else {
-                showError(error ?? underlyingError ?? SharedImportError.invalidFile)
-                return
-            }
-
-            do {
-                let store = try SharedImportStore()
-                _ = try store.enqueue(
-                    data: data,
-                    typeIdentifier: typeIdentifier,
-                    originalFileName: sharedFileName(
-                        provider: provider,
-                        typeIdentifier: typeIdentifier
-                    )
+        do {
+            let store = try SharedImportStore()
+            _ = try store.enqueue(
+                data: data,
+                typeIdentifier: typeIdentifier,
+                originalFileName: sharedFileName(
+                    provider: provider,
+                    typeIdentifier: typeIdentifier
                 )
-                DispatchQueue.main.async { [weak self] in
-                    self?.extensionContext?.completeRequest(returningItems: nil)
-                }
-            } catch {
-                showError(error)
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.extensionContext?.completeRequest(returningItems: nil)
             }
+        } catch {
+            showError(error)
         }
     }
 

--- a/TinfoilShareExtension/ShareViewController.swift
+++ b/TinfoilShareExtension/ShareViewController.swift
@@ -137,16 +137,19 @@ final class ShareViewController: UIViewController {
                 return
             }
 
-            let temporaryURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent(UUID().uuidString.lowercased())
             do {
-                try data.write(to: temporaryURL, options: .atomic)
-                saveSharedItem(
-                    from: temporaryURL,
-                    provider: provider,
-                    typeIdentifier: typeIdentifier
+                let store = try SharedImportStore()
+                _ = try store.enqueue(
+                    data: data,
+                    typeIdentifier: typeIdentifier,
+                    originalFileName: sharedFileName(
+                        provider: provider,
+                        typeIdentifier: typeIdentifier
+                    )
                 )
-                try? FileManager.default.removeItem(at: temporaryURL)
+                DispatchQueue.main.async { [weak self] in
+                    self?.extensionContext?.completeRequest(returningItems: nil)
+                }
             } catch {
                 showError(error)
             }

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -15,6 +15,7 @@ enum SharedImportConfiguration {
     /// Hidden staging directories older than this are treated as abandoned
     /// by an interrupted share and swept from the app-group inbox.
     static let staleStagingLifetimeSeconds: TimeInterval = 24 * 60 * 60
+    static let unreadableRequestLifetimeSeconds: TimeInterval = 7 * 24 * 60 * 60
     static let supportedDocumentExtensions: Set<String> = [
         "pdf", "docx", "pptx", "xlsx", "txt", "md", "csv", "html", "json", "xml",
     ]

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -5,6 +5,7 @@ enum SharedImportConfiguration {
     static let appGroupIdentifier = "group.sh.tinfoil.TinfoilChat"
     static let inboxDirectoryName = "ShareInbox"
     static let manifestFileName = "request.json"
+    static let maximumManifestSizeBytes: Int64 = 64 * 1024
     static let maximumFileNameLength = 120
     static let maximumImageSizeBytes: Int64 = 10 * 1024 * 1024
     static let maximumDocumentSizeBytes: Int64 = 20 * 1024 * 1024

--- a/TinfoilShared/SharedImportContract.swift
+++ b/TinfoilShared/SharedImportContract.swift
@@ -5,10 +5,13 @@ enum SharedImportConfiguration {
     static let appGroupIdentifier = "group.sh.tinfoil.TinfoilChat"
     static let inboxDirectoryName = "ShareInbox"
     static let manifestFileName = "request.json"
+    static let enqueueLockFileName = ".enqueue.lock"
     static let maximumManifestSizeBytes: Int64 = 64 * 1024
     static let maximumFileNameLength = 120
     static let maximumImageSizeBytes: Int64 = 10 * 1024 * 1024
     static let maximumDocumentSizeBytes: Int64 = 20 * 1024 * 1024
+    static let maximumPendingRequestCount = 32
+    static let maximumPendingPayloadBytes: Int64 = 100 * 1024 * 1024
     /// Hidden staging directories older than this are treated as abandoned
     /// by an interrupted share and swept from the app-group inbox.
     static let staleStagingLifetimeSeconds: TimeInterval = 24 * 60 * 60
@@ -77,11 +80,13 @@ enum SharedImportClassifier {
     }
 }
 
-enum SharedImportError: LocalizedError {
+enum SharedImportError: LocalizedError, Equatable {
     case sharedContainerUnavailable
     case unsupportedType
     case invalidFile
     case fileTooLarge(kind: SharedImportKind, size: Int64)
+    case tooManyPendingRequests(maximum: Int)
+    case pendingPayloadQuotaExceeded(maximumBytes: Int64)
     case invalidRequest
 
     var errorDescription: String? {
@@ -101,6 +106,10 @@ enum SharedImportError: LocalizedError {
                 sizeInMegabytes,
                 maximumSize
             )
+        case .tooManyPendingRequests:
+            return "Too many shared files are waiting in Tinfoil. Open Tinfoil to send or discard one, then try again."
+        case .pendingPayloadQuotaExceeded:
+            return "Shared files waiting in Tinfoil use too much storage. Open Tinfoil to send or discard some, then try again."
         case .invalidRequest:
             return "The shared file request is invalid."
         }

--- a/TinfoilShared/SharedImportRepresentationLoader.swift
+++ b/TinfoilShared/SharedImportRepresentationLoader.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum SharedImportRepresentation {
+    case file(URL)
+    case data(Data)
+}
+
+enum SharedImportRepresentationLoader {
+    typealias FileLoader = (@escaping (URL?, Error?) -> Void) -> Void
+    typealias DataLoader = (@escaping (Data?, Error?) -> Void) -> Void
+
+    static func load(
+        fileRepresentation: @escaping FileLoader,
+        dataRepresentation: @escaping DataLoader,
+        completion: @escaping (Result<SharedImportRepresentation, Error>) -> Void
+    ) {
+        fileRepresentation { url, fileError in
+            if let url {
+                completion(.success(.file(url)))
+                return
+            }
+
+            // Apple provides no streaming Data representation API. Prefer a
+            // file, then enforce limits as soon as fallback Data materializes.
+            dataRepresentation { data, dataError in
+                if let data {
+                    completion(.success(.data(data)))
+                } else {
+                    completion(.failure(dataError ?? fileError ?? SharedImportError.invalidFile))
+                }
+            }
+        }
+    }
+}

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -1,18 +1,27 @@
+import Darwin
 import Foundation
 import UniformTypeIdentifiers
 
 struct SharedImportStore {
+    private static let enqueueLock = NSLock()
+
     private let fileManager: FileManager
     private let currentDate: () -> Date
+    private let maximumPendingRequestCount: Int
+    private let maximumPendingPayloadBytes: Int64
     let inboxURL: URL
 
     init(
         fileManager: FileManager = .default,
         inboxURL: URL? = nil,
-        currentDate: @escaping () -> Date = Date.init
+        currentDate: @escaping () -> Date = Date.init,
+        maximumPendingRequestCount: Int = SharedImportConfiguration.maximumPendingRequestCount,
+        maximumPendingPayloadBytes: Int64 = SharedImportConfiguration.maximumPendingPayloadBytes
     ) throws {
         self.fileManager = fileManager
         self.currentDate = currentDate
+        self.maximumPendingRequestCount = maximumPendingRequestCount
+        self.maximumPendingPayloadBytes = maximumPendingPayloadBytes
 
         if let inboxURL {
             self.inboxURL = inboxURL
@@ -57,15 +66,18 @@ struct SharedImportStore {
             originalFileName: originalFileName,
             byteCount: byteCount
         )
-        return try publish(requestID: UUID(), item: item) { destinationURL in
-            do {
-                return try BoundedFileIO.copy(
-                    from: sourceURL,
-                    to: destinationURL,
-                    maximumBytes: item.kind.maximumSizeBytes
-                )
-            } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
-                throw SharedImportError.fileTooLarge(kind: item.kind, size: size)
+        return try withExclusiveEnqueueLock {
+            try enforcePendingLimits(addingPayloadBytes: byteCount)
+            return try publish(requestID: UUID(), item: item) { destinationURL in
+                do {
+                    return try BoundedFileIO.copy(
+                        from: sourceURL,
+                        to: destinationURL,
+                        maximumBytes: item.kind.maximumSizeBytes
+                    )
+                } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
+                    throw SharedImportError.fileTooLarge(kind: item.kind, size: size)
+                }
             }
         }
     }
@@ -91,13 +103,60 @@ struct SharedImportStore {
             byteCount: byteCount
         )
 
-        return try publish(requestID: UUID(), item: item) { destinationURL in
-            try data.write(to: destinationURL, options: .withoutOverwriting)
-            return try BoundedFileIO.size(
-                of: destinationURL,
-                maximumBytes: item.kind.maximumSizeBytes
+        return try withExclusiveEnqueueLock {
+            try enforcePendingLimits(addingPayloadBytes: byteCount)
+            return try publish(requestID: UUID(), item: item) { destinationURL in
+                try data.write(to: destinationURL, options: .withoutOverwriting)
+                return try BoundedFileIO.size(
+                    of: destinationURL,
+                    maximumBytes: item.kind.maximumSizeBytes
+                )
+            }
+        }
+    }
+
+    private func enforcePendingLimits(addingPayloadBytes byteCount: Int64) throws {
+        let pendingRequests = pendingRequests()
+        guard pendingRequests.count < maximumPendingRequestCount else {
+            throw SharedImportError.tooManyPendingRequests(maximum: maximumPendingRequestCount)
+        }
+
+        var aggregateBytes: Int64 = 0
+        for request in pendingRequests {
+            let result = aggregateBytes.addingReportingOverflow(request.item.byteCount)
+            guard !result.overflow else {
+                throw SharedImportError.pendingPayloadQuotaExceeded(
+                    maximumBytes: maximumPendingPayloadBytes
+                )
+            }
+            aggregateBytes = result.partialValue
+        }
+        guard byteCount <= maximumPendingPayloadBytes,
+              aggregateBytes <= maximumPendingPayloadBytes - byteCount else {
+            throw SharedImportError.pendingPayloadQuotaExceeded(
+                maximumBytes: maximumPendingPayloadBytes
             )
         }
+    }
+
+    private func withExclusiveEnqueueLock<T>(_ operation: () throws -> T) throws -> T {
+        Self.enqueueLock.lock()
+        defer { Self.enqueueLock.unlock() }
+
+        let lockURL = inboxURL.appendingPathComponent(SharedImportConfiguration.enqueueLockFileName)
+        let descriptor = Darwin.open(
+            lockURL.path,
+            O_RDWR | O_CREAT | O_NOFOLLOW | O_CLOEXEC,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else { throw SharedImportError.invalidFile }
+        defer { Darwin.close(descriptor) }
+
+        while Darwin.flock(descriptor, LOCK_EX) != 0 {
+            guard errno == EINTR else { throw SharedImportError.invalidFile }
+        }
+        defer { _ = Darwin.flock(descriptor, LOCK_UN) }
+        return try operation()
     }
 
     private func publish(

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -3,10 +3,16 @@ import UniformTypeIdentifiers
 
 struct SharedImportStore {
     private let fileManager: FileManager
+    private let currentDate: () -> Date
     let inboxURL: URL
 
-    init(fileManager: FileManager = .default, inboxURL: URL? = nil) throws {
+    init(
+        fileManager: FileManager = .default,
+        inboxURL: URL? = nil,
+        currentDate: @escaping () -> Date = Date.init
+    ) throws {
         self.fileManager = fileManager
+        self.currentDate = currentDate
 
         if let inboxURL {
             self.inboxURL = inboxURL
@@ -35,45 +41,71 @@ struct SharedImportStore {
         typeIdentifier: String,
         originalFileName: String
     ) throws -> SharedImportRequest {
-        guard let kind = SharedImportClassifier.kind(
+        let kind = try classifiedKind(
             typeIdentifier: typeIdentifier,
-            fileName: originalFileName
-        ) else {
-            throw SharedImportError.unsupportedType
-        }
-
-        let sourceValues = try sourceURL.resourceValues(
-            forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
+            originalFileName: originalFileName
         )
-        guard sourceValues.isRegularFile == true, sourceValues.isSymbolicLink != true else {
-            throw SharedImportError.invalidFile
+        let byteCount: Int64
+        do {
+            byteCount = try BoundedFileIO.size(of: sourceURL, maximumBytes: kind.maximumSizeBytes)
+        } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
+            throw SharedImportError.fileTooLarge(kind: kind, size: size)
         }
+        let item = makeItem(
+            kind: kind,
+            typeIdentifier: typeIdentifier,
+            originalFileName: originalFileName,
+            byteCount: byteCount
+        )
+        return try publish(requestID: UUID(), item: item) { destinationURL in
+            do {
+                return try BoundedFileIO.copy(
+                    from: sourceURL,
+                    to: destinationURL,
+                    maximumBytes: item.kind.maximumSizeBytes
+                )
+            } catch BoundedFileIO.Error.fileTooLarge(let size, _) {
+                throw SharedImportError.fileTooLarge(kind: item.kind, size: size)
+            }
+        }
+    }
 
-        let byteCount = Int64(sourceValues.fileSize ?? 0)
+    @discardableResult
+    func enqueue(
+        data: Data,
+        typeIdentifier: String,
+        originalFileName: String
+    ) throws -> SharedImportRequest {
+        let kind = try classifiedKind(
+            typeIdentifier: typeIdentifier,
+            originalFileName: originalFileName
+        )
+        let byteCount = Int64(data.count)
         guard byteCount <= kind.maximumSizeBytes else {
             throw SharedImportError.fileTooLarge(kind: kind, size: byteCount)
         }
+        let item = makeItem(
+            kind: kind,
+            typeIdentifier: typeIdentifier,
+            originalFileName: originalFileName,
+            byteCount: byteCount
+        )
 
-        let requestID = UUID()
-        let itemID = UUID()
-        let fileName = Self.sanitizedFileName(originalFileName)
-        let stagedFileName = Self.stagedFileName(
-            id: itemID,
-            originalFileName: fileName,
-            typeIdentifier: typeIdentifier
-        )
-        let request = SharedImportRequest(
-            id: requestID,
-            createdAt: Date(),
-            item: SharedImportItem(
-                id: itemID,
-                kind: kind,
-                typeIdentifier: typeIdentifier,
-                originalFileName: fileName,
-                stagedFileName: stagedFileName,
-                byteCount: byteCount
+        return try publish(requestID: UUID(), item: item) { destinationURL in
+            try data.write(to: destinationURL, options: .withoutOverwriting)
+            return try BoundedFileIO.size(
+                of: destinationURL,
+                maximumBytes: item.kind.maximumSizeBytes
             )
-        )
+        }
+    }
+
+    private func publish(
+        requestID: UUID,
+        item: SharedImportItem,
+        writePayload: (URL) throws -> Int64
+    ) throws -> SharedImportRequest {
+        let request = SharedImportRequest(id: requestID, createdAt: currentDate(), item: item)
 
         let temporaryDirectory = inboxURL.appendingPathComponent(
             ".\(requestID.uuidString.lowercased()).tmp",
@@ -88,11 +120,9 @@ struct SharedImportStore {
         )
 
         do {
-            let stagedURL = temporaryDirectory.appendingPathComponent(stagedFileName)
-            try fileManager.copyItem(at: sourceURL, to: stagedURL)
-
-            let copiedSize = try fileSize(at: stagedURL)
-            guard copiedSize == byteCount else {
+            let stagedURL = temporaryDirectory.appendingPathComponent(item.stagedFileName)
+            let copiedSize = try writePayload(stagedURL)
+            guard copiedSize == item.byteCount else {
                 throw SharedImportError.invalidFile
             }
 
@@ -100,7 +130,11 @@ struct SharedImportStore {
                 SharedImportConfiguration.manifestFileName
             )
             let encoder = JSONEncoder()
-            try encoder.encode(request).write(to: manifestURL, options: .atomic)
+            let manifestData = try encoder.encode(request)
+            guard Int64(manifestData.count) <= SharedImportConfiguration.maximumManifestSizeBytes else {
+                throw SharedImportError.invalidRequest
+            }
+            try manifestData.write(to: manifestURL, options: .atomic)
 
             protectAndExcludeFromBackup(stagedURL)
             protectAndExcludeFromBackup(manifestURL)
@@ -123,7 +157,13 @@ struct SharedImportStore {
         )) ?? []
 
         return directories
-            .compactMap { loadRequest(from: $0) }
+            .compactMap { directoryURL in
+                let request = loadRequest(from: directoryURL)
+                if request == nil {
+                    removeMalformedRequestDirectoryIfStale(directoryURL)
+                }
+                return request
+            }
             .sorted { $0.createdAt < $1.createdAt }
     }
 
@@ -132,7 +172,7 @@ struct SharedImportStore {
     /// app-group storage indefinitely. Only directories older than the
     /// staging lifetime are removed, to never race a share in progress.
     private func removeStaleTemporaryDirectories() {
-        let cutoff = Date().addingTimeInterval(
+        let cutoff = currentDate().addingTimeInterval(
             -SharedImportConfiguration.staleStagingLifetimeSeconds
         )
         let entries = (try? fileManager.contentsOfDirectory(
@@ -160,13 +200,10 @@ struct SharedImportStore {
 
         let payloadURL = directoryURL(for: request.id)
             .appendingPathComponent(request.item.stagedFileName)
-        let values = try payloadURL.resourceValues(
-            forKeys: [.isRegularFileKey, .isSymbolicLinkKey]
-        )
-        guard values.isRegularFile == true,
-              values.isSymbolicLink != true,
-              try fileSize(at: payloadURL) == request.item.byteCount,
-              request.item.byteCount <= request.item.kind.maximumSizeBytes,
+        guard try BoundedFileIO.size(
+            of: payloadURL,
+            maximumBytes: request.item.kind.maximumSizeBytes
+        ) == request.item.byteCount,
               SharedImportClassifier.kind(
                 typeIdentifier: request.item.typeIdentifier,
                 fileName: request.item.originalFileName
@@ -174,6 +211,14 @@ struct SharedImportStore {
             throw SharedImportError.invalidRequest
         }
         return payloadURL
+    }
+
+    func payloadData(for request: SharedImportRequest) throws -> Data {
+        let payloadURL = try payloadURL(for: request)
+        return try BoundedFileIO.read(
+            from: payloadURL,
+            maximumBytes: request.item.kind.maximumSizeBytes
+        )
     }
 
     func removeRequest(id: UUID) {
@@ -217,7 +262,10 @@ struct SharedImportStore {
         )
         let decoder = JSONDecoder()
 
-        guard let data = try? Data(contentsOf: manifestURL),
+        guard let data = try? BoundedFileIO.read(
+            from: manifestURL,
+            maximumBytes: SharedImportConfiguration.maximumManifestSizeBytes
+        ),
               let request = try? decoder.decode(SharedImportRequest.self, from: data),
               directoryURL == self.directoryURL(for: request.id),
               (try? payloadURL(for: request)) != nil else {
@@ -230,12 +278,19 @@ struct SharedImportStore {
         inboxURL.appendingPathComponent(requestID.uuidString.lowercased(), isDirectory: true)
     }
 
-    private func fileSize(at url: URL) throws -> Int64 {
-        let attributes = try fileManager.attributesOfItem(atPath: url.path)
-        guard let size = attributes[.size] as? NSNumber else {
-            throw SharedImportError.invalidFile
+    private func removeMalformedRequestDirectoryIfStale(_ directoryURL: URL) {
+        guard UUID(uuidString: directoryURL.lastPathComponent) != nil,
+              (try? directoryURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+            return
         }
-        return size.int64Value
+        let cutoff = currentDate().addingTimeInterval(
+            -SharedImportConfiguration.staleStagingLifetimeSeconds
+        )
+        guard let created = (try? directoryURL.resourceValues(forKeys: [.creationDateKey]))?
+            .creationDate else { return }
+        if created < cutoff {
+            try? fileManager.removeItem(at: directoryURL)
+        }
     }
 
     private func protectAndExcludeFromBackup(_ url: URL) {
@@ -263,5 +318,40 @@ struct SharedImportStore {
             return id.uuidString.lowercased()
         }
         return "\(id.uuidString.lowercased()).\(fileExtension)"
+    }
+
+    private func classifiedKind(
+        typeIdentifier: String,
+        originalFileName: String
+    ) throws -> SharedImportKind {
+        guard let kind = SharedImportClassifier.kind(
+            typeIdentifier: typeIdentifier,
+            fileName: originalFileName
+        ) else {
+            throw SharedImportError.unsupportedType
+        }
+        return kind
+    }
+
+    private func makeItem(
+        kind: SharedImportKind,
+        typeIdentifier: String,
+        originalFileName: String,
+        byteCount: Int64
+    ) -> SharedImportItem {
+        let itemID = UUID()
+        let fileName = Self.sanitizedFileName(originalFileName)
+        return SharedImportItem(
+            id: itemID,
+            kind: kind,
+            typeIdentifier: typeIdentifier,
+            originalFileName: fileName,
+            stagedFileName: Self.stagedFileName(
+                id: itemID,
+                originalFileName: fileName,
+                typeIdentifier: typeIdentifier
+            ),
+            byteCount: byteCount
+        )
     }
 }

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -9,6 +9,11 @@ struct SharedImportStore {
         case unreadable
     }
 
+    private struct PendingStorageUsage {
+        let requestCount: Int
+        let payloadBytes: Int64
+    }
+
     private static let enqueueLock = NSLock()
 
     private let fileManager: FileManager
@@ -122,23 +127,21 @@ struct SharedImportStore {
     }
 
     private func enforcePendingLimits(addingPayloadBytes byteCount: Int64) throws {
-        let pendingRequests = pendingRequests()
-        guard pendingRequests.count < maximumPendingRequestCount else {
+        _ = pendingRequests()
+        let usage: PendingStorageUsage
+        do {
+            usage = try pendingStorageUsage()
+        } catch {
+            throw SharedImportError.pendingPayloadQuotaExceeded(
+                maximumBytes: maximumPendingPayloadBytes
+            )
+        }
+        guard usage.requestCount < maximumPendingRequestCount else {
             throw SharedImportError.tooManyPendingRequests(maximum: maximumPendingRequestCount)
         }
 
-        var aggregateBytes: Int64 = 0
-        for request in pendingRequests {
-            let result = aggregateBytes.addingReportingOverflow(request.item.byteCount)
-            guard !result.overflow else {
-                throw SharedImportError.pendingPayloadQuotaExceeded(
-                    maximumBytes: maximumPendingPayloadBytes
-                )
-            }
-            aggregateBytes = result.partialValue
-        }
         guard byteCount <= maximumPendingPayloadBytes,
-              aggregateBytes <= maximumPendingPayloadBytes - byteCount else {
+              usage.payloadBytes <= maximumPendingPayloadBytes - byteCount else {
             throw SharedImportError.pendingPayloadQuotaExceeded(
                 maximumBytes: maximumPendingPayloadBytes
             )
@@ -227,13 +230,56 @@ struct SharedImportStore {
                 case .loaded(let request):
                     return request
                 case .malformed:
-                    removeMalformedRequestDirectoryIfStale(directoryURL)
+                    removeRequestDirectoryIfStale(
+                        directoryURL,
+                        lifetime: SharedImportConfiguration.staleStagingLifetimeSeconds
+                    )
                     return nil
                 case .unreadable:
+                    removeRequestDirectoryIfStale(
+                        directoryURL,
+                        lifetime: SharedImportConfiguration.unreadableRequestLifetimeSeconds
+                    )
                     return nil
                 }
             }
             .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    private func pendingStorageUsage() throws -> PendingStorageUsage {
+        let requestDirectories = try fileManager.contentsOfDirectory(
+            at: inboxURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ).filter { UUID(uuidString: $0.lastPathComponent) != nil }
+
+        var payloadBytes: Int64 = 0
+        for directoryURL in requestDirectories {
+            let children = try fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+                options: [.skipsHiddenFiles]
+            )
+            for child in children where child.lastPathComponent != SharedImportConfiguration.manifestFileName {
+                let values = try child.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+                guard values.isRegularFile == true, let fileSize = values.fileSize else {
+                    throw SharedImportError.pendingPayloadQuotaExceeded(
+                        maximumBytes: maximumPendingPayloadBytes
+                    )
+                }
+                let result = payloadBytes.addingReportingOverflow(Int64(fileSize))
+                guard !result.overflow else {
+                    throw SharedImportError.pendingPayloadQuotaExceeded(
+                        maximumBytes: maximumPendingPayloadBytes
+                    )
+                }
+                payloadBytes = result.partialValue
+            }
+        }
+        return PendingStorageUsage(
+            requestCount: requestDirectories.count,
+            payloadBytes: payloadBytes
+        )
     }
 
     /// Removes staging directories abandoned by an interrupted share (the
@@ -383,14 +429,15 @@ struct SharedImportStore {
         inboxURL.appendingPathComponent(requestID.uuidString.lowercased(), isDirectory: true)
     }
 
-    private func removeMalformedRequestDirectoryIfStale(_ directoryURL: URL) {
+    private func removeRequestDirectoryIfStale(
+        _ directoryURL: URL,
+        lifetime: TimeInterval
+    ) {
         guard UUID(uuidString: directoryURL.lastPathComponent) != nil,
               (try? directoryURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
             return
         }
-        let cutoff = currentDate().addingTimeInterval(
-            -SharedImportConfiguration.staleStagingLifetimeSeconds
-        )
+        let cutoff = currentDate().addingTimeInterval(-lifetime)
         guard let created = (try? directoryURL.resourceValues(forKeys: [.creationDateKey]))?
             .creationDate else { return }
         if created < cutoff {

--- a/TinfoilShared/SharedImportStore.swift
+++ b/TinfoilShared/SharedImportStore.swift
@@ -3,6 +3,12 @@ import Foundation
 import UniformTypeIdentifiers
 
 struct SharedImportStore {
+    private enum RequestLoadResult {
+        case loaded(SharedImportRequest)
+        case malformed
+        case unreadable
+    }
+
     private static let enqueueLock = NSLock()
 
     private let fileManager: FileManager
@@ -217,11 +223,15 @@ struct SharedImportStore {
 
         return directories
             .compactMap { directoryURL in
-                let request = loadRequest(from: directoryURL)
-                if request == nil {
+                switch loadRequest(from: directoryURL) {
+                case .loaded(let request):
+                    return request
+                case .malformed:
                     removeMalformedRequestDirectoryIfStale(directoryURL)
+                    return nil
+                case .unreadable:
+                    return nil
                 }
-                return request
             }
             .sorted { $0.createdAt < $1.createdAt }
     }
@@ -311,9 +321,9 @@ struct SharedImportStore {
         return "\(stem.prefix(maxLength - fileExtension.count - 1)).\(fileExtension)"
     }
 
-    private func loadRequest(from directoryURL: URL) -> SharedImportRequest? {
+    private func loadRequest(from directoryURL: URL) -> RequestLoadResult {
         guard UUID(uuidString: directoryURL.lastPathComponent) != nil else {
-            return nil
+            return .malformed
         }
 
         let manifestURL = directoryURL.appendingPathComponent(
@@ -321,16 +331,52 @@ struct SharedImportStore {
         )
         let decoder = JSONDecoder()
 
-        guard let data = try? BoundedFileIO.read(
-            from: manifestURL,
-            maximumBytes: SharedImportConfiguration.maximumManifestSizeBytes
-        ),
-              let request = try? decoder.decode(SharedImportRequest.self, from: data),
-              directoryURL == self.directoryURL(for: request.id),
-              (try? payloadURL(for: request)) != nil else {
-            return nil
+        let data: Data
+        do {
+            data = try BoundedFileIO.read(
+                from: manifestURL,
+                maximumBytes: SharedImportConfiguration.maximumManifestSizeBytes
+            )
+        } catch let error as BoundedFileIO.Error {
+            switch error {
+            case .fileTooLarge, .notRegularFile:
+                return .malformed
+            default:
+                return .unreadable
+            }
+        } catch {
+            return .unreadable
         }
-        return request
+        guard let request = try? decoder.decode(SharedImportRequest.self, from: data),
+              directoryURL == self.directoryURL(for: request.id),
+              request.item.stagedFileName == URL(
+                  fileURLWithPath: request.item.stagedFileName
+              ).lastPathComponent,
+              SharedImportClassifier.kind(
+                  typeIdentifier: request.item.typeIdentifier,
+                  fileName: request.item.originalFileName
+              ) == request.item.kind else {
+            return .malformed
+        }
+        let payloadURL = directoryURL.appendingPathComponent(request.item.stagedFileName)
+        let payloadSize: Int64
+        do {
+            payloadSize = try BoundedFileIO.size(
+                of: payloadURL,
+                maximumBytes: request.item.kind.maximumSizeBytes
+            )
+        } catch let error as BoundedFileIO.Error {
+            switch error {
+            case .fileTooLarge, .notRegularFile:
+                return .malformed
+            default:
+                return .unreadable
+            }
+        } catch {
+            return .unreadable
+        }
+        guard payloadSize == request.item.byteCount else { return .malformed }
+        return .loaded(request)
     }
 
     private func directoryURL(for requestID: UUID) -> URL {


### PR DESCRIPTION
## Summary
- bound ShareInbox manifests, payload reads, and file copies
- reuse managed staging while preserving send/discard retries
- cap pending request count and aggregate bytes without expiring valid requests

## Testing
- added bounded import, direct-data, quota, and cleanup tests
- `git diff --check`

## Dependency
- stacked on staged document cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds Share Inbox manifests and payloads, stages documents into managed files, and caps pending share storage to prevent runaway usage and crashes. Previously the share extension wrote temporary files and imports weren’t serialized or quota‑checked; now enqueues are serialized, limits are enforced, and temporarily unreadable requests are time‑bound.

- Enforces limits: maximum manifest size; per‑kind payload bounds on read/copy; quotas (`maximumPendingRequestCount`, `maximumPendingPayloadBytes`) with explicit rejections; preserves unreadable (manifest/payload) requests for 7 days; removes malformed request directories after the stale interval; sweeps abandoned temp staging.
- Serializes enqueue with an app‑group file lock (`.enqueue.lock` via flock) plus an in‑process lock; computes aggregate pending payload bytes under lock to avoid races.
- Adds SharedImportRepresentationLoader to prefer file representations, then immediately bound fallback Data; the share extension now calls SharedImportStore.enqueue(data:) directly (no temporary files).
- In SharedImportCoordinator, stages documents into the managed file store and passes a ManagedStagedFile; images use payloadData(for:) to bound reads. The inbox request remains until acknowledge to support retry.
- Introduces SharedImportAttachmentReceiving and updates importPendingAttachments to accept it; ChatViewModel conforms, so no caller changes required.
- Adds tests for direct‑data persistence, quotas and concurrency, oversize rejection, bounded reads, staging/ack flow, and malformed/unreadable/stale cleanup behavior.

<sup>Written for commit e2092fcab686bd3efabc66b9268509bf5aa6d8d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

