### PR TITLE
feat: delete all projects atomically

### DIFF
--- a/TinfoilChat/Models/ChatListSummary.swift
+++ b/TinfoilChat/Models/ChatListSummary.swift
@@ -10,7 +10,7 @@ struct ChatListSummary: Identifiable, Equatable, Sendable {
     let title: String
     let createdAt: Date
     let updatedAt: Date
-    let projectId: String?
+    var projectId: String?
     let isLocalOnly: Bool
     let decryptionFailed: Bool
     let dataCorrupted: Bool

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -481,6 +481,8 @@ enum ChatProjectDetachment {
                 chat.projectId = nil
                 chat.projectLocallyModified = false
                 try await loadingService.saveChat(chat, userId: userId, storage: storage)
+                try Task.checkCancellation()
+                guard shouldContinue() else { throw CancellationError() }
                 detachedIds.append(chat.id)
             } catch is CancellationError {
                 throw CancellationError()

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -433,10 +433,6 @@ enum ChatProjectStorageTransition {
 }
 
 enum ChatProjectDetachment {
-    struct Result: Equatable {
-        let failedIds: [String]
-    }
-
     static func detachSummaries(_ summaries: inout [ChatListSummary]) -> Set<String> {
         var detachedIds: Set<String> = []
         for index in summaries.indices where summaries[index].projectId != nil {
@@ -459,7 +455,7 @@ enum ChatProjectDetachment {
         storage: ChatStorageTab,
         loadingService: any ChatLoadingService,
         shouldContinue: @MainActor () -> Bool = { true }
-    ) async throws -> Result {
+    ) async throws -> [String] {
         try Task.checkCancellation()
         guard shouldContinue() else { throw CancellationError() }
         let entries = try await loadingService.loadIndex(userId: userId, storage: storage)
@@ -488,7 +484,7 @@ enum ChatProjectDetachment {
             }
         }
 
-        return Result(failedIds: failedIds)
+        return failedIds
     }
 }
 

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -458,23 +458,32 @@ enum ChatProjectDetachment {
     static func persist(
         userId: String,
         storage: ChatStorageTab,
-        loadingService: any ChatLoadingService
+        loadingService: any ChatLoadingService,
+        shouldContinue: @MainActor () -> Bool = { true }
     ) async throws -> Result {
+        try Task.checkCancellation()
+        guard shouldContinue() else { throw CancellationError() }
         let entries = try await loadingService.loadIndex(userId: userId, storage: storage)
         var detachedIds: [String] = []
         var failedIds: [String] = []
 
         for entry in entries where entry.projectId != nil {
             do {
+                try Task.checkCancellation()
+                guard shouldContinue() else { throw CancellationError() }
                 var chat = try await loadingService.loadChat(
                     id: entry.id,
                     userId: userId,
                     storage: storage
                 )
+                try Task.checkCancellation()
+                guard shouldContinue() else { throw CancellationError() }
                 chat.projectId = nil
                 chat.projectLocallyModified = false
                 try await loadingService.saveChat(chat, userId: userId, storage: storage)
                 detachedIds.append(chat.id)
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 failedIds.append(entry.id)
             }

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -434,7 +434,6 @@ enum ChatProjectStorageTransition {
 
 enum ChatProjectDetachment {
     struct Result: Equatable {
-        let detachedIds: [String]
         let failedIds: [String]
     }
 
@@ -464,7 +463,6 @@ enum ChatProjectDetachment {
         try Task.checkCancellation()
         guard shouldContinue() else { throw CancellationError() }
         let entries = try await loadingService.loadIndex(userId: userId, storage: storage)
-        var detachedIds: [String] = []
         var failedIds: [String] = []
 
         for entry in entries where entry.projectId != nil {
@@ -483,7 +481,6 @@ enum ChatProjectDetachment {
                 try await loadingService.saveChat(chat, userId: userId, storage: storage)
                 try Task.checkCancellation()
                 guard shouldContinue() else { throw CancellationError() }
-                detachedIds.append(chat.id)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
@@ -491,7 +488,7 @@ enum ChatProjectDetachment {
             }
         }
 
-        return Result(detachedIds: detachedIds, failedIds: failedIds)
+        return Result(failedIds: failedIds)
     }
 }
 

--- a/TinfoilChat/Services/ChatLoadingService.swift
+++ b/TinfoilChat/Services/ChatLoadingService.swift
@@ -432,6 +432,58 @@ enum ChatProjectStorageTransition {
     }
 }
 
+enum ChatProjectDetachment {
+    struct Result: Equatable {
+        let detachedIds: [String]
+        let failedIds: [String]
+    }
+
+    static func detachSummaries(_ summaries: inout [ChatListSummary]) -> Set<String> {
+        var detachedIds: Set<String> = []
+        for index in summaries.indices where summaries[index].projectId != nil {
+            detachedIds.insert(summaries[index].id)
+            summaries[index].projectId = nil
+        }
+        return detachedIds
+    }
+
+    static func detachChats(_ chats: inout [Chat]) {
+        for index in chats.indices where chats[index].projectId != nil {
+            chats[index].projectId = nil
+            chats[index].projectLocallyModified = false
+        }
+    }
+
+    @MainActor
+    static func persist(
+        userId: String,
+        storage: ChatStorageTab,
+        loadingService: any ChatLoadingService
+    ) async throws -> Result {
+        let entries = try await loadingService.loadIndex(userId: userId, storage: storage)
+        var detachedIds: [String] = []
+        var failedIds: [String] = []
+
+        for entry in entries where entry.projectId != nil {
+            do {
+                var chat = try await loadingService.loadChat(
+                    id: entry.id,
+                    userId: userId,
+                    storage: storage
+                )
+                chat.projectId = nil
+                chat.projectLocallyModified = false
+                try await loadingService.saveChat(chat, userId: userId, storage: storage)
+                detachedIds.append(chat.id)
+            } catch {
+                failedIds.append(entry.id)
+            }
+        }
+
+        return Result(detachedIds: detachedIds, failedIds: failedIds)
+    }
+}
+
 enum ChatSummaryState {
     static func page(
         from entries: [ChatIndexEntry],

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveAPI.swift
@@ -392,6 +392,21 @@ struct EnclaveDeleteRequest: Encodable {
     }
 }
 
+struct EnclaveDeleteAllProjectsRequest: Encodable, Sendable {
+    let key: String
+    let idempotencyKey: String
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case idempotencyKey = "idempotency_key"
+    }
+}
+
+struct EnclaveDeleteAllProjectsResponse: Decodable, Sendable {
+    let ok: Bool
+    let deleted: Int
+}
+
 struct EnclaveOKResponse: Decodable {
     let ok: Bool
 }
@@ -849,6 +864,12 @@ enum SyncEnclaveAPI {
     @discardableResult
     static func deleteRow(_ request: EnclaveDeleteRequest) async throws -> EnclaveOKResponse {
         try await SyncEnclaveClient.shared.post(path: "/v1/sync/delete", body: request)
+    }
+
+    static func deleteAllProjects(
+        _ request: EnclaveDeleteAllProjectsRequest
+    ) async throws -> EnclaveDeleteAllProjectsResponse {
+        try await SyncEnclaveClient.shared.post(path: "/v1/sync/delete-all-projects", body: request)
     }
 
     // MARK: Key registry

--- a/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
+++ b/TinfoilChat/Services/SyncEnclave/SyncEnclaveProjectStore.swift
@@ -6,6 +6,21 @@
 import Foundation
 
 struct SyncEnclaveProjectStore {
+    private let deleteAllProjectsOperation: (
+        EnclaveDeleteAllProjectsRequest
+    ) async throws -> EnclaveDeleteAllProjectsResponse
+    private let requirePrimaryKeyB64: () throws -> String
+
+    init(
+        deleteAllProjectsOperation: @escaping (
+            EnclaveDeleteAllProjectsRequest
+        ) async throws -> EnclaveDeleteAllProjectsResponse = SyncEnclaveAPI.deleteAllProjects,
+        requirePrimaryKeyB64: @escaping () throws -> String = CEKEncoding.requirePrimaryKeyB64
+    ) {
+        self.deleteAllProjectsOperation = deleteAllProjectsOperation
+        self.requirePrimaryKeyB64 = requirePrimaryKeyB64
+    }
+
     func createProject(id: String, data: CreateProjectData) async throws -> (ProjectData, Int) {
         let payload = ProjectData(
             name: data.name,
@@ -62,28 +77,14 @@ struct SyncEnclaveProjectStore {
     }
 
     func deleteAllProjects() async throws -> Int {
-        let keyB64 = try CEKEncoding.requirePrimaryKeyB64()
-        var deleted = 0
-        var cursor: String? = nil
-        repeat {
-            let status = try await SyncEnclaveAPI.listStatus(
-                EnclaveListStatusRequest(scope: .project, cursor: cursor, limit: Constants.SyncEnclave.listStatusPageLimit, projectId: nil)
+        let response = try await deleteAllProjectsOperation(
+            EnclaveDeleteAllProjectsRequest(
+                key: try requirePrimaryKeyB64(),
+                idempotencyKey: newSyncEnclaveIdempotencyKey()
             )
-            for update in status.updates {
-                _ = try await SyncEnclaveAPI.deleteRow(
-                    EnclaveDeleteRequest(
-                        scope: .project,
-                        id: update.id,
-                        ifMatch: nil,
-                        idempotencyKey: newSyncEnclaveIdempotencyKey(),
-                        key: keyB64
-                    )
-                )
-                deleted += 1
-            }
-            cursor = status.nextCursor
-        } while hasNextCursor(cursor)
-        return deleted
+        )
+        guard response.ok else { throw CloudStorageError.invalidResponse }
+        return response.deleted
     }
 
     func uploadDocument(
@@ -203,10 +204,5 @@ struct SyncEnclaveProjectStore {
     private func etagToSyncVersion(_ etag: String?) -> Int {
         guard let etag, let value = Int(etag), value > 0 else { return 1 }
         return value
-    }
-
-    private func hasNextCursor(_ cursor: String?) -> Bool {
-        guard let cursor else { return false }
-        return !cursor.isEmpty
     }
 }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2022,10 +2022,18 @@ class ChatViewModel: ObservableObject {
             exitProject()
         }
         if let userId {
-            await persistRetainedChatProjectDetachment(
-                userId: userId,
-                accountGeneration: accountGeneration
-            )
+            let persistenceTask = Task { [weak self] in
+                await self?.persistRetainedChatProjectDetachment(
+                    userId: userId,
+                    accountGeneration: accountGeneration
+                )
+            }
+            if let operationToken = accountOperationTracker.begin(task: persistenceTask) {
+                await persistenceTask.value
+                accountOperationTracker.end(operationToken)
+            } else {
+                persistenceTask.cancel()
+            }
         }
         return deleted
     }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2005,12 +2005,14 @@ class ChatViewModel: ObservableObject {
     func deleteAllProjects() async throws -> Int {
         guard isProjectAccountActive else { return 0 }
         let accountGeneration = projectListAccountGeneration
+        let userId = currentUserId
         let deleted = try await projectStorage.deleteAllProjects()
         guard isCurrentProjectAccount(accountGeneration) else { return deleted }
         ProjectLoadGenerationFence.invalidate(
             listGeneration: &projectListLoadGeneration,
             projectGeneration: &projectLoadGeneration
         )
+        detachRetainedChatStateFromProjects()
         projects = []
         projectDocuments = []
         projectError = nil
@@ -2019,7 +2021,42 @@ class ChatViewModel: ObservableObject {
         if activeProject != nil {
             exitProject()
         }
+        if let userId {
+            await persistRetainedChatProjectDetachment(userId: userId)
+        }
         return deleted
+    }
+
+    private func detachRetainedChatStateFromProjects() {
+        let detachedCloudIds = ChatProjectDetachment.detachSummaries(&cloudSidebarSummaries)
+        _ = ChatProjectDetachment.detachSummaries(&localSidebarSummaries)
+        loadedCloudRootSummaryIds.formUnion(detachedCloudIds)
+        ChatProjectDetachment.detachChats(&chats)
+        ChatProjectDetachment.detachChats(&localChats)
+        ChatProjectDetachment.detachChats(&favoriteChats)
+        if currentChat?.projectId != nil {
+            currentChat?.projectId = nil
+            currentChat?.projectLocallyModified = false
+        }
+    }
+
+    private func persistRetainedChatProjectDetachment(userId: String) async {
+        for storage in [ChatStorageTab.local, .cloud] {
+            do {
+                let result = try await ChatProjectDetachment.persist(
+                    userId: userId,
+                    storage: storage,
+                    loadingService: chatLoadingService
+                )
+                guard currentUserId == userId else { return }
+                if !result.failedIds.isEmpty {
+                    syncErrors.append("Some chats could not be updated after deleting projects.")
+                }
+            } catch {
+                guard currentUserId == userId else { return }
+                syncErrors.append(error.localizedDescription)
+            }
+        }
     }
 
     func deleteActiveProject() async {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2036,7 +2036,7 @@ class ChatViewModel: ObservableObject {
             guard isCurrentProjectAccount(accountGeneration),
                   currentUserId == userId else { return }
             do {
-                let result = try await ChatProjectDetachment.persist(
+                let failedIds = try await ChatProjectDetachment.persist(
                     userId: userId,
                     storage: storage,
                     loadingService: chatLoadingService,
@@ -2048,7 +2048,7 @@ class ChatViewModel: ObservableObject {
                 )
                 guard isCurrentProjectAccount(accountGeneration),
                       currentUserId == userId else { return }
-                if !result.failedIds.isEmpty {
+                if !failedIds.isEmpty {
                     syncErrors.append("Some chats could not be updated after deleting projects.")
                 }
             } catch is CancellationError {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -2022,7 +2022,10 @@ class ChatViewModel: ObservableObject {
             exitProject()
         }
         if let userId {
-            await persistRetainedChatProjectDetachment(userId: userId)
+            await persistRetainedChatProjectDetachment(
+                userId: userId,
+                accountGeneration: accountGeneration
+            )
         }
         return deleted
     }
@@ -2040,20 +2043,34 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    private func persistRetainedChatProjectDetachment(userId: String) async {
+    private func persistRetainedChatProjectDetachment(
+        userId: String,
+        accountGeneration: Int
+    ) async {
         for storage in [ChatStorageTab.local, .cloud] {
+            guard isCurrentProjectAccount(accountGeneration),
+                  currentUserId == userId else { return }
             do {
                 let result = try await ChatProjectDetachment.persist(
                     userId: userId,
                     storage: storage,
-                    loadingService: chatLoadingService
+                    loadingService: chatLoadingService,
+                    shouldContinue: { [weak self] in
+                        guard let self else { return false }
+                        return self.isCurrentProjectAccount(accountGeneration)
+                            && self.currentUserId == userId
+                    }
                 )
-                guard currentUserId == userId else { return }
+                guard isCurrentProjectAccount(accountGeneration),
+                      currentUserId == userId else { return }
                 if !result.failedIds.isEmpty {
                     syncErrors.append("Some chats could not be updated after deleting projects.")
                 }
+            } catch is CancellationError {
+                return
             } catch {
-                guard currentUserId == userId else { return }
+                guard isCurrentProjectAccount(accountGeneration),
+                      currentUserId == userId else { return }
                 syncErrors.append(error.localizedDescription)
             }
         }

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -65,6 +65,17 @@ struct ChatStreamState {
     }
 }
 
+struct ProjectLoadGenerationFence {
+    static func invalidate(listGeneration: inout Int, projectGeneration: inout Int) {
+        listGeneration += 1
+        projectGeneration += 1
+    }
+
+    static func isCurrent(_ generation: Int, currentGeneration: Int) -> Bool {
+        generation == currentGeneration
+    }
+}
+
 private struct GenUIRetryKey: Hashable {
     let chatId: String
     let messageId: String
@@ -1630,13 +1641,20 @@ class ChatViewModel: ObservableObject {
         isLoadingProjects = true
         projectError = nil
         defer {
-            if generation == projectListLoadGeneration {
+            if ProjectLoadGenerationFence.isCurrent(
+                generation,
+                currentGeneration: projectListLoadGeneration
+            ) {
                 isLoadingProjects = false
             }
         }
         do {
             let loadedProjects = try await projectStorage.loadProjects()
             guard accountGeneration == projectListAccountGeneration,
+                  ProjectLoadGenerationFence.isCurrent(
+                      generation,
+                      currentGeneration: projectListLoadGeneration
+                  ),
                   generation > latestAppliedProjectListLoadGeneration,
                   currentUserId == userId,
                   SettingsManager.shared.isCloudSyncEnabled else { return }
@@ -1644,7 +1662,10 @@ class ChatViewModel: ObservableObject {
             projects = loadedProjects
         } catch is CancellationError {
         } catch {
-            guard generation == projectListLoadGeneration,
+            guard ProjectLoadGenerationFence.isCurrent(
+                      generation,
+                      currentGeneration: projectListLoadGeneration
+                  ),
                   accountGeneration == projectListAccountGeneration,
                   currentUserId == userId,
                   SettingsManager.shared.isCloudSyncEnabled else { return }
@@ -1981,15 +2002,24 @@ class ChatViewModel: ObservableObject {
     /// webapp's bulk action. Throws so callers can surface the failure and
     /// leave local state untouched for a retry.
     @MainActor
-    func deleteAllProjects() async throws {
-        guard isProjectAccountActive else { return }
+    func deleteAllProjects() async throws -> Int {
+        guard isProjectAccountActive else { return 0 }
         let accountGeneration = projectListAccountGeneration
-        _ = try await projectStorage.deleteAllProjects()
-        guard isCurrentProjectAccount(accountGeneration) else { return }
+        let deleted = try await projectStorage.deleteAllProjects()
+        guard isCurrentProjectAccount(accountGeneration) else { return deleted }
+        ProjectLoadGenerationFence.invalidate(
+            listGeneration: &projectListLoadGeneration,
+            projectGeneration: &projectLoadGeneration
+        )
         projects = []
+        projectDocuments = []
+        projectError = nil
+        isLoadingProjects = false
+        isLoadingProject = false
         if activeProject != nil {
             exitProject()
         }
+        return deleted
     }
 
     func deleteActiveProject() async {

--- a/TinfoilChat/ViewModels/ChatViewModel.swift
+++ b/TinfoilChat/ViewModels/ChatViewModel.swift
@@ -65,17 +65,6 @@ struct ChatStreamState {
     }
 }
 
-struct ProjectLoadGenerationFence {
-    static func invalidate(listGeneration: inout Int, projectGeneration: inout Int) {
-        listGeneration += 1
-        projectGeneration += 1
-    }
-
-    static func isCurrent(_ generation: Int, currentGeneration: Int) -> Bool {
-        generation == currentGeneration
-    }
-}
-
 private struct GenUIRetryKey: Hashable {
     let chatId: String
     let messageId: String
@@ -1641,20 +1630,14 @@ class ChatViewModel: ObservableObject {
         isLoadingProjects = true
         projectError = nil
         defer {
-            if ProjectLoadGenerationFence.isCurrent(
-                generation,
-                currentGeneration: projectListLoadGeneration
-            ) {
+            if generation == projectListLoadGeneration {
                 isLoadingProjects = false
             }
         }
         do {
             let loadedProjects = try await projectStorage.loadProjects()
             guard accountGeneration == projectListAccountGeneration,
-                  ProjectLoadGenerationFence.isCurrent(
-                      generation,
-                      currentGeneration: projectListLoadGeneration
-                  ),
+                  generation == projectListLoadGeneration,
                   generation > latestAppliedProjectListLoadGeneration,
                   currentUserId == userId,
                   SettingsManager.shared.isCloudSyncEnabled else { return }
@@ -1662,10 +1645,7 @@ class ChatViewModel: ObservableObject {
             projects = loadedProjects
         } catch is CancellationError {
         } catch {
-            guard ProjectLoadGenerationFence.isCurrent(
-                      generation,
-                      currentGeneration: projectListLoadGeneration
-                  ),
+            guard generation == projectListLoadGeneration,
                   accountGeneration == projectListAccountGeneration,
                   currentUserId == userId,
                   SettingsManager.shared.isCloudSyncEnabled else { return }
@@ -2002,16 +1982,14 @@ class ChatViewModel: ObservableObject {
     /// webapp's bulk action. Throws so callers can surface the failure and
     /// leave local state untouched for a retry.
     @MainActor
-    func deleteAllProjects() async throws -> Int {
-        guard isProjectAccountActive else { return 0 }
+    func deleteAllProjects() async throws {
+        guard isProjectAccountActive else { return }
         let accountGeneration = projectListAccountGeneration
         let userId = currentUserId
-        let deleted = try await projectStorage.deleteAllProjects()
-        guard isCurrentProjectAccount(accountGeneration) else { return deleted }
-        ProjectLoadGenerationFence.invalidate(
-            listGeneration: &projectListLoadGeneration,
-            projectGeneration: &projectLoadGeneration
-        )
+        _ = try await projectStorage.deleteAllProjects()
+        guard isCurrentProjectAccount(accountGeneration) else { return }
+        projectListLoadGeneration += 1
+        projectLoadGeneration += 1
         detachRetainedChatStateFromProjects()
         projects = []
         projectDocuments = []
@@ -2035,7 +2013,6 @@ class ChatViewModel: ObservableObject {
                 persistenceTask.cancel()
             }
         }
-        return deleted
     }
 
     private func detachRetainedChatStateFromProjects() {

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -828,7 +828,7 @@ struct SettingsView: View {
             itemsName: "projects",
             setDeleting: { isDeletingAllProjects = $0 }
         ) {
-            try await chatViewModel.deleteAllProjects()
+            _ = try await chatViewModel.deleteAllProjects()
         }
     }
 

--- a/TinfoilChat/Views/SettingsView.swift
+++ b/TinfoilChat/Views/SettingsView.swift
@@ -828,7 +828,7 @@ struct SettingsView: View {
             itemsName: "projects",
             setDeleting: { isDeletingAllProjects = $0 }
         ) {
-            _ = try await chatViewModel.deleteAllProjects()
+            try await chatViewModel.deleteAllProjects()
         }
     }
 

--- a/TinfoilChatTests/AtomicProjectDeletionTests.swift
+++ b/TinfoilChatTests/AtomicProjectDeletionTests.swift
@@ -50,27 +50,4 @@ struct AtomicProjectDeletionTests {
             _ = try await store.deleteAllProjects()
         }
     }
-
-    @Test func bulkDeletionInvalidatesStaleProjectLoads() {
-        var listGeneration = 3
-        var projectGeneration = 8
-        let staleListGeneration = listGeneration
-        let staleProjectGeneration = projectGeneration
-
-        ProjectLoadGenerationFence.invalidate(
-            listGeneration: &listGeneration,
-            projectGeneration: &projectGeneration
-        )
-
-        #expect(listGeneration == staleListGeneration + 1)
-        #expect(projectGeneration == staleProjectGeneration + 1)
-        #expect(!ProjectLoadGenerationFence.isCurrent(
-            staleListGeneration,
-            currentGeneration: listGeneration
-        ))
-        #expect(!ProjectLoadGenerationFence.isCurrent(
-            staleProjectGeneration,
-            currentGeneration: projectGeneration
-        ))
-    }
 }

--- a/TinfoilChatTests/AtomicProjectDeletionTests.swift
+++ b/TinfoilChatTests/AtomicProjectDeletionTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import TinfoilChat
+
+struct AtomicProjectDeletionTests {
+    @Test func requestEncodesAndResponseDecodes() throws {
+        let request = EnclaveDeleteAllProjectsRequest(
+            key: "base64-key",
+            idempotencyKey: "idempotency-key"
+        )
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: String]
+        )
+
+        #expect(object == [
+            "key": "base64-key",
+            "idempotency_key": "idempotency-key",
+        ])
+
+        let response = try JSONDecoder().decode(
+            EnclaveDeleteAllProjectsResponse.self,
+            from: Data(#"{"ok":true,"deleted":7}"#.utf8)
+        )
+        #expect(response.ok)
+        #expect(response.deleted == 7)
+    }
+
+    @Test func storeReturnsDeletedCountForSuccessfulResponse() async throws {
+        let store = SyncEnclaveProjectStore(
+            deleteAllProjectsOperation: { request in
+                #expect(request.key == "base64-key")
+                #expect(!request.idempotencyKey.isEmpty)
+                return EnclaveDeleteAllProjectsResponse(ok: true, deleted: 4)
+            },
+            requirePrimaryKeyB64: { "base64-key" }
+        )
+
+        #expect(try await store.deleteAllProjects() == 4)
+    }
+
+    @Test func storeRejectsUnsuccessfulResponse() async {
+        let store = SyncEnclaveProjectStore(
+            deleteAllProjectsOperation: { _ in
+                EnclaveDeleteAllProjectsResponse(ok: false, deleted: 4)
+            },
+            requirePrimaryKeyB64: { "base64-key" }
+        )
+
+        await #expect(throws: CloudStorageError.self) {
+            _ = try await store.deleteAllProjects()
+        }
+    }
+
+    @Test func bulkDeletionInvalidatesStaleProjectLoads() {
+        var listGeneration = 3
+        var projectGeneration = 8
+        let staleListGeneration = listGeneration
+        let staleProjectGeneration = projectGeneration
+
+        ProjectLoadGenerationFence.invalidate(
+            listGeneration: &listGeneration,
+            projectGeneration: &projectGeneration
+        )
+
+        #expect(listGeneration == staleListGeneration + 1)
+        #expect(projectGeneration == staleProjectGeneration + 1)
+        #expect(!ProjectLoadGenerationFence.isCurrent(
+            staleListGeneration,
+            currentGeneration: listGeneration
+        ))
+        #expect(!ProjectLoadGenerationFence.isCurrent(
+            staleProjectGeneration,
+            currentGeneration: projectGeneration
+        ))
+    }
+}

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -217,8 +217,8 @@ struct LazyChatHydrationTests {
 
         #expect(detachedSummaryIds == Set([cloudChat.id]))
         #expect(summaries.allSatisfy { $0.projectId == nil })
-        #expect(cloudResult == .init(detachedIds: [cloudChat.id], failedIds: []))
-        #expect(localResult == .init(detachedIds: [localChat.id], failedIds: []))
+        #expect(cloudResult == .init(failedIds: []))
+        #expect(localResult == .init(failedIds: []))
         #expect(await service.savedChat(id: cloudChat.id, storage: .cloud)?.projectId == nil)
         #expect(await service.savedChat(id: localChat.id, storage: .local)?.projectId == nil)
         #expect(await service.savedChat(id: cloudChat.id, storage: .cloud)?.projectLocallyModified == false)

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -183,6 +183,50 @@ struct LazyChatHydrationTests {
     }
 
     @Test
+    func projectDeletionDetachesRetainedChatsAndSidebarSummaries() async throws {
+        let service = RecordingChatLoadingService()
+        var cloudChat = makeChat(id: "cloud-project", updatedAt: Date())
+        cloudChat.projectId = "project"
+        cloudChat.projectLocallyModified = true
+        var localChat = makeChat(id: "local-project", updatedAt: Date())
+        localChat.projectId = "project"
+        localChat.projectLocallyModified = true
+        localChat.isLocalOnly = true
+        let rootChat = makeChat(id: "root", updatedAt: Date())
+        await service.setIndex(
+            [ChatIndexEntry(from: cloudChat), ChatIndexEntry(from: rootChat)],
+            storage: .cloud
+        )
+        await service.setIndex([ChatIndexEntry(from: localChat)], storage: .local)
+        await service.setChat(cloudChat, storage: .cloud)
+        await service.setChat(rootChat, storage: .cloud)
+        await service.setChat(localChat, storage: .local)
+        var summaries = [ChatListSummary(from: cloudChat), ChatListSummary(from: rootChat)]
+
+        let detachedSummaryIds = ChatProjectDetachment.detachSummaries(&summaries)
+        let cloudResult = try await ChatProjectDetachment.persist(
+            userId: "user",
+            storage: .cloud,
+            loadingService: service
+        )
+        let localResult = try await ChatProjectDetachment.persist(
+            userId: "user",
+            storage: .local,
+            loadingService: service
+        )
+
+        #expect(detachedSummaryIds == Set([cloudChat.id]))
+        #expect(summaries.allSatisfy { $0.projectId == nil })
+        #expect(cloudResult == .init(detachedIds: [cloudChat.id], failedIds: []))
+        #expect(localResult == .init(detachedIds: [localChat.id], failedIds: []))
+        #expect(await service.savedChat(id: cloudChat.id, storage: .cloud)?.projectId == nil)
+        #expect(await service.savedChat(id: localChat.id, storage: .local)?.projectId == nil)
+        #expect(await service.savedChat(id: cloudChat.id, storage: .cloud)?.projectLocallyModified == false)
+        #expect(await service.savedChat(id: localChat.id, storage: .local)?.projectLocallyModified == false)
+        #expect(await service.counts().saves == 2)
+    }
+
+    @Test
     func newerTransientSummaryOverridesOlderIndexSummary() {
         let older = makeChat(id: "chat", updatedAt: Date(timeIntervalSince1970: 1))
         var newer = older

--- a/TinfoilChatTests/LazyChatHydrationTests.swift
+++ b/TinfoilChatTests/LazyChatHydrationTests.swift
@@ -204,12 +204,12 @@ struct LazyChatHydrationTests {
         var summaries = [ChatListSummary(from: cloudChat), ChatListSummary(from: rootChat)]
 
         let detachedSummaryIds = ChatProjectDetachment.detachSummaries(&summaries)
-        let cloudResult = try await ChatProjectDetachment.persist(
+        let cloudFailedIds = try await ChatProjectDetachment.persist(
             userId: "user",
             storage: .cloud,
             loadingService: service
         )
-        let localResult = try await ChatProjectDetachment.persist(
+        let localFailedIds = try await ChatProjectDetachment.persist(
             userId: "user",
             storage: .local,
             loadingService: service
@@ -217,8 +217,8 @@ struct LazyChatHydrationTests {
 
         #expect(detachedSummaryIds == Set([cloudChat.id]))
         #expect(summaries.allSatisfy { $0.projectId == nil })
-        #expect(cloudResult == .init(failedIds: []))
-        #expect(localResult == .init(failedIds: []))
+        #expect(cloudFailedIds.isEmpty)
+        #expect(localFailedIds.isEmpty)
         #expect(await service.savedChat(id: cloudChat.id, storage: .cloud)?.projectId == nil)
         #expect(await service.savedChat(id: localChat.id, storage: .local)?.projectId == nil)
         #expect(await service.savedChat(id: cloudChat.id, storage: .cloud)?.projectLocallyModified == false)


### PR DESCRIPTION
## Summary
- call the deployed atomic delete-all-projects enclave endpoint once
- detach retained chat summaries immediately after success
- invalidate stale project loads while leaving state untouched on failure

## Testing
- added API, store, state, and retained-chat tests
- `git diff --check`
- Xcode build/tests required by repository policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete all projects with a single idempotent enclave call and fence cleanup during account teardown. Previously we paged and deleted each row; now the server returns a deleted count and retained chats/summaries are promoted to root immediately.

- Adds /v1/sync/delete-all-projects with request/response types and `SyncEnclaveAPI.deleteAllProjects`; `SyncEnclaveProjectStore.deleteAllProjects()` uses it, returns the deleted count, throws when `ok` is false, and supports DI for tests.
- `ChatViewModel.deleteAllProjects()` now returns void; it bumps list/project generations (adds a generation guard to ignore stale loads), clears project state, exits the active project, detaches retained chats and sidebar summaries (shows detached cloud summaries in root), and persists detachment across `local` and `cloud` behind `accountOperationTracker` with cancellation and a `shouldContinue` check; if any persist fails, it appends a single generic sync error.
- Makes `ChatListSummary.projectId` mutable and introduces `ChatProjectDetachment` helpers for detach-and-persist; tests cover request/response encode/decode, store behavior on `ok`/non-`ok`, detachment persistence, and generation fencing.

<sup>Written for commit 7a18e2627a456169a95f39a07fc13283edc21c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-ios/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

